### PR TITLE
Align account settings rows and group plan features for consistent layout

### DIFF
--- a/src/features/settings/components/SettingRow.tsx
+++ b/src/features/settings/components/SettingRow.tsx
@@ -6,14 +6,16 @@ import { cn } from '@/shared/utils/cn';
 export interface SettingRowProps {
   label: string;
   labelClassName?: string;
+  labelNode?: ComponentChildren;
   description?: string | ComponentChildren;
-  children: ComponentChildren;
+  children?: ComponentChildren;
   className?: string;
 }
 
 export const SettingRow = ({
   label,
   labelClassName = '',
+  labelNode,
   description,
   children,
   className = ''
@@ -21,7 +23,7 @@ export const SettingRow = ({
   return (
     <div className={cn('flex items-center justify-between py-3', className)}>
       <div className="flex-1 min-w-0">
-        <FormLabel className={labelClassName}>{label}</FormLabel>
+        {labelNode ?? <FormLabel className={labelClassName}>{label}</FormLabel>}
         {description && (
           typeof description === 'string' ? (
             <SettingDescription text={description} />
@@ -32,9 +34,11 @@ export const SettingRow = ({
           )
         )}
       </div>
-      <div className="ml-4">
-        {children}
-      </div>
+      {children !== undefined && children !== null && (
+        <div className="ml-4">
+          {children}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -25,6 +25,7 @@ import { PlanFeaturesList } from '@/features/settings/components/PlanFeaturesLis
 import { EmailSettingsSection } from '@/features/settings/components/EmailSettingsSection';
 import { getPreferencesCategory, updatePreferencesCategory } from '@/shared/lib/preferencesApi';
 import type { AccountPreferences } from '@/shared/types/preferences';
+import { FormLabel } from '@/shared/ui/form';
 
 
 export interface AccountPageProps {
@@ -672,17 +673,22 @@ export const AccountPage = ({
             </div>
           </SettingRow>
 
-          <SectionDivider />
-
           {/* Plan Features Section */}
-          <div className="py-3 space-y-3">
-            {hasSubscription && (
-              <p className="text-sm font-semibold text-gray-900 dark:text-white">
-                {t('settings:account.plan.thanksForSubscribing')}
-              </p>
-            )}
-            <PlanFeaturesList features={currentPlanFeatures} />
-          </div>
+          <SettingRow
+            label=""
+            labelNode={
+              <div className="space-y-3">
+                {hasSubscription && (
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                    {t('settings:account.plan.thanksForSubscribing')}
+                  </p>
+                )}
+                <PlanFeaturesList features={currentPlanFeatures} />
+              </div>
+            }
+          />
+
+          <SectionDivider />
 
           <SettingRow
             label={t('settings:account.payments.sectionTitle')}
@@ -753,33 +759,39 @@ export const AccountPage = ({
           {/* Links Section */}
           <SettingSection title={t('settings:account.links.title')}>
             {/* Domain Selector */}
-            <div className="flex items-center justify-between py-3">
-              <div className="flex items-center gap-3">
-                <GlobeAltIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
-                <span className="sr-only">{t('settings:account.links.domainLabel')}</span>
-              </div>
-              <div className="min-w-[220px]">
-                <Select
-                  value={selectedDomain}
-                  options={[
-                    { value: DOMAIN_SELECT_VALUE, label: t('settings:account.links.selectOption') },
-                    ...customDomainOptions,
-                    { value: 'verify-new', label: `+ ${t('settings:account.links.verifyNew')}` }
-                  ]}
-                  onChange={handleDomainChange}
-                  placeholder={t('settings:account.links.selectOption')}
-                />
-              </div>
-            </div>
+            <SettingRow
+              label={t('settings:account.links.domainLabel')}
+              labelNode={
+                <div className="flex items-center gap-3">
+                  <GlobeAltIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+                  <FormLabel>{t('settings:account.links.domainLabel')}</FormLabel>
+                </div>
+              }
+            >
+              <Select
+                value={selectedDomain}
+                options={[
+                  { value: DOMAIN_SELECT_VALUE, label: t('settings:account.links.selectOption') },
+                  ...customDomainOptions,
+                  { value: 'verify-new', label: `+ ${t('settings:account.links.verifyNew')}` }
+                ]}
+                onChange={handleDomainChange}
+                placeholder={t('settings:account.links.selectOption')}
+              />
+            </SettingRow>
 
             {/* LinkedIn */}
-            <div className="flex items-center justify-between py-3">
-              <div className="flex items-center gap-3">
-                <div className="w-4 h-4 bg-black rounded flex items-center justify-center">
-                  <span className="text-white text-xs font-bold">in</span>
+            <SettingRow
+              label="LinkedIn"
+              labelNode={
+                <div className="flex items-center gap-3">
+                  <div className="w-4 h-4 bg-black rounded flex items-center justify-center">
+                    <span className="text-white text-xs font-bold">in</span>
+                  </div>
+                  <FormLabel>LinkedIn</FormLabel>
                 </div>
-                <span className="text-sm text-gray-900 dark:text-gray-100">LinkedIn</span>
-              </div>
+              }
+            >
               <Button
                 variant="secondary"
                 size="sm"
@@ -789,18 +801,22 @@ export const AccountPage = ({
               >
                 {t('settings:account.links.addButton')}
               </Button>
-            </div>
+            </SettingRow>
 
             {/* GitHub */}
-            <div className="flex items-center justify-between py-3">
-              <div className="flex items-center gap-3">
-                <div className="w-4 h-4">
-                  <svg viewBox="0 0 24 24" className="w-4 h-4 text-gray-500 dark:text-gray-400 fill-current">
-                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                  </svg>
+            <SettingRow
+              label="GitHub"
+              labelNode={
+                <div className="flex items-center gap-3">
+                  <div className="w-4 h-4">
+                    <svg viewBox="0 0 24 24" className="w-4 h-4 text-gray-500 dark:text-gray-400 fill-current">
+                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                    </svg>
+                  </div>
+                  <FormLabel>GitHub</FormLabel>
                 </div>
-                <span className="text-sm text-gray-900 dark:text-gray-100">GitHub</span>
-              </div>
+              }
+            >
               <Button
                 variant="secondary"
                 size="sm"
@@ -810,7 +826,7 @@ export const AccountPage = ({
               >
                 {t('settings:account.links.addButton')}
               </Button>
-            </div>
+            </SettingRow>
           </SettingSection>
 
           <SectionDivider />


### PR DESCRIPTION
### Motivation
- Ensure the Account settings page follows the same row/section structure and vertical rhythm used across other settings pages for consistent padding, label typography, and action alignment.
- Group subscription plan and its feature list visually so the `SectionDivider` does not split related content.
- Use shared components for link/domain rows so select controls and row actions align to the right like other settings pages.

### Description
- Add an optional `labelNode` prop to `SettingRow` and make the action column conditional so rows can render custom label content or omit the action area when empty, by updating `src/features/settings/components/SettingRow.tsx`.
- Move the plan features block into a `SettingRow` (instead of a custom div) and place the `SectionDivider` after it so the plan and its features are visually grouped, in `src/features/settings/pages/AccountPage.tsx`.
- Replace custom link rows (Domain / LinkedIn / GitHub) with `SettingRow` usages and use `FormLabel` + `Select` to align the domain selector and other link actions with other settings rows, in `src/features/settings/pages/AccountPage.tsx`.
- Add the `FormLabel` import where needed to render consistent label typography for custom label nodes in the account links section.

### Testing
- Ran lint (`npm run lint`) to validate TypeScript/ESLint rules and formatting, which completed successfully.
- Executed an automated Playwright script to load `/settings/account` and capture a screenshot of the updated layout, which produced an artifact without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef1edb02c8321ae67b0d50498c772)