### PR TITLE
Normalize E2E auth fixtures and caching

### DIFF
--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,62 @@
+import { test as base, expect, type BrowserContext, type Page } from '@playwright/test';
+import { AUTH_STATE_PATHS } from './helpers/authState';
+import { resolveBaseUrl } from './helpers/baseUrl';
+
+type E2EFixtures = {
+  baseURL: string;
+  ownerContext: BrowserContext;
+  clientContext: BrowserContext;
+  anonContext: BrowserContext;
+  unauthContext: BrowserContext;
+  ownerPage: Page;
+  clientPage: Page;
+  anonPage: Page;
+};
+
+const test = base.extend<E2EFixtures>({
+  baseURL: async ({}, use, testInfo) => {
+    const baseURL = resolveBaseUrl(testInfo.project.use.baseURL as string | undefined);
+    await use(baseURL);
+  },
+  ownerContext: async ({ browser, baseURL }, use) => {
+    const context = await browser.newContext({ storageState: AUTH_STATE_PATHS.owner, baseURL });
+    await use(context);
+    await context.close();
+  },
+  clientContext: async ({ browser, baseURL }, use) => {
+    const context = await browser.newContext({ storageState: AUTH_STATE_PATHS.client, baseURL });
+    await use(context);
+    await context.close();
+  },
+  anonContext: async ({ browser, baseURL }, use) => {
+    const context = await browser.newContext({ storageState: AUTH_STATE_PATHS.anonymous, baseURL });
+    await use(context);
+    await context.close();
+  },
+  unauthContext: async ({ browser, baseURL }, use) => {
+    const context = await browser.newContext({
+      baseURL,
+      storageState: { cookies: [], origins: [] },
+      extraHTTPHeaders: { Cookie: '' }
+    });
+    await use(context);
+    await context.close();
+  },
+  ownerPage: async ({ ownerContext }, use) => {
+    const page = await ownerContext.newPage();
+    await use(page);
+    await page.close();
+  },
+  clientPage: async ({ clientContext }, use) => {
+    const page = await clientContext.newPage();
+    await use(page);
+    await page.close();
+  },
+  anonPage: async ({ anonContext }, use) => {
+    const page = await anonContext.newPage();
+    await use(page);
+    await page.close();
+  }
+});
+
+export { expect, test };

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,32 +1,95 @@
 import type { Page } from 'playwright';
 
