### PR TITLE
Add expenses panel to matter time tab

### DIFF
--- a/src/features/matters/components/expenses/ExpenseForm.tsx
+++ b/src/features/matters/components/expenses/ExpenseForm.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'preact/hooks';
+import { Button } from '@/shared/ui/Button';
+import { Checkbox, CurrencyInput, DatePicker, Input } from '@/shared/ui/input';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import { formatDateOnlyStringUtc } from '@/shared/utils/dateOnly';
+import type { MatterExpense } from '@/features/matters/data/mockMatters';
+
+export type ExpenseFormValues = {
+  description: string;
+  amount: number | undefined;
+  date: string;
+  billable: boolean;
+};
+
+const buildDefaultValues = (expense?: MatterExpense): ExpenseFormValues => ({
+  description: expense?.description ?? '',
+  amount: typeof expense?.amount === 'number' ? expense.amount / 100 : undefined,
+  date: expense?.date ?? formatDateOnlyStringUtc(new Date()),
+  billable: expense?.billable ?? true
+});
+
+interface ExpenseFormProps {
+  initialExpense?: MatterExpense;
+  onSubmit: (values: ExpenseFormValues) => void;
+  onCancel: () => void;
+  onDelete?: () => void;
+}
+
+export const ExpenseForm = ({ initialExpense, onSubmit, onCancel, onDelete }: ExpenseFormProps) => {
+  const [values, setValues] = useState<ExpenseFormValues>(() => buildDefaultValues(initialExpense));
+
+  const formattedAmount = useMemo(() => {
+    return formatCurrency(values.amount ?? 0);
+  }, [values.amount]);
+
+  const canSubmit = Boolean(values.description.trim()) && values.amount !== undefined && Boolean(values.date);
+
+  const handleSubmit = (event: Event) => {
+    event.preventDefault();
+    if (!canSubmit || values.amount === undefined) return;
+    onSubmit({
+      ...values,
+      description: values.description.trim()
+    });
+  };
+
+  return (
+    <form className="space-y-5" onSubmit={handleSubmit}>
+      <Input
+        label="Description"
+        value={values.description}
+        onChange={(nextValue) => setValues((prev) => ({ ...prev, description: nextValue }))}
+        placeholder="Court filing fee"
+        required
+      />
+
+      <div className="space-y-1">
+        <CurrencyInput
+          label="Amount"
+          value={values.amount}
+          onChange={(nextValue) => setValues((prev) => ({ ...prev, amount: nextValue }))}
+          required
+          min={0}
+          step={0.01}
+        />
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Formatted total: <span className="font-medium text-gray-700 dark:text-gray-200">{formattedAmount}</span>
+        </p>
+      </div>
+
+      <DatePicker
+        label="Date"
+        value={values.date}
+        onChange={(nextValue) => setValues((prev) => ({ ...prev, date: nextValue }))}
+        required
+      />
+
+      <Checkbox
+        checked={values.billable}
+        onChange={(checked) => setValues((prev) => ({ ...prev, billable: checked }))}
+        label="Billable"
+        description="Mark as billable to include this expense on invoices."
+      />
+
+      <div className="flex flex-wrap items-center justify-end gap-3">
+        {onDelete && (
+          <Button variant="secondary" type="button" onClick={onDelete}>
+            Delete
+          </Button>
+        )}
+        <Button variant="secondary" type="button" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSubmit}>
+          {initialExpense ? 'Update Expense' : 'Add Expense'}
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/src/features/matters/components/expenses/MatterExpensesPanel.tsx
+++ b/src/features/matters/components/expenses/MatterExpensesPanel.tsx
@@ -1,0 +1,225 @@
+import { useMemo, useState } from 'preact/hooks';
+import { EllipsisVerticalIcon, PlusIcon, TrashIcon, PencilIcon } from '@heroicons/react/24/outline';
+import { ulid } from 'ulid';
+import { format, parseISO } from 'date-fns';
+import Modal from '@/shared/components/Modal';
+import { Button } from '@/shared/ui/Button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/shared/ui/dropdown';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import type { MatterDetail, MatterExpense } from '@/features/matters/data/mockMatters';
+import { ExpenseForm, type ExpenseFormValues } from './ExpenseForm';
+
+const formatExpenseDate = (dateString: string) => format(parseISO(dateString), 'MMM d, yyyy');
+
+const statusStyles: Record<'billable' | 'nonbillable', string> = {
+  billable: 'text-green-700 bg-green-50 ring-green-600/20 dark:text-green-200 dark:bg-green-500/10',
+  nonbillable: 'text-red-700 bg-red-50 ring-red-600/20 dark:text-red-200 dark:bg-red-500/10'
+};
+
+interface MatterExpensesPanelProps {
+  matter: MatterDetail;
+}
+
+export const MatterExpensesPanel = ({ matter }: MatterExpensesPanelProps) => {
+  const [expenses, setExpenses] = useState<MatterExpense[]>(() => matter.expenses ?? []);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<MatterExpense | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<MatterExpense | null>(null);
+  const [formKey, setFormKey] = useState(0);
+
+  const sortedExpenses = useMemo(() => {
+    return [...expenses].sort((a, b) => b.date.localeCompare(a.date));
+  }, [expenses]);
+
+  const totalExpenses = useMemo(() => {
+    return expenses.reduce((total, expense) => total + expense.amount, 0);
+  }, [expenses]);
+
+  const billableTotal = useMemo(() => {
+    return expenses.filter((expense) => expense.billable).reduce((total, expense) => total + expense.amount, 0);
+  }, [expenses]);
+
+  const openNewExpense = () => {
+    setEditingExpense(null);
+    setFormKey((prev) => prev + 1);
+    setIsFormOpen(true);
+  };
+
+  const openEditExpense = (expense: MatterExpense) => {
+    setEditingExpense(expense);
+    setFormKey((prev) => prev + 1);
+    setIsFormOpen(true);
+  };
+
+  const closeForm = () => {
+    setIsFormOpen(false);
+    setEditingExpense(null);
+  };
+
+  const handleSave = (values: ExpenseFormValues) => {
+    if (values.amount === undefined) return;
+    const nextExpense: MatterExpense = {
+      id: editingExpense?.id ?? ulid(),
+      description: values.description,
+      amount: Math.round(values.amount * 100),
+      date: values.date,
+      billable: values.billable
+    };
+
+    setExpenses((prev) => (
+      editingExpense
+        ? prev.map((expense) => (expense.id === editingExpense.id ? nextExpense : expense))
+        : [nextExpense, ...prev]
+    ));
+
+    closeForm();
+  };
+
+  const confirmDelete = (expense: MatterExpense) => {
+    setDeleteTarget(expense);
+  };
+
+  const handleDelete = () => {
+    if (!deleteTarget) return;
+    setExpenses((prev) => prev.filter((expense) => expense.id !== deleteTarget.id));
+    setDeleteTarget(null);
+    if (editingExpense?.id === deleteTarget.id) {
+      closeForm();
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-gray-200 dark:border-dark-border bg-white dark:bg-dark-card-bg">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 dark:border-white/10 px-6 py-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Expenses</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {sortedExpenses.length} recorded · {formatCurrency(totalExpenses / 100)} total · {formatCurrency(billableTotal / 100)} billable
+          </p>
+        </div>
+        <Button icon={<PlusIcon className="h-4 w-4" />} onClick={openNewExpense}>
+          Add expense
+        </Button>
+      </header>
+
+      {sortedExpenses.length === 0 ? (
+        <div className="px-6 py-6 text-sm text-gray-500 dark:text-gray-400">
+          No expenses yet. Add receipts, filing fees, or other costs tied to this matter.
+        </div>
+      ) : (
+        <ul className="divide-y divide-gray-200 dark:divide-white/10">
+          {sortedExpenses.map((expense) => {
+            const statusClass = expense.billable ? statusStyles.billable : statusStyles.nonbillable;
+            return (
+              <li key={expense.id} className="flex flex-wrap items-start justify-between gap-4 px-6 py-4">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                      {expense.description}
+                    </p>
+                    <span
+                      className={[
+                        statusClass,
+                        'whitespace-nowrap rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset'
+                      ].join(' ')}
+                    >
+                      {expense.billable ? 'Billable' : 'Not billable'}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-x-2 text-xs leading-5 text-gray-500 dark:text-gray-400">
+                    <span className="whitespace-nowrap">
+                      Date: <time dateTime={expense.date}>{formatExpenseDate(expense.date)}</time>
+                    </span>
+                    <svg viewBox="0 0 2 2" className="h-0.5 w-0.5 fill-current">
+                      <circle cx="1" cy="1" r="1" />
+                    </svg>
+                    <span className="truncate">Amount: {formatCurrency(expense.amount / 100)}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="hidden sm:inline-flex"
+                    onClick={() => openEditExpense(expense)}
+                  >
+                    Edit
+                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label="Open expense actions"
+                        icon={<EllipsisVerticalIcon className="h-4 w-4" />}
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-32">
+                      <div className="py-1">
+                        <DropdownMenuItem onSelect={() => openEditExpense(expense)}>
+                          <span className="flex items-center gap-2">
+                            <PencilIcon className="h-4 w-4" />
+                            Edit
+                          </span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onSelect={() => confirmDelete(expense)}>
+                          <span className="flex items-center gap-2 text-red-600 dark:text-red-400">
+                            <TrashIcon className="h-4 w-4" />
+                            Delete
+                          </span>
+                        </DropdownMenuItem>
+                      </div>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {isFormOpen && (
+        <Modal
+          isOpen={isFormOpen}
+          onClose={closeForm}
+          title={editingExpense ? 'Edit expense' : 'Add expense'}
+          contentClassName="max-w-2xl"
+        >
+          <ExpenseForm
+            key={`${editingExpense?.id ?? 'new'}-${formKey}`}
+            initialExpense={editingExpense ?? undefined}
+            onSubmit={handleSave}
+            onCancel={closeForm}
+            onDelete={editingExpense ? () => confirmDelete(editingExpense) : undefined}
+          />
+        </Modal>
+      )}
+
+      {deleteTarget && (
+        <Modal
+          isOpen={Boolean(deleteTarget)}
+          onClose={() => setDeleteTarget(null)}
+          title="Delete expense"
+          contentClassName="max-w-xl"
+        >
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Are you sure you want to delete this expense? This action cannot be undone.
+            </p>
+            <div className="flex items-center justify-end gap-3">
+              <Button variant="secondary" onClick={() => setDeleteTarget(null)}>
+                Cancel
+              </Button>
+              <Button onClick={handleDelete}>Delete expense</Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+};

--- a/src/features/matters/data/mockMatters.ts
+++ b/src/features/matters/data/mockMatters.ts
@@ -39,6 +39,7 @@ export type MatterDetail = MatterSummary & {
   tasks?: MatterTask[];
   contingencyPercent?: number;
   timeEntries?: TimeEntry[];
+  expenses?: MatterExpense[];
 };
 
 export type TimeEntry = {
@@ -46,6 +47,14 @@ export type TimeEntry = {
   startTime: string;
   endTime: string;
   description: string;
+};
+
+export type MatterExpense = {
+  id: string;
+  description: string;
+  amount: number;
+  date: string;
+  billable: boolean;
 };
 
 export type MatterOption = {
@@ -60,6 +69,9 @@ const hoursAgo = (hours: number) =>
 
 const daysAgo = (days: number, hours = 0) =>
   new Date(Date.now() - (days * 24 + hours) * 60 * 60 * 1000).toISOString();
+
+const daysAgoDate = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
 const daysFromNow = (days: number) =>
   new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
@@ -88,6 +100,20 @@ const buildTimeEntry = (
     description
   };
 };
+
+const buildExpense = (
+  id: string,
+  daysOffset: number,
+  description: string,
+  amount: number,
+  billable: boolean
+): MatterExpense => ({
+  id,
+  description,
+  amount,
+  date: daysAgoDate(daysOffset),
+  billable
+});
 
 export const mockClients: MatterOption[] = [
   { id: 'client-avery-chen', name: 'Avery Chen', email: 'avery.chen@blawby.com' },
@@ -261,6 +287,11 @@ export const mockMatterDetails: Record<string, MatterDetail> = {
       buildTimeEntry('time-entry-4', 3, '15:00', '16:15', 'Coordinated with secretary of state office.'),
       buildTimeEntry('time-entry-5', 4, '08:45', '10:00', 'Compiled entity name availability report.'),
       buildTimeEntry('time-entry-6', 6, '11:30', '13:00', 'Drafted engagement letter revisions.')
+    ],
+    expenses: [
+      buildExpense('expense-1', 1, 'State filing fee', 35000, true),
+      buildExpense('expense-2', 2, 'Registered agent renewal', 12500, true),
+      buildExpense('expense-3', 4, 'Courier delivery', 4200, false)
     ]
   },
   'matter-estate': {

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -27,6 +27,7 @@ import { MatterStatusDot } from '@/features/matters/components/MatterStatusDot';
 import { MatterStatusPill } from '@/features/matters/components/MatterStatusPill';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { TimeEntriesPanel } from '@/features/matters/components/time-entries/TimeEntriesPanel';
+import { MatterExpensesPanel } from '@/features/matters/components/expenses/MatterExpensesPanel';
 import { getUtcStartOfToday, parseDateOnlyUtc } from '@/shared/utils/dateOnly';
 
 const statusOrder: Record<MattersSidebarStatus, number> = {
@@ -38,7 +39,7 @@ const statusOrder: Record<MattersSidebarStatus, number> = {
 };
 
 type MatterTabId = 'all' | MattersSidebarStatus;
-type DetailTabId = 'overview' | 'time' | 'expenses' | 'notes' | 'edit' | 'invoice';
+type DetailTabId = 'overview' | 'time' | 'notes' | 'edit' | 'invoice';
 
 type SortOption = 'updated' | 'title' | 'status';
 
@@ -69,7 +70,6 @@ const TAB_HEADINGS: Record<MatterTabId, string> = {
 const DETAIL_TABS: Array<{ id: DetailTabId; label: string }> = [
   { id: 'overview', label: 'Overview' },
   { id: 'time', label: 'Time' },
-  { id: 'expenses', label: 'Expenses' },
   { id: 'notes', label: 'Notes' },
   { id: 'edit', label: 'Edit Matter' },
   { id: 'invoice', label: 'Generate Invoice' }
@@ -339,8 +339,9 @@ export const PracticeMattersPage = () => {
                 </div>
               </div>
             ) : detailTab === 'time' && selectedMatterDetail ? (
-              <div className="px-6 py-6">
-                <TimeEntriesPanel key={selectedMatterDetail.id} matter={selectedMatterDetail} />
+              <div className="px-6 py-6 space-y-6">
+                <TimeEntriesPanel key={`time-${selectedMatterDetail.id}`} matter={selectedMatterDetail} />
+                <MatterExpensesPanel key={`expenses-${selectedMatterDetail.id}`} matter={selectedMatterDetail} />
               </div>
             ) : (
               <div className="px-6 py-6 text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
### Motivation
- Migrate the expenses UI from the previous Vue implementation into the Preact matters flow and surface expenses alongside time entries in the Matter detail view.
- Reuse the app's existing shared UI primitives to keep the new components consistent and reusable across the codebase.

### Description
- Added a reusable `ExpenseForm` component at `src/features/matters/components/expenses/ExpenseForm.tsx` that uses existing `Input`, `CurrencyInput`, `DatePicker`, `Checkbox`, and `Button` components and emits normalized values (amount in dollars; caller stores cents).
- Added a `MatterExpensesPanel` at `src/features/matters/components/expenses/MatterExpensesPanel.tsx` which lists, creates, edits and deletes expenses using the shared `Modal` and dropdown primitives and handles totals and billable/non-billable status.
- Extended mock data with a `MatterExpense` type, `buildExpense` helper, and seeded expenses in `src/features/matters/data/mockMatters.ts` so the UI can render sample data locally.
- Integrated the expenses panel into the Matter detail `Time` tab by embedding `MatterExpensesPanel` in `src/features/matters/pages/PracticeMattersPage.tsx` and removed the standalone `Expenses` detail tab entry.

### Testing
- Ran linting with `npm run lint:src` and it completed without introduced warnings above the allowed threshold.
- Ran TypeScript checks with `npm run type-check` and there were no type errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772a013ba88321972ebad5aadcae7d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive expense management for matters, including the ability to create, edit, and delete expenses.
  * Expenses now display inline with time entries, showing key details such as description, date, amount, and billable status.
  * Added support for marking expenses as billable for better cost tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->