### PR TITLE
feat: expand frontend role contract to match backend (owner/admin/att…

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -42,6 +42,7 @@ import type { ConversationMetadata, ConversationMode } from '@/shared/types/conv
 import { logConversationEvent } from '@/shared/lib/conversationApi';
 import { LeadsPage } from '@/features/leads/pages/LeadsPage';
 import { hasLeadReviewPermission } from '@/shared/utils/leadPermissions';
+import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { PracticeHomePage } from '@/features/home/pages/PracticeHomePage';
 import { PracticePaymentsPage } from '@/features/payments/pages/PracticePaymentsPage';
 import { PracticePayoutsPage } from '@/features/payouts/pages/PracticePayoutsPage';
@@ -770,7 +771,7 @@ export function MainApp({
     window.localStorage.setItem(conversationCacheKey, conversationId);
   }, [conversationCacheKey, conversationId]);
 
-  const currentUserRole = activeMemberRole ?? 'member';
+  const currentUserRole = normalizePracticeRole(activeMemberRole) ?? 'member';
   const canReviewLeads = hasLeadReviewPermission(currentUserRole, currentPractice?.metadata ?? null);
 
 

--- a/src/features/pricing/pages/PracticePricingPage.tsx
+++ b/src/features/pricing/pages/PracticePricingPage.tsx
@@ -28,6 +28,7 @@ import {
 import Modal from '@/shared/components/Modal';
 import Message from '@/features/chat/components/Message';
 import type { IntakePaymentRequest } from '@/shared/utils/intakePayments';
+import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 
 const DEFAULT_PREVIEW_FEE = 150;
 
@@ -59,7 +60,8 @@ export const PracticePricingPage = () => {
   const checkoutPreviewRef = useRef<HTMLDivElement | null>(null);
 
   const locale = typeof navigator !== 'undefined' ? navigator.language : 'en';
-  const canEdit = activeMemberRole === 'owner' || activeMemberRole === 'admin';
+  const normalizedRole = normalizePracticeRole(activeMemberRole);
+  const canEdit = normalizedRole === 'owner' || normalizedRole === 'admin';
   const isReadOnly = !activeMemberRoleLoading && !canEdit;
 
   const pathSegments = location.path.split('/').filter(Boolean);

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -26,6 +26,7 @@ import type { PracticeDetails } from '@/shared/lib/apiClient';
 import { uploadPracticeLogo } from '@/shared/utils/practiceLogoUpload';
 import { buildPracticeProfilePayloads } from '@/shared/utils/practiceProfile';
 import { getFrontendHost } from '@/config/urls';
+import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import {
   usePracticeMembersSync,
   usePracticeSyncParamRefetch,
@@ -182,7 +183,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
   }, [practice, currentUserEmail, members, session?.user?.id]);
 
   const roleFromMembers = currentMember?.role ?? null;
-  const currentUserRole = activeMemberRole ?? roleFromMembers ?? 'member';
+  const currentUserRole = normalizePracticeRole(activeMemberRole) ?? roleFromMembers ?? 'member';
   const isOwner = currentUserRole === 'owner';
   const servicesList = useMemo(() => {
     const source = practiceDetails?.services ?? practice?.services;

--- a/src/shared/hooks/usePracticeManagement.ts
+++ b/src/shared/hooks/usePracticeManagement.ts
@@ -919,7 +919,7 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
       const rawInvitations = await listPracticeInvitations();
 
       // Define valid role and status values
-      const validRoles: Role[] = ['owner', 'admin', 'member'];
+      const validRoles: Role[] = ['owner', 'admin', 'attorney', 'paralegal', 'member', 'client'];
       const validStatuses: Array<'pending' | 'accepted' | 'declined'> = ['pending', 'accepted', 'declined'];
 
       const validatedInvitations = rawInvitations
@@ -1181,7 +1181,7 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
     const promise = (async () => {
       const data = await listPracticeMembers(practiceId);
       // Validate and normalize members manually
-    const validRoles: Role[] = ['owner', 'admin', 'member'];
+    const validRoles: Role[] = ['owner', 'admin', 'attorney', 'paralegal', 'member', 'client'];
 
       return (Array.isArray(data) ? data : [])
         .map(m => {

--- a/src/shared/ui/badges/RoleBadge.tsx
+++ b/src/shared/ui/badges/RoleBadge.tsx
@@ -5,7 +5,10 @@ import { getPracticeRoleLabel } from '@/shared/utils/practiceRoles';
 const ROLE_STYLES = {
   owner: 'bg-accent-500 text-gray-900',
   admin: 'bg-primary-500 text-white',
-  member: 'bg-emerald-500 text-white'
+  attorney: 'bg-blue-500 text-white',
+  paralegal: 'bg-indigo-500 text-white',
+  member: 'bg-emerald-500 text-white',
+  client: 'bg-gray-500 text-white'
 };
 
 interface RoleBadgeProps {

--- a/src/shared/ui/badges/__tests__/RoleBadge.test.tsx
+++ b/src/shared/ui/badges/__tests__/RoleBadge.test.tsx
@@ -14,17 +14,41 @@ describe('RoleBadge', () => {
   it('should render admin role with correct styling', () => {
     render(<RoleBadge roleType="admin" />);
     
-    const badge = screen.getByText('Lawyer');
+    const badge = screen.getByText('Admin');
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveClass('bg-primary-500', 'text-white');
+  });
+
+  it('should render attorney role with correct styling', () => {
+    render(<RoleBadge roleType="attorney" />);
+    
+    const badge = screen.getByText('Attorney');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('bg-blue-500', 'text-white');
+  });
+
+  it('should render paralegal role with correct styling', () => {
+    render(<RoleBadge roleType="paralegal" />);
+    
+    const badge = screen.getByText('Paralegal');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('bg-indigo-500', 'text-white');
   });
 
   it('should render member role with correct styling', () => {
     render(<RoleBadge roleType="member" />);
     
-    const badge = screen.getByText('Client');
+    const badge = screen.getByText('Member');
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveClass('bg-emerald-500', 'text-white');
+  });
+
+  it('should render client role with correct styling', () => {
+    render(<RoleBadge roleType="client" />);
+    
+    const badge = screen.getByText('Client');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('bg-gray-500', 'text-white');
   });
 
   it('should apply custom className when provided', () => {
@@ -35,12 +59,19 @@ describe('RoleBadge', () => {
   });
 
   it('should have consistent base classes for all roles', () => {
-    const roles = ['owner', 'admin', 'member'] as const;
+    const roles = ['owner', 'admin', 'attorney', 'paralegal', 'member', 'client'] as const;
     
     roles.forEach(role => {
       const { unmount } = render(<RoleBadge roleType={role} />);
-      const label = role === 'admin' ? 'Lawyer' : role === 'member' ? 'Client' : 'Owner';
-      const badge = screen.getByText(label);
+      const labels: Record<typeof role, string> = {
+        owner: 'Owner',
+        admin: 'Admin',
+        attorney: 'Attorney',
+        paralegal: 'Paralegal',
+        member: 'Member',
+        client: 'Client'
+      };
+      const badge = screen.getByText(labels[role]);
       
       expect(badge).toHaveClass(
         'px-2',

--- a/src/shared/utils/practiceRoles.ts
+++ b/src/shared/utils/practiceRoles.ts
@@ -1,15 +1,49 @@
-export type PracticeRole = 'owner' | 'admin' | 'member';
+export type PracticeRole = 'owner' | 'admin' | 'attorney' | 'paralegal' | 'member' | 'client';
 
 export const PRACTICE_ROLE_LABELS: Record<PracticeRole, string> = {
   owner: 'Owner',
-  admin: 'Lawyer',
-  member: 'Client'
+  admin: 'Admin',
+  attorney: 'Attorney',
+  paralegal: 'Paralegal',
+  member: 'Member',
+  client: 'Client'
+};
+
+/**
+ * Role hierarchy levels for permission gating.
+ * Higher numbers indicate more privileges.
+ */
+export const ROLE_LEVEL: Record<PracticeRole, number> = {
+  owner: 5,
+  admin: 4,
+  attorney: 3,
+  paralegal: 2,
+  member: 1,
+  client: 0
 };
 
 export const getPracticeRoleLabel = (role: PracticeRole): string => PRACTICE_ROLE_LABELS[role];
 
+/**
+ * Check if a role has at least the specified minimum level.
+ * @param role The role to check
+ * @param minRole The minimum required role
+ * @returns true if role >= minRole in the hierarchy
+ */
+export const hasRoleLevel = (role: PracticeRole | null, minRole: PracticeRole): boolean => {
+  if (!role) return false;
+  return ROLE_LEVEL[role] >= ROLE_LEVEL[minRole];
+};
+
+/**
+ * Role options for invitations and role editing.
+ * Note: 'client' is excluded from options as it cannot be assigned via UI.
+ * The backend may set 'client' role through other flows (intake/link/invite).
+ */
 export const PRACTICE_ROLE_OPTIONS: Array<{ value: PracticeRole; label: string }> = [
   { value: 'member', label: PRACTICE_ROLE_LABELS.member },
+  { value: 'paralegal', label: PRACTICE_ROLE_LABELS.paralegal },
+  { value: 'attorney', label: PRACTICE_ROLE_LABELS.attorney },
   { value: 'admin', label: PRACTICE_ROLE_LABELS.admin },
   { value: 'owner', label: PRACTICE_ROLE_LABELS.owner }
 ];
@@ -17,7 +51,14 @@ export const PRACTICE_ROLE_OPTIONS: Array<{ value: PracticeRole; label: string }
 export const normalizePracticeRole = (value: unknown): PracticeRole | null => {
   if (typeof value !== 'string') return null;
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'owner' || normalized === 'admin' || normalized === 'member') {
+  if (
+    normalized === 'owner' ||
+    normalized === 'admin' ||
+    normalized === 'attorney' ||
+    normalized === 'paralegal' ||
+    normalized === 'member' ||
+    normalized === 'client'
+  ) {
     return normalized;
   }
   return null;


### PR DESCRIPTION
…orney/paralegal/member/client)

- Expand PracticeRole type to include all 6 roles from Better Auth
- Add ROLE_LEVEL hierarchy map for permission gating
- Add hasRoleLevel utility for role comparison
- Update normalizePracticeRole to accept all 6 roles
- Update validRoles arrays in usePracticeManagement
- Add role styles for attorney, paralegal, and client in RoleBadge
- Normalize activeMemberRole in PracticePage, MainApp, and PracticePricingPage
- Update RoleBadge tests to cover all 6 roles
- Fix role labels: admin -> Admin, member -> Member (not 'Lawyer'/'Client')

This eliminates the 3-role assumption and prevents 'client' members from being filtered out with 'Invalid member role' errors. The frontend now accepts the full role set that the backend can return.