+const SESSION_COOKIE_PATTERN = /better-auth\.session_token/i;
+
+const hasSessionCookie = async (page: Page, cookieUrl?: string): Promise<boolean> => {
+  const cookies = cookieUrl
+    ? await page.context().cookies(cookieUrl)
+    : await page.context().cookies();
+  const nowSeconds = Date.now() / 1000;
+  return cookies.some((cookie) => (
+    SESSION_COOKIE_PATTERN.test(cookie.name)
+    && (cookie.expires <= 0 || cookie.expires > nowSeconds + 1)
+  ));
+};
+
 export const waitForSession = async (
   page: Page,
-  options: { timeoutMs?: number; intervalMs?: number } = {}
+  options: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    maxIntervalMs?: number;
+    skipIfCookiePresent?: boolean;
+    cookieUrl?: string;
+  } = {}
 ): Promise<void> => {
   const timeoutMs = options.timeoutMs ?? 30000;
   const intervalMs = options.intervalMs ?? 400;
+  const maxIntervalMs = options.maxIntervalMs ?? 5000;
+  const skipIfCookiePresent = options.skipIfCookiePresent ?? true;
+  const cookieUrl = options.cookieUrl ?? (page.url() && page.url() !== 'about:blank' ? page.url() : undefined);
   const start = Date.now();
+  let nextIntervalMs = intervalMs;
+
+  if (skipIfCookiePresent) {
+    try {
+      if (await hasSessionCookie(page, cookieUrl)) {
+        return;
+      }
+    } catch {
+      // fall through to network validation
+    }
+  }
 
   while (Date.now() - start < timeoutMs) {
     let hasSession = false;
+    let status = 0;
+    let retryAfterMs: number | null = null;
     try {
-      hasSession = await page.evaluate(async () => {
+      const result = await page.evaluate(async () => {
         try {
           const response = await fetch('/api/auth/get-session', { credentials: 'include' });
-          if (!response.ok) return false;
+          const retryAfter = response.headers.get('Retry-After');
+          let retryAfterMs: number | null = null;
+          if (retryAfter) {
+            const parsed = Number(retryAfter);
+            if (Number.isFinite(parsed)) {
+              retryAfterMs = parsed * 1000;
+            }
+          }
+          if (!response.ok) {
+            return { hasSession: false, status: response.status, retryAfterMs };
+          }
           const data: any = await response.json().catch(() => null);
-          return Boolean(data?.session || data?.user || data?.data?.session || data?.data?.user);
+          return {
+            hasSession: Boolean(data?.session || data?.user || data?.data?.session || data?.data?.user),
+            status: response.status,
+            retryAfterMs
+          };
         } catch {
-          return false;
+          return { hasSession: false, status: 0, retryAfterMs: null };
         }
       });
+      hasSession = result.hasSession;
+      status = result.status;
+      retryAfterMs = result.retryAfterMs;
     } catch {
       hasSession = false;
     }
 
     if (hasSession) return;
-    await page.waitForTimeout(intervalMs);
+
+    if (status === 429) {
+      if (retryAfterMs) {
+        nextIntervalMs = Math.min(Math.max(retryAfterMs, intervalMs), maxIntervalMs);
+      } else {
+        nextIntervalMs = Math.min(Math.max(nextIntervalMs * 2, intervalMs), maxIntervalMs);
+      }
+    } else {
+      nextIntervalMs = intervalMs;
+    }
+
+    await page.waitForTimeout(nextIntervalMs);
   }
 
   throw new Error('Timed out waiting for session');

--- a/tests/e2e/helpers/authState.ts
+++ b/tests/e2e/helpers/authState.ts
@@ -1,0 +1,9 @@
+import { join } from 'path';
+
+export const AUTH_DIR = join(process.cwd(), 'playwright', '.auth');
+
+export const AUTH_STATE_PATHS = {
+  owner: join(AUTH_DIR, 'owner.json'),
+  client: join(AUTH_DIR, 'client.json'),
+  anonymous: join(AUTH_DIR, 'anonymous.json')
+};

--- a/tests/e2e/helpers/baseUrl.ts
+++ b/tests/e2e/helpers/baseUrl.ts
@@ -1,0 +1,15 @@
+import type { FullConfig } from '@playwright/test';
+
+const DEFAULT_BASE_URL = process.env.E2E_BASE_URL || 'https://local.blawby.com';
+
+export const resolveBaseUrl = (baseURL?: string): string => {
+  if (typeof baseURL === 'string' && baseURL.length > 0) {
+    return baseURL;
+  }
+  return DEFAULT_BASE_URL;
+};
+
+export const getBaseUrlFromConfig = (config: FullConfig): string => {
+  const project = config.projects[0];
+  return resolveBaseUrl(project?.use?.baseURL as string | undefined);
+};

--- a/tests/e2e/helpers/networkLogger.ts
+++ b/tests/e2e/helpers/networkLogger.ts
@@ -1,0 +1,153 @@
+import type { BrowserContext, Request, Response, TestInfo } from '@playwright/test';
+
+type NetworkDebugMode = 'off' | 'errors' | 'all';
+
+type NetworkLoggerHandle = {
+  flush: () => Promise<void>;
+};
+
+const DEFAULT_SLOW_THRESHOLD_MS = 5000;
+
+const getNetworkDebugMode = (): NetworkDebugMode => {
+  const raw = (process.env.E2E_DEBUG_NETWORK || '').toLowerCase();
+  if (!raw) return 'off';
+  if (raw === 'all') return 'all';
+  if (raw === 'errors' || raw === 'true' || raw === '1' || raw === 'yes') return 'errors';
+  return 'off';
+};
+
+const getSlowThresholdMs = (): number => {
+  const raw = process.env.E2E_SLOW_REQUEST_MS;
+  if (!raw) return DEFAULT_SLOW_THRESHOLD_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SLOW_THRESHOLD_MS;
+  return parsed;
+};
+
+const formatUrl = (url: string, baseURL?: string): string => {
+  if (!baseURL) return url;
+  try {
+    const origin = new URL(baseURL).origin;
+    if (url.startsWith(origin)) {
+      const trimmed = url.slice(origin.length);
+      return trimmed.length ? trimmed : '/';
+    }
+  } catch {
+    // Ignore URL parsing errors; fall back to full URL.
+  }
+  return url;
+};
+
+const formatEntry = (options: {
+  label: string;
+  method: string;
+  url: string;
+  status?: number | string;
+  durationMs?: number;
+  resourceType?: string;
+  errorText?: string | null;
+  baseURL?: string;
+}): string => {
+  const timestamp = new Date().toISOString();
+  const segments = [
+    `[${timestamp}]`,
+    `[${options.label}]`,
+    options.method,
+    options.status !== undefined ? String(options.status) : '-',
+    formatUrl(options.url, options.baseURL)
+  ];
+
+  if (options.durationMs !== undefined) {
+    segments.push(`${options.durationMs}ms`);
+  }
+  if (options.resourceType) {
+    segments.push(options.resourceType);
+  }
+  if (options.errorText) {
+    segments.push(`error="${options.errorText}"`);
+  }
+
+  return segments.join(' ');
+};
+
+export const attachNetworkLogger = (options: {
+  context: BrowserContext;
+  testInfo: TestInfo;
+  label: string;
+  baseURL?: string;
+}): NetworkLoggerHandle | null => {
+  const mode = getNetworkDebugMode();
+  if (mode === 'off') return null;
+
+  const slowThresholdMs = getSlowThresholdMs();
+  const entries: string[] = [];
+  const startTimes = new WeakMap<Request, number>();
+
+  const recordEntry = (line: string, shouldConsole: boolean): void => {
+    entries.push(line);
+    if (shouldConsole) {
+      console.warn(line);
+    }
+  };
+
+  const onRequest = (request: Request): void => {
+    startTimes.set(request, Date.now());
+  };
+
+  const onResponse = async (response: Response): Promise<void> => {
+    const request = response.request();
+    const start = startTimes.get(request);
+    const durationMs = start ? Date.now() - start : undefined;
+    const status = response.status();
+    const isSlow = durationMs !== undefined && durationMs >= slowThresholdMs;
+    const isError = status >= 400;
+
+    if (mode === 'all' || isSlow || isError) {
+      const line = formatEntry({
+        label: options.label,
+        method: request.method(),
+        url: request.url(),
+        status,
+        durationMs,
+        resourceType: request.resourceType(),
+        baseURL: options.baseURL
+      });
+      recordEntry(line, isSlow || isError);
+    }
+  };
+
+  const onRequestFailed = (request: Request): void => {
+    const failure = request.failure();
+    const line = formatEntry({
+      label: options.label,
+      method: request.method(),
+      url: request.url(),
+      status: 'FAILED',
+      durationMs: startTimes.get(request)
+        ? Date.now() - (startTimes.get(request) as number)
+        : undefined,
+      resourceType: request.resourceType(),
+      errorText: failure?.errorText ?? null,
+      baseURL: options.baseURL
+    });
+    recordEntry(line, true);
+  };
+
+  options.context.on('request', onRequest);
+  options.context.on('response', onResponse);
+  options.context.on('requestfailed', onRequestFailed);
+
+  return {
+    flush: async () => {
+      options.context.off('request', onRequest);
+      options.context.off('response', onResponse);
+      options.context.off('requestfailed', onRequestFailed);
+
+      if (!entries.length) return;
+      await options.testInfo.attach(`network-${options.label}`, {
+        body: entries.join('\n'),
+        contentType: 'text/plain'
+      });
+    }
+  };
+};

--- a/tests/e2e/lead-flow.spec.ts
+++ b/tests/e2e/lead-flow.spec.ts
@@ -1,18 +1,15 @@
-import { test, expect, type APIRequestContext } from '@playwright/test';
+import { expect, test } from './fixtures';
+import type { APIRequestContext } from '@playwright/test';
 import { randomUUID } from 'crypto';
-import { loadE2EConfig } from './helpers/e2eConfig';
 import { waitForSession } from './helpers/auth';
+import { loadE2EConfig } from './helpers/e2eConfig';
 
 const e2eConfig = loadE2EConfig();
 const BACKEND_API_URL = process.env.E2E_BACKEND_API_URL;
 if (!BACKEND_API_URL) {
   throw new Error('E2E_BACKEND_API_URL is required for lead flow tests.');
 }
-const DEFAULT_BASE_URL = process.env.E2E_BASE_URL || 'https://local.blawby.com';
 const PAYMENT_MODE = (process.env.E2E_PAYMENT_MODE || 'auto').toLowerCase();
-const AUTH_STATE_OWNER = 'playwright/.auth/owner.json';
-const AUTH_STATE_CLIENT = 'playwright/.auth/client.json';
-const AUTH_STATE_ANON = 'playwright/.auth/anonymous.json';
 
 interface ConversationMessage {
   id: string;
@@ -235,16 +232,17 @@ const shouldRunPaymentMode = (required: boolean): boolean => {
   return true;
 };
 
-const resolveBaseUrl = (baseURL?: string): string => {
-  if (typeof baseURL === 'string' && baseURL.length > 0) return baseURL;
-  return DEFAULT_BASE_URL;
-};
-
 test.describe('Lead intake workflow', () => {
   test.describe.configure({ mode: 'serial' });
   test.skip(!e2eConfig, 'E2E credentials are not configured.');
 
-  test('owner accepts lead for signed-in client (no payment required)', async ({ browser }) => {
+  test('owner accepts lead for signed-in client (no payment required)', async ({
+    baseURL,
+    ownerContext,
+    clientContext,
+    ownerPage,
+    clientPage
+  }) => {
     if (!e2eConfig) return;
 
     const intakeSettings = await getIntakeSettings(e2eConfig.practice.slug);
@@ -256,70 +254,65 @@ test.describe('Lead intake workflow', () => {
       test.skip(true, `Skipping free intake test for E2E_PAYMENT_MODE=${PAYMENT_MODE}.`);
     }
 
-    const baseURL = resolveBaseUrl(test.info().project.use.baseURL as string | undefined);
-    const ownerContext = await browser.newContext({ storageState: AUTH_STATE_OWNER, baseURL });
-    const clientContext = await browser.newContext({ storageState: AUTH_STATE_CLIENT, baseURL });
-    const ownerPage = await ownerContext.newPage();
-    const clientPage = await clientContext.newPage();
+    await clientPage.goto('/');
+    await waitForSession(clientPage, { timeoutMs: 30000 });
 
-    try {
-      await clientPage.goto('/');
-      await waitForSession(clientPage, { timeoutMs: 30000 });
+    const conversationId = await getOrCreateConversation(clientContext.request, e2eConfig.practice.id);
+    const clientName = `E2E Client ${randomUUID().slice(0, 6)}`;
 
-      const conversationId = await getOrCreateConversation(clientContext.request, e2eConfig.practice.id);
-      const clientName = `E2E Client ${randomUUID().slice(0, 6)}`;
+    const intake = await createIntake({
+      slug: e2eConfig.practice.slug,
+      name: clientName,
+      email: e2eConfig.client.email,
+      description: 'E2E accept flow',
+      amount: intakeSettings?.prefillAmount,
+      request: clientContext.request,
+      origin: baseURL
+    });
 
-      const intake = await createIntake({
-        slug: e2eConfig.practice.slug,
-        name: clientName,
-        email: e2eConfig.client.email,
-        description: 'E2E accept flow',
-        amount: intakeSettings?.prefillAmount,
-        request: clientContext.request,
-        origin: baseURL
-      });
-
-      if (!intake.uuid) {
-        throw new Error('Intake create did not return uuid');
-      }
-
-      const confirmResult = await confirmIntakeLead({
-        request: clientContext.request,
-        practiceId: e2eConfig.practice.id,
-        intakeUuid: intake.uuid,
-        conversationId
-      });
-
-      expect(confirmResult.status).toBe(200);
-      const matterId = confirmResult.data?.matterId;
-      if (!matterId) {
-        throw new Error('Intake confirm did not return matterId');
-      }
-
-      await ownerPage.goto('/practice/leads');
-      const leadCard = ownerPage.getByTestId(`lead-card-${matterId}`);
-      await expect(leadCard).toBeVisible({ timeout: 20000 });
-
-      await ownerPage.getByTestId(`lead-accept-${matterId}`).click();
-      await ownerPage.getByRole('button', { name: 'Accept Lead' }).click();
-
-      await expect(leadCard).toHaveCount(0, { timeout: 20000 });
-
-      const decisionMessage = await waitForDecisionMessage({
-        request: clientContext.request,
-        practiceId: e2eConfig.practice.id,
-        conversationId,
-        decision: 'accepted'
-      });
-
-      expect(decisionMessage.content.toLowerCase()).toContain('accepted');
-    } finally {
-      await clientContext.close();
-      await ownerContext.close();
+    if (!intake.uuid) {
+      throw new Error('Intake create did not return uuid');
     }
+
+    const confirmResult = await confirmIntakeLead({
+      request: clientContext.request,
+      practiceId: e2eConfig.practice.id,
+      intakeUuid: intake.uuid,
+      conversationId
+    });
+
+    expect(confirmResult.status).toBe(200);
+    const matterId = confirmResult.data?.matterId;
+    if (!matterId) {
+      throw new Error('Intake confirm did not return matterId');
+    }
+
+    await ownerPage.goto('/practice/leads');
+    const leadCard = ownerPage.getByTestId(`lead-card-${matterId}`);
+    await expect(leadCard).toBeVisible({ timeout: 20000 });
+
+    await ownerPage.getByTestId(`lead-accept-${matterId}`).click();
+    await ownerPage.getByRole('button', { name: 'Accept Lead' }).click();
+
+    await expect(leadCard).toHaveCount(0, { timeout: 20000 });
+
+    const decisionMessage = await waitForDecisionMessage({
+      request: clientContext.request,
+      practiceId: e2eConfig.practice.id,
+      conversationId,
+      decision: 'accepted'
+    });
+
+    expect(decisionMessage.content.toLowerCase()).toContain('accepted');
   });
 
-  test('owner rejects lead for anonymous guest (no payment required)', async ({ browser }) => {
+  test('owner rejects lead for anonymous guest (no payment required)', async ({
+    baseURL,
+    ownerContext,
+    anonContext,
+    ownerPage,
+    anonPage
+  }) => {
     if (!e2eConfig) return;
 
     const intakeSettings = await getIntakeSettings(e2eConfig.practice.slug);
@@ -334,74 +327,63 @@ test.describe('Lead intake workflow', () => {
       test.skip(true, `Skipping payment-gated test for E2E_PAYMENT_MODE=${PAYMENT_MODE}.`);
     }
 
-    const baseURL = resolveBaseUrl(test.info().project.use.baseURL as string | undefined);
-    const ownerContext = await browser.newContext({ storageState: AUTH_STATE_OWNER, baseURL });
-    const anonymousContext = await browser.newContext({ storageState: AUTH_STATE_ANON, baseURL });
-    const ownerPage = await ownerContext.newPage();
-    const anonymousPage = await anonymousContext.newPage();
+    await anonPage.goto(`/p/${encodeURIComponent(e2eConfig.practice.slug)}`);
+    await waitForSession(anonPage, { timeoutMs: 30000 });
 
-    try {
-      await anonymousPage.goto(`/p/${encodeURIComponent(e2eConfig.practice.slug)}`);
-      await waitForSession(anonymousPage, { timeoutMs: 30000 });
+    const conversationId = await getOrCreateConversation(anonContext.request, e2eConfig.practice.id);
+    const intakeUuid = randomUUID();
+    const clientName = `E2E Guest ${intakeUuid.slice(0, 8)}`;
+    const rejectReason = `Conflict check ${intakeUuid.slice(0, 4)}`;
 
-      const conversationId = await getOrCreateConversation(anonymousContext.request, e2eConfig.practice.id);
-      const intakeUuid = randomUUID();
-      const clientName = `E2E Guest ${intakeUuid.slice(0, 8)}`;
-      const rejectReason = `Conflict check ${intakeUuid.slice(0, 4)}`;
+    const intake = await createIntake({
+      slug: e2eConfig.practice.slug,
+      name: clientName,
+      email: `guest+${intakeUuid.slice(0, 6)}@example.com`,
+      description: 'E2E reject flow',
+      amount: intakeSettings?.prefillAmount,
+      request: anonContext.request,
+      origin: baseURL
+    });
 
-      const intake = await createIntake({
-        slug: e2eConfig.practice.slug,
-        name: clientName,
-        email: `guest+${intakeUuid.slice(0, 6)}@example.com`,
-        description: 'E2E reject flow',
-        amount: intakeSettings?.prefillAmount,
-        request: anonymousContext.request,
-        origin: baseURL
-      });
-
-      if (!intake.uuid) {
-        throw new Error('Intake create did not return uuid');
-      }
-
-      const confirmResult = await confirmIntakeLead({
-        request: anonymousContext.request,
-        practiceId: e2eConfig.practice.id,
-        intakeUuid: intake.uuid,
-        conversationId
-      });
-
-      expect(confirmResult.status).toBe(200);
-      const matterId = confirmResult.data?.matterId;
-      if (!matterId) {
-        throw new Error('Intake confirm did not return matterId');
-      }
-
-      await ownerPage.goto('/practice/leads');
-      const leadCard = ownerPage.getByTestId(`lead-card-${matterId}`);
-      await expect(leadCard).toBeVisible({ timeout: 20000 });
-
-      await ownerPage.getByTestId(`lead-reject-${matterId}`).click();
-      await ownerPage.fill('#lead-reject-reason', rejectReason);
-      await ownerPage.getByRole('button', { name: 'Reject Lead' }).click();
-
-      await expect(leadCard).toHaveCount(0, { timeout: 20000 });
-
-      const decisionMessage = await waitForDecisionMessage({
-        request: anonymousContext.request,
-        practiceId: e2eConfig.practice.id,
-        conversationId,
-        decision: 'rejected'
-      });
-
-      expect(decisionMessage.content.toLowerCase()).toContain('declined');
-      expect(decisionMessage.content).toContain(rejectReason);
-    } finally {
-      await anonymousContext.close();
-      await ownerContext.close();
+    if (!intake.uuid) {
+      throw new Error('Intake create did not return uuid');
     }
+
+    const confirmResult = await confirmIntakeLead({
+      request: anonContext.request,
+      practiceId: e2eConfig.practice.id,
+      intakeUuid: intake.uuid,
+      conversationId
+    });
+
+    expect(confirmResult.status).toBe(200);
+    const matterId = confirmResult.data?.matterId;
+    if (!matterId) {
+      throw new Error('Intake confirm did not return matterId');
+    }
+
+    await ownerPage.goto('/practice/leads');
+    const leadCard = ownerPage.getByTestId(`lead-card-${matterId}`);
+    await expect(leadCard).toBeVisible({ timeout: 20000 });
+
+    await ownerPage.getByTestId(`lead-reject-${matterId}`).click();
+    await ownerPage.fill('#lead-reject-reason', rejectReason);
+    await ownerPage.getByRole('button', { name: 'Reject Lead' }).click();
+
+    await expect(leadCard).toHaveCount(0, { timeout: 20000 });
+
+    const decisionMessage = await waitForDecisionMessage({
+      request: anonContext.request,
+      practiceId: e2eConfig.practice.id,
+      conversationId,
+      decision: 'rejected'
+    });
+
+    expect(decisionMessage.content.toLowerCase()).toContain('declined');
+    expect(decisionMessage.content).toContain(rejectReason);
   });
 
-  test('payment-required intake is gated until completion', async ({ browser }) => {
+  test('payment-required intake is gated until completion', async ({ baseURL, clientContext, clientPage }) => {
     if (!e2eConfig) return;
 
     const intakeSettings = await getIntakeSettings(e2eConfig.practice.slug);
@@ -414,39 +396,31 @@ test.describe('Lead intake workflow', () => {
       test.skip(true, `Skipping ${label} flow for E2E_PAYMENT_MODE=${PAYMENT_MODE}.`);
     }
 
-    const baseURL = resolveBaseUrl(test.info().project.use.baseURL as string | undefined);
-    const clientContext = await browser.newContext({ storageState: AUTH_STATE_CLIENT, baseURL });
-    const clientPage = await clientContext.newPage();
+    await clientPage.goto('/');
+    await waitForSession(clientPage, { timeoutMs: 30000 });
 
-    try {
-      await clientPage.goto('/');
-      await waitForSession(clientPage, { timeoutMs: 30000 });
+    const conversationId = await getOrCreateConversation(clientContext.request, e2eConfig.practice.id);
+    const intake = await createIntake({
+      slug: e2eConfig.practice.slug,
+      name: 'E2E Paid Intake',
+      email: e2eConfig.client.email,
+      description: 'E2E payment gated',
+      amount: intakeSettings?.prefillAmount,
+      request: clientContext.request,
+      origin: baseURL
+    });
 
-      const conversationId = await getOrCreateConversation(clientContext.request, e2eConfig.practice.id);
-      const intake = await createIntake({
-        slug: e2eConfig.practice.slug,
-        name: 'E2E Paid Intake',
-        email: e2eConfig.client.email,
-        description: 'E2E payment gated',
-        amount: intakeSettings?.prefillAmount,
-        request: clientContext.request,
-        origin: baseURL
-      });
-
-      if (!intake.uuid) {
-        throw new Error('Intake create did not return uuid');
-      }
-
-      const confirmResult = await confirmIntakeLead({
-        request: clientContext.request,
-        practiceId: e2eConfig.practice.id,
-        intakeUuid: intake.uuid,
-        conversationId
-      });
-
-      expect(confirmResult.status).toBe(402);
-    } finally {
-      await clientContext.close();
+    if (!intake.uuid) {
+      throw new Error('Intake create did not return uuid');
     }
+
+    const confirmResult = await confirmIntakeLead({
+      request: clientContext.request,
+      practiceId: e2eConfig.practice.id,
+      intakeUuid: intake.uuid,
+      conversationId
+    });
+
+    expect(confirmResult.status).toBe(402);
   });
 });


### PR DESCRIPTION
### Motivation
- Reduce repeated `browser.newContext` and storage-state revalidation across E2E specs by centralizing role-based contexts and baseURL resolution.
- Avoid unnecessary Better Auth validation/logins during local iteration while keeping behavior identical when E2E creds are missing.
- Provide a single, reusable notification setup to avoid per-test profile recreation and OneSignal re-registration overhead.

### Description
- Add shared fixtures in `tests/e2e/fixtures.ts` that expose `baseURL`, `ownerContext`/`clientContext`/`anonContext`, `unauthContext`, and pre-opened `ownerPage`/`clientPage`/`anonPage` for tests to reuse.
- Centralize base URL and auth state paths in `tests/e2e/helpers/baseUrl.ts` and `tests/e2e/helpers/authState.ts` and update specs to import `test`/`expect` from the fixtures.
- Enhance `tests/e2e/global-setup.ts` with a TTL-based validation cache (`playwright/.auth/last-validated.json`) and `E2E_FORCE_AUTH_REFRESH` override to skip /api/auth/get-session checks when recent validation exists.
- Refactor E2E specs (`auth-modes.spec.ts`, `lead-flow.spec.ts`, `chat-messages.spec.ts`, `notifications.spec.ts`) to use the new fixtures and shared helpers, and add a shared notification setup with `beforeAll`/`afterAll` to reuse a single persisted notification profile for the file.

### Testing
- Ran TypeScript check with `npm run type-check`, which completed successfully. 
- Ran lint with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eefdd711c8321998ea4a7ba27c6c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored end-to-end tests to use centralized fixtures and page contexts, improving stability and request handling.
  * Updated chat, lead, notification, and auth-related test flows to use unified session and base-URL management.

* **Chores**
  * Added centralized test fixtures, session validation cache, network logging, and improved session/cookie handling to reduce flakiness and speed setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->