### PR TITLE
Connect conversation thread UI and lead status data

### DIFF
--- a/docs/multi-tenant-conversations-plan.md
+++ b/docs/multi-tenant-conversations-plan.md
@@ -1,0 +1,672 @@
+# Multi-Tenant Conversations — Full Implementation Plan (Upwork-style)
+
+## 0) Goals & Scope (v1)
+
+* **Linear 1:1 chats** between client and assigned lawyer; optional org members can be invited later.
+* **AI → lead creation → handoff:** Client starts with AI; when ready, AI creates a `matter(status='lead')`, links it to a conversation, notifies assigned lawyer; lawyer accepts → joins chat; or rejects → locks chat.
+* **No full threads** (Discord-style) in v1; allow lightweight quote (`reply_to_message_id`).
+* **Realtime** via SSE + Durable Object (fan-out to all participants).
+* **Notifications**: email + in-app (no push yet).
+* **Strict multi-tenant isolation** and participant-level authz.
+
+**Non-goals (v1)**: emoji reactions, per-message read receipts, push notifications, deep search, webhooks.
+
+---
+
+## 1) Data Model (D1)
+
+> Add as a migration: `worker/migrations/2025xxxx_conversations.sql` and merge into `worker/schema.sql`.
+
+### 1.1 Tables
+
+```sql
+-- conversations
+CREATE TABLE IF NOT EXISTS conversations (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL,
+  matter_id TEXT, -- set on lead creation or later
+  type TEXT NOT NULL CHECK (type IN ('ai','human','mixed')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','locked','archived')),
+  title TEXT,
+  created_by_user_id TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_message_at DATETIME,
+  FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+  FOREIGN KEY (matter_id) REFERENCES matters(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_conversations_org_status
+  ON conversations(organization_id, status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_matter
+  ON conversations(matter_id);
+
+-- participants
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  conversation_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('client','paralegal','attorney','admin','owner')),
+  joined_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  left_at DATETIME,
+  is_muted INTEGER DEFAULT 0,
+  last_read_message_id TEXT,
+  PRIMARY KEY (conversation_id, user_id),
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_participants_user_org
+  ON conversation_participants(user_id, organization_id);
+CREATE INDEX IF NOT EXISTS idx_participants_conv
+  ON conversation_participants(conversation_id);
+
+-- messages
+CREATE TABLE IF NOT EXISTS conversation_messages (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  sender_user_id TEXT, -- NULL for AI/system
+  role TEXT NOT NULL CHECK (role IN ('user','assistant','system')),
+  content TEXT, -- redacted to '' on soft delete
+  message_type TEXT NOT NULL DEFAULT 'text' CHECK (message_type IN ('text','system','file','matter_update')),
+  reply_to_message_id TEXT,
+  metadata TEXT, -- JSON as TEXT
+  is_edited INTEGER DEFAULT 0,
+  edited_at DATETIME,
+  is_deleted INTEGER DEFAULT 0,
+  deleted_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created
+  ON conversation_messages(conversation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_sender_org
+  ON conversation_messages(sender_user_id, organization_id);
+CREATE INDEX IF NOT EXISTS idx_messages_reply_to
+  ON conversation_messages(reply_to_message_id);
+
+-- optional v1: files attached to messages (if not already covered by your files table)
+CREATE TABLE IF NOT EXISTS conversation_files (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  r2_key TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  mime TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+  FOREIGN KEY (message_id) REFERENCES conversation_messages(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_files_conv ON conversation_files(conversation_id);
+```
+
+### 1.2 Existing tables/index fixes (add in same migration)
+
+```sql
+-- files table: strengthen multi-tenant queries
+CREATE INDEX IF NOT EXISTS idx_files_org_session ON files(organization_id, session_id);
+CREATE INDEX IF NOT EXISTS idx_files_conversation ON files(conversation_id);
+
+-- chat_messages perf (org+session scanning)
+CREATE INDEX IF NOT EXISTS idx_chat_messages_org_session_created
+  ON chat_messages(organization_id, session_id, created_at);
+```
+
+---
+
+## 2) Auth & Tenancy
+
+### 2.1 Middleware
+
+**File:** `worker/middleware/auth.ts`
+
+Add:
+
+```ts
+export async function requireConversationParticipant(env: Env, req: Request, conversationId: string, allowPrivileged = true) {
+  const session = await requireAuth(env, req);
+  const convo = await env.DB.prepare(`SELECT organization_id FROM conversations WHERE id = ?`)
+    .bind(conversationId).first<{ organization_id: string }>();
+  if (!convo) throw new Response('Not found', { status: 404 });
+
+  // Admin/owner bypass (read-only if you prefer)
+  if (allowPrivileged && await userIsAdminOrOwner(env, session.user.id, convo.organization_id)) {
+    return { session, organizationId: convo.organization_id };
+  }
+
+  const isParticipant = await env.DB.prepare(
+    `SELECT 1 FROM conversation_participants WHERE conversation_id = ? AND user_id = ?`
+  ).bind(conversationId, session.user.id).first();
+
+  if (!isParticipant) throw new Response('Forbidden', { status: 403 });
+  return { session, organizationId: convo.organization_id };
+}
+```
+
+**Fix gaps you flagged:**
+
+* In `worker/routes/agent.ts (POST /api/agent/stream)`: **enforce org membership** before processing. Use `requireOrgMember(env, req, organizationId, 'paralegal' | 'attorney' | etc.)` or participant validation when linked to a conversation.
+
+* In `worker/routes/sessions.ts`: tighten the “public org” fallback; rate-limit and require org existence; avoid cross-org leakage.
+
+---
+
+## 3) Services
+
+Create:
+
+* `worker/services/ConversationService.ts`
+* `worker/services/ConversationMessageService.ts`
+
+### 3.1 ConversationService
+
+```ts
+export class ConversationService {
+  constructor(private env: Env) {}
+
+  async createConversation(args: {
+    organizationId: string;
+    createdByUserId: string;
+    type: 'ai'|'human'|'mixed';
+    matterId?: string | null;
+    title?: string | null;
+    participantUserIds: Array<{ userId: string; role: 'client'|'paralegal'|'attorney'|'admin'|'owner' }>;
+  }) {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await this.env.DB.batch([
+      this.env.DB.prepare(`
+        INSERT INTO conversations (id, organization_id, matter_id, type, status, title, created_by_user_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, 'open', ?, ?, ?, ?)
+      `).bind(id, args.organizationId, args.matterId ?? null, args.type, args.title ?? null, args.createdByUserId, now, now),
+      ...args.participantUserIds.map(p =>
+        this.env.DB.prepare(`
+          INSERT OR IGNORE INTO conversation_participants (conversation_id, user_id, organization_id, role)
+          VALUES (?, ?, ?, ?)
+        `).bind(id, p.userId, args.organizationId, p.role)
+      )
+    ]);
+
+    return { id };
+  }
+
+  async addParticipant(conversationId: string, organizationId: string, userId: string, role: string) {
+    await this.env.DB.prepare(`
+      INSERT OR IGNORE INTO conversation_participants (conversation_id, user_id, organization_id, role)
+      VALUES (?, ?, ?, ?)
+    `).bind(conversationId, userId, organizationId, role).run();
+  }
+
+  async removeParticipant(conversationId: string, userId: string) {
+    await this.env.DB.prepare(`DELETE FROM conversation_participants WHERE conversation_id = ? AND user_id = ?`)
+      .bind(conversationId, userId).run();
+  }
+
+  async linkMatter(conversationId: string, matterId: string) {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`UPDATE conversations SET matter_id = ?, updated_at = ? WHERE id = ?`)
+      .bind(matterId, now, conversationId).run();
+  }
+
+  async setType(conversationId: string, type: 'ai'|'human'|'mixed') {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`UPDATE conversations SET type = ?, updated_at = ? WHERE id = ?`)
+      .bind(type, now, conversationId).run();
+  }
+
+  async setStatus(conversationId: string, status: 'open'|'locked'|'archived') {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`UPDATE conversations SET status = ?, updated_at = ? WHERE id = ?`)
+      .bind(status, now, conversationId).run();
+  }
+}
+```
+
+### 3.2 ConversationMessageService
+
+```ts
+export class ConversationMessageService {
+  constructor(private env: Env) {}
+
+  async sendUserMessage(args: {
+    conversationId: string;
+    organizationId: string;
+    senderUserId: string;
+    content: string;
+    replyToMessageId?: string | null;
+    messageType?: 'text'|'file'|'system'|'matter_update';
+    clientNonce?: string;
+  }) {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await this.env.DB.batch([
+      this.env.DB.prepare(`
+        INSERT INTO conversation_messages
+          (id, conversation_id, organization_id, sender_user_id, role, content, message_type, reply_to_message_id, metadata, created_at)
+        VALUES (?, ?, ?, ?, 'user', ?, ?, ?, ?, ?)
+      `).bind(id, args.conversationId, args.organizationId, args.senderUserId,
+              args.content, args.messageType ?? 'text', args.replyToMessageId ?? null,
+              JSON.stringify({ clientNonce: args.clientNonce ?? null }), now),
+      this.env.DB.prepare(`UPDATE conversations SET last_message_at = ?, updated_at = ? WHERE id = ?`)
+        .bind(now, now, args.conversationId)
+    ]);
+
+    return { id, createdAt: now };
+  }
+
+  async sendSystemMessage(args: {
+    conversationId: string;
+    organizationId: string;
+    content: string;
+    messageType?: 'system'|'matter_update';
+    metadata?: any;
+  }) {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    await this.env.DB.batch([
+      this.env.DB.prepare(`
+        INSERT INTO conversation_messages
+          (id, conversation_id, organization_id, sender_user_id, role, content, message_type, metadata, created_at)
+        VALUES (?, ?, ?, NULL, 'system', ?, ?, ?, ?)
+      `).bind(id, args.conversationId, args.organizationId, args.content, args.messageType ?? 'system', JSON.stringify(args.metadata ?? {}), now),
+      this.env.DB.prepare(`UPDATE conversations SET last_message_at = ?, updated_at = ? WHERE id = ?`)
+        .bind(now, now, args.conversationId)
+    ]);
+    return { id, createdAt: now };
+  }
+
+  async editMessage(messageId: string, editorUserId: string, newContent: string) {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`
+      UPDATE conversation_messages
+      SET content = ?, is_edited = 1, edited_at = ?
+      WHERE id = ? AND sender_user_id = ? AND julianday('now') - julianday(created_at) <= (10.0/1440.0)
+    `).bind(newContent, now, messageId, editorUserId).run();
+  }
+
+  async softDeleteMessage(messageId: string, requesterUserId: string) {
+    const now = new Date().toISOString();
+    // Allow sender or privileged staff to soft delete; guard at route level
+    await this.env.DB.prepare(`
+      UPDATE conversation_messages
+      SET content = '', is_deleted = 1, deleted_at = ?
+      WHERE id = ?
+    `).bind(now, messageId).run();
+  }
+
+  async markLastRead(conversationId: string, userId: string, lastMessageId: string) {
+    await this.env.DB.prepare(`
+      UPDATE conversation_participants SET last_read_message_id = ?
+      WHERE conversation_id = ? AND user_id = ?
+    `).bind(lastMessageId, conversationId, userId).run();
+  }
+}
+```
+
+---
+
+## 4) Routes (Workers)
+
+Create: `worker/routes/conversations.ts` and register in `worker/index.ts`.
+
+### 4.1 Endpoints
+
+```
+POST   /api/conversations
+GET    /api/conversations?organizationId=&status=&cursor=&limit=
+GET    /api/conversations/:id
+POST   /api/conversations/:id/participants    { userId, role }
+DELETE /api/conversations/:id/participants/:userId
+POST   /api/conversations/:id/messages        { content, replyToMessageId?, messageType?, clientNonce? }
+GET    /api/conversations/:id/messages?before=&limit=
+PATCH  /api/conversations/:id/messages/:messageId  { action: 'edit'|'delete', content? }
+POST   /api/conversations/:id/accept
+POST   /api/conversations/:id/reject
+POST   /api/conversations/:id/read            { lastMessageId }
+GET    /api/conversations/:id/stream          (SSE)
+```
+
+### 4.2 Handlers (outline)
+
+* All **GET/POST/PATCH** routes:
+
+  * `requireAuth`
+  * Load/validate org context
+  * `requireConversationParticipant` OR `requireOrgMember` (admin/owner)
+
+* **Create conversation** (system/AI or staff):
+
+  * `requireOrgMember(organizationId, 'paralegal')`
+  * Upsert participants (creator + client/assignee)
+  * Return `conversationId`
+
+* **Send message**:
+
+  * `requireConversationParticipant`
+  * Use `ConversationMessageService.sendUserMessage`
+  * **Broadcast** via DO (see §5) and **notify** via `NotificationService` (see §6)
+
+* **Accept / Reject**:
+
+  * `requireOrgMember(organizationId, 'attorney')`
+  * `MatterService.acceptLead()/rejectLead()`
+  * `ConversationService.setType('human')` or `setStatus('locked')`
+  * `sendSystemMessage("Accepted by X" | "Rejected by Y")`
+  * Notify client
+
+* **Read marker**:
+
+  * `requireConversationParticipant`
+  * Update `last_read_message_id`
+
+* **Edit/Delete**:
+
+  * Author-only edit within 10 minutes; soft delete by sender or privileged staff
+
+* **List conversations**:
+
+  * Admin/owner: all in org
+  * Others: only where participant
+  * Paginate by `updated_at DESC`
+
+* **List messages**:
+
+  * Paginate by `created_at DESC` with `before` cursor
+
+---
+
+## 5) Realtime (SSE + Durable Object)
+
+Create DO: `worker/durable/ConversationRoom.ts`
+
+### 5.1 Durable Object
+
+```ts
+export class ConversationRoom {
+  state: DurableObjectState; env: Env;
+  clients = new Map<string, WritableStreamDefaultWriter>();
+
+  constructor(state: DurableObjectState, env: Env) { this.state = state; this.env = env; }
+
+  async fetch(req: Request) {
+    const url = new URL(req.url);
+    if (req.method === 'GET' && url.pathname.endsWith('/stream')) {
+      // Optionally carry signed token headers to re-validate here.
+      const { readable, writable } = new TransformStream();
+      const writer = writable.getWriter();
+      const id = crypto.randomUUID();
+      this.clients.set(id, writer);
+
+      const heartbeat = setInterval(() => this.safeWrite(writer, { type: 'ping' }), 15000);
+      req.signal.addEventListener('abort', () => { clearInterval(heartbeat); writer.close(); this.clients.delete(id); });
+
+      return new Response(readable, { headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive' }});
+    }
+
+    if (req.method === 'POST' && url.pathname.endsWith('/broadcast')) {
+      const payload = await req.json(); // { event, data }
+      await this.broadcast(payload);
+      return new Response('ok');
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  private async safeWrite(w: WritableStreamDefaultWriter, obj: any) {
+    try { await w.write(new TextEncoder().encode(`data: ${JSON.stringify(obj)}\n\n`)); } catch {}
+  }
+
+  private async broadcast(evt: any) {
+    const drop: string[] = [];
+    for (const [id, w] of this.clients) {
+      try { await this.safeWrite(w, evt); } catch { drop.push(id); }
+    }
+    drop.forEach(id => this.clients.delete(id));
+  }
+}
+```
+
+### 5.2 Bindings & Router
+
+* Add DO binding in `wrangler.toml`:
+
+```toml
+[[durable_objects.bindings]]
+name = "CONVERSATION_ROOM"
+class_name = "ConversationRoom"
+```
+
+* In `worker/index.ts`, route:
+
+  * `GET /api/conversations/:id/stream` → `env.CONVERSATION_ROOM.idFromName(conversationId)`; **verify participant**, then `room.fetch('/stream')`.
+  * On message persisted, POST to `.../broadcast` with `{ event: 'message', data: {...} }`.
+
+**Client:** Reuse SSE handler from `useMessageHandling`, subscribe per conversation.
+
+---
+
+## 6) Notifications
+
+**File:** `worker/services/NotificationService.ts` — extend with 3 helpers:
+
+```ts
+async sendConversationMessageNotification(input: {
+  organizationId: string;
+  conversationId: string;
+  senderName: string;
+  messagePreview: string;
+  recipientUserIds: string[];
+}) { /* email + in-app */ }
+
+async sendConversationAcceptedNotification(input: {
+  organizationId: string; conversationId: string; matterNumber: string; clientUserId: string;
+}) { /* email + in-app */ }
+
+async sendConversationRejectedNotification(input: {
+  organizationId: string; conversationId: string; clientUserId: string; reason?: string;
+}) { /* email + in-app */ }
+```
+
+**Where to call:**
+
+* After `sendUserMessage()` (only for recipients other than sender and currently offline).
+* After accept/reject handlers.
+
+**In-app (v1):**
+
+* Reuse `StatusService` to push a `type: 'conversation_message'` payload keyed by userId; display with your Toast system and add a basic **badge** count (KV-backed) until you add persistent logs.
+
+---
+
+## 7) Matter Integration (AI → Lead → Handoff)
+
+**File:** `worker/services/MatterService.ts`
+
+* On **lead creation** (contact or AI intake):
+
+  * Create (or upsert) a **conversation** with `type='ai'| 'mixed'`, `matter_id=leadId`.
+  * Ensure **client** and **assigned member** are participants.
+  * Post a **system message**: “Lead created #M-123”.
+  * Call `sendMatterCreatedNotification` (existing) + **sendConversationMessageNotification** (new) to assigned user.
+
+* On **accept**:
+
+  * `acceptLead()` existing behavior.
+  * `ConversationService.setType('human')`; ensure accepting lawyer is participant; system message “Accepted by …”; notify client.
+
+* On **reject**:
+
+  * `rejectLead()` existing behavior.
+  * `ConversationService.setStatus('locked')`; system message “Rejected by …”; notify client.
+
+---
+
+## 8) Files & Security Hardening
+
+**File:** `worker/routes/files.ts`
+
+* **Validate MIME + size** in upload:
+
+  * Allow list (PDF, images, docx, txt)
+  * Size limit 25MB (align with agent cap or raise globally)
+* **Virus scanning:** (optional v1) — if not feasible now, document risk and plan later.
+* **Retrieval guard:** Add org + participant check on `GET /api/files/:fileId` (use `files.organization_id` and if `files.conversation_id` present, ensure participant).
+* **Signed URLs:** (optional v1) — if you keep `/api/files/...` server-proxied, no R2 public URLs. If you move to signed URLs, generate short-lived URLs per participant request.
+
+**Schema indexes:** already included in §1.2.
+
+---
+
+## 9) Frontend (Preact)
+
+Create:
+
+* `src/hooks/useConversations.ts`
+
+  * `listConversations(organizationId)`
+  * `getConversation(id)`
+  * `addParticipant/removeParticipant`
+  * `acceptConversation/rejectConversation`
+
+* `src/hooks/useConversationMessages.ts`
+
+  * `listMessages(conversationId, { before, limit })`
+  * `sendMessage(content, opts?)` (include `clientNonce`)
+  * `editMessage`, `deleteMessage`
+  * `markRead(lastMessageId)`
+  * `useConversationStream(conversationId)` (SSE)
+
+Components:
+
+* `src/components/conversations/ConversationList.tsx`
+* `src/components/conversations/ConversationThread.tsx`
+* `src/components/conversations/MessageComposer.tsx`
+* Update `SidebarContent.tsx` to add a “Conversations” section (by matter or all).
+
+**AI handoff UX:**
+
+* In `ChatContainer.tsx`, when AI creates a lead:
+
+  * Show banner “Lead created #M-123 — Awaiting lawyer acceptance”
+  * If accepted, show “Your lawyer joined the conversation” and keep history continuous.
+
+---
+
+## 10) Fixes to Existing Routes
+
+* `worker/routes/agent.ts`
+
+  * **Before** streaming or persisting, check organization membership (for staff) or allowable public intake rules.
+  * Enforce **size limits** for attachments consistently with `/files.ts`.
+  * If agent posts into a conversation (mixed-type), write to `conversation_messages` via `ConversationMessageService.sendSystemMessage` or `role='assistant'`.
+
+* `worker/routes/sessions.ts`
+
+  * Remove or constrain “public org fallback”; attach API rate limiting; ensure org exists and caller is allowed.
+
+---
+
+## 11) Observability & Auditing
+
+* Log **accept/reject/add/remove** into `matter_events` (existing) and plan a `conversation_events` table later.
+* Add structured logs on broadcast failures and DO connection counts.
+* Metrics: messages/sec, SSE connections count, accept/reject counts.
+
+---
+
+## 12) Testing Matrix
+
+**Unit (services):**
+
+* Create conversation, add/remove participant
+* Send message, edit (<=10 min), delete (soft)
+* Mark last read
+* Accept/reject transitions mutate conversation as expected
+
+**Integration (routes):**
+
+* All endpoints with authz: participant vs admin/owner vs outsider
+* SSE: open stream, post message, observe event
+* Notifications: verify email sending is called (mock) + in-app status event
+
+**Security:**
+
+* Cross-org access attempts rejected
+* File retrieval enforces org & participant
+* Agent route checks org membership/session consistently
+
+---
+
+## 13) Deployment Steps
+
+1. Apply migration `2025xxxx_conversations.sql`.
+2. Bind DO `ConversationRoom` in `wrangler.toml`.
+3. Deploy Worker with new routes registered.
+4. Roll behind feature flag:
+
+   * `FEATURE_CONVERSATIONS=true` (in `src/config/features.ts` and Worker env)
+5. Smoke tests: create lead via AI → ensure conversation linked; accept → ensure lawyer joins and messaging works.
+
+---
+
+## 14) Timeline (suggested)
+
+* **Day 1–2:** Schema + services + auth middleware + route stubs.
+* **Day 3:** DO + SSE stream + broadcast path wired.
+* **Day 4:** Matter integration (create/accept/reject) + notifications.
+* **Day 5:** Frontend hooks/components + badge/unread.
+* **Day 6:** Security/file hardening + tests.
+* **Day 7:** Bake & deploy behind flag.
+
+---
+
+## 15) Drop-in TODOs for Codex (per file)
+
+**Create**
+
+* `worker/services/ConversationService.ts` (code above)
+* `worker/services/ConversationMessageService.ts` (code above)
+* `worker/routes/conversations.ts` (handlers per §4)
+* `worker/durable/ConversationRoom.ts` (code above)
+* `worker/migrations/2025xxxx_conversations.sql` (SQL §1)
+* `src/hooks/useConversations.ts`, `src/hooks/useConversationMessages.ts`
+* `src/components/conversations/*` (4 components listed)
+
+**Modify**
+
+* `worker/index.ts`: register routes + DO routing
+* `worker/middleware/auth.ts`: add `requireConversationParticipant`, fix gaps
+* `worker/services/MatterService.ts`: link conversation + handoff events
+* `worker/services/NotificationService.ts`: add 3 methods (§6)
+* `worker/routes/agent.ts`: org membership checks + optional write into `conversation_messages`
+* `worker/routes/files.ts`: MIME/size validation; retrieval authz
+* `worker/schema.sql`: append new tables/indexes (and keep migration as source of truth)
+* `src/components/ui/sidebar/organisms/SidebarContent.tsx`: add Conversations section
+* `src/components/ChatContainer.tsx`: handoff banners
+
+---
+
+## 16) Security Checklist (must pass)
+
+* [ ] Every conversation/message query **filters by `organization_id`**.
+* [ ] Every read/write checks **participant or admin/owner**.
+* [ ] File GET checks **org AND participant** if `conversation_id` is set.
+* [ ] Message edit time-boxed (<=10 minutes).
+* [ ] Soft delete redacts `content` but keeps audit.
+* [ ] Rate limit public & session endpoints; Turnstile on public forms.
+* [ ] Idempotency key (`X-Idempotency-Key`) for `POST /messages` (store recent keys in KV with 5-minute TTL).
+
+---
+
+## 17) Upwork-style Flow Wiring (recap)
+
+1. **Client ↔ AI** (`type='ai'`), conversation auto-created.
+2. AI creates **lead** → **link conversation** → system message + notify assigned.
+3. Lawyer **Accepts** → `type='human'`, becomes participant, system message + notify client; or **Rejects** → `status='locked'`, system message + notify client.
+4. Optional: **invite** additional org members via participants endpoint.
+
+---
+
+This is everything your codegen needs. If you want, I can generate specific handler code for `worker/routes/conversations.ts` next (CRUD + SSE join) to make it fully turnkey.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -61,6 +61,8 @@ interface AppLayoutProps {
   onOnboardingCompleted?: () => Promise<void> | void;
   selectedMatterId?: string | null;
   onMatterSelect?: (matterId: string) => void;
+  selectedConversationId?: string | null;
+  onConversationSelect?: (conversationId: string) => void;
 }
 
 const AppLayout: FunctionComponent<AppLayoutProps> = ({
@@ -81,7 +83,9 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
   children,
   onOnboardingCompleted,
   selectedMatterId,
-  onMatterSelect
+  onMatterSelect,
+  selectedConversationId,
+  onConversationSelect
 }) => {
   // Matter state management
   const { matter, status: matterStatus } = useMatterState(chatMessages);
@@ -268,6 +272,8 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
               onboardingHasDraft={hasOnboardingDraft}
               selectedMatterId={selectedMatterId}
               onSelectMatter={onMatterSelect}
+              selectedConversationId={selectedConversationId}
+              onSelectConversation={onConversationSelect}
             />
           </div>
           
@@ -335,6 +341,11 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
                     selectedMatterId={selectedMatterId}
                     onSelectMatter={(id) => {
                       onMatterSelect?.(id);
+                      onToggleMobileSidebar(false);
+                    }}
+                    selectedConversationId={selectedConversationId}
+                    onSelectConversation={(conversationId) => {
+                      onConversationSelect?.(conversationId);
                       onToggleMobileSidebar(false);
                     }}
                   />

--- a/src/components/ChatContainer.tsx
+++ b/src/components/ChatContainer.tsx
@@ -41,6 +41,9 @@ interface ChatContainerProps {
 
   // Input control prop
   clearInput?: number;
+  leadStatus?: 'idle' | 'pending' | 'accepted' | 'rejected';
+  leadMatterNumber?: string | null;
+  leadRejectionReason?: string | null;
 }
 
 const ChatContainer: FunctionComponent<ChatContainerProps> = ({
@@ -66,7 +69,10 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   isSessionReady,
   isUsageRestricted,
   usageMessage,
-  clearInput
+  clearInput,
+  leadStatus = 'idle',
+  leadMatterNumber,
+  leadRejectionReason
 }) => {
   const [inputValue, setInputValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -144,6 +150,41 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   return (
     <div className="flex flex-col h-screen md:h-screen w-full m-0 p-0 relative overflow-hidden bg-white dark:bg-dark-bg" data-testid="chat-container">
       <main className="flex flex-col h-full w-full overflow-hidden relative bg-white dark:bg-dark-bg">
+        {leadStatus !== 'idle' && (
+          <div
+            className={`mx-4 mt-4 rounded-lg border px-4 py-3 text-sm shadow-sm ${
+              leadStatus === 'pending'
+                ? 'border-amber-400 bg-amber-50 text-amber-900'
+                : leadStatus === 'accepted'
+                  ? 'border-emerald-400 bg-emerald-50 text-emerald-900'
+                  : 'border-rose-400 bg-rose-50 text-rose-900'
+            }`}
+          >
+            {leadStatus === 'pending' && (
+              <div>
+                <strong>Lead created</strong>
+                {leadMatterNumber ? ` · Matter ${leadMatterNumber}` : ''}
+                <div className="mt-1 text-xs">A lawyer will review your details and join the conversation shortly.</div>
+              </div>
+            )}
+            {leadStatus === 'accepted' && (
+              <div>
+                <strong>Your lawyer has joined the conversation</strong>
+                {leadMatterNumber ? ` · Matter ${leadMatterNumber}` : ''}
+                <div className="mt-1 text-xs">Feel free to continue the discussion and share any additional information.</div>
+              </div>
+            )}
+            {leadStatus === 'rejected' && (
+              <div>
+                <strong>Lead unavailable</strong>
+                <div className="mt-1 text-xs">
+                  {leadRejectionReason || 'This matter could not be accepted at this time. A team member will follow up with next steps.'}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         <VirtualMessageList
           messages={messages}
           organizationConfig={organizationConfig}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -24,9 +24,11 @@ interface LeftSidebarProps {
   onboardingHasDraft?: boolean;
   selectedMatterId?: string | null;
   onSelectMatter?: (matterId: string) => void;
+  selectedConversationId?: string | null;
+  onSelectConversation?: (conversationId: string) => void;
 }
 
-const LeftSidebar = ({ currentRoute, onGoToChats, onGoToMatter, onOpenOnboarding, onClose, matterStatus, organizationConfig, currentOrganization, onboardingStatus, onboardingHasDraft, selectedMatterId, onSelectMatter }: LeftSidebarProps) => {
+const LeftSidebar = ({ currentRoute, onGoToChats, onGoToMatter, onOpenOnboarding, onClose, matterStatus, organizationConfig, currentOrganization, onboardingStatus, onboardingHasDraft, selectedMatterId, onSelectMatter, selectedConversationId, onSelectConversation }: LeftSidebarProps) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const isMobile = useMobileDetection();
   
@@ -50,6 +52,8 @@ const LeftSidebar = ({ currentRoute, onGoToChats, onGoToMatter, onOpenOnboarding
         onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
         selectedMatterId={selectedMatterId}
         onSelectMatter={onSelectMatter}
+        selectedConversationId={selectedConversationId}
+        onSelectConversation={onSelectConversation}
       />
     </div>
   );

--- a/src/components/conversations/ConversationList.tsx
+++ b/src/components/conversations/ConversationList.tsx
@@ -1,0 +1,92 @@
+import { FunctionComponent } from 'preact';
+import { useMemo } from 'preact/hooks';
+import { useConversations } from '../../hooks/useConversations';
+
+interface ConversationListProps {
+  organizationId?: string;
+  selectedConversationId?: string | null;
+  onSelectConversation?: (conversationId: string) => void;
+  statusFilter?: 'open' | 'locked' | 'archived';
+}
+
+export const ConversationList: FunctionComponent<ConversationListProps> = ({
+  organizationId,
+  selectedConversationId,
+  onSelectConversation,
+  statusFilter = 'open'
+}) => {
+  const { conversations, loading, error, hasMore, loadMore } = useConversations({
+    organizationId,
+    status: statusFilter,
+    autoFetch: Boolean(organizationId)
+  });
+
+  const emptyState = useMemo(() => {
+    if (loading) {
+      return 'Loading conversations…';
+    }
+    if (error) {
+      return error;
+    }
+    if (!conversations.length) {
+      return 'No conversations yet';
+    }
+    return null;
+  }, [loading, error, conversations.length]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-3 py-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Conversations</h3>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {emptyState ? (
+          <div className="px-3 py-4 text-xs text-muted-foreground">{emptyState}</div>
+        ) : (
+          <ul className="px-2 space-y-1">
+            {conversations.map(conversation => {
+              const isActive = conversation.id === selectedConversationId;
+              const title = conversation.title?.trim() || 'Untitled conversation';
+              const subtitle = conversation.lastMessageAt
+                ? new Date(conversation.lastMessageAt).toLocaleString()
+                : 'No messages yet';
+
+              return (
+                <li key={conversation.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectConversation?.(conversation.id)}
+                    className={`w-full text-left rounded-md px-3 py-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 ${
+                      isActive
+                        ? 'bg-primary/10 text-primary'
+                        : 'hover:bg-muted'
+                    }`}
+                  >
+                    <div className="text-sm font-medium line-clamp-1">{title}</div>
+                    <div className="text-xs text-muted-foreground line-clamp-1">
+                      {subtitle}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {hasMore && (
+        <div className="px-3 py-2">
+          <button
+            type="button"
+            className="w-full rounded-md border border-border px-3 py-1 text-xs font-medium hover:bg-muted"
+            onClick={() => loadMore().catch(err => console.error('Failed to load more conversations', err))}
+            disabled={loading}
+          >
+            {loading ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/conversations/ConversationThread.tsx
+++ b/src/components/conversations/ConversationThread.tsx
@@ -1,0 +1,97 @@
+import { FunctionComponent } from 'preact';
+import { useEffect, useMemo, useRef } from 'preact/hooks';
+import { useConversationMessages } from '../../hooks/useConversationMessages';
+import { MessageComposer } from './MessageComposer';
+
+interface ConversationThreadProps {
+  conversationId?: string | null;
+}
+
+export const ConversationThread: FunctionComponent<ConversationThreadProps> = ({ conversationId }) => {
+  const {
+    messages,
+    loading,
+    error,
+    hasMore,
+    loadMore,
+    sendMessage,
+    markRead
+  } = useConversationMessages({ conversationId, autoConnect: true });
+
+  const lastReadRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!messages.length || !conversationId) {
+      return;
+    }
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage && lastMessage.id !== lastReadRef.current) {
+      lastReadRef.current = lastMessage.id;
+      markRead(lastMessage.id).catch(err => console.warn('Failed to mark conversation as read', err));
+    }
+  }, [messages, conversationId, markRead]);
+
+  const body = useMemo(() => {
+    if (!conversationId) {
+      return <div className="p-6 text-sm text-muted-foreground">Select a conversation to begin.</div>;
+    }
+    if (loading && !messages.length) {
+      return <div className="p-6 text-sm text-muted-foreground">Loading conversation…</div>;
+    }
+    if (error) {
+      return <div className="p-6 text-sm text-destructive">{error}</div>;
+    }
+    if (!messages.length) {
+      return <div className="p-6 text-sm text-muted-foreground">This conversation is empty. Send the first message to get started.</div>;
+    }
+    return null;
+  }, [conversationId, loading, messages.length, error]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-auto bg-background">
+        {body ?? (
+          <div className="flex h-full flex-col">
+            {hasMore && (
+              <div className="px-4 py-2 text-center">
+                <button
+                  type="button"
+                  className="text-xs font-medium text-primary hover:underline"
+                  onClick={() => loadMore().catch(err => console.error('Failed to load earlier messages', err))}
+                  disabled={loading}
+                >
+                  {loading ? 'Loading…' : 'Load earlier messages'}
+                </button>
+              </div>
+            )}
+            <div className="flex-1 space-y-3 px-4 py-3">
+              {messages.map(message => (
+                <div
+                  key={message.id}
+                  className={`max-w-xl rounded-lg border border-border px-3 py-2 text-sm shadow-sm ${
+                    message.role === 'user' ? 'bg-primary/10 text-primary-foreground' : 'bg-muted'
+                  }`}
+                >
+                  <div className="text-xs text-muted-foreground">
+                    {new Date(message.created_at).toLocaleString()}
+                    {message.is_edited ? ' · edited' : ''}
+                  </div>
+                  <div className={`mt-1 whitespace-pre-wrap ${message.is_deleted ? 'italic text-muted-foreground' : ''}`}>
+                    {message.is_deleted ? 'Message removed' : message.content || '(no content)'}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <MessageComposer
+        onSend={async content => {
+          await sendMessage(content);
+        }}
+        disabled={!conversationId}
+      />
+    </div>
+  );
+};

--- a/src/components/conversations/MessageComposer.tsx
+++ b/src/components/conversations/MessageComposer.tsx
@@ -1,0 +1,54 @@
+import { FunctionComponent } from 'preact';
+import { useState, useCallback } from 'preact/hooks';
+
+interface MessageComposerProps {
+  onSend: (content: string) => Promise<void> | void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export const MessageComposer: FunctionComponent<MessageComposerProps> = ({
+  onSend,
+  placeholder = 'Type a message…',
+  disabled = false
+}) => {
+  const [value, setValue] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled || sending) {
+      return;
+    }
+    try {
+      setSending(true);
+      await onSend(trimmed);
+      setValue('');
+    } finally {
+      setSending(false);
+    }
+  }, [value, onSend, disabled, sending]);
+
+  return (
+    <div className="border-t border-border bg-background p-3">
+      <div className="flex items-start space-x-2">
+        <textarea
+          className="flex-1 resize-none rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder={placeholder}
+          rows={3}
+          value={value}
+          onInput={event => setValue((event.target as HTMLTextAreaElement).value)}
+          disabled={disabled || sending}
+        />
+        <button
+          type="button"
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={() => handleSubmit().catch(err => console.error('Failed to send message', err))}
+          disabled={disabled || sending}
+        >
+          {sending ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/sidebar/organisms/SidebarContent.tsx
+++ b/src/components/ui/sidebar/organisms/SidebarContent.tsx
@@ -16,6 +16,7 @@ import type { BusinessOnboardingStatus } from '../../../../hooks/useOrganization
 import { useMattersSidebar, MattersSidebarStatus } from '../../../../hooks/useMattersSidebar';
 import { Input } from '../../input/Input';
 import { Button } from '../../Button';
+import { ConversationList } from '../../../conversations/ConversationList';
 
 interface SidebarContentProps {
   organizationConfig?: {
@@ -39,6 +40,8 @@ interface SidebarContentProps {
   onToggleCollapse: () => void;
   selectedMatterId?: string | null;
   onSelectMatter?: (matterId: string) => void;
+  selectedConversationId?: string | null;
+  onSelectConversation?: (conversationId: string) => void;
 }
 
 export const SidebarContent = ({
@@ -55,7 +58,9 @@ export const SidebarContent = ({
   isCollapsed,
   onToggleCollapse,
   selectedMatterId,
-  onSelectMatter
+  onSelectMatter,
+  selectedConversationId,
+  onSelectConversation
 }: SidebarContentProps) => {
   
   const onboardingLabel = (() => {
@@ -66,6 +71,7 @@ export const SidebarContent = ({
 
   const organizationId = organizationConfig?.organizationId;
   const showMattersSection = Boolean(organizationId) && !isCollapsed;
+  const showConversationsSection = Boolean(organizationId) && !isCollapsed;
 
   const {
     matters,
@@ -236,6 +242,16 @@ export const SidebarContent = ({
                 </Button>
               )}
             </div>
+          </div>
+        )}
+
+        {showConversationsSection && (
+          <div className="border-t border-border">
+            <ConversationList
+              organizationId={organizationId}
+              selectedConversationId={selectedConversationId}
+              onSelectConversation={onSelectConversation}
+            />
           </div>
         )}
 

--- a/src/hooks/__tests__/useMatterSummary.test.ts
+++ b/src/hooks/__tests__/useMatterSummary.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useMatterSummary } from '../useMatterSummary';
+import { Window as HappyDomWindow } from 'happy-dom';
+
+describe('useMatterSummary', () => {
+  const originalFetch = globalThis.fetch;
+  beforeAll(() => {
+    const dom = new HappyDomWindow();
+    Object.defineProperty(globalThis, 'window', { value: dom, configurable: true });
+    Object.defineProperty(globalThis, 'document', { value: dom.document, configurable: true });
+    Object.defineProperty(globalThis, 'navigator', { value: dom.navigator, configurable: true });
+  });
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('fetches matter summary when identifiers are provided', async () => {
+    const mockMatter = {
+      id: 'matter-1',
+      title: 'Family Consultation',
+      matterType: 'Family Law',
+      status: 'lead',
+      priority: 'high',
+      clientName: 'Jane Doe',
+      leadSource: 'Website',
+      matterNumber: 'MAT-001',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z',
+      acceptedBy: null
+    };
+
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { matter: mockMatter } })
+    });
+
+    const { result } = renderHook(() => useMatterSummary('org-1', 'matter-1'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/organizations/org-1/workspace/matters/matter-1'),
+      expect.objectContaining({ method: 'GET', credentials: 'include' })
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.matter).toMatchObject({
+      id: 'matter-1',
+      matterType: 'Family Law',
+      status: 'lead',
+      clientName: 'Jane Doe',
+      matterNumber: 'MAT-001'
+    });
+  });
+
+  it('captures errors when the server response is not ok', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({})
+    });
+
+    const { result } = renderHook(() => useMatterSummary('org-1', 'matter-1'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.matter).toBeNull();
+    expect(result.current.error).toContain('500');
+  });
+
+  it('does not attempt to fetch when identifiers are missing', async () => {
+    const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useMatterSummary(undefined, null));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.matter).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useConversationMessages.ts
+++ b/src/hooks/useConversationMessages.ts
@@ -1,0 +1,314 @@
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+
+export interface ConversationMessage {
+  id: string;
+  conversation_id: string;
+  organization_id: string;
+  sender_user_id: string | null;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  message_type: 'text' | 'system' | 'file' | 'matter_update';
+  reply_to_message_id: string | null;
+  metadata: string | null;
+  is_edited: number;
+  edited_at: string | null;
+  is_deleted: number;
+  deleted_at: string | null;
+  created_at: string;
+}
+
+export interface UseConversationMessagesOptions {
+  conversationId?: string | null;
+  pageSize?: number;
+  autoConnect?: boolean;
+}
+
+export interface UseConversationMessagesResult {
+  messages: ConversationMessage[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  refresh: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  sendMessage: (content: string, options?: { replyTo?: string | null; messageType?: ConversationMessage['message_type']; metadata?: Record<string, unknown>; }) => Promise<ConversationMessage | null>;
+  editMessage: (messageId: string, content: string) => Promise<void>;
+  deleteMessage: (messageId: string) => Promise<void>;
+  markRead: (messageId: string) => Promise<void>;
+}
+
+function mergeMessage(list: ConversationMessage[], incoming: ConversationMessage): ConversationMessage[] {
+  const existingIndex = list.findIndex(msg => msg.id === incoming.id);
+  if (existingIndex >= 0) {
+    const updated = [...list];
+    updated[existingIndex] = incoming;
+    return updated;
+  }
+  return [...list, incoming].sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+}
+
+export function useConversationMessages(options: UseConversationMessagesOptions): UseConversationMessagesResult {
+  const { conversationId, pageSize = 50, autoConnect = true } = options;
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const nextCursorRef = useRef<string | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const isFetchingRef = useRef(false);
+
+  const buildUrl = useCallback((isLoadMore: boolean) => {
+    if (!conversationId) {
+      return null;
+    }
+    const params = new URLSearchParams();
+    params.set('limit', Math.max(1, Math.min(pageSize, 200)).toString());
+    if (isLoadMore && nextCursorRef.current) {
+      params.set('before', nextCursorRef.current);
+    }
+    return `/api/conversations/${conversationId}/messages?${params.toString()}`;
+  }, [conversationId, pageSize]);
+
+  const fetchMessages = useCallback(async (isLoadMore: boolean) => {
+    if (!conversationId || isFetchingRef.current) {
+      return;
+    }
+
+    isFetchingRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = buildUrl(isLoadMore);
+      if (!url) {
+        throw new Error('Missing conversationId');
+      }
+
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || `Failed to fetch conversation messages (${response.status})`);
+      }
+
+      const payload = await response.json() as { data?: { items?: ConversationMessage[]; nextCursor?: string | null } };
+      const items = payload.data?.items ?? [];
+      const nextCursor = payload.data?.nextCursor ?? null;
+      nextCursorRef.current = nextCursor;
+      setHasMore(Boolean(nextCursor));
+
+      setMessages(prev => {
+        if (isLoadMore) {
+          const merged = [...items, ...prev];
+          const unique = new Map<string, ConversationMessage>();
+          for (const message of merged) {
+            unique.set(message.id, message);
+          }
+          return Array.from(unique.values()).sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+        }
+        return [...items].sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+      });
+    } catch (err) {
+      console.error('Failed to fetch conversation messages', err);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+      isFetchingRef.current = false;
+    }
+  }, [buildUrl, conversationId]);
+
+  const refresh = useCallback(async () => {
+    nextCursorRef.current = null;
+    await fetchMessages(false);
+  }, [fetchMessages]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore) {
+      return;
+    }
+    await fetchMessages(true);
+  }, [fetchMessages, hasMore]);
+
+  const connectStream = useCallback(() => {
+    if (!conversationId || !autoConnect) {
+      return;
+    }
+
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+    }
+
+    const source = new EventSource(`/api/conversations/${conversationId}/stream`, { withCredentials: true });
+    eventSourceRef.current = source;
+
+    source.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as { event: string; data: unknown };
+        if (!payload || typeof payload !== 'object') {
+          return;
+        }
+
+        switch (payload.event) {
+          case 'message':
+          case 'message_updated': {
+            const message = payload.data as ConversationMessage;
+            if (message?.id) {
+              setMessages(prev => mergeMessage(prev, message));
+            }
+            break;
+          }
+          case 'message_deleted': {
+            const message = payload.data as ConversationMessage;
+            if (message?.id) {
+              setMessages(prev => prev.map(item => item.id === message.id ? message : item));
+            }
+            break;
+          }
+          default:
+            break;
+        }
+      } catch (err) {
+        console.warn('Failed to parse conversation stream event', err);
+      }
+    };
+
+    source.onerror = (err) => {
+      console.warn('Conversation stream error', err);
+      source.close();
+      eventSourceRef.current = null;
+    };
+  }, [conversationId, autoConnect]);
+
+  const disconnectStream = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    nextCursorRef.current = null;
+    setMessages([]);
+    if (conversationId) {
+      fetchMessages(false).catch(error => {
+        console.error('Initial conversation message fetch failed', error);
+      });
+    }
+    connectStream();
+    return () => {
+      disconnectStream();
+    };
+  }, [conversationId, fetchMessages, connectStream, disconnectStream]);
+
+  const sendMessage = useCallback(async (content: string, opts?: { replyTo?: string | null; messageType?: ConversationMessage['message_type']; metadata?: Record<string, unknown>; }) => {
+    if (!conversationId) {
+      throw new Error('Conversation ID is required');
+    }
+    const trimmed = content.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const payload: Record<string, unknown> = {
+      content: trimmed,
+      clientNonce: crypto.randomUUID()
+    };
+    if (opts?.replyTo) {
+      payload.replyToMessageId = opts.replyTo;
+    }
+    if (opts?.messageType) {
+      payload.messageType = opts.messageType;
+    }
+    if (opts?.metadata) {
+      payload.metadata = opts.metadata;
+    }
+
+    const response = await fetch(`/api/conversations/${conversationId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Failed to send message');
+    }
+
+    const body = await response.json() as { data?: { message?: ConversationMessage } };
+    const message = body.data?.message ?? null;
+    if (message) {
+      setMessages(prev => mergeMessage(prev, message));
+    }
+    return message;
+  }, [conversationId]);
+
+  const editMessage = useCallback(async (messageId: string, content: string) => {
+    if (!conversationId) {
+      throw new Error('Conversation ID is required');
+    }
+    const response = await fetch(`/api/conversations/${conversationId}/messages/${messageId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ action: 'edit', content })
+    });
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Failed to edit message');
+    }
+    const body = await response.json() as { data?: { message?: ConversationMessage } };
+    const message = body.data?.message;
+    if (message) {
+      setMessages(prev => mergeMessage(prev, message));
+    }
+  }, [conversationId]);
+
+  const deleteMessage = useCallback(async (messageId: string) => {
+    if (!conversationId) {
+      throw new Error('Conversation ID is required');
+    }
+    const response = await fetch(`/api/conversations/${conversationId}/messages/${messageId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ action: 'delete' })
+    });
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Failed to delete message');
+    }
+    const body = await response.json() as { data?: { message?: ConversationMessage } };
+    const message = body.data?.message;
+    if (message) {
+      setMessages(prev => mergeMessage(prev, message));
+    }
+  }, [conversationId]);
+
+  const markRead = useCallback(async (messageId: string) => {
+    if (!conversationId) {
+      throw new Error('Conversation ID is required');
+    }
+    await fetch(`/api/conversations/${conversationId}/read`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ lastMessageId: messageId })
+    });
+  }, [conversationId]);
+
+  return {
+    messages,
+    loading,
+    error,
+    hasMore,
+    refresh,
+    loadMore,
+    sendMessage,
+    editMessage,
+    deleteMessage,
+    markRead
+  };
+}

--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -1,0 +1,156 @@
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+
+export interface ConversationSummary {
+  id: string;
+  organizationId: string;
+  matterId: string | null;
+  type: 'ai' | 'human' | 'mixed';
+  status: 'open' | 'locked' | 'archived';
+  title: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastMessageAt: string | null;
+}
+
+export interface UseConversationsOptions {
+  organizationId?: string | null;
+  status?: 'open' | 'locked' | 'archived';
+  pageSize?: number;
+  autoFetch?: boolean;
+}
+
+export interface UseConversationsResult {
+  conversations: ConversationSummary[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  refresh: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  setStatus: (status: 'open' | 'locked' | 'archived' | undefined) => void;
+}
+
+export function useConversations(options: UseConversationsOptions): UseConversationsResult {
+  const { organizationId, status, pageSize = 25, autoFetch = true } = options;
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [currentStatus, setCurrentStatus] = useState<typeof status>(status);
+  const nextCursorRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const buildUrl = useCallback(() => {
+    if (!organizationId) {
+      return null;
+    }
+    const params = new URLSearchParams();
+    params.set('organizationId', organizationId);
+    params.set('limit', Math.max(1, Math.min(pageSize, 100)).toString());
+    if (currentStatus) {
+      params.set('status', currentStatus);
+    }
+    if (nextCursorRef.current) {
+      params.set('cursor', nextCursorRef.current);
+    }
+    return `/api/conversations?${params.toString()}`;
+  }, [organizationId, currentStatus, pageSize]);
+
+  const fetchConversations = useCallback(async (isLoadMore = false) => {
+    if (!organizationId) {
+      return;
+    }
+
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = buildUrl();
+      if (!url) {
+        throw new Error('Missing organizationId');
+      }
+
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || `Failed to fetch conversations (${response.status})`);
+      }
+
+      const payload = await response.json() as { data?: { items?: ConversationSummary[]; nextCursor?: string | null } };
+      const items = payload.data?.items ?? [];
+      const nextCursor = payload.data?.nextCursor ?? null;
+
+      nextCursorRef.current = nextCursor;
+      setHasMore(Boolean(nextCursor));
+      setConversations(prev => {
+        if (isLoadMore) {
+          const merged = [...prev];
+          const existingIds = new Set(merged.map(item => item.id));
+          for (const item of items) {
+            if (!existingIds.has(item.id)) {
+              merged.push(item);
+            }
+          }
+          return merged;
+        }
+        return items;
+      });
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        return;
+      }
+      console.error('Failed to fetch conversations', err);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [buildUrl, organizationId]);
+
+  const refresh = useCallback(async () => {
+    nextCursorRef.current = null;
+    await fetchConversations(false);
+  }, [fetchConversations]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || loading) {
+      return;
+    }
+    await fetchConversations(true);
+  }, [fetchConversations, hasMore, loading]);
+
+  useEffect(() => {
+    nextCursorRef.current = null;
+    if (autoFetch && organizationId) {
+      fetchConversations(false).catch(error => {
+        console.error('Initial conversation fetch failed', error);
+      });
+    }
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [organizationId, currentStatus, autoFetch, fetchConversations]);
+
+  useEffect(() => {
+    setCurrentStatus(status);
+  }, [status]);
+
+  return {
+    conversations,
+    loading,
+    error,
+    hasMore,
+    refresh,
+    loadMore,
+    setStatus: setCurrentStatus
+  };
+}

--- a/src/hooks/useMatterSummary.ts
+++ b/src/hooks/useMatterSummary.ts
@@ -1,0 +1,171 @@
+import { useState, useEffect, useCallback, useRef, type StateUpdater } from 'preact/hooks';
+import { getOrganizationWorkspaceEndpoint } from '../config/api';
+import type { MatterWorkflowStatus } from './useOrganizationManagement';
+
+const WORKFLOW_STATUSES: MatterWorkflowStatus[] = ['lead', 'open', 'in_progress', 'completed', 'archived'];
+
+export interface MatterSummary {
+  id: string;
+  title: string;
+  matterType: string;
+  status: MatterWorkflowStatus;
+  priority?: string | null;
+  clientName: string | null;
+  leadSource: string | null;
+  matterNumber: string | null;
+  createdAt: string;
+  updatedAt: string;
+  acceptedBy: { userId: string | null; acceptedAt: string | null } | null;
+}
+
+interface WorkspaceMatterResponse {
+  success?: boolean;
+  error?: string;
+  data?: { matter?: Record<string, unknown> };
+}
+
+function normalizeStatus(value: unknown): MatterWorkflowStatus {
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase() as MatterWorkflowStatus;
+    if (WORKFLOW_STATUSES.includes(normalized)) {
+      return normalized;
+    }
+  }
+  return 'lead';
+}
+
+function normalizeMatter(record: Record<string, unknown>): MatterSummary {
+  const acceptedByRaw = record.acceptedBy as Record<string, unknown> | null | undefined;
+  const acceptedBy = acceptedByRaw && typeof acceptedByRaw === 'object'
+    ? {
+        userId: typeof acceptedByRaw.userId === 'string' && acceptedByRaw.userId.trim().length > 0
+          ? acceptedByRaw.userId
+          : null,
+        acceptedAt: typeof acceptedByRaw.acceptedAt === 'string' ? acceptedByRaw.acceptedAt : null
+      }
+    : null;
+
+  return {
+    id: typeof record.id === 'string' ? record.id : String(record.id ?? ''),
+    title: typeof record.title === 'string' && record.title.trim().length > 0
+      ? record.title
+      : 'Matter',
+    matterType: typeof record.matterType === 'string' && record.matterType.trim().length > 0
+      ? record.matterType
+      : 'General',
+    status: normalizeStatus(record.status),
+    priority: typeof record.priority === 'string' ? record.priority : null,
+    clientName: typeof record.clientName === 'string' ? record.clientName : null,
+    leadSource: typeof record.leadSource === 'string' ? record.leadSource : null,
+    matterNumber: typeof record.matterNumber === 'string' ? record.matterNumber : null,
+    createdAt: typeof record.createdAt === 'string' ? record.createdAt : new Date().toISOString(),
+    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : new Date().toISOString(),
+    acceptedBy
+  };
+}
+
+export interface UseMatterSummaryResult {
+  matter: MatterSummary | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  setMatter: StateUpdater<MatterSummary | null>;
+}
+
+export function useMatterSummary(
+  organizationId?: string,
+  matterId?: string | null
+): UseMatterSummaryResult {
+  const [matter, setMatter] = useState<MatterSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const fetchMatter = useCallback(async () => {
+    if (!organizationId || !matterId) {
+      setMatter(null);
+      setError(null);
+      setLoading(false);
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+        controllerRef.current = null;
+      }
+      return;
+    }
+
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const endpoint = `${getOrganizationWorkspaceEndpoint(organizationId, 'matters')}/${encodeURIComponent(matterId)}`;
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        credentials: 'include',
+        headers: { 'Accept': 'application/json' },
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load matter (${response.status})`);
+      }
+
+      const payload = await response.json() as WorkspaceMatterResponse;
+      const matterRecord = payload.data?.matter;
+      if (!matterRecord || typeof matterRecord !== 'object') {
+        throw new Error('Matter not found');
+      }
+
+      setMatter(normalizeMatter(matterRecord));
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'Failed to load matter';
+      setError(message);
+      setMatter(null);
+    } finally {
+      if (controllerRef.current === controller && !controller.signal.aborted) {
+        setLoading(false);
+        controllerRef.current = null;
+      }
+    }
+  }, [organizationId, matterId]);
+
+  useEffect(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+      controllerRef.current = null;
+    }
+
+    if (!organizationId || !matterId) {
+      setMatter(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    fetchMatter().catch(error => {
+      console.error('Failed to fetch matter summary', error);
+    });
+
+    return () => {
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+        controllerRef.current = null;
+      }
+    };
+  }, [organizationId, matterId, fetchMatter]);
+
+  const refresh = useCallback(async () => {
+    await fetchMatter();
+  }, [fetchMatter]);
+
+  return { matter, loading, error, refresh, setMatter };
+}

--- a/worker/durable/ConversationRoom.ts
+++ b/worker/durable/ConversationRoom.ts
@@ -1,0 +1,81 @@
+import type { DurableObjectState } from '@cloudflare/workers-types';
+import { Env } from '../types';
+
+interface BroadcastPayload {
+  event: string;
+  data: unknown;
+}
+
+export class ConversationRoom {
+  private readonly clients = new Map<string, WritableStreamDefaultWriter<Uint8Array>>();
+
+  constructor(private readonly state: DurableObjectState, private readonly env: Env) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'GET' && url.pathname.endsWith('/stream')) {
+      return this.handleStream(request.signal);
+    }
+
+    if (request.method === 'POST' && url.pathname.endsWith('/broadcast')) {
+      const payload = await request.json<BroadcastPayload>();
+      await this.broadcast(payload);
+      return new Response('ok');
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  private handleStream(abortSignal: AbortSignal): Response {
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = writable.getWriter();
+    const clientId = crypto.randomUUID();
+
+    this.clients.set(clientId, writer);
+
+    const heartbeatInterval = setInterval(() => {
+      this.safeWrite(writer, { event: 'ping', data: { ts: Date.now() } }).catch(() => {
+        clearInterval(heartbeatInterval);
+        writer.close().catch(() => {});
+        this.clients.delete(clientId);
+      });
+    }, 15000);
+
+    abortSignal.addEventListener('abort', () => {
+      clearInterval(heartbeatInterval);
+      writer.close().catch(() => {});
+      this.clients.delete(clientId);
+    }, { once: true });
+
+    return new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive'
+      }
+    });
+  }
+
+  private async broadcast(payload: BroadcastPayload): Promise<void> {
+    const failed: string[] = [];
+
+    await Promise.all(Array.from(this.clients.entries()).map(async ([clientId, writer]) => {
+      try {
+        await this.safeWrite(writer, payload);
+      } catch (error) {
+        console.warn('Failed to broadcast to client', { clientId, error });
+        failed.push(clientId);
+      }
+    }));
+
+    for (const clientId of failed) {
+      this.clients.delete(clientId);
+    }
+  }
+
+  private async safeWrite(writer: WritableStreamDefaultWriter<Uint8Array>, payload: BroadcastPayload | { event: string; data: unknown }): Promise<void> {
+    const text = `event: ${payload.event}\ndata: ${JSON.stringify(payload.data ?? null)}\n\n`;
+    await writer.write(new TextEncoder().encode(text));
+  }
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -20,7 +20,8 @@ import {
   handleConfig,
   handleUsage,
   handleStripeWebhook,
-  handleUsers
+  handleUsers,
+  handleConversations
 } from './routes';
 import { handleStatus } from './routes/status.js';
 import { Env } from './types';
@@ -116,6 +117,8 @@ async function handleRequestInternal(request: Request, env: Env, _ctx: Execution
       response = await handleConfig(request, env);
     } else if (path.startsWith('/api/usage')) {
       response = await handleUsage(request, env);
+    } else if (path.startsWith('/api/conversations')) {
+      response = await handleConversations(request, env);
     } else if (path === '/api/health') {
       response = await handleHealth(request, env);
     } else if (path === '/') {
@@ -158,4 +161,4 @@ export async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionC
   ctx.waitUntil(cleanupPromise);
 }
 
-// Export Durable Object classes (none currently)
+export { ConversationRoom } from './durable/ConversationRoom';

--- a/worker/migrations/20250218_conversations.sql
+++ b/worker/migrations/20250218_conversations.sql
@@ -1,0 +1,90 @@
+-- Conversations feature schema
+CREATE TABLE IF NOT EXISTS conversations (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL,
+  matter_id TEXT,
+  type TEXT NOT NULL CHECK (type IN ('ai','human','mixed')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','locked','archived')),
+  title TEXT,
+  created_by_user_id TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_message_at DATETIME,
+  FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+  FOREIGN KEY (matter_id) REFERENCES matters(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_org_status
+  ON conversations(organization_id, status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_matter
+  ON conversations(matter_id);
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  conversation_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('client','paralegal','attorney','admin','owner')),
+  joined_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  left_at DATETIME,
+  is_muted INTEGER DEFAULT 0,
+  last_read_message_id TEXT,
+  PRIMARY KEY (conversation_id, user_id),
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_participants_user_org
+  ON conversation_participants(user_id, organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_participants_conv
+  ON conversation_participants(conversation_id);
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  sender_user_id TEXT,
+  role TEXT NOT NULL CHECK (role IN ('user','assistant','system')),
+  content TEXT,
+  message_type TEXT NOT NULL DEFAULT 'text' CHECK (message_type IN ('text','system','file','matter_update')),
+  reply_to_message_id TEXT,
+  metadata TEXT,
+  is_edited INTEGER DEFAULT 0,
+  edited_at DATETIME,
+  is_deleted INTEGER DEFAULT 0,
+  deleted_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created
+  ON conversation_messages(conversation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_messages_sender_org
+  ON conversation_messages(sender_user_id, organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_messages_reply_to
+  ON conversation_messages(reply_to_message_id);
+
+CREATE TABLE IF NOT EXISTS conversation_files (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  r2_key TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  mime TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+  FOREIGN KEY (message_id) REFERENCES conversation_messages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_files_conv
+  ON conversation_files(conversation_id);
+
+-- Existing table index enhancements
+CREATE INDEX IF NOT EXISTS idx_files_org_session ON files(organization_id, session_id);
+CREATE INDEX IF NOT EXISTS idx_files_conversation ON files(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_chat_messages_org_session_created
+  ON chat_messages(organization_id, session_id, created_at);

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -1,0 +1,579 @@
+import { Env } from '../types';
+import { createSuccessResponse, handleError, HttpErrors } from '../errorHandler';
+import { parseJsonBody } from '../utils.js';
+import {
+  requireConversationParticipant,
+  requireOrgMember,
+  userIsAdminOrOwner
+} from '../middleware/auth';
+import { ConversationService } from '../services/ConversationService.js';
+import { ConversationMessageService } from '../services/ConversationMessageService.js';
+import { NotificationService } from '../services/NotificationService.js';
+import { MatterService } from '../services/MatterService.js';
+import {
+  getConversation,
+  listParticipants,
+  getMessage
+} from '../services/ConversationRepository.js';
+
+interface CreateConversationPayload {
+  organizationId: string;
+  matterId?: string | null;
+  type: 'ai' | 'human' | 'mixed';
+  title?: string | null;
+  participantUserIds: Array<{ userId: string; role: 'client' | 'paralegal' | 'attorney' | 'admin' | 'owner' }>;
+}
+
+interface SendMessagePayload {
+  content: string;
+  replyToMessageId?: string | null;
+  messageType?: 'text' | 'file' | 'system' | 'matter_update';
+  clientNonce?: string;
+}
+
+interface MessageActionPayload {
+  action: 'edit' | 'delete';
+  content?: string;
+  reason?: string | null;
+}
+
+interface MarkReadPayload {
+  lastMessageId: string;
+}
+
+async function loadConversation(env: Env, conversationId: string) {
+  const conversation = await getConversation(env, conversationId);
+  if (!conversation) {
+    throw HttpErrors.notFound('Conversation not found');
+  }
+  return conversation;
+}
+
+async function listConversationParticipants(env: Env, conversationId: string) {
+  return listParticipants(env, conversationId);
+}
+
+async function getConversationMessage(env: Env, messageId: string) {
+  return getMessage(env, messageId);
+}
+
+export async function handleConversations(request: Request, env: Env): Promise<Response> {
+  try {
+    const url = new URL(request.url);
+    const basePath = '/api/conversations';
+    const subPath = url.pathname.startsWith(basePath)
+      ? url.pathname.slice(basePath.length)
+      : '';
+    const segments = subPath.split('/').filter(Boolean);
+
+    if (segments.length === 0) {
+      if (request.method === 'POST') {
+        return await createConversation(request, env);
+      }
+      if (request.method === 'GET') {
+        return await listConversations(request, env, url);
+      }
+      throw HttpErrors.methodNotAllowed('Unsupported method for /api/conversations');
+    }
+
+    const conversationId = segments[0];
+    if (!conversationId) {
+      throw HttpErrors.badRequest('Conversation id is required');
+    }
+
+    if (segments.length === 1) {
+      if (request.method === 'GET') {
+        return await getConversation(request, env, conversationId);
+      }
+      throw HttpErrors.methodNotAllowed('Unsupported method');
+    }
+
+    const action = segments[1];
+
+    if (action === 'participants') {
+      if (segments.length === 2 && request.method === 'POST') {
+        return await addParticipant(request, env, conversationId);
+      }
+      if (segments.length === 3 && request.method === 'DELETE') {
+        return await removeParticipant(request, env, conversationId, segments[2]);
+      }
+      throw HttpErrors.methodNotAllowed('Unsupported participants operation');
+    }
+
+    if (action === 'messages') {
+      if (segments.length === 2 && request.method === 'POST') {
+        return await sendMessage(request, env, conversationId);
+      }
+      if (segments.length === 2 && request.method === 'GET') {
+        return await listMessages(request, env, conversationId, url);
+      }
+      if (segments.length === 3 && request.method === 'PATCH') {
+        return await modifyMessage(request, env, conversationId, segments[2]);
+      }
+      throw HttpErrors.methodNotAllowed('Unsupported messages operation');
+    }
+
+    if (action === 'accept' && request.method === 'POST') {
+      return await acceptConversation(request, env, conversationId);
+    }
+
+    if (action === 'reject' && request.method === 'POST') {
+      return await rejectConversation(request, env, conversationId);
+    }
+
+    if (action === 'read' && request.method === 'POST') {
+      return await markConversationRead(request, env, conversationId);
+    }
+
+    if (action === 'stream' && request.method === 'GET') {
+      return await openConversationStream(request, env, conversationId);
+    }
+
+    throw HttpErrors.notFound('Unknown conversations endpoint');
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+async function createConversation(request: Request, env: Env): Promise<Response> {
+  const body = await parseJsonBody(request) as Partial<CreateConversationPayload>;
+
+  if (!body.organizationId || typeof body.organizationId !== 'string') {
+    throw HttpErrors.badRequest('organizationId is required');
+  }
+  if (!body.type || !['ai', 'human', 'mixed'].includes(body.type)) {
+    throw HttpErrors.badRequest('Conversation type is required');
+  }
+
+  const auth = await requireOrgMember(request, env, body.organizationId, 'paralegal');
+
+  const participants = Array.isArray(body.participantUserIds) ? body.participantUserIds : [];
+  const participantMap = new Map<string, 'client' | 'paralegal' | 'attorney' | 'admin' | 'owner'>();
+
+  for (const participant of participants) {
+    if (!participant || typeof participant.userId !== 'string' || typeof participant.role !== 'string') {
+      continue;
+    }
+
+    const normalizedRole = participant.role as 'client' | 'paralegal' | 'attorney' | 'admin' | 'owner';
+    participantMap.set(participant.userId, normalizedRole);
+  }
+
+  const selfRole = (auth.memberRole as 'client' | 'paralegal' | 'attorney' | 'admin' | 'owner') ?? 'attorney';
+  participantMap.set(auth.user.id, selfRole === 'client' ? 'attorney' : selfRole);
+
+  const normalizedParticipants = Array.from(participantMap.entries()).map(([userId, role]) => ({
+    userId,
+    role
+  }));
+
+  const conversationService = new ConversationService(env);
+  const { id } = await conversationService.createConversation({
+    organizationId: body.organizationId,
+    createdByUserId: auth.user.id,
+    type: body.type,
+    matterId: body.matterId ?? null,
+    title: body.title ?? null,
+    participantUserIds: normalizedParticipants
+  });
+
+  const conversation = await loadConversation(env, id);
+  const participantsList = await listConversationParticipants(env, id);
+
+  return createSuccessResponse({
+    conversation,
+    participants: participantsList
+  });
+}
+
+async function listConversations(request: Request, env: Env, url: URL): Promise<Response> {
+  const organizationId = url.searchParams.get('organizationId');
+  if (!organizationId) {
+    throw HttpErrors.badRequest('organizationId is required');
+  }
+
+  const { user, memberRole } = await requireOrgMember(request, env, organizationId);
+  const status = url.searchParams.get('status');
+  const allowedStatuses = new Set(['open', 'locked', 'archived']);
+  if (status && !allowedStatuses.has(status)) {
+    throw HttpErrors.badRequest('Invalid status filter');
+  }
+  const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit') ?? '20') || 20, 100));
+  const cursor = url.searchParams.get('cursor');
+
+  const params: unknown[] = [organizationId];
+  let query = `SELECT id, organization_id, matter_id, type, status, title, created_by_user_id, created_at, updated_at, last_message_at
+               FROM conversations WHERE organization_id = ?`;
+
+  if (status) {
+    query += ' AND status = ?';
+    params.push(status);
+  }
+
+  if (!(memberRole === 'owner' || memberRole === 'admin')) {
+    query += ' AND id IN (SELECT conversation_id FROM conversation_participants WHERE user_id = ? AND organization_id = ? )';
+    params.push(user.id, organizationId);
+  }
+
+  if (cursor) {
+    query += ' AND datetime(updated_at) < datetime(?)';
+    params.push(cursor);
+  }
+
+  query += ' ORDER BY datetime(updated_at) DESC LIMIT ?';
+  params.push(limit + 1);
+
+  const result = await env.DB.prepare(query).bind(...params).all();
+  const records = result.results ?? [];
+
+  const hasMore = records.length > limit;
+  const items = hasMore ? records.slice(0, limit) : records;
+  const nextCursor = hasMore && items.length > 0 ? (items[items.length - 1] as { updated_at: string }).updated_at : null;
+
+  return createSuccessResponse({
+    items,
+    nextCursor
+  });
+}
+
+async function getConversation(request: Request, env: Env, conversationId: string): Promise<Response> {
+  const { organizationId } = await requireConversationParticipant(request, env, conversationId);
+  const conversation = await loadConversation(env, conversationId);
+
+  if (conversation.organization_id !== organizationId) {
+    throw HttpErrors.forbidden('Conversation does not belong to this organization');
+  }
+
+  const participants = await listConversationParticipants(env, conversationId);
+  return createSuccessResponse({
+    conversation,
+    participants
+  });
+}
+
+async function addParticipant(request: Request, env: Env, conversationId: string): Promise<Response> {
+  const conversation = await loadConversation(env, conversationId);
+  const auth = await requireOrgMember(request, env, conversation.organization_id, 'paralegal');
+  const body = await parseJsonBody(request) as Partial<{ userId: string; role: string }>;
+
+  if (!body.userId || typeof body.userId !== 'string') {
+    throw HttpErrors.badRequest('userId is required');
+  }
+
+  const role = (body.role ?? 'client') as 'client' | 'paralegal' | 'attorney' | 'admin' | 'owner';
+
+  const memberCheck = await env.DB.prepare(
+    'SELECT 1 FROM members WHERE organization_id = ? AND user_id = ?'
+  ).bind(conversation.organization_id, body.userId).first();
+
+  if (!memberCheck && role !== 'client') {
+    throw HttpErrors.badRequest('User must be an organization member to be assigned this role');
+  }
+
+  const conversationService = new ConversationService(env);
+  await conversationService.addParticipant(conversationId, conversation.organization_id, body.userId, role);
+
+  await conversationService.broadcastEvent(conversationId, 'participant_added', {
+    userId: body.userId,
+    role,
+    addedBy: auth.user.id
+  });
+
+  return createSuccessResponse({ success: true });
+}
+
+async function removeParticipant(request: Request, env: Env, conversationId: string, userId: string): Promise<Response> {
+  const conversation = await loadConversation(env, conversationId);
+  await requireOrgMember(request, env, conversation.organization_id, 'paralegal');
+
+  const conversationService = new ConversationService(env);
+  await conversationService.removeParticipant(conversationId, userId);
+
+  await conversationService.broadcastEvent(conversationId, 'participant_removed', {
+    userId
+  });
+
+  return createSuccessResponse({ success: true });
+}
+
+async function sendMessage(request: Request, env: Env, conversationId: string): Promise<Response> {
+  const auth = await requireConversationParticipant(request, env, conversationId);
+  const body = await parseJsonBody(request) as Partial<SendMessagePayload>;
+
+  if (!body.content || typeof body.content !== 'string') {
+    throw HttpErrors.badRequest('Message content is required');
+  }
+
+  const conversation = await loadConversation(env, conversationId);
+  const conversationService = new ConversationService(env);
+  const messageService = new ConversationMessageService(env);
+
+  const { id } = await messageService.sendUserMessage({
+    conversationId,
+    organizationId: conversation.organization_id,
+    senderUserId: auth.user.id,
+    content: body.content,
+    replyToMessageId: body.replyToMessageId ?? null,
+    messageType: body.messageType ?? 'text',
+    clientNonce: body.clientNonce
+  });
+
+  const message = await getConversationMessage(env, id);
+
+  if (message) {
+    await conversationService.broadcastEvent(conversationId, 'message', message);
+  }
+
+  const participants = await listConversationParticipants(env, conversationId);
+  const recipientIds = participants
+    .map(p => p.user_id)
+    .filter(userId => userId !== auth.user.id);
+
+  if (recipientIds.length > 0) {
+    const notificationService = new NotificationService(env);
+    await notificationService.sendConversationMessageNotification({
+      organizationId: conversation.organization_id,
+      conversationId,
+      senderName: auth.user.name,
+      messagePreview: body.content,
+      recipientUserIds: recipientIds
+    });
+  }
+
+  return createSuccessResponse({ message });
+}
+
+async function listMessages(request: Request, env: Env, conversationId: string, url: URL): Promise<Response> {
+  const { organizationId } = await requireConversationParticipant(request, env, conversationId);
+  const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit') ?? '50') || 50, 200));
+  const before = url.searchParams.get('before');
+
+  const params: unknown[] = [conversationId, organizationId];
+  let query = `SELECT id, conversation_id, organization_id, sender_user_id, role, content, message_type, reply_to_message_id,
+                     metadata, is_edited, edited_at, is_deleted, deleted_at, created_at
+              FROM conversation_messages
+              WHERE conversation_id = ? AND organization_id = ?`;
+
+  if (before) {
+    query += ' AND datetime(created_at) < datetime(?)';
+    params.push(before);
+  }
+
+  query += ' ORDER BY datetime(created_at) DESC LIMIT ?';
+  params.push(limit + 1);
+
+  const result = await env.DB.prepare(query).bind(...params).all();
+  const records = result.results ?? [];
+
+  const hasMore = records.length > limit;
+  const messages = hasMore ? records.slice(0, limit) : records;
+  const nextCursor = hasMore && messages.length > 0 ? (messages[messages.length - 1] as { created_at: string }).created_at : null;
+
+  return createSuccessResponse({
+    items: [...messages].reverse(),
+    nextCursor
+  });
+}
+
+async function modifyMessage(request: Request, env: Env, conversationId: string, messageId: string): Promise<Response> {
+  const auth = await requireConversationParticipant(request, env, conversationId);
+  const body = await parseJsonBody(request) as Partial<MessageActionPayload>;
+
+  const message = await getConversationMessage(env, messageId);
+  if (!message || message.conversation_id !== conversationId) {
+    throw HttpErrors.notFound('Message not found');
+  }
+
+  if (body.action === 'edit') {
+    if (!body.content || typeof body.content !== 'string') {
+      throw HttpErrors.badRequest('Updated content is required');
+    }
+
+    if (message.sender_user_id !== auth.user.id) {
+      throw HttpErrors.forbidden('Only the original sender may edit the message');
+    }
+
+    const messageService = new ConversationMessageService(env);
+    const updated = await messageService.editMessage(messageId, auth.user.id, body.content);
+    if (!updated) {
+      throw HttpErrors.forbidden('Message can no longer be edited');
+    }
+    const refreshed = await getConversationMessage(env, messageId);
+    if (refreshed) {
+      const conversationService = new ConversationService(env);
+      await conversationService.broadcastEvent(conversationId, 'message_updated', refreshed);
+    }
+    return createSuccessResponse({ message: refreshed });
+  }
+
+  if (body.action === 'delete') {
+    const isPrivileged = await userIsAdminOrOwner(env, auth.user.id, message.organization_id);
+    if (!isPrivileged && message.sender_user_id !== auth.user.id) {
+      throw HttpErrors.forbidden('Insufficient permissions to delete this message');
+    }
+
+    const messageService = new ConversationMessageService(env);
+    const deleted = await messageService.softDeleteMessage(messageId, conversationId);
+    if (!deleted) {
+      throw HttpErrors.badRequest('Message could not be deleted');
+    }
+    const refreshed = await getConversationMessage(env, messageId);
+    if (refreshed) {
+      const conversationService = new ConversationService(env);
+      await conversationService.broadcastEvent(conversationId, 'message_deleted', refreshed);
+    }
+    return createSuccessResponse({ message: refreshed });
+  }
+
+  throw HttpErrors.badRequest('Unsupported message action');
+}
+
+async function markConversationRead(request: Request, env: Env, conversationId: string): Promise<Response> {
+  const auth = await requireConversationParticipant(request, env, conversationId);
+  const body = await parseJsonBody(request) as Partial<MarkReadPayload>;
+
+  if (!body.lastMessageId || typeof body.lastMessageId !== 'string') {
+    throw HttpErrors.badRequest('lastMessageId is required');
+  }
+
+  const message = await getConversationMessage(env, body.lastMessageId);
+  if (!message || message.conversation_id !== conversationId) {
+    throw HttpErrors.notFound('Message not found in conversation');
+  }
+
+  const messageService = new ConversationMessageService(env);
+  await messageService.markLastRead(conversationId, auth.user.id, body.lastMessageId);
+
+  const conversationService = new ConversationService(env);
+  await conversationService.broadcastEvent(conversationId, 'read_receipt', {
+    userId: auth.user.id,
+    lastMessageId: body.lastMessageId
+  });
+
+  return createSuccessResponse({ success: true });
+}
+
+async function acceptConversation(request: Request, env: Env, conversationId: string): Promise<Response> {
+  const conversation = await loadConversation(env, conversationId);
+  const auth = await requireOrgMember(request, env, conversation.organization_id, 'attorney');
+
+  if (!conversation.matter_id) {
+    throw HttpErrors.badRequest('Conversation is not linked to a lead');
+  }
+
+  const matterService = new MatterService(env);
+  const conversationService = new ConversationService(env);
+  const messageService = new ConversationMessageService(env);
+  const notificationService = new NotificationService(env);
+
+  const transition = await matterService.acceptLead({
+    organizationId: conversation.organization_id,
+    matterId: conversation.matter_id,
+    actorUserId: auth.user.id
+  });
+
+  await conversationService.setType(conversationId, 'human');
+  await conversationService.addParticipant(conversationId, conversation.organization_id, auth.user.id, 'attorney');
+  const systemMessage = await messageService.sendSystemMessage({
+    conversationId,
+    organizationId: conversation.organization_id,
+    content: `${auth.user.name} accepted this matter`,
+    messageType: 'system'
+  });
+
+  const systemRecord = await getConversationMessage(env, systemMessage.id);
+  if (systemRecord) {
+    await conversationService.broadcastEvent(conversationId, 'message', systemRecord);
+  }
+
+  const participants = await listConversationParticipants(env, conversationId);
+  const clientParticipant = participants.find(participant => participant.role === 'client');
+  const matterRecord = await env.DB.prepare(
+    'SELECT matter_number FROM matters WHERE id = ? AND organization_id = ?'
+  ).bind(conversation.matter_id, conversation.organization_id).first<{ matter_number: string | null }>();
+  const matterNumber = matterRecord?.matter_number ?? undefined;
+  if (clientParticipant) {
+    await notificationService.sendConversationAcceptedNotification({
+      organizationId: conversation.organization_id,
+      conversationId,
+      clientUserId: clientParticipant.user_id,
+      actorName: auth.user.name,
+      matterNumber
+    });
+  }
+
+  return createSuccessResponse({
+    status: 'accepted',
+    matter: transition
+  });
+}
+
+async function rejectConversation(request: Request, env: Env, conversationId: string): Promise<Response> {
+  const conversation = await loadConversation(env, conversationId);
+  const auth = await requireOrgMember(request, env, conversation.organization_id, 'attorney');
+  const body = await parseJsonBody(request) as Partial<{ reason?: string | null }>;
+
+  if (!conversation.matter_id) {
+    throw HttpErrors.badRequest('Conversation is not linked to a lead');
+  }
+
+  const matterService = new MatterService(env);
+  const conversationService = new ConversationService(env);
+  const messageService = new ConversationMessageService(env);
+  const notificationService = new NotificationService(env);
+
+  const transition = await matterService.rejectLead({
+    organizationId: conversation.organization_id,
+    matterId: conversation.matter_id,
+    actorUserId: auth.user.id,
+    reason: body.reason ?? null
+  });
+
+  await conversationService.setStatus(conversationId, 'locked');
+  const systemMessage = await messageService.sendSystemMessage({
+    conversationId,
+    organizationId: conversation.organization_id,
+    content: `${auth.user.name} was unable to accept this matter`,
+    messageType: 'matter_update',
+    metadata: body.reason ? { reason: body.reason } : undefined
+  });
+
+  const systemRecord = await getConversationMessage(env, systemMessage.id);
+  if (systemRecord) {
+    await conversationService.broadcastEvent(conversationId, 'message', systemRecord);
+  }
+
+  const participants = await listConversationParticipants(env, conversationId);
+  const clientParticipant = participants.find(participant => participant.role === 'client');
+  const matterRecord = await env.DB.prepare(
+    'SELECT matter_number FROM matters WHERE id = ? AND organization_id = ?'
+  ).bind(conversation.matter_id, conversation.organization_id).first<{ matter_number: string | null }>();
+  const matterNumber = matterRecord?.matter_number ?? undefined;
+  if (clientParticipant) {
+    await notificationService.sendConversationRejectedNotification({
+      organizationId: conversation.organization_id,
+      conversationId,
+      clientUserId: clientParticipant.user_id,
+      actorName: auth.user.name,
+      reason: body.reason ?? undefined,
+      matterNumber
+    });
+  }
+
+  return createSuccessResponse({
+    status: 'rejected',
+    matter: transition
+  });
+}
+
+async function openConversationStream(request: Request, env: Env, conversationId: string): Promise<Response> {
+  await requireConversationParticipant(request, env, conversationId);
+  const id = env.CONVERSATION_ROOM.idFromName(conversationId);
+  const stub = env.CONVERSATION_ROOM.get(id);
+  const response = await stub.fetch(`https://conversations/${conversationId}/stream`, { method: 'GET' });
+
+  return new Response(response.body, {
+    headers: response.headers,
+    status: response.status
+  });
+}

--- a/worker/routes/index.ts
+++ b/worker/routes/index.ts
@@ -20,3 +20,4 @@ export { handleDebug } from './debug';
 export { handleUsage } from './usage';
 export { handleStripeWebhookWithErrorHandling as handleStripeWebhook } from './stripeWebhook';
 export { handleUsers } from './users';
+export { handleConversations } from './conversations';

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -673,3 +673,94 @@ CREATE TRIGGER IF NOT EXISTS trigger_subscriptions_updated_at
 BEGIN
   UPDATE subscriptions SET updated_at = (strftime('%s', 'now') * 1000) WHERE id = NEW.id;
 END;
+
+-- Conversations feature schema
+CREATE TABLE IF NOT EXISTS conversations (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL,
+  matter_id TEXT,
+  type TEXT NOT NULL CHECK (type IN ('ai','human','mixed')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','locked','archived')),
+  title TEXT,
+  created_by_user_id TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_message_at DATETIME,
+  FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+  FOREIGN KEY (matter_id) REFERENCES matters(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_org_status
+  ON conversations(organization_id, status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_matter
+  ON conversations(matter_id);
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  conversation_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('client','paralegal','attorney','admin','owner')),
+  joined_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  left_at DATETIME,
+  is_muted INTEGER DEFAULT 0,
+  last_read_message_id TEXT,
+  PRIMARY KEY (conversation_id, user_id),
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_participants_user_org
+  ON conversation_participants(user_id, organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_participants_conv
+  ON conversation_participants(conversation_id);
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  sender_user_id TEXT,
+  role TEXT NOT NULL CHECK (role IN ('user','assistant','system')),
+  content TEXT,
+  message_type TEXT NOT NULL DEFAULT 'text' CHECK (message_type IN ('text','system','file','matter_update')),
+  reply_to_message_id TEXT,
+  metadata TEXT,
+  is_edited INTEGER DEFAULT 0,
+  edited_at DATETIME,
+  is_deleted INTEGER DEFAULT 0,
+  deleted_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created
+  ON conversation_messages(conversation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_messages_sender_org
+  ON conversation_messages(sender_user_id, organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_messages_reply_to
+  ON conversation_messages(reply_to_message_id);
+
+CREATE TABLE IF NOT EXISTS conversation_files (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  r2_key TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  mime TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+  FOREIGN KEY (message_id) REFERENCES conversation_messages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_files_conv
+  ON conversation_files(conversation_id);
+
+-- Existing table index enhancements
+CREATE INDEX IF NOT EXISTS idx_files_org_session ON files(organization_id, session_id);
+CREATE INDEX IF NOT EXISTS idx_files_conversation ON files(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_chat_messages_org_session_created
+  ON chat_messages(organization_id, session_id, created_at);

--- a/worker/services/ConversationMessageService.ts
+++ b/worker/services/ConversationMessageService.ts
@@ -1,0 +1,136 @@
+import type { Env } from '../types';
+
+export type ConversationMessageType = 'text' | 'system' | 'file' | 'matter_update';
+
+interface SendUserMessageInput {
+  conversationId: string;
+  organizationId: string;
+  senderUserId: string;
+  content: string;
+  replyToMessageId?: string | null;
+  messageType?: ConversationMessageType;
+  clientNonce?: string | null;
+}
+
+interface SendSystemMessageInput {
+  conversationId: string;
+  organizationId: string;
+  content: string;
+  messageType?: Extract<ConversationMessageType, 'system' | 'matter_update'>;
+  metadata?: unknown;
+}
+
+export class ConversationMessageService {
+  constructor(private readonly env: Env) {}
+
+  async sendUserMessage(input: SendUserMessageInput): Promise<{ id: string; createdAt: string }> {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    const metadataPayload = input.clientNonce ? { clientNonce: input.clientNonce } : {};
+
+    await this.env.DB.batch([
+      this.env.DB.prepare(`
+        INSERT INTO conversation_messages (
+          id,
+          conversation_id,
+          organization_id,
+          sender_user_id,
+          role,
+          content,
+          message_type,
+          reply_to_message_id,
+          metadata,
+          created_at
+        )
+        VALUES (?, ?, ?, ?, 'user', ?, ?, ?, ?, ?)
+      `).bind(
+        id,
+        input.conversationId,
+        input.organizationId,
+        input.senderUserId,
+        input.content,
+        input.messageType ?? 'text',
+        input.replyToMessageId ?? null,
+        Object.keys(metadataPayload).length > 0 ? JSON.stringify(metadataPayload) : null,
+        now
+      ),
+      this.env.DB.prepare(`
+        UPDATE conversations
+        SET last_message_at = ?, updated_at = ?
+        WHERE id = ?
+      `).bind(now, now, input.conversationId)
+    ]);
+
+    return { id, createdAt: now };
+  }
+
+  async sendSystemMessage(input: SendSystemMessageInput): Promise<{ id: string; createdAt: string }> {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await this.env.DB.batch([
+      this.env.DB.prepare(`
+        INSERT INTO conversation_messages (
+          id,
+          conversation_id,
+          organization_id,
+          sender_user_id,
+          role,
+          content,
+          message_type,
+          metadata,
+          created_at
+        )
+        VALUES (?, ?, ?, NULL, 'system', ?, ?, ?, ?)
+      `).bind(
+        id,
+        input.conversationId,
+        input.organizationId,
+        input.content,
+        input.messageType ?? 'system',
+        input.metadata ? JSON.stringify(input.metadata) : null,
+        now
+      ),
+      this.env.DB.prepare(`
+        UPDATE conversations
+        SET last_message_at = ?, updated_at = ?
+        WHERE id = ?
+      `).bind(now, now, input.conversationId)
+    ]);
+
+    return { id, createdAt: now };
+  }
+
+  async editMessage(messageId: string, editorUserId: string, newContent: string): Promise<boolean> {
+    const now = new Date().toISOString();
+    const result = await this.env.DB.prepare(`
+      UPDATE conversation_messages
+      SET content = ?, is_edited = 1, edited_at = ?
+      WHERE id = ?
+        AND sender_user_id = ?
+        AND julianday('now') - julianday(created_at) <= (10.0 / 1440.0)
+    `).bind(newContent, now, messageId, editorUserId).run();
+
+    return Boolean(result.success && (result.meta?.changes ?? 0) > 0);
+  }
+
+  async softDeleteMessage(messageId: string, conversationId: string): Promise<boolean> {
+    const now = new Date().toISOString();
+    const result = await this.env.DB.prepare(`
+      UPDATE conversation_messages
+      SET content = '', is_deleted = 1, deleted_at = ?
+      WHERE id = ? AND conversation_id = ?
+    `).bind(now, messageId, conversationId).run();
+
+    return Boolean(result.success && (result.meta?.changes ?? 0) > 0);
+  }
+
+  async markLastRead(conversationId: string, userId: string, lastMessageId: string): Promise<void> {
+    await this.env.DB.prepare(`
+      UPDATE conversation_participants
+      SET last_read_message_id = ?
+      WHERE conversation_id = ? AND user_id = ?
+    `).bind(lastMessageId, conversationId, userId).run();
+  }
+}

--- a/worker/services/ConversationRepository.ts
+++ b/worker/services/ConversationRepository.ts
@@ -1,0 +1,85 @@
+import type { Env } from '../types';
+
+export interface ConversationRecord {
+  id: string;
+  organization_id: string;
+  matter_id: string | null;
+  type: 'ai' | 'human' | 'mixed';
+  status: 'open' | 'locked' | 'archived';
+  title: string | null;
+  created_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+  last_message_at: string | null;
+}
+
+export interface ConversationParticipantRecord {
+  conversation_id: string;
+  user_id: string;
+  role: string;
+  joined_at: string;
+  left_at: string | null;
+  is_muted: number;
+  last_read_message_id: string | null;
+}
+
+export interface ConversationMessageRecord {
+  id: string;
+  conversation_id: string;
+  organization_id: string;
+  sender_user_id: string | null;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  message_type: 'text' | 'system' | 'file' | 'matter_update';
+  reply_to_message_id: string | null;
+  metadata: string | null;
+  is_edited: number;
+  edited_at: string | null;
+  is_deleted: number;
+  deleted_at: string | null;
+  created_at: string;
+}
+
+export async function getConversation(env: Env, conversationId: string): Promise<ConversationRecord | null> {
+  const conversation = await env.DB.prepare(
+    `SELECT id, organization_id, matter_id, type, status, title, created_by_user_id, created_at, updated_at, last_message_at
+     FROM conversations WHERE id = ?`
+  ).bind(conversationId).first<ConversationRecord>();
+
+  return conversation ?? null;
+}
+
+export async function requireConversation(env: Env, conversationId: string): Promise<ConversationRecord> {
+  const conversation = await getConversation(env, conversationId);
+  if (!conversation) {
+    throw new Error('Conversation not found');
+  }
+  return conversation;
+}
+
+export async function listParticipants(env: Env, conversationId: string): Promise<ConversationParticipantRecord[]> {
+  const results = await env.DB.prepare(
+    `SELECT conversation_id, user_id, role, joined_at, left_at, is_muted, last_read_message_id
+     FROM conversation_participants WHERE conversation_id = ?`
+  ).bind(conversationId).all<ConversationParticipantRecord>();
+
+  return results.results ?? [];
+}
+
+export async function getMessage(env: Env, messageId: string): Promise<ConversationMessageRecord | null> {
+  const record = await env.DB.prepare(
+    `SELECT id, conversation_id, organization_id, sender_user_id, role, content, message_type, reply_to_message_id,
+            metadata, is_edited, edited_at, is_deleted, deleted_at, created_at
+     FROM conversation_messages WHERE id = ?`
+  ).bind(messageId).first<ConversationMessageRecord>();
+
+  return record ?? null;
+}
+
+export async function listConversationIdsForMatter(env: Env, organizationId: string, matterId: string): Promise<string[]> {
+  const result = await env.DB.prepare(
+    `SELECT id FROM conversations WHERE organization_id = ? AND matter_id = ?`
+  ).bind(organizationId, matterId).all<{ id: string }>();
+
+  return (result.results ?? []).map(row => row.id);
+}

--- a/worker/services/ConversationService.ts
+++ b/worker/services/ConversationService.ts
@@ -1,0 +1,143 @@
+import type { Env } from '../types';
+
+export type ConversationType = 'ai' | 'human' | 'mixed';
+export type ConversationStatus = 'open' | 'locked' | 'archived';
+export type ConversationParticipantRole = 'client' | 'paralegal' | 'attorney' | 'admin' | 'owner';
+
+interface CreateConversationParticipantInput {
+  userId: string;
+  role: ConversationParticipantRole;
+}
+
+interface CreateConversationInput {
+  organizationId: string;
+  createdByUserId: string;
+  type: ConversationType;
+  matterId?: string | null;
+  title?: string | null;
+  participantUserIds: CreateConversationParticipantInput[];
+}
+
+export class ConversationService {
+  constructor(private readonly env: Env) {}
+
+  async createConversation(input: CreateConversationInput): Promise<{ id: string }> {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    const statements = [
+      this.env.DB.prepare(`
+        INSERT INTO conversations (
+          id,
+          organization_id,
+          matter_id,
+          type,
+          status,
+          title,
+          created_by_user_id,
+          created_at,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, 'open', ?, ?, ?, ?)
+      `).bind(
+        id,
+        input.organizationId,
+        input.matterId ?? null,
+        input.type,
+        input.title ?? null,
+        input.createdByUserId,
+        now,
+        now
+      ),
+      ...input.participantUserIds.map(participant =>
+        this.env.DB.prepare(`
+          INSERT OR IGNORE INTO conversation_participants (
+            conversation_id,
+            user_id,
+            organization_id,
+            role,
+            joined_at
+          )
+          VALUES (?, ?, ?, ?, ?)
+        `).bind(id, participant.userId, input.organizationId, participant.role, now)
+      )
+    ];
+
+    await this.env.DB.batch(statements);
+
+    return { id };
+  }
+
+  async addParticipant(
+    conversationId: string,
+    organizationId: string,
+    userId: string,
+    role: ConversationParticipantRole
+  ): Promise<void> {
+    await this.env.DB.prepare(`
+      INSERT OR IGNORE INTO conversation_participants (
+        conversation_id,
+        user_id,
+        organization_id,
+        role
+      )
+      VALUES (?, ?, ?, ?)
+    `).bind(conversationId, userId, organizationId, role).run();
+  }
+
+  async removeParticipant(conversationId: string, userId: string): Promise<void> {
+    await this.env.DB.prepare(`
+      DELETE FROM conversation_participants
+      WHERE conversation_id = ? AND user_id = ?
+    `).bind(conversationId, userId).run();
+  }
+
+  async linkMatter(conversationId: string, matterId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`
+      UPDATE conversations
+      SET matter_id = ?, updated_at = ?
+      WHERE id = ?
+    `).bind(matterId, now, conversationId).run();
+  }
+
+  async setType(conversationId: string, type: ConversationType): Promise<void> {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`
+      UPDATE conversations
+      SET type = ?, updated_at = ?
+      WHERE id = ?
+    `).bind(type, now, conversationId).run();
+  }
+
+  async setStatus(conversationId: string, status: ConversationStatus): Promise<void> {
+    const now = new Date().toISOString();
+    await this.env.DB.prepare(`
+      UPDATE conversations
+      SET status = ?, updated_at = ?
+      WHERE id = ?
+    `).bind(status, now, conversationId).run();
+  }
+
+  async touchLastMessage(conversationId: string, timestamp: string): Promise<void> {
+    await this.env.DB.prepare(`
+      UPDATE conversations
+      SET last_message_at = ?, updated_at = ?
+      WHERE id = ?
+    `).bind(timestamp, timestamp, conversationId).run();
+  }
+
+  async broadcastEvent(conversationId: string, event: string, data: unknown): Promise<void> {
+    try {
+      const id = this.env.CONVERSATION_ROOM.idFromName(conversationId);
+      const stub = this.env.CONVERSATION_ROOM.get(id);
+      await stub.fetch(`https://conversations/${conversationId}/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event, data })
+      });
+    } catch (error) {
+      console.warn('Conversation broadcast failed', { conversationId, event, error });
+    }
+  }
+}

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -1,4 +1,11 @@
-import type { Ai, KVNamespace, R2Bucket, D1Database, Queue } from '@cloudflare/workers-types';
+import type {
+  Ai,
+  KVNamespace,
+  R2Bucket,
+  D1Database,
+  Queue,
+  DurableObjectNamespace
+} from '@cloudflare/workers-types';
 
 // Environment interface with proper Cloudflare Workers types
 export interface Env {
@@ -10,6 +17,7 @@ export interface Env {
   FILES_BUCKET?: R2Bucket;
   DOC_EVENTS: Queue;
   PARALEGAL_TASKS: Queue;
+  CONVERSATION_ROOM: DurableObjectNamespace;
   PAYMENT_API_KEY?: string;
   PAYMENT_API_URL?: string;
   ADOBE_CLIENT_ID?: string;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,10 @@ main = "worker/index.ts"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 
+[[durable_objects.bindings]]
+name = "CONVERSATION_ROOM"
+class_name = "ConversationRoom"
+
 [ai]
 binding = "AI"
 
@@ -126,6 +130,9 @@ kv_namespaces = [
 ]
 d1_databases = [
   { binding = "DB", database_name = "blawby-ai-chatbot", database_id = "e4ed51fa-4787-4222-afed-bcddfefd13bf", migrations_dir = "worker/migrations" }
+]
+durable_objects = [
+  { binding = "CONVERSATION_ROOM", class_name = "ConversationRoom" }
 ]
 [[env.dev.queues.producers]]
 queue = "doc-events"


### PR DESCRIPTION
## Summary
- integrate conversation thread selection into the application shell and main chat view, including a back-to-chat control
- add a shared matter summary hook and expose matter numbers in the worker route so chat lead banners reflect real statuses
- update the conversation header to consume shared matter data and cover the new hook with focused unit tests

## Testing
- npx vitest run -c vitest.config.unit.ts src/hooks/__tests__/useMatterSummary.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690cbff55aac832180c40a60cd097d9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-user conversations with real-time messaging
  * Matter integration with status updates displayed in conversations
  * Message editing and deletion capabilities
  * File sharing within conversations
  * Read receipt tracking
  * Notifications for new messages and matter status changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->