### PR TITLE
Remove lead review queue from practice settings

### DIFF
--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'preact/hooks';
+import { useState, useMemo } from 'preact/hooks';
 import {
   ChevronRightIcon,
   GlobeAltIcon,
@@ -31,8 +31,6 @@ import {
   usePracticeSyncParamRefetch,
   type EditPracticeFormState
 } from '@/features/settings/hooks/usePracticePageEffects';
-import { LeadReviewQueue } from '@/features/leads/components/LeadReviewQueue';
-import { hasLeadReviewPermission } from '@/shared/utils/leadPermissions';
 
 interface OnboardingDetails {
   contactPhone?: string;
@@ -134,8 +132,6 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
     deletePractice,
     fetchMembers,
     refetch,
-    acceptMatter,
-    rejectMatter
   } = usePracticeManagement();
   const activePracticeId = currentPractice?.id ?? practices[0]?.id ?? null;
   const { details: practiceDetails, updateDetails } = usePracticeDetails(activePracticeId);
@@ -187,7 +183,6 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
 
   const currentUserRole = currentMember?.role || 'paralegal';
   const isOwner = currentUserRole === 'owner';
-  const canReviewLeads = hasLeadReviewPermission(currentUserRole, practice?.metadata ?? null);
   const servicesList = useMemo(() => {
     const source = practiceDetails?.services ?? practice?.services;
     if (!Array.isArray(source)) return [];
@@ -289,10 +284,6 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
   });
   const [introDraft, setIntroDraft] = useState('');
   const [descriptionDraft, setDescriptionDraft] = useState('');
-
-  const handleOpenLeadConversation = useCallback((conversationId: string) => {
-    navigateTo(`/practice/chats/${encodeURIComponent(conversationId)}`);
-  }, [navigateTo]);
 
   // SSR-safe origin for return URLs
   const origin = (typeof window !== 'undefined' && window.location)
@@ -853,19 +844,6 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                   value={isPublicValue}
                   onChange={handleTogglePublic}
                   disabled={isSettingsSaving}
-                />
-              </div>
-
-              <div className="border-t border-gray-200 dark:border-dark-border" />
-
-              {/* Lead Review Queue */}
-              <div className="py-3">
-                <LeadReviewQueue
-                  practiceId={practice?.id ?? null}
-                  canReviewLeads={canReviewLeads}
-                  acceptMatter={acceptMatter}
-                  rejectMatter={rejectMatter}
-                  onOpenConversation={handleOpenLeadConversation}
                 />
               </div>
 


### PR DESCRIPTION
### Motivation
- The lead review queue on the practice settings page is redundant with the sidebar leads tab and should be removed to avoid duplicate UI and logic.

### Description
- Deleted the `LeadReviewQueue` component rendering from `src/features/settings/pages/PracticePage.tsx` so the queue no longer appears in settings.
- Removed related imports and wiring: `LeadReviewQueue`, `hasLeadReviewPermission`, the `canReviewLeads` computation, the `handleOpenLeadConversation` handler, and the `acceptMatter`/`rejectMatter` destructured props from `usePracticeManagement` usage.
- Removed the unused `useCallback` import from the component top-level imports and cleaned up surrounding markup and separators.

### Testing
- Ran `npm run lint`, which failed due to an environment missing the `@eslint/js` dependency (lint did not complete).
- Ran `npm run type-check` (`tsc`), which reported missing dev dependencies/type declarations and configuration-related type errors (type-check did not complete).
- Attempted `npm install`, which failed due to registry access (403) preventing a full install and subsequent test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f396b44748321af9e13c22b4ca740)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed Lead Review Queue functionality from the Practice Page
  * Simplified page logic by eliminating related permission checks and handlers
  * Streamlined control flow and data dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->