### PR TITLE
Hydrate public practice name and logo from /api/practice/details/:slug

### DIFF
--- a/src/shared/hooks/usePracticeConfig.ts
+++ b/src/shared/hooks/usePracticeConfig.ts
@@ -147,6 +147,8 @@ export const usePracticeConfig = ({
           const config = buildDefaultPracticeConfig({
             id: publicDetails.practiceId,
             slug: publicDetails.slug ?? currentPracticeId,
+            name: publicDetails.name ?? PLATFORM_SETTINGS.name,
+            profileImage: publicDetails.logo ?? PLATFORM_SETTINGS.profileImage ?? null,
             introMessage: details?.introMessage ?? PLATFORM_SETTINGS.introMessage ?? '',
             description: details?.description ?? PLATFORM_SETTINGS.description ?? '',
             isPublic: details?.isPublic


### PR DESCRIPTION
### Motivation
- The public practice details endpoint will begin returning practice `name` and `logo` (mirroring the private endpoint), and unauthenticated public pages should show the practice branding instead of platform defaults.

### Description
- Extended `PublicPracticeDetails` in `src/shared/lib/apiClient.ts` to include optional `name` and `logo` fields.
- Added `extractPublicPracticeDisplayDetails` to parse `name` and `logo` from response containers (`practice`, `data`, or top-level) and wired it into `getPublicPracticeDetails` to return `name`/`logo` alongside `details`.
- Updated `usePracticeConfig` (unauthenticated branch) to map `publicDetails.name` into `config.name` and `publicDetails.logo` into `config.profileImage` while preserving existing platform fallbacks.

### Testing
- Ran `npm run lint`, which failed in this environment due to a missing dev dependency (`@eslint/js`).
- Ran `npm run type-check` (`tsc --noEmit`), which failed in this environment due to missing modules/type declarations and other workspace-specific type errors.
- No unit or e2e tests were executed in this environment as dependency/type issues prevented full test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f3bffd1b88321b14e0de166688ba0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Public practice details now reliably display practice name and logo information. The system intelligently applies default platform settings as fallbacks when specific practice information isn't available, ensuring complete and accurate practice information is consistently displayed to users when viewing public profiles, practice listings, and shared practice information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->