### PR TITLE
init preview home

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -30,7 +30,6 @@ import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { PracticeMattersPage } from '@/features/matters/pages/PracticeMattersPage';
 import { PracticeClientsPage } from '@/features/clients/pages/PracticeClientsPage';
 import { ClientMattersPage } from '@/features/matters/pages/ClientMattersPage';
-import AnnouncementBanner from '@/shared/components/AnnouncementBanner';
 import { useConversationSystemMessages } from '@/features/chat/hooks/useConversationSystemMessages';
 import WorkspaceConversationHeader from '@/features/chat/components/WorkspaceConversationHeader';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
@@ -115,30 +114,6 @@ export function MainApp({
     if (isPublicWorkspace) return resolvedPublicPracticeSlug ?? '';
     return practiceId;
   }, [isPublicWorkspace, practiceId, resolvedPublicPracticeSlug]);
-
-  const practiceBanner = useMemo(() => {
-    if (workspace !== 'practice') return null;
-    if (!currentPractice?.id) return null;
-
-    const stripeStatus = currentPractice.businessOnboardingStatus;
-    const stripeReady = stripeStatus === 'completed' || stripeStatus === 'not_required';
-    if (stripeReady) return null;
-
-    return (
-      <AnnouncementBanner
-        title="Almost ready to go"
-        actions={[
-          {
-            label: 'Set up payouts',
-            onClick: () => navigate('/settings/account/payouts'),
-            variant: 'primary' as const
-          }
-        ]}
-        tone="warning"
-        variant="flat"
-      />
-    );
-  }, [currentPractice, navigate, workspace]);
 
   useEffect(() => {
     setConversationId(null);
@@ -950,7 +925,6 @@ export function MainApp({
         />
       }
       clientsView={<PracticeClientsPage />}
-      header={practiceBanner ?? undefined}
     />
   ) : null;
 

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -3,7 +3,7 @@ import type { ComponentChildren } from 'preact';
 import { useMemo, useRef, useState, useEffect } from 'preact/hooks';
 import { useNavigation } from '@/shared/utils/navigation';
 import WorkspaceHomeView from '@/features/chat/views/WorkspaceHomeView';
-import WorkspaceNav from '@/features/chat/views/WorkspaceNav';
+import WorkspaceNav, { type WorkspaceNavTab } from '@/features/chat/views/WorkspaceNav';
 import ConversationListView from '@/features/chat/views/ConversationListView';
 import { SplitView } from '@/shared/ui/layout/SplitView';
 import { AppShell } from '@/shared/ui/layout/AppShell';
@@ -65,7 +65,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   headerClassName,
 }) => {
   const { navigate } = useNavigation();
-  const [previewTab, setPreviewTab] = useState<'home' | 'messages' | 'matters' | 'settings' | 'clients'>('home');
+  const [previewTab, setPreviewTab] = useState<WorkspaceNavTab>('home');
   const filteredMessages = useMemo(() => filterWorkspaceMessages(messages), [messages]);
   const isPracticeWorkspace = workspace === 'practice';
 
@@ -269,33 +269,11 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
 
   const renderContent = () => {
     if (workspace === 'practice' && view === 'home') {
-      const { currentPractice } = usePracticeManagement();
-      const { details: setupDetails } = usePracticeDetails(currentPractice?.id ?? null);
-      const setupStatus = resolvePracticeSetupStatus(currentPractice, setupDetails ?? null);
-
-      const handleSetupNavigate = (target: 'basics' | 'contact' | 'services' | 'payouts') => {
-        switch (target) {
-          case 'contact':
-            navigate('/settings/practice?setup=contact');
-            break;
-          case 'services':
-            navigate('/settings/practice/services');
-            break;
-          case 'payouts':
-            navigate('/settings/account/payouts');
-            break;
-          case 'basics':
-          default:
-            navigate('/settings/practice');
-            break;
-        }
-      };
-
       return (
-        <div className="flex h-full min-h-0 w-full overflow-hidden bg-white dark:bg-dark-bg">
+        <div className="flex h-full min-h-0 w-full flex-col overflow-y-auto lg:flex-row lg:overflow-hidden bg-white dark:bg-dark-bg">
           {/* Left: Setup Panel - Expanded */}
-          <div className="flex h-full flex-1 flex-col border-r border-light-border dark:border-dark-border">
-            <div className="flex-1 overflow-y-auto p-12">
+          <div className="flex min-h-0 flex-1 flex-col border-b border-light-border lg:border-b-0 lg:border-r dark:border-dark-border">
+            <div className="flex-1 overflow-y-auto p-6 md:p-12">
               <div className="mx-auto max-w-2xl">
                 <PracticeSetupBanner
                   status={setupStatus}
@@ -306,9 +284,9 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
           </div>
 
           {/* Right: Public View Preview - Focused */}
-          <div className="flex w-[500px] shrink-0 flex-col items-center justify-center bg-gray-50 p-8 dark:bg-black/20">
+          <div className="flex w-full shrink-0 flex-col items-center justify-center bg-gray-50 p-6 md:p-8 lg:w-[500px] dark:bg-black/20">
             <div className="mb-4 text-xs font-bold uppercase tracking-widest text-gray-400">Public Preview</div>
-            <div className="relative flex h-full max-h-[800px] w-full max-w-[400px] flex-col overflow-hidden rounded-[40px] border-[8px] border-gray-900 bg-white shadow-2xl transition-all dark:border-gray-800 dark:bg-dark-bg">
+            <div className="relative flex h-[600px] w-full max-w-[360px] flex-col overflow-hidden rounded-[40px] border-[8px] border-gray-900 bg-white shadow-2xl transition-all md:h-[700px] lg:h-full lg:max-h-[800px] lg:max-w-[400px] dark:border-gray-800 dark:bg-dark-bg">
               <div className="flex-1 overflow-y-auto">
                 {previewTab === 'home' ? (
                   <WorkspaceHomeView
@@ -326,7 +304,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
                   <div className="flex h-full flex-col items-center justify-center p-12 text-center text-gray-400">
                     <div className="mb-4 h-12 w-12 rounded-full bg-gray-100 dark:bg-white/5 flex items-center justify-center">
                       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                       </svg>
                     </div>
                     <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 capitalize">{previewTab}</h4>
@@ -337,11 +315,15 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
               <WorkspaceNav
                 variant="bottom"
                 activeTab={previewTab}
-                onSelectTab={(tab) => setPreviewTab(tab as any)}
+                onSelectTab={(tab) => setPreviewTab(tab)}
                 showClientTabs={true}
                 className="border-t-0 p-2"
               />
             </div>
+            {/* Mobile Helper Text */}
+            <p className="mt-6 text-center text-xs text-gray-400 lg:hidden">
+              This is a preview of your public-facing page.
+            </p>
           </div>
         </div>
       );
@@ -421,7 +403,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     : view === 'clients'
     ? 'clients'
     : view;
-  const handleSelectTab = (tab: 'home' | 'messages' | 'matters' | 'settings' | 'clients') => {
+  const handleSelectTab = (tab: WorkspaceNavTab) => {
     if (tab === 'messages') {
       void refreshConversations();
       navigate(conversationsPath);

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -316,7 +316,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
                 variant="bottom"
                 activeTab={previewTab}
                 onSelectTab={(tab) => setPreviewTab(tab)}
-                showClientTabs={true}
+                showClientTabs={showClientTabs}
+                showPracticeTabs={showPracticeTabs}
                 className="border-t-0 p-2"
               />
             </div>

--- a/src/features/chat/views/WorkspaceNav.tsx
+++ b/src/features/chat/views/WorkspaceNav.tsx
@@ -11,10 +11,12 @@ import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { Avatar } from '@/shared/ui/profile/atoms/Avatar';
 import { cn } from '@/shared/utils/cn';
 
+export type WorkspaceNavTab = 'home' | 'messages' | 'matters' | 'settings' | 'clients';
+
 interface WorkspaceNavProps {
   variant: 'bottom' | 'sidebar';
-  activeTab: 'home' | 'messages' | 'matters' | 'settings' | 'clients';
-  onSelectTab: (tab: 'home' | 'messages' | 'matters' | 'settings' | 'clients') => void;
+  activeTab: WorkspaceNavTab;
+  onSelectTab: (tab: WorkspaceNavTab) => void;
   showClientTabs?: boolean;
   showPracticeTabs?: boolean;
   className?: string;

--- a/src/features/practice-setup/components/PracticeSetupBanner.tsx
+++ b/src/features/practice-setup/components/PracticeSetupBanner.tsx
@@ -4,7 +4,7 @@ import type { PracticeSetupStatus } from '../utils/status';
 
 interface PracticeSetupBannerProps {
   status: PracticeSetupStatus;
-  onNavigate: (target: 'basics' | 'contact' | 'services') => void;
+  onNavigate: (target: 'basics' | 'contact' | 'services' | 'payouts') => void;
 }
 
 export const PracticeSetupBanner = ({ status, onNavigate }: PracticeSetupBannerProps) => {
@@ -31,6 +31,13 @@ export const PracticeSetupBanner = ({ status, onNavigate }: PracticeSetupBannerP
       description: 'Choose the services you want to intake.',
       complete: status.servicesComplete,
       actionLabel: 'Configure services'
+    },
+    {
+      id: 'payouts' as const,
+      label: 'Set up payouts',
+      description: 'Connect your Stripe account to receive payments.',
+      complete: status.payoutsComplete,
+      actionLabel: 'Set up payouts'
     }
   ];
 

--- a/src/features/practice-setup/utils/status.ts
+++ b/src/features/practice-setup/utils/status.ts
@@ -5,6 +5,7 @@ export interface PracticeSetupStatus {
   basicsComplete: boolean;
   contactComplete: boolean;
   servicesComplete: boolean;
+  payoutsComplete: boolean;
   needsSetup: boolean;
 }
 
@@ -22,11 +23,14 @@ export const resolvePracticeSetupStatus = (
     )
   );
   const servicesComplete = Boolean(details?.services && details.services.length > 0);
-  const needsSetup = !(basicsComplete && contactComplete && servicesComplete);
+  const stripeStatus = practice?.businessOnboardingStatus;
+  const payoutsComplete = stripeStatus === 'completed' || stripeStatus === 'not_required';
+  const needsSetup = !(basicsComplete && contactComplete && servicesComplete && payoutsComplete);
   return {
     basicsComplete,
     contactComplete,
     servicesComplete,
+    payoutsComplete,
     needsSetup
   };
 };

--- a/src/features/practice-setup/utils/status.ts
+++ b/src/features/practice-setup/utils/status.ts
@@ -24,7 +24,9 @@ export const resolvePracticeSetupStatus = (
   );
   const servicesComplete = Boolean(details?.services && details.services.length > 0);
   const stripeStatus = practice?.businessOnboardingStatus;
-  const payoutsComplete = stripeStatus === 'completed' || stripeStatus === 'not_required';
+  const payoutsComplete = stripeStatus === 'completed'
+    || stripeStatus === 'not_required'
+    || stripeStatus === 'skipped';
   const needsSetup = !(basicsComplete && contactComplete && servicesComplete && payoutsComplete);
   return {
     basicsComplete,

--- a/src/features/settings/pages/SettingsPage.tsx
+++ b/src/features/settings/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from 'preact-iso';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { AnimatePresence, motion } from 'framer-motion';
 import { GeneralPage } from './GeneralPage';
 import { NotificationsPage } from './NotificationsPage';

--- a/src/features/settings/pages/SettingsPage.tsx
+++ b/src/features/settings/pages/SettingsPage.tsx
@@ -35,11 +35,7 @@ import { signOut } from '@/shared/utils/auth';
 import { mockApps, type App } from './appsData';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useWorkspace } from '@/shared/hooks/useWorkspace';
-import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 import { AppShell, Page, Panel, SplitView } from '@/shared/ui/layout';
-import { PracticeSetupBanner } from '@/features/practice-setup/components/PracticeSetupBanner';
-import { resolvePracticeSetupStatus } from '@/features/practice-setup/utils/status';
-import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 
 
 export interface SettingsPageProps {
@@ -61,10 +57,6 @@ export const SettingsPage = ({
   const { isPending: sessionPending } = useSessionContext();
   const { canAccessPractice } = useWorkspace();
   const canShowPracticeSettings = canAccessPractice;
-  const { currentPractice } = usePracticeManagement();
-  const { details: setupDetails } = usePracticeDetails(currentPractice?.id ?? null);
-  const setupStatus = resolvePracticeSetupStatus(currentPractice, setupDetails ?? null);
-  const showSetupBanner = canShowPracticeSettings && setupStatus.needsSetup;
   
   // Get current page from URL path
   const getCurrentPage = () => {
@@ -177,20 +169,7 @@ export const SettingsPage = ({
     setApps((prev) => prev.map((app) => app.id === appId ? { ...app, ...updates } : app));
   };
 
-  const handleSetupNavigate = useCallback((target: 'basics' | 'contact' | 'services') => {
-    switch (target) {
-      case 'contact':
-        navigate('/settings/practice?setup=contact');
-        break;
-      case 'services':
-        navigate('/settings/practice/services');
-        break;
-      case 'basics':
-      default:
-        navigate('/settings/practice');
-        break;
-    }
-  }, [navigate]);
+  // Setup navigation logic moved to home page
 
   // Render content based on current page
   const renderContent = () => {
@@ -276,12 +255,7 @@ export const SettingsPage = ({
     </div>
   );
 
-  const setupBanner = showSetupBanner ? (
-    <PracticeSetupBanner
-      status={setupStatus}
-      onNavigate={handleSetupNavigate}
-    />
-  ) : null;
+  const setupBanner = null;
 
   const contentPanel = (
     <Page className="h-full min-h-0">

--- a/src/shared/hooks/usePaymentUpgrade.ts
+++ b/src/shared/hooks/usePaymentUpgrade.ts
@@ -206,7 +206,7 @@ export const usePaymentUpgrade = () => {
       params.set('practiceId', practiceId);
     }
     const query = params.toString();
-    return `/settings/practice${query ? `?${query}` : ''}`;
+    return `/${query ? `?${query}` : ''}`;
   }, []);
 
   const buildCancelUrl = useCallback((_practiceId?: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Practice workspace home now shows a setup panel with completion status and a public preview pane.
  * Added a payouts step to the practice setup workflow.

* **Refactor**
  * Streamlined practice setup UI and simplified header handling by removing the practice announcement banner.
  * Settings page no longer displays the practice setup banner.

* **Chore**
  * Payment upgrade success redirects now use the site root URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->