### PR TITLE
Align notification docs with schema, fix subscription example, add DO JSON handling, and duplicate Wrangler bindings

### DIFF
--- a/worker/durable-objects/NotificationHub.ts
+++ b/worker/durable-objects/NotificationHub.ts
@@ -55,7 +55,20 @@ export class NotificationHub {
   }
 
   private async handlePublish(request: Request): Promise<Response> {
-    const payload = await request.json();
+    let payload: unknown;
+
+    try {
+      payload = await request.json();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown JSON parse error';
+      console.error('Failed to parse publish payload:', message);
+
+      return new Response(JSON.stringify({ error: 'Invalid JSON payload', message }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     const message = `event: notification\ndata: ${JSON.stringify(payload)}\n\n`;
     const encoded = this.encoder.encode(message);
 

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -47,6 +47,19 @@ d1_databases = [
 binding = "FILES_BUCKET"
 bucket_name = "blawby-ai-files"
 
+[[env.dev.queues.producers]]
+queue = "notification-events"
+binding = "NOTIFICATION_EVENTS"
+
+[[env.dev.queues.consumers]]
+queue = "notification-events"
+max_batch_size = 10
+max_batch_timeout = 30
+
+[[env.dev.durable_objects.bindings]]
+name = "NOTIFICATION_HUB"
+class_name = "NotificationHub"
+
 [env.dev.vars]
 NODE_ENV = "development"
 LOG_LEVEL = "debug"
@@ -77,6 +90,19 @@ d1_databases = [
 [[env.production.r2_buckets]]
 binding = "FILES_BUCKET"
 bucket_name = "blawby-ai-files"
+
+[[env.production.queues.producers]]
+queue = "notification-events"
+binding = "NOTIFICATION_EVENTS"
+
+[[env.production.queues.consumers]]
+queue = "notification-events"
+max_batch_size = 10
+max_batch_timeout = 30
+
+[[env.production.durable_objects.bindings]]
+name = "NOTIFICATION_HUB"
+class_name = "NotificationHub"
 
 [env.production.vars]
 NODE_ENV = "production"


### PR DESCRIPTION
### Motivation
- Ensure the `notification_destinations` documentation matches the actual `worker/schema.sql` implementation so readers and migrations remain consistent.
- Fix a variable-name mismatch in the push subscription example so the example code compiles and matches runtime usage.
- Make the NotificationHub publish endpoint robust to invalid input by returning a proper error instead of throwing on bad JSON.
- Ensure environment-specific deployments include the `NOTIFICATION_EVENTS` queue and `NotificationHub` durable object by duplicating bindings under each env in `wrangler.toml`.

### Description
- Updated `docs/archive/misc/notification-implementation-plan.md` to remove `organization_id`, change the uniqueness constraint to `UNIQUE(provider, onesignal_id)`, add `created_at/updated_at` defaults using `strftime`, and add the provider/index `CREATE UNIQUE INDEX` and user index to match `worker/schema.sql`.
- Fixed the push subscription example by renaming the destructured request field from `subscription` to `destination` so bindings and DB calls reference the same identifier.
- Added try/catch around `await request.json()` in `worker/durable-objects/NotificationHub.ts` to return a `400` JSON response with the original error message for invalid JSON payloads.
- Duplicated `[[queues.producers]]`, `[[queues.consumers]]`, and `[[durable_objects.bindings]]` entries under both `env.dev` and `env.production` in `worker/wrangler.toml` so env-specific deployments include the queue and durable object.

### Testing
- Ran `npm run lint` and it completed without errors.
- Ran `npm run type-check` (via `tsc --noEmit`) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b2311cc8832190a78ba9b9f8d6cb)