### PR TITLE
Make app logos fill containers

### DIFF
--- a/src/features/settings/pages/AppDetailPage.tsx
+++ b/src/features/settings/pages/AppDetailPage.tsx
@@ -89,8 +89,17 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
 
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="w-16 h-16 rounded-full bg-white dark:bg-gray-800 flex items-center justify-center border border-gray-200 dark:border-dark-border">
-                <PuzzlePieceIcon className="w-8 h-8 text-gray-700 dark:text-gray-200" aria-hidden="true" />
+              <div className="w-16 h-16 rounded-full bg-white dark:bg-gray-800 flex items-center justify-center border border-gray-200 dark:border-dark-border overflow-hidden">
+                {app.logo ? (
+                  <img
+                    src={app.logo}
+                    alt={`${app.name} logo`}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                ) : (
+                  <PuzzlePieceIcon className="w-8 h-8 text-gray-700 dark:text-gray-200" aria-hidden="true" />
+                )}
               </div>
               <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{app.name}</h2>
             </div>

--- a/src/features/settings/pages/AppsPage.tsx
+++ b/src/features/settings/pages/AppsPage.tsx
@@ -32,8 +32,17 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
                 onClick={() => onSelect(app.id)}
                 className="w-full py-4 flex items-center gap-4 text-left"
               >
-                <div className="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-                  <PuzzlePieceIcon className="w-6 h-6 text-gray-600 dark:text-gray-300" aria-hidden="true" />
+                <div className="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center overflow-hidden">
+                  {app.logo ? (
+                    <img
+                      src={app.logo}
+                      alt={`${app.name} logo`}
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <PuzzlePieceIcon className="w-6 h-6 text-gray-600 dark:text-gray-300" aria-hidden="true" />
+                  )}
                 </div>
 
                 <div className="flex-1 min-w-0">

--- a/src/features/settings/pages/appsData.ts
+++ b/src/features/settings/pages/appsData.ts
@@ -28,6 +28,7 @@ export const mockApps: App[] = [
     developer: 'Clio',
     website: 'https://www.clio.com',
     privacyPolicy: 'https://www.clio.com/privacy',
+    logo: 'https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/be24ae2a-0286-4946-abf1-2250f6cc5800/public',
     connected: false,
     actions: [
       {


### PR DESCRIPTION
### Motivation
- Remove the padding around app logos so they fully occupy their icon containers in both the apps list and app detail header.
- Use app-specific images when available instead of always falling back to the puzzle-piece icon.
- Improve visual consistency and clarity across the settings UI by ensuring logos align and crop predictably.

### Description
- Updated image rendering in `src/features/settings/pages/AppsPage.tsx` and `src/features/settings/pages/AppDetailPage.tsx` to use `className="w-full h-full object-cover"` so logos fill and crop to their containers.
- Added `overflow-hidden` to the logo container divs to clip images to the rounded shapes and remove visible padding.
- Kept the `PuzzlePieceIcon` as the fallback when `app.logo` is not provided.
- Added a `logo` field to the mock `App` data with the Clio image URL in `src/features/settings/pages/appsData.ts`.

### Testing
- Ran `npm run lint` (ESLint) and it completed successfully.
- Ran `npm run type-check` (`tsc --noEmit`) and it completed successfully.
- Launched the dev server and executed a Playwright script to capture a screenshot of `/settings/apps`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960935abae88321b176fa690d1436f2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apps now display custom logos when available, providing better visual branding and identification.
  * Added lazy loading for app logos to improve performance.
  * Enhanced accessibility with descriptive alt text for all app images.

* **Improvements**
  * Logo images are properly contained within their designated frames, preventing overflow issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->