### PR TITLE
Prefer business logo and surface practice slug/description in headers

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -54,9 +54,11 @@ interface AppLayoutProps {
     name: string;
     profileImage: string | null;
     description?: string | null;
+    slug?: string | null;
   };
   currentPractice?: {
     id: string;
+    slug?: string | null;
     subscriptionTier?: SubscriptionTier;
     businessOnboardingStatus?: BusinessOnboardingStatus;
     businessOnboardingCompletedAt?: number | null;
@@ -121,6 +123,8 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
   const { openBillingPortal } = usePaymentUpgrade();
   const [matterAction, setMatterAction] = useState<'pay' | 'pdf' | 'share' | null>(null);
   const [shareCopied, setShareCopied] = useState(false);
+  const practiceSlug = practiceConfig.slug ?? currentPractice?.slug ?? practiceId;
+  const practiceDescription = practiceDetails?.description ?? currentPractice?.description ?? practiceConfig.description ?? null;
 
   const showDashboardTab = workspace !== 'public';
   const showChatsTab = true;
@@ -554,8 +558,8 @@ const AppLayout: FunctionComponent<AppLayoutProps> = ({
             <PracticeProfile
               name={practiceConfig.name}
               profileImage={practiceConfig.profileImage}
-              practiceId={practiceId}
-              description={practiceConfig.description}
+              practiceSlug={practiceSlug}
+              description={practiceDescription}
               variant="sidebar"
               showVerified={true}
             />

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -710,6 +710,8 @@ export function MainApp({
     }
   };
 
+  const resolvedPracticeLogo = currentPractice?.logo ?? practiceConfig?.profileImage ?? null;
+
   // Handle navigation to chats - removed since bottom nav is disabled
   const shouldShowChatPlaceholder = workspace !== 'public' && !conversationId;
   const chatPanel = chatContent ?? (
@@ -743,9 +745,10 @@ export function MainApp({
               composerDisabled={isComposerDisabled}
               practiceConfig={{
                 name: practiceConfig.name ?? '',
-                profileImage: practiceConfig?.profileImage ?? null,
+                profileImage: resolvedPracticeLogo,
                 practiceId,
-                description: practiceConfig?.description ?? ''
+                description: practiceConfig?.description ?? '',
+                slug: practiceConfig?.slug ?? practiceId
               }}
               onOpenSidebar={() => setIsMobileSidebarOpen(true)}
               practiceId={practiceId}
@@ -827,8 +830,9 @@ export function MainApp({
         onSelectNotificationCategory={handleNotificationCategoryChange}
         practiceConfig={{
           name: practiceConfig.name ?? '',
-          profileImage: practiceConfig?.profileImage ?? null,
-          description: practiceConfig?.description ?? ''
+          profileImage: resolvedPracticeLogo,
+          description: practiceConfig?.description ?? '',
+          slug: practiceConfig?.slug ?? practiceId
         }}
         currentPractice={currentPractice}
         practiceDetails={practiceDetails}

--- a/src/features/chat/components/ChatContainer.tsx
+++ b/src/features/chat/components/ChatContainer.tsx
@@ -27,6 +27,7 @@ interface ChatContainerProps {
     profileImage: string | null;
     practiceId: string;
     description?: string | null;
+    slug?: string | null;
   };
   onOpenSidebar?: () => void;
   practiceId?: string;

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -16,6 +16,7 @@ interface VirtualMessageListProps {
         profileImage: string | null;
         practiceId: string;
         description?: string | null;
+        slug?: string | null;
     };
     onOpenSidebar?: () => void;
     onContactFormSubmit?: (data: ContactData) => void;
@@ -144,7 +145,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
                     <PracticeProfile
                         name={practiceConfig.name}
                         profileImage={practiceConfig.profileImage}
-                        practiceId={practiceId}
+                        practiceSlug={practiceConfig.slug ?? practiceConfig.practiceId}
                         description={practiceConfig.description}
                         variant="welcome"
                         showVerified={true}

--- a/src/features/practice/components/PracticeProfile.tsx
+++ b/src/features/practice/components/PracticeProfile.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 interface PracticeProfileProps {
 	name: string;
 	profileImage: string | null;
-	practiceId: string;
+	practiceSlug: string;
 	description?: string | null;
 	variant?: 'sidebar' | 'welcome';
 	showVerified?: boolean;
@@ -13,7 +13,7 @@ interface PracticeProfileProps {
 export default function PracticeProfile({ 
 	name, 
 	profileImage, 
-	practiceId, 
+	practiceSlug, 
 	description,
 	variant = 'sidebar',
 	showVerified = true,
@@ -48,15 +48,21 @@ export default function PracticeProfile({
 
 			{/* Practice ID */}
 			<div className="text-center w-full">
-				<span className="text-sm sm:text-base lg:text-lg font-medium text-[#d4af37] truncate block" title={t('profile.slug', { slug: practiceId })}>@{practiceId}</span>
+				<span className="text-sm sm:text-base lg:text-lg font-medium text-[#d4af37] truncate block" title={t('profile.slug', { slug: practiceSlug })}>@{practiceSlug}</span>
 			</div>
 
 			{/* Onboarding reminder removed in favor of global top banner */}
 
-			{/* Practice Description - Only show for welcome variant */}
-			{description && variant === 'welcome' && (
+			{/* Practice Description */}
+			{description && (
 				<div className="text-center">
-					<p className="text-gray-700 dark:text-gray-400 text-center text-sm sm:text-base lg:text-lg leading-relaxed max-w-xs mx-auto line-clamp-3">{description}</p>
+					<p
+						className={`text-gray-700 dark:text-gray-400 text-center leading-relaxed max-w-xs mx-auto line-clamp-3 ${
+							isWelcome ? 'text-sm sm:text-base lg:text-lg' : 'text-xs sm:text-sm'
+						}`}
+					>
+						{description}
+					</p>
 				</div>
 			)}
 		</div>

--- a/src/shared/hooks/usePracticeManagement.ts
+++ b/src/shared/hooks/usePracticeManagement.ts
@@ -406,6 +406,7 @@ function normalizePracticeRecord(raw: Record<string, unknown>): Practice {
     businessPhone: getDetailString('businessPhone', 'business_phone') ?? null,
     businessEmail: getDetailString('businessEmail', 'business_email') ?? null,
     calendlyUrl: getDetailString('calendlyUrl', 'calendly_url') ?? null,
+    logo: getDetailString('logo', 'logo') ?? null,
     subscriptionTier: normalizedTier,
     seats,
     subscriptionStatus: normalizedStatus,


### PR DESCRIPTION
### Motivation
- Ensure the UI shows the business logo when available instead of the fallback image and avoid exposing UUIDs by using the human-readable practice slug; also surface the practice description consistently in profile headers. 

### Description
- Prefer `currentPractice.logo` when constructing profile data by introducing `resolvedPracticeLogo` in `MainApp` and passing it into `ChatContainer` and `AppLayout` as `practiceConfig.profileImage`.
- Add and propagate `slug` through `practiceConfig` and component props, compute `practiceSlug` in `AppLayout`, and use it in `PracticeProfile` instead of the practice id.
- Update `PracticeProfile` to accept `practiceSlug`, always render the `description` (with variant-aware typography), and use the provided `profileImage` for both sidebar and welcome headers with the existing icon as a fallback.
- Update prop/type shapes in `AppLayout`, `ChatContainer`, and `VirtualMessageList` to include optional `slug` fields and pass the slug into `PracticeProfile` where appropriate.

### Testing
- Ran `npm run lint` and the lint step completed successfully. (success)
- Ran `npm run type-check` (`tsc --noEmit --skipLibCheck`) and type-checking passed. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed9282b548321ab3bb13e73735dac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized practice identification to prefer slug-based identifiers with fallback to practice ID.
  * Streamlined propagation of practice info across the app for more consistent display.

* **New Features**
  * Improved logo resolution so the correct practice image is shown more reliably.
  * Practice profile now shows descriptions more broadly and adapts typography based on context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->