### PR TITLE
Centralize frontend base URL and remove deprecated env fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ URLs and env variables (don’t guess; follow src/config/urls.ts, README.md, and
 Frontend (local dev): .env in repo root for VITE_* vars. Production: Cloudflare Pages env vars.
 - Worker API base: VITE_WORKER_API_URL; defaults to http://localhost:8787 in dev and https://ai.blawby.com in prod (base URL should NOT include /api; callers append /api/*).
 - Backend API base: VITE_BACKEND_API_URL (required in production); dev fallback to https://staging-api.blawby.com unless VITE_ENABLE_MSW=true.
-- Frontend host validation uses VITE_APP_BASE_URL / VITE_PUBLIC_APP_URL / VITE_APP_URL when window.location is unavailable.
+- Frontend host validation uses VITE_APP_BASE_URL when window.location is unavailable.
 Worker (local dev): worker/.dev.vars for secrets (see dev.vars.example). Worker non-secrets live in worker/wrangler.toml [env.*.vars].
 - BACKEND_API_URL determines which remote backend the worker calls (RemoteApiService); must be set explicitly.
 - Production worker route: ai.blawby.com/api/* (worker/wrangler.toml).

--- a/docs/engineering/URL_CONFIG_PROBLEMS_AND_SOLUTIONS.md
+++ b/docs/engineering/URL_CONFIG_PROBLEMS_AND_SOLUTIONS.md
@@ -58,6 +58,7 @@ Use `src/config/urls.ts` as the single source of truth for URL routing and valid
 Frontend environment variables:
 - `VITE_WORKER_API_URL` (optional): Worker base URL (no `/api` suffix).
 - `VITE_BACKEND_API_URL` (required): Remote backend base URL.
+- `VITE_APP_BASE_URL` (required for SSR/builds): Frontend base URL when `window.location` is unavailable.
 
 Worker environment variables:
 - `BACKEND_API_URL`: Remote backend base URL used by the Worker (must match frontend backend base).

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -7,6 +7,7 @@ import { handleError } from '@/shared/utils/errorHandler';
 import { getClient } from '@/shared/lib/authClient';
 import { linkConversationToUser } from '@/shared/lib/apiClient';
 import { useNavigation } from '@/shared/utils/navigation';
+import { getFrontendBaseUrl } from '@/config/urls';
 
 type AuthMode = 'signin' | 'signup';
 
@@ -265,7 +266,7 @@ const AuthForm = ({
 
       // callbackURL tells Better Auth where to redirect after OAuth completes
       // Better Auth will set the session cookie on redirect.
-      const callbackURL = defaultPostAuthPath();
+      const callbackURL = new URL(defaultPostAuthPath(), getFrontendBaseUrl()).toString();
       const result = await client.signIn.social({
         provider: 'google',
         callbackURL,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -26,8 +26,6 @@ interface ImportMetaEnv {
 
   // Frontend base URL (for SSR/fallback scenarios)
   readonly VITE_APP_BASE_URL?: string;
-  readonly VITE_PUBLIC_APP_URL?: string;
-  readonly VITE_APP_URL?: string;
 
   readonly [key: string]: string | undefined;
 }


### PR DESCRIPTION
### Motivation
- Consolidate frontend URL resolution to avoid duplicated env fallbacks and make SSR/build behavior explicit.
- Ensure absolute OAuth callback URLs are built reliably from a single source of truth.
- Remove deprecated environment variables (`VITE_PUBLIC_APP_URL`, `VITE_APP_URL`) from types and docs to reduce confusion.

### Description
- Added `getFrontendBaseUrl()` in `src/config/urls.ts` which prefers `window.location.origin` and falls back to `VITE_APP_BASE_URL` for SSR/build contexts.
- Refactored `getWorkerApiUrl()` and `getFrontendHost()` to use `getFrontendBaseUrl()` and removed the old `VITE_PUBLIC_APP_URL`/`VITE_APP_URL` fallbacks.
- Built an absolute Google OAuth callback URL in `src/shared/components/AuthForm.tsx` using `new URL(defaultPostAuthPath(), getFrontendBaseUrl()).toString()`.
- Removed `VITE_PUBLIC_APP_URL` and `VITE_APP_URL` from `src/vite-env.d.ts` and updated documentation in `AGENTS.md` and `docs/engineering/URL_CONFIG_PROBLEMS_AND_SOLUTIONS.md` to reference only `VITE_APP_BASE_URL` for SSR/build scenarios.

### Testing
- Ran `npm run lint` and the lint checks passed successfully. 
- Ran `npm run type-check` (`tsc --noEmit`) and type checking passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dde78d7a483218f04c69c425eabe8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified frontend URL configuration to use a single environment variable, improving deployment reliability for SSR and builds.
  * Enhanced sign-in callback URL handling with absolute URLs.

* **Documentation**
  * Updated configuration documentation for environment variable requirements.

* **Chores**
  * Cleaned up unused environment variable declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->