### PR TITLE
Add time entry UI to matters detail view

### DIFF
--- a/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
+++ b/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
@@ -1,0 +1,333 @@
+import { useMemo, useState } from 'preact/hooks';
+import { ChevronLeftIcon, ChevronRightIcon, PencilIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { ulid } from 'ulid';
+import Modal from '@/shared/components/Modal';
+import { Button } from '@/shared/ui/Button';
+import type { MatterDetail, TimeEntry } from '@/features/matters/data/mockMatters';
+import { TimeEntryForm, type TimeEntryFormValues } from './TimeEntryForm';
+
+const buildDateString = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const getStartOfWeek = (date: Date) => {
+  const start = new Date(date);
+  const dayIndex = start.getDay();
+  start.setDate(start.getDate() - dayIndex);
+  start.setHours(0, 0, 0, 0);
+  return start;
+};
+
+const addDays = (date: Date, amount: number) => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + amount);
+  return next;
+};
+
+const formatDateLabel = (date: Date) => date.toLocaleDateString('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric'
+});
+
+const formatTimeLabel = (date: Date) => date.toLocaleTimeString('en-US', {
+  hour: 'numeric',
+  minute: '2-digit'
+});
+
+const formatDuration = (totalSeconds: number) => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.round((totalSeconds % 3600) / 60);
+  return `${hours}:${String(minutes).padStart(2, '0')} hrs`;
+};
+
+interface TimeEntriesPanelProps {
+  matter: MatterDetail;
+}
+
+export const TimeEntriesPanel = ({ matter }: TimeEntriesPanelProps) => {
+  const [entries, setEntries] = useState<TimeEntry[]>(() => matter.timeEntries ?? []);
+  const [selectedWeekStart, setSelectedWeekStart] = useState(() => getStartOfWeek(new Date()));
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<TimeEntry | null>(null);
+  const [draftDate, setDraftDate] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TimeEntry | null>(null);
+
+  const weekDays = useMemo(() => {
+    return Array.from({ length: 7 }, (_, index) => addDays(selectedWeekStart, index));
+  }, [selectedWeekStart]);
+
+  const weekRangeLabel = useMemo(() => {
+    const start = weekDays[0];
+    const end = weekDays[6];
+    if (!start || !end) return '';
+    const startLabel = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const endLabel = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    return `${startLabel} - ${endLabel}`;
+  }, [weekDays]);
+
+  const dailyEntries = useMemo(() => {
+    return weekDays.map((day) => {
+      const dayKey = buildDateString(day);
+      const dayEntries = entries.filter((entry) => buildDateString(new Date(entry.startTime)) === dayKey);
+      const totalSeconds = dayEntries.reduce((total, entry) => {
+        const start = new Date(entry.startTime).getTime();
+        const end = new Date(entry.endTime).getTime();
+        return total + Math.max(0, Math.floor((end - start) / 1000));
+      }, 0);
+      const progressPercentage = Math.min((totalSeconds / (8 * 3600)) * 100, 100);
+      return {
+        dateKey: dayKey,
+        date: day,
+        entries: dayEntries,
+        totalSeconds,
+        progressPercentage
+      };
+    });
+  }, [entries, weekDays]);
+
+  const weekEntries = useMemo(() => {
+    const weekStart = selectedWeekStart.getTime();
+    const weekEnd = addDays(selectedWeekStart, 7).getTime();
+    return entries
+      .filter((entry) => {
+        const start = new Date(entry.startTime).getTime();
+        return start >= weekStart && start < weekEnd;
+      })
+      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+  }, [entries, selectedWeekStart]);
+
+  const openNewEntry = (dateKey?: string) => {
+    setEditingEntry(null);
+    setDraftDate(dateKey ?? buildDateString(new Date()));
+    setIsFormOpen(true);
+  };
+
+  const openEditEntry = (entry: TimeEntry) => {
+    setEditingEntry(entry);
+    setDraftDate(null);
+    setIsFormOpen(true);
+  };
+
+  const closeForm = () => {
+    setIsFormOpen(false);
+    setEditingEntry(null);
+    setDraftDate(null);
+  };
+
+  const handleSave = (values: TimeEntryFormValues) => {
+    if (editingEntry) {
+      setEntries((prev) => prev.map((entry) => (
+        entry.id === editingEntry.id
+          ? { ...entry, startTime: values.startTime, endTime: values.endTime, description: values.description }
+          : entry
+      )));
+    } else {
+      const newEntry: TimeEntry = {
+        id: ulid(),
+        startTime: values.startTime,
+        endTime: values.endTime,
+        description: values.description
+      };
+      setEntries((prev) => [newEntry, ...prev]);
+    }
+    closeForm();
+  };
+
+  const confirmDelete = (entry: TimeEntry) => {
+    setDeleteTarget(entry);
+  };
+
+  const handleDelete = () => {
+    if (!deleteTarget) return;
+    setEntries((prev) => prev.filter((entry) => entry.id !== deleteTarget.id));
+    setDeleteTarget(null);
+    if (editingEntry?.id === deleteTarget.id) {
+      closeForm();
+    }
+  };
+
+  const totalWeekSeconds = useMemo(() => {
+    return weekEntries.reduce((total, entry) => {
+      const start = new Date(entry.startTime).getTime();
+      const end = new Date(entry.endTime).getTime();
+      return total + Math.max(0, Math.floor((end - start) / 1000));
+    }, 0);
+  }, [weekEntries]);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Previous week"
+            icon={<ChevronLeftIcon className="h-4 w-4" />}
+            onClick={() => setSelectedWeekStart((prev) => addDays(prev, -7))}
+          />
+          <div>
+            <p className="text-sm font-semibold text-gray-900 dark:text-white">{weekRangeLabel}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {weekEntries.length} entries · {formatDuration(totalWeekSeconds)}
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Next week"
+            icon={<ChevronRightIcon className="h-4 w-4" />}
+            onClick={() => setSelectedWeekStart((prev) => addDays(prev, 7))}
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setSelectedWeekStart(getStartOfWeek(new Date()))}
+          >
+            This week
+          </Button>
+        </div>
+        <Button icon={<PlusIcon className="h-4 w-4" />} onClick={() => openNewEntry()}>
+          Add time entry
+        </Button>
+      </header>
+
+      <div className="rounded-2xl border border-gray-200 dark:border-dark-border bg-white dark:bg-dark-card-bg overflow-hidden">
+        <div className="divide-y divide-gray-200 dark:divide-white/10">
+          {dailyEntries.map((day) => (
+            <button
+              key={day.dateKey}
+              type="button"
+              onClick={() => openNewEntry(day.dateKey)}
+              className="w-full text-left px-4 py-3 sm:px-6 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+            >
+              <div className="grid gap-2 sm:grid-cols-12 sm:items-center">
+                <div className="text-sm font-medium text-gray-600 dark:text-gray-300 sm:col-span-3">
+                  {formatDateLabel(day.date)}
+                </div>
+                <div className="sm:col-span-9">
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1 h-2 rounded-full bg-gray-200 dark:bg-white/10">
+                      <div
+                        className="h-2 rounded-full bg-accent-500"
+                        style={{ width: `${day.progressPercentage}%` }}
+                      />
+                    </div>
+                    <div className="text-sm font-semibold text-gray-900 dark:text-white min-w-[96px] text-right">
+                      {formatDuration(day.totalSeconds)}
+                    </div>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {day.entries.length} entry{day.entries.length === 1 ? '' : 'ies'}
+                  </p>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <section className="rounded-2xl border border-gray-200 dark:border-dark-border bg-white dark:bg-dark-card-bg">
+        <header className="flex items-center justify-between border-b border-gray-200 dark:border-white/10 px-6 py-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Entries this week</h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Review and edit individual time entries.
+            </p>
+          </div>
+        </header>
+        {weekEntries.length === 0 ? (
+          <div className="px-6 py-6 text-sm text-gray-500 dark:text-gray-400">
+            No time entries yet for this week.
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-200 dark:divide-white/10">
+            {weekEntries.map((entry) => {
+              const start = new Date(entry.startTime);
+              const end = new Date(entry.endTime);
+              const durationSeconds = Math.max(0, Math.floor((end.getTime() - start.getTime()) / 1000));
+              return (
+                <li key={entry.id} className="px-6 py-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                        {formatDateLabel(start)}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {formatTimeLabel(start)} – {formatTimeLabel(end)} · {formatDuration(durationSeconds)}
+                      </p>
+                      {entry.description && (
+                        <p className="mt-2 text-sm text-gray-700 dark:text-gray-200">{entry.description}</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label="Edit time entry"
+                        icon={<PencilIcon className="h-4 w-4" />}
+                        onClick={() => openEditEntry(entry)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label="Delete time entry"
+                        icon={<TrashIcon className="h-4 w-4" />}
+                        onClick={() => confirmDelete(entry)}
+                      />
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {isFormOpen && (
+        <Modal
+          isOpen={isFormOpen}
+          onClose={closeForm}
+          title={editingEntry ? 'Edit time entry' : 'Add time entry'}
+          contentClassName="max-w-2xl"
+        >
+          <TimeEntryForm
+            key={editingEntry?.id ?? `new-${draftDate ?? 'today'}`}
+            initialEntry={editingEntry ?? undefined}
+            initialDate={draftDate ?? undefined}
+            onSubmit={handleSave}
+            onCancel={closeForm}
+            onDelete={editingEntry ? () => confirmDelete(editingEntry) : undefined}
+          />
+        </Modal>
+      )}
+
+      {deleteTarget && (
+        <Modal
+          isOpen={Boolean(deleteTarget)}
+          onClose={() => setDeleteTarget(null)}
+          title="Delete time entry"
+          contentClassName="max-w-xl"
+        >
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Are you sure you want to delete this time entry? This action cannot be undone.
+            </p>
+            <div className="flex items-center justify-end gap-3">
+              <Button variant="secondary" onClick={() => setDeleteTarget(null)}>
+                Cancel
+              </Button>
+              <Button onClick={handleDelete}>
+                Delete time entry
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+};

--- a/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
+++ b/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
@@ -7,27 +7,28 @@ import type { MatterDetail, TimeEntry } from '@/features/matters/data/mockMatter
 import { TimeEntryForm, type TimeEntryFormValues } from './TimeEntryForm';
 
 const buildDateString = (date: Date) => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 };
 
 const getStartOfWeek = (date: Date) => {
   const start = new Date(date);
-  const dayIndex = start.getDay();
-  start.setDate(start.getDate() - dayIndex);
-  start.setHours(0, 0, 0, 0);
+  const dayIndex = start.getUTCDay();
+  start.setUTCDate(start.getUTCDate() - dayIndex);
+  start.setUTCHours(0, 0, 0, 0);
   return start;
 };
 
 const addDays = (date: Date, amount: number) => {
   const next = new Date(date);
-  next.setDate(next.getDate() + amount);
+  next.setUTCDate(next.getUTCDate() + amount);
   return next;
 };
 
 const formatDateLabel = (date: Date) => date.toLocaleDateString('en-US', {
+  timeZone: 'UTC',
   weekday: 'short',
   month: 'short',
   day: 'numeric',
@@ -35,6 +36,7 @@ const formatDateLabel = (date: Date) => date.toLocaleDateString('en-US', {
 });
 
 const formatTimeLabel = (date: Date) => date.toLocaleTimeString('en-US', {
+  timeZone: 'UTC',
   hour: 'numeric',
   minute: '2-digit'
 });
@@ -65,8 +67,8 @@ export const TimeEntriesPanel = ({ matter }: TimeEntriesPanelProps) => {
     const start = weekDays[0];
     const end = weekDays[6];
     if (!start || !end) return '';
-    const startLabel = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    const endLabel = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const startLabel = start.toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric' });
+    const endLabel = end.toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric', year: 'numeric' });
     return `${startLabel} - ${endLabel}`;
   }, [weekDays]);
 

--- a/src/features/matters/components/time-entries/TimeEntryForm.tsx
+++ b/src/features/matters/components/time-entries/TimeEntryForm.tsx
@@ -6,15 +6,15 @@ import { Textarea } from '@/shared/ui/input/Textarea';
 import type { TimeEntry } from '@/features/matters/data/mockMatters';
 
 const buildDateString = (date: Date) => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 };
 
 const buildTimeString = (date: Date) => {
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
   return `${hours}:${minutes}`;
 };
 
@@ -87,8 +87,11 @@ export const TimeEntryForm = ({ initialEntry, initialDate, onSubmit, onCancel, o
   const handleSubmit = (event: Event) => {
     event.preventDefault();
 
-    const startDateTime = new Date(`${formState.date}T${formState.startTime}`);
-    const endDateTime = new Date(`${formState.date}T${formState.endTime}`);
+    const [startHours, startMinutes] = formState.startTime.split(':').map(Number);
+    const [endHours, endMinutes] = formState.endTime.split(':').map(Number);
+    const [year, month, day] = formState.date.split('-').map(Number);
+    const startDateTime = new Date(Date.UTC(year, month - 1, day, startHours, startMinutes));
+    const endDateTime = new Date(Date.UTC(year, month - 1, day, endHours, endMinutes));
 
     if (Number.isNaN(startDateTime.getTime()) || Number.isNaN(endDateTime.getTime())) {
       setErrors({ endTime: 'Start and end times must be valid.' });

--- a/src/features/matters/components/time-entries/TimeEntryForm.tsx
+++ b/src/features/matters/components/time-entries/TimeEntryForm.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'preact/hooks';
+import { Button } from '@/shared/ui/Button';
+import { DatePicker } from '@/shared/ui/input/DatePicker';
+import { Select } from '@/shared/ui/input/Select';
+import { Textarea } from '@/shared/ui/input/Textarea';
+import type { TimeEntry } from '@/features/matters/data/mockMatters';
+
+const buildDateString = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const buildTimeString = (date: Date) => {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+};
+
+const buildDateOptions = () => {
+  const options: Array<{ value: string; label: string }> = [];
+  const start = new Date();
+  start.setFullYear(start.getFullYear() - 1);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date();
+  end.setDate(end.getDate() + 30);
+  end.setHours(0, 0, 0, 0);
+
+  for (let current = new Date(start); current <= end; current.setDate(current.getDate() + 1)) {
+    const value = buildDateString(current);
+    const label = current.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+    options.push({ value, label });
+  }
+
+  return options;
+};
+
+const buildInitialFormState = (initialEntry: TimeEntry | null | undefined, initialDate?: string) => {
+  if (initialEntry) {
+    const startDate = new Date(initialEntry.startTime);
+    const endDate = new Date(initialEntry.endTime);
+    return {
+      date: buildDateString(startDate),
+      startTime: buildTimeString(startDate),
+      endTime: buildTimeString(endDate),
+      description: initialEntry.description ?? ''
+    };
+  }
+
+  const today = new Date();
+  const dateValue = initialDate ?? buildDateString(today);
+
+  return {
+    date: dateValue,
+    startTime: '09:00',
+    endTime: '17:00',
+    description: ''
+  };
+};
+
+export type TimeEntryFormValues = {
+  startTime: string;
+  endTime: string;
+  description: string;
+};
+
+interface TimeEntryFormProps {
+  initialEntry?: TimeEntry | null;
+  initialDate?: string;
+  onSubmit: (values: TimeEntryFormValues) => void;
+  onCancel: () => void;
+  onDelete?: () => void;
+}
+
+export const TimeEntryForm = ({ initialEntry, initialDate, onSubmit, onCancel, onDelete }: TimeEntryFormProps) => {
+  const [formState, setFormState] = useState(() => buildInitialFormState(initialEntry, initialDate));
+  const [errors, setErrors] = useState<{ endTime?: string }>({});
+
+  const dateOptions = useMemo(() => buildDateOptions(), []);
+
+  const handleSubmit = (event: Event) => {
+    event.preventDefault();
+
+    const startDateTime = new Date(`${formState.date}T${formState.startTime}`);
+    const endDateTime = new Date(`${formState.date}T${formState.endTime}`);
+
+    if (Number.isNaN(startDateTime.getTime()) || Number.isNaN(endDateTime.getTime())) {
+      setErrors({ endTime: 'Start and end times must be valid.' });
+      return;
+    }
+
+    if (endDateTime <= startDateTime) {
+      setErrors({ endTime: 'End time must be after start time.' });
+      return;
+    }
+
+    setErrors({});
+    onSubmit({
+      startTime: startDateTime.toISOString(),
+      endTime: endDateTime.toISOString(),
+      description: formState.description.trim()
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          {initialEntry ? 'Edit Time Entry' : 'Add Time Entry'}
+        </h3>
+        {initialEntry && onDelete ? (
+          <Button variant="secondary" size="sm" onClick={onDelete}>
+            Delete
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Select
+          label="Date"
+          value={formState.date}
+          options={dateOptions}
+          onChange={(value) => setFormState((prev) => ({ ...prev, date: value }))}
+        />
+        <div>
+          <span className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">Timezone</span>
+          <div className="min-h-[44px] rounded-lg border border-gray-200 dark:border-dark-border bg-gray-100 dark:bg-white/10 px-3 py-2 text-sm text-gray-500 dark:text-gray-300 flex items-center">
+            UTC
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <DatePicker
+          label="Start Time"
+          value={formState.startTime}
+          onChange={(value) => setFormState((prev) => ({ ...prev, startTime: value }))}
+          format="time"
+        />
+        <DatePicker
+          label="End Time"
+          value={formState.endTime}
+          onChange={(value) => setFormState((prev) => ({ ...prev, endTime: value }))}
+          format="time"
+          error={errors.endTime}
+        />
+      </div>
+
+      <Textarea
+        label="Description"
+        value={formState.description}
+        onChange={(value) => setFormState((prev) => ({ ...prev, description: value }))}
+        rows={3}
+      />
+
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit">
+          {initialEntry ? 'Update' : 'Create'} Time Entry
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/src/features/matters/data/mockMatters.ts
+++ b/src/features/matters/data/mockMatters.ts
@@ -28,6 +28,14 @@ export type MatterDetail = MatterSummary & {
   totalFixedPrice?: number;
   milestones?: MatterMilestone[];
   contingencyPercent?: number;
+  timeEntries?: TimeEntry[];
+};
+
+export type TimeEntry = {
+  id: string;
+  startTime: string;
+  endTime: string;
+  description: string;
 };
 
 export type MatterOption = {
@@ -45,6 +53,31 @@ const daysAgo = (days: number, hours = 0) =>
 
 const daysFromNow = (days: number) =>
   new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+const buildTimeEntry = (
+  id: string,
+  daysOffset: number,
+  startTime: string,
+  endTime: string,
+  description: string
+): TimeEntry => {
+  const base = new Date();
+  base.setDate(base.getDate() - daysOffset);
+
+  const buildDateTime = (timeValue: string) => {
+    const [hours, minutes] = timeValue.split(':').map(Number);
+    const date = new Date(base);
+    date.setHours(hours, minutes, 0, 0);
+    return date.toISOString();
+  };
+
+  return {
+    id,
+    startTime: buildDateTime(startTime),
+    endTime: buildDateTime(endTime),
+    description
+  };
+};
 
 export const mockClients: MatterOption[] = [
   { id: 'client-avery-chen', name: 'Avery Chen', email: 'avery.chen@blawby.com' },
@@ -184,6 +217,14 @@ export const mockMatterDetails: Record<string, MatterDetail> = {
     milestones: [
       { description: 'Name availability + formation filing', dueDate: daysFromNow(10), amount: 1200 },
       { description: 'Operating agreement + EIN', dueDate: daysFromNow(24), amount: 1800 }
+    ],
+    timeEntries: [
+      buildTimeEntry('time-entry-1', 1, '09:00', '11:15', 'Drafted operating agreement provisions.'),
+      buildTimeEntry('time-entry-2', 1, '13:00', '14:30', 'Reviewed client intake notes and follow-up.'),
+      buildTimeEntry('time-entry-3', 2, '10:00', '12:00', 'Prepared filing checklist and timeline.'),
+      buildTimeEntry('time-entry-4', 3, '15:00', '16:15', 'Coordinated with secretary of state office.'),
+      buildTimeEntry('time-entry-5', 4, '08:45', '10:00', 'Compiled entity name availability report.'),
+      buildTimeEntry('time-entry-6', 6, '11:30', '13:00', 'Drafted engagement letter revisions.')
     ]
   },
   'matter-estate': {

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -26,6 +26,7 @@ import { MatterListItem } from '@/features/matters/components/MatterListItem';
 import { MatterStatusDot } from '@/features/matters/components/MatterStatusDot';
 import { MatterStatusPill } from '@/features/matters/components/MatterStatusPill';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
+import { TimeEntriesPanel } from '@/features/matters/components/time-entries/TimeEntriesPanel';
 
 const statusOrder: Record<MattersSidebarStatus, number> = {
   lead: 0,
@@ -75,6 +76,12 @@ const DETAIL_TABS: Array<{ id: DetailTabId; label: string }> = [
 ];
 
 const basePath = '/practice/matters';
+
+const formatDuration = (totalSeconds: number) => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.round((totalSeconds % 3600) / 60);
+  return `${hours}:${String(minutes).padStart(2, '0')} hrs`;
+};
 
 const EmptyState = () => (
   <div className="flex h-full items-center justify-center p-8">
@@ -155,6 +162,14 @@ export const PracticeMattersPage = () => {
   }, [filteredMatters, sortOption]);
 
   const activeTabLabel = TAB_HEADINGS[activeTab] ?? 'All';
+  const totalTimeSeconds = useMemo(() => {
+    const entries = selectedMatterDetail?.timeEntries ?? [];
+    return entries.reduce((total, entry) => {
+      const start = new Date(entry.startTime).getTime();
+      const end = new Date(entry.endTime).getTime();
+      return total + Math.max(0, Math.floor((end - start) / 1000));
+    }, 0);
+  }, [selectedMatterDetail]);
 
   if (selectedMatterId) {
     if (!selectedMatter) {
@@ -251,7 +266,7 @@ export const PracticeMattersPage = () => {
 
           <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {[
-              { label: 'Total time', value: '12.4h', helper: 'Estimated 18h' },
+              { label: 'Total time', value: formatDuration(totalTimeSeconds), helper: 'Estimated 18h' },
               { label: 'Billable amount', value: '$18,400', helper: 'Collected $9,200' },
               { label: 'Tasks', value: '5 open', helper: '2 overdue' },
               { label: 'Progress', value: '68%', helper: 'In progress' }
@@ -299,6 +314,10 @@ export const PracticeMattersPage = () => {
                     </div>
                   </div>
                 </div>
+              </div>
+            ) : detailTab === 'time' && selectedMatterDetail ? (
+              <div className="px-6 py-6">
+                <TimeEntriesPanel key={selectedMatterDetail.id} matter={selectedMatterDetail} />
               </div>
             ) : (
               <div className="px-6 py-6 text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
### Motivation
- Migrate time-entry UI from the previous Vue implementation into the Preact codebase and surface it under the "Time" tab of a matter detail. 
- Reuse existing shared UI primitives (Modal, Button, DatePicker, Select, Textarea) and create small, focused, reusable components for form and weekly panel behavior. 

### Description
- Add `TimeEntry` type and sample `timeEntries` data to `src/features/matters/data/mockMatters.ts` to provide realistic mock data for the new UI. 
- Implement a reusable `TimeEntryForm` at `src/features/matters/components/time-entries/TimeEntryForm.tsx` for creating/editing entries (date, start/end times, description, validation). 
- Implement a weekly `TimeEntriesPanel` at `src/features/matters/components/time-entries/TimeEntriesPanel.tsx` to list daily progress, open the form in a `Modal`, and support create/edit/delete with local state. 
- Wire the time UI into `PracticeMattersPage` by importing `TimeEntriesPanel`, adding a `totalTimeSeconds` calculation and `formatDuration` helper, and rendering the panel when the detail tab is `time`. 
- Use `ulid()` for client-side IDs and existing shared components for consistent styling and accessibility. 

### Testing
- Ran `npm run lint`, which completed without errors. 
- Ran `npm run type-check` (TypeScript `tsc --noEmit`) and it completed without type errors. 
- Started the dev server with `npm run dev` and verified the matters page renders; captured a headless screenshot (`artifacts/matters-page-loaded.png`). 
- Attempted Playwright interactions to open the Time tab, but the automated click timed out because the local worker/backend proxy (`/api/auth/get-session`) was unreachable during the run, so full E2E interaction of the Time tab was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976d88d85688321b6b26da216f644c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly time-tracking panel for matters with week navigation and "This week" reset.
  * Create/edit/delete time entries via modal form (date, start/end times, description) with delete confirmation.
  * Daily summaries with progress bars (against 8‑hour day) and per-week total aggregation.
  * Time inputs show UTC, sensible defaults, and validation; totals update immediately in the UI.
  * Time data included in matter detail view and reflected in total-time display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->