### PR TITLE
Add participant management for conversations

### DIFF
--- a/src/hooks/useMessageHandling.ts
+++ b/src/hooks/useMessageHandling.ts
@@ -63,6 +63,7 @@ export const useMessageHandling = ({ practiceId, sessionId, conversationId, onEr
   const [messages, setMessages] = useState<ChatMessageUI[]>([]);
   const abortControllerRef = useRef<globalThis.AbortController | null>(null);
   const isDisposedRef = useRef(false);
+  const lastConversationIdRef = useRef<string | undefined>();
   
   // Debug hooks for test environment (development only)
   useEffect(() => {
@@ -356,6 +357,19 @@ Location: ${contactData.location ? '[PROVIDED]' : '[NOT PROVIDED]'}${contactData
       isDisposedRef.current = true;
     };
   }, [conversationId, practiceId, fetchMessages]);
+
+  // Clear UI state when switching to a different conversation to avoid showing stale messages
+  useEffect(() => {
+    if (
+      lastConversationIdRef.current &&
+      conversationId &&
+      lastConversationIdRef.current !== conversationId
+    ) {
+      setMessages([]);
+    }
+
+    lastConversationIdRef.current = conversationId;
+  }, [conversationId]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -3,7 +3,7 @@
 /**
  * Conversation status
  */
-export type ConversationStatus = 'active' | 'archived' | 'completed';
+export type ConversationStatus = 'active' | 'archived' | 'completed' | 'closed';
 
 /**
  * Message role in conversation
@@ -81,6 +81,13 @@ export interface CreateConversationRequest {
   participantUserIds?: string[];
   metadata?: Record<string, unknown>;
   title?: string;
+}
+
+/**
+ * Add participants request payload
+ */
+export interface AddParticipantsRequest {
+  participantUserIds: string[];
 }
 
 /**

--- a/tests/component/hooks/useMessageHandling.test.tsx
+++ b/tests/component/hooks/useMessageHandling.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act, waitFor } from '@testing-library/preact';
+import { useEffect } from 'preact/hooks';
+import { useMessageHandling } from '@/hooks/useMessageHandling';
+import type { ChatMessageUI } from '~/worker/types';
+import { getTokenAsync } from '@/lib/tokenStorage';
+
+vi.mock('@/lib/tokenStorage', () => ({
+  getTokenAsync: vi.fn().mockResolvedValue('test-token'),
+}));
+
+vi.mock('@/config/api', () => ({
+  getApiConfig: () => ({ baseUrl: 'https://api.example.com' }),
+}));
+
+type HookSnapshot = ReturnType<typeof useMessageHandling> | null;
+
+const createFetchResponse = (body: unknown, ok = true, status = 200) => ({
+  ok,
+  status,
+  json: async () => body,
+}) as unknown as Response;
+
+type HarnessProps = Parameters<typeof useMessageHandling>[0] & {
+  onChange: (value: ReturnType<typeof useMessageHandling>) => void;
+};
+
+const HookHarness = (props: HarnessProps) => {
+  const value = useMessageHandling(props);
+  useEffect(() => {
+    props.onChange(value);
+  }, [value, props]);
+  return null;
+};
+
+describe('useMessageHandling', () => {
+  let latest: HookSnapshot;
+  const onError = vi.fn();
+
+  beforeEach(() => {
+    latest = null;
+    vi.clearAllMocks();
+    vi.mocked(getTokenAsync).mockResolvedValue('test-token');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('requires practice and conversation IDs before sending a message', async () => {
+    const fetchMock = vi.fn();
+    // @ts-expect-error - assigning mock fetch for tests
+    global.fetch = fetchMock;
+
+    render(<HookHarness practiceId={undefined} conversationId={undefined} onError={onError} onChange={(v) => { latest = v; }} />);
+
+    await waitFor(() => expect(latest).not.toBeNull());
+    await act(async () => {
+      await latest!.sendMessage('hello');
+    });
+
+    expect(onError).toHaveBeenCalledWith('Practice ID is required. Please wait a moment and try again.');
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    cleanup();
+
+    render(<HookHarness practiceId="practice-1" conversationId={undefined} onError={onError} onChange={(v) => { latest = v; }} />);
+    await waitFor(() => expect(latest).not.toBeNull());
+
+    await act(async () => {
+      await latest!.sendMessage('hello');
+    });
+
+    expect(onError).toHaveBeenLastCalledWith('Conversation ID is required for sending messages.');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches existing messages when a conversation is available', async () => {
+    const fetchMock = vi.fn()
+      // Initial history fetch
+      .mockResolvedValueOnce(createFetchResponse({
+        success: true,
+        data: {
+          messages: [{
+            id: 'm1',
+            role: 'assistant',
+            content: 'Previous message',
+            created_at: '2024-01-01T00:00:00.000Z',
+            metadata: {},
+          }],
+          hasMore: false,
+          nextCursor: null,
+        },
+      }))
+      // No further calls expected
+      .mockResolvedValue(createFetchResponse({ success: true }));
+
+    // @ts-expect-error - assigning mock fetch for tests
+    global.fetch = fetchMock;
+
+    render(
+      <HookHarness
+        practiceId="practice-1"
+        conversationId="conversation-1"
+        onError={onError}
+        onChange={(v) => { latest = v; }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/chat/messages'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(latest?.messages).toEqual([
+        {
+          id: 'm1',
+          role: 'assistant',
+          content: 'Previous message',
+          timestamp: new Date('2024-01-01T00:00:00.000Z').getTime(),
+          metadata: {},
+          isUser: false,
+          files: undefined,
+        },
+      ]);
+    });
+  });
+
+  it('replaces optimistic messages and clears stale state on conversation switch', async () => {
+    const serverMessage = {
+      id: 'real-id',
+      role: 'user',
+      content: 'hello',
+      created_at: '2024-02-01T00:00:00.000Z',
+      metadata: {},
+    };
+
+    let resolveFetch: ((value: Response) => void) | null = null;
+    const fetchPromise = new Promise<Response>((res) => { resolveFetch = res; });
+
+    const fetchMock = vi.fn()
+      // Initial history fetch
+      .mockResolvedValueOnce(createFetchResponse({
+        success: true,
+        data: { messages: [], hasMore: false, nextCursor: null },
+      }))
+      // Send message
+      .mockResolvedValueOnce(createFetchResponse({ success: true, data: serverMessage }))
+      // History fetch for new conversation (delayed)
+      .mockReturnValueOnce(fetchPromise);
+
+    // @ts-expect-error - assigning mock fetch for tests
+    global.fetch = fetchMock;
+
+    render(
+      <HookHarness
+        practiceId="practice-1"
+        conversationId="conversation-1"
+        onError={onError}
+        onChange={(v) => { latest = v; }}
+      />
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await latest!.sendMessage('hello');
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/chat/messages'),
+      expect.objectContaining({ method: 'POST' })
+    );
+
+    expect(latest?.messages).toEqual([
+      {
+        id: 'real-id',
+        role: 'user',
+        content: 'hello',
+        timestamp: new Date('2024-02-01T00:00:00.000Z').getTime(),
+        metadata: {},
+        isUser: true,
+        files: undefined,
+      },
+    ]);
+
+    // Seed with a fake message to ensure it clears on switch
+    act(() => {
+      latest?.addMessage({
+        id: 'stale',
+        role: 'assistant',
+        content: 'old',
+        isUser: false,
+        timestamp: 0,
+      } as ChatMessageUI);
+    });
+
+    render(
+      <HookHarness
+        practiceId="practice-1"
+        conversationId="conversation-2"
+        onError={onError}
+        onChange={(v) => { latest = v; }}
+      />
+    );
+
+    // Messages should clear immediately while waiting for fetch
+    await waitFor(() => expect(latest?.messages).toEqual([]));
+
+    // Now resolve the pending fetch for the new conversation
+    resolveFetch?.(createFetchResponse({
+      success: true,
+      data: {
+        messages: [{
+          id: 'm-new',
+          role: 'assistant',
+          content: 'new',
+          created_at: '2024-03-01T00:00:00.000Z',
+          metadata: {},
+        }],
+        hasMore: false,
+        nextCursor: null,
+      },
+    }));
+
+    await waitFor(() => {
+      expect(latest?.messages).toEqual([
+        {
+          id: 'm-new',
+          role: 'assistant',
+          content: 'new',
+          timestamp: new Date('2024-03-01T00:00:00.000Z').getTime(),
+          metadata: {},
+          isUser: false,
+          files: undefined,
+        },
+      ]);
+    });
+  });
+});

--- a/tests/setup-unit.ts
+++ b/tests/setup-unit.ts
@@ -16,3 +16,9 @@ if (typeof globalThis.fetch === 'undefined') {
   globalThis.Request = nodeFetch.Request as unknown as typeof globalThis.Request;
   globalThis.Response = nodeFetch.Response as unknown as typeof globalThis.Response;
 }
+
+// Node 18 doesn't provide Float16Array; polyfill for tests that rely on typed arrays detection
+if (typeof (globalThis as any).Float16Array === 'undefined') {
+  class PolyfillFloat16Array extends Uint16Array {}
+  (globalThis as any).Float16Array = PolyfillFloat16Array as unknown as typeof Float16Array;
+}

--- a/tests/unit/routes/conversations.participants.test.ts
+++ b/tests/unit/routes/conversations.participants.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import type { Env } from '../../../worker/types.js';
+
+const mocks = vi.hoisted(() => ({
+  optionalAuthMock: vi.fn(),
+  withPracticeContextMock: vi.fn(async (request: Request) => request),
+  getPracticeIdMock: vi.fn(() => 'practice-1'),
+  validateParticipantAccessMock: vi.fn(),
+  addParticipantsMock: vi.fn(),
+}));
+
+vi.mock('../../../worker/middleware/auth.js', () => ({
+  optionalAuth: mocks.optionalAuthMock,
+}));
+
+vi.mock('../../../worker/middleware/practiceContext.js', () => ({
+  withPracticeContext: mocks.withPracticeContextMock,
+  getPracticeId: mocks.getPracticeIdMock,
+}));
+
+vi.mock('../../../worker/services/ConversationService.js', () => ({
+  ConversationService: vi.fn().mockImplementation(() => ({
+    createConversation: vi.fn(),
+    getConversations: vi.fn(),
+    getConversation: vi.fn(),
+    updateConversation: vi.fn(),
+    validateParticipantAccess: mocks.validateParticipantAccessMock,
+    addParticipants: mocks.addParticipantsMock,
+  })),
+}));
+
+let handleConversations: (request: Request, env: Env) => Promise<Response>;
+
+beforeAll(async () => {
+  ({ handleConversations } = await import('../../../worker/routes/conversations.js'));
+});
+
+describe('handleConversations - participants endpoint', () => {
+  const env = {
+    DB: {} as Env['DB'],
+    CHAT_SESSIONS: {} as Env['CHAT_SESSIONS'],
+    RESEND_API_KEY: 'test-key',
+  } as Env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.optionalAuthMock.mockResolvedValue({ user: { id: 'user-1' } });
+    mocks.addParticipantsMock.mockResolvedValue({ id: 'conv-1' });
+  });
+
+  it('adds participants when caller is authorized', async () => {
+    const request = new Request('https://example.com/api/conversations/conv-1/participants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participantUserIds: ['user-2', 'user-3'] }),
+    });
+
+    const response = await handleConversations(request, env);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(mocks.validateParticipantAccessMock).toHaveBeenCalledWith('conv-1', 'practice-1', 'user-1');
+    expect(mocks.addParticipantsMock).toHaveBeenCalledWith('conv-1', 'practice-1', ['user-2', 'user-3']);
+  });
+
+  it('rejects requests without auth context', async () => {
+    mocks.optionalAuthMock.mockResolvedValueOnce(null);
+
+    const request = new Request('https://example.com/api/conversations/conv-1/participants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participantUserIds: ['user-2'] }),
+    });
+
+    await expect(handleConversations(request, env)).rejects.toHaveProperty('status', 401);
+  });
+
+  it('rejects missing participantUserIds', async () => {
+    const request = new Request('https://example.com/api/conversations/conv-1/participants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participantUserIds: [] }),
+    });
+
+    await expect(handleConversations(request, env)).rejects.toHaveProperty('status', 400);
+    expect(mocks.addParticipantsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/worker/services/ConversationService.addParticipants.test.ts
+++ b/tests/unit/worker/services/ConversationService.addParticipants.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConversationService } from '../../../../worker/services/ConversationService.js';
+import { HttpErrors } from '../../../../worker/errorHandler.js';
+import type { Env } from '../../../../worker/types.js';
+
+const createMockEnv = () => {
+  const run = vi.fn().mockResolvedValue({});
+  const bind = vi.fn().mockReturnValue({ run });
+  const prepare = vi.fn().mockReturnValue({ bind });
+
+  const env = {
+    DB: { prepare } as unknown as Env['DB'],
+    CHAT_SESSIONS: {} as Env['CHAT_SESSIONS'],
+    RESEND_API_KEY: 'test-key',
+  } as Env;
+
+  return { env, prepare, bind, run };
+};
+
+describe('ConversationService.addParticipants', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('adds unique participants and updates the conversation', async () => {
+    const { env, prepare, bind } = createMockEnv();
+    const service = new ConversationService(env);
+
+    const existingConversation = {
+      id: 'conv-1',
+      practice_id: 'practice-1',
+      user_id: 'owner',
+      matter_id: null,
+      participants: ['owner'],
+      user_info: null,
+      status: 'active' as const,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const updatedConversation = {
+      ...existingConversation,
+      participants: ['owner', 'user-2'],
+    };
+
+    const getConversationSpy = vi
+      .spyOn(service, 'getConversation')
+      .mockResolvedValueOnce(existingConversation)
+      .mockResolvedValueOnce(updatedConversation);
+
+    const result = await service.addParticipants('conv-1', 'practice-1', ['user-2']);
+
+    expect(getConversationSpy).toHaveBeenCalledTimes(2);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(bind).toHaveBeenCalledWith(
+      JSON.stringify(['owner', 'user-2']),
+      expect.any(String),
+      'conv-1',
+      'practice-1'
+    );
+    expect(result.participants).toEqual(['owner', 'user-2']);
+  });
+
+  it('returns existing conversation when all participants already present', async () => {
+    const { env, prepare } = createMockEnv();
+    const service = new ConversationService(env);
+
+    const existingConversation = {
+      id: 'conv-1',
+      practice_id: 'practice-1',
+      user_id: 'owner',
+      matter_id: null,
+      participants: ['owner', 'user-2'],
+      user_info: null,
+      status: 'active' as const,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    vi.spyOn(service, 'getConversation').mockResolvedValue(existingConversation);
+
+    const result = await service.addParticipants('conv-1', 'practice-1', ['owner']);
+
+    expect(prepare).not.toHaveBeenCalled();
+    expect(result.participants).toEqual(['owner', 'user-2']);
+  });
+
+  it('throws when no participantUserIds are provided', async () => {
+    const { env } = createMockEnv();
+    const service = new ConversationService(env);
+
+    await expect(
+      service.addParticipants('conv-1', 'practice-1', [])
+    ).rejects.toHaveProperty('status', HttpErrors.badRequest('').status);
+  });
+});

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -113,6 +113,29 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     return createJsonResponse(conversation);
   }
 
+  // POST /api/conversations/:id/participants - Add participants to a conversation
+  if (segments.length === 4 && segments[3] === 'participants' && request.method === 'POST') {
+    const conversationId = segments[2];
+    const body = await parseJsonBody(request) as {
+      participantUserIds: string[];
+    };
+
+    if (!Array.isArray(body.participantUserIds) || body.participantUserIds.length === 0) {
+      throw HttpErrors.badRequest('participantUserIds must be a non-empty array');
+    }
+
+    // Validate user has access before allowing them to add others
+    await conversationService.validateParticipantAccess(conversationId, practiceId, userId);
+
+    const conversation = await conversationService.addParticipants(
+      conversationId,
+      practiceId,
+      body.participantUserIds
+    );
+
+    return createJsonResponse(conversation);
+  }
+
   throw HttpErrors.methodNotAllowed('Unsupported method for conversations endpoint');
 }
 

--- a/worker/services/ConversationService.ts
+++ b/worker/services/ConversationService.ts
@@ -241,21 +241,32 @@ export class ConversationService {
   }
 
   /**
-   * Add a participant to a conversation
+   * Add one or more participants to a conversation
+   *
+   * Ensures uniqueness, preserves existing participants, and updates the
+   * conversation's updated_at timestamp.
    */
-  async addParticipant(
+  async addParticipants(
     conversationId: string,
     practiceId: string,
-    userId: string
+    userIds: string[]
   ): Promise<Conversation> {
-    const conversation = await this.getConversation(conversationId, practiceId);
-
-    // Check if user is already a participant
-    if (conversation.participants.includes(userId)) {
-      return conversation; // Already a participant
+    if (!Array.isArray(userIds) || userIds.length === 0) {
+      throw HttpErrors.badRequest('participantUserIds must be a non-empty array');
     }
 
-    const updatedParticipants = [...conversation.participants, userId];
+    const conversation = await this.getConversation(conversationId, practiceId);
+
+    // Merge and de-duplicate participants
+    const mergedParticipants = Array.from(
+      new Set([...conversation.participants, ...userIds.filter(Boolean)])
+    );
+
+    // If no changes, return existing conversation
+    if (mergedParticipants.length === conversation.participants.length) {
+      return conversation;
+    }
+
     const now = new Date().toISOString();
 
     await this.env.DB.prepare(`
@@ -263,13 +274,24 @@ export class ConversationService {
       SET participants = ?, updated_at = ?
       WHERE id = ? AND practice_id = ?
     `).bind(
-      JSON.stringify(updatedParticipants),
+      JSON.stringify(mergedParticipants),
       now,
       conversationId,
       practiceId
     ).run();
 
     return this.getConversation(conversationId, practiceId);
+  }
+
+  /**
+   * Add a participant to a conversation
+   */
+  async addParticipant(
+    conversationId: string,
+    practiceId: string,
+    userId: string
+  ): Promise<Conversation> {
+    return this.addParticipants(conversationId, practiceId, [userId]);
   }
 
   /**

--- a/worker/utils/domain.ts
+++ b/worker/utils/domain.ts
@@ -61,6 +61,26 @@ export function isValidCookieDomain(domain: string): boolean {
   if (domain === 'localhost') {
     return true;
   }
-  
+
   return domainRegex.test(domain);
+}
+
+/**
+ * Resolves the best configured domain from environment variables
+ * Priority: DOMAIN > CLOUDFLARE_PUBLIC_URL > BETTER_AUTH_URL > localhost
+ */
+export function getConfiguredDomain(env: { DOMAIN?: string; CLOUDFLARE_PUBLIC_URL?: string; BETTER_AUTH_URL?: string }): string {
+  if (env.DOMAIN) {
+    return normalizeDomain(env.DOMAIN);
+  }
+
+  if (env.CLOUDFLARE_PUBLIC_URL) {
+    return normalizeDomain(env.CLOUDFLARE_PUBLIC_URL);
+  }
+
+  if (env.BETTER_AUTH_URL) {
+    return normalizeDomain(env.BETTER_AUTH_URL);
+  }
+
+  return 'localhost';
 }


### PR DESCRIPTION
## Summary
- add a participants endpoint and validation to the conversations worker route and service to support multi-user threads
- expose an addParticipants client helper in the conversations hook and align conversation status/types with the backend
- stabilize unit test setup for typed arrays and cover participant flows with new route/service unit tests

## Testing
- npx vitest run -c config/vitest/vitest.config.unit.ts --reporter=basic tests/unit/routes/conversations.participants.test.ts tests/unit/worker/services/ConversationService.addParticipants.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dbecbbd8c8321b73d062093ddf8a6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to add participants to existing conversations
  * Conversation status now includes 'closed' state
  * Improved conversation initialization with automatic creation when needed

* **Bug Fixes**
  * Fixed display of stale messages when switching between conversations

* **Tests**
  * Added comprehensive test coverage for message handling and conversation participants

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->