### PR TITLE
Lead flo

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -223,6 +223,13 @@ export function MainApp({
     loadMoreMessages, isSocketReady,
   } = messageHandling;
 
+  useEffect(() => {
+    const persistedMode = conversationMetadata?.mode;
+    if (persistedMode === 'ASK_QUESTION' || persistedMode === 'REQUEST_CONSULTATION') {
+      setConversationMode(persistedMode);
+    }
+  }, [conversationMetadata?.mode]);
+
   useEffect(() => { clearMessages(); }, [practiceId, clearMessages]);
 
   // ── intake auth prompt ─────────────────────────────────────────────────────

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -200,7 +200,10 @@ export function MainApp({
   }, []);
 
   const handleConversationMetadataUpdated = useCallback((metadata: ConversationMetadata | null) => {
-    if (metadata?.mode) setConversationMode(metadata.mode);
+    const persistedMode = metadata?.mode;
+    if (persistedMode === 'ASK_QUESTION' || persistedMode === 'REQUEST_CONSULTATION') {
+      setConversationMode(persistedMode);
+    }
   }, []);
 
   const messageHandling = useMessageHandling({
@@ -223,12 +226,7 @@ export function MainApp({
     loadMoreMessages, isSocketReady,
   } = messageHandling;
 
-  useEffect(() => {
-    const persistedMode = conversationMetadata?.mode;
-    if (persistedMode === 'ASK_QUESTION' || persistedMode === 'REQUEST_CONSULTATION') {
-      setConversationMode(persistedMode);
-    }
-  }, [conversationMetadata?.mode]);
+
 
   useEffect(() => { clearMessages(); }, [practiceId, clearMessages]);
 

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -560,11 +560,12 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
 
     useEffect(() => {
         // Update indices when new messages are added
-        if (isScrolledToBottomRef.current) {
+        const isNearTail = endIndex >= Math.max(0, dedupedMessages.length - 2);
+        if (isScrolledToBottomRef.current || isNearTail) {
             setEndIndex(dedupedMessages.length);
             setStartIndex(Math.max(0, dedupedMessages.length - BATCH_SIZE));
         }
-    }, [dedupedMessages.length]);
+    }, [dedupedMessages.length, endIndex]);
 
     useEffect(() => {
         // If server pagination is exhausted, show full local history instead of

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -635,20 +635,18 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
 
   const handleStartConversation = async (mode: ConversationMode) => {
     try {
-      // Find the most recent conversation (for both ASK_QUESTION and REQUEST_CONSULTATION).
-      // The home view already shows it as a "recent message" card, so navigating to it
-      // is the expected action. Only create a fresh conversation when none exist yet.
-      const latestConversation = conversations.length > 0
+      const shouldReuseConversation = mode !== 'REQUEST_CONSULTATION';
+      const latestConversation = shouldReuseConversation && conversations.length > 0
         ? [...conversations].sort((a, b) => {
-          const aTime = new Date(a.last_message_at ?? a.updated_at ?? a.created_at).getTime() || 0;
-          const bTime = new Date(b.last_message_at ?? b.updated_at ?? b.created_at).getTime() || 0;
-          return bTime - aTime;
-        })[0]
+            const aTime = new Date(a.last_message_at ?? a.updated_at ?? a.created_at).getTime() || 0;
+            const bTime = new Date(b.last_message_at ?? b.updated_at ?? b.created_at).getTime() || 0;
+            return bTime - aTime;
+          })[0]
         : null;
 
-      const preferredConversationId = latestConversation?.id;
-      // Only forceCreate when there really are no conversations yet.
-      const forceCreate = !preferredConversationId;
+      const preferredConversationId = shouldReuseConversation ? latestConversation?.id : undefined;
+      // Consultation CTA should start a fresh intake thread so mode/form state is deterministic.
+      const forceCreate = mode === 'REQUEST_CONSULTATION' || !preferredConversationId;
 
       const conversationId = await onStartNewConversation(
         mode,

--- a/src/shared/hooks/useChatComposer.ts
+++ b/src/shared/hooks/useChatComposer.ts
@@ -141,7 +141,8 @@ export const useChatComposer = ({
       timestamp: Date.now(), userId: null, reply_to_message_id: null,
       metadata: { source: 'ai' },
     };
-    setMessages(prev => [...prev, bubble]);
+    // Upsert to avoid duplicate streaming bubbles when a prior SSE turn left a stale bubble behind.
+    setMessages(prev => [...prev.filter(msg => msg.id !== bubbleId), bubble]);
   }, [setMessages]);
 
   const appendStreamingToken = useCallback((bubbleId: string, token: string) => {

--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -813,7 +813,12 @@ export const useConversation = ({
 
   const startConsultFlow = useCallback((targetConversationId?: string) => {
     if (!sessionReady || !targetConversationId || !practiceId) return;
-    void updateConversationMetadata({ intakeConversationState: initialIntakeState, intakeSlimContactDraft: null, intakeAiBriefActive: false }, targetConversationId);
+    void updateConversationMetadata({
+      mode: 'REQUEST_CONSULTATION',
+      intakeConversationState: initialIntakeState,
+      intakeSlimContactDraft: null,
+      intakeAiBriefActive: false
+    }, targetConversationId);
     consultFlowAbortRef.current?.abort();
     const controller = new AbortController();
     consultFlowAbortRef.current = controller;

--- a/tests/e2e/lead-flow.spec.ts
+++ b/tests/e2e/lead-flow.spec.ts
@@ -4,7 +4,9 @@ import { loadE2EConfig } from './helpers/e2eConfig';
 
 const e2eConfig = loadE2EConfig();
 const DEFAULT_PRACTICE_SLUG = process.env.E2E_PRACTICE_SLUG ?? process.env.E2E_WIDGET_SLUG ?? e2eConfig?.practice.slug ?? 'paul-yahoo';
-const MAX_AI_RESPONSE_MS = Number(process.env.E2E_WIDGET_AI_RESPONSE_BUDGET_MS ?? 30000);
+const rawBudget = process.env.E2E_WIDGET_AI_RESPONSE_BUDGET_MS;
+const parsedBudget = rawBudget ? parseInt(rawBudget, 10) : 30000;
+const MAX_AI_RESPONSE_MS = Number.isFinite(parsedBudget) ? parsedBudget : 30000;
 const LEAD_TURN_TIMEOUT_MS = MAX_AI_RESPONSE_MS;
 
 const normalizePracticeSlug = (value: string): string => {

--- a/tests/e2e/lead-flow.spec.ts
+++ b/tests/e2e/lead-flow.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from './fixtures';
 import { randomUUID } from 'crypto';
-import { waitForSession } from './helpers/auth';
 import { loadE2EConfig } from './helpers/e2eConfig';
 
 const e2eConfig = loadE2EConfig();
+const DEFAULT_PRACTICE_SLUG = process.env.E2E_PRACTICE_SLUG ?? process.env.E2E_WIDGET_SLUG ?? e2eConfig?.practice.slug ?? 'paul-yahoo';
+const MAX_AI_RESPONSE_MS = Number(process.env.E2E_WIDGET_AI_RESPONSE_BUDGET_MS ?? 30000);
+const LEAD_TURN_TIMEOUT_MS = MAX_AI_RESPONSE_MS;
 
 const normalizePracticeSlug = (value: string): string => {
   const trimmed = value.trim();
@@ -25,103 +27,365 @@ const normalizePracticeSlug = (value: string): string => {
 };
 
 test.describe('Lead intake workflow', () => {
-  test.describe.configure({ mode: 'serial', timeout: 90000 });
-  test.skip(!e2eConfig, 'E2E credentials are not configured.');
+  test.describe.configure({ timeout: 120000 });
 
-test('public intake prompts auth and lands on holding page', async ({
-  anonContext,
-  anonPage
-}, testInfo) => {
-  if (!e2eConfig) return;
+  test('public intake reaches submit CTA and submit button advances flow', async ({
+    anonPage,
+  }, testInfo) => {
+    const practiceSlug = normalizePracticeSlug(DEFAULT_PRACTICE_SLUG);
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
 
-  const practiceSlug = normalizePracticeSlug(e2eConfig.practice.slug);
-  await anonPage.goto(`/public/${encodeURIComponent(practiceSlug)}`, { waitUntil: 'domcontentloaded' });
-  await waitForSession(anonPage, { timeoutMs: 30000 });
+    anonPage.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    anonPage.on('pageerror', (error) => {
+      pageErrors.push(error.message);
+    });
 
-  const consoleErrors: string[] = [];
-  const consoleLogs: string[] = [];
-  anonPage.on('console', (msg) => {
-    const text = `[${msg.type()}] ${msg.text()}`;
-    if (msg.type() === 'error') {
-      consoleErrors.push(text);
-    } else {
-      consoleLogs.push(text);
+    await anonPage.goto(`/public/${encodeURIComponent(practiceSlug)}?v=widget`, { waitUntil: 'domcontentloaded' });
+
+    const messageInput = anonPage.getByTestId('message-input');
+    const consultationCta = anonPage.getByRole('button', { name: /request consultation/i }).first();
+    await consultationCta.click();
+
+    const slimFormName = anonPage.getByLabel('Name');
+    const slimFormEmail = anonPage.getByLabel('Email');
+    const slimFormPhone = anonPage.getByLabel('Phone');
+    const slimFormContinue = anonPage.getByRole('button', { name: /continue/i }).first();
+    const uniqueId = randomUUID().slice(0, 8);
+    await expect
+      .poll(
+        async () => {
+          const [nameVisible, inputVisible] = await Promise.all([
+            slimFormName.isVisible().catch(() => false),
+            messageInput.isVisible().catch(() => false),
+          ]);
+          return { nameVisible, inputVisible };
+        },
+        {
+          timeout: 10000,
+          message: 'Expected slim consultation form or chat composer to appear after Request Consultation.',
+        }
+      )
+      .not.toEqual({ nameVisible: false, inputVisible: false });
+    const slimFormVisible = await slimFormName.isVisible().catch(() => false);
+    if (slimFormVisible) {
+      await expect(slimFormName).toBeEditable({ timeout: 5000 });
+      await slimFormName.fill(`Lead E2E ${uniqueId}`);
+      await slimFormEmail.fill(`lead-e2e+${uniqueId}@example.com`);
+      await slimFormPhone.fill('555-555-1212');
+      await slimFormContinue.click();
     }
-  });
-  anonPage.on('pageerror', (error) => {
-    consoleErrors.push(`[pageerror] ${error.message}`);
-  });
 
-  await anonPage.getByRole('button', { name: /request consultation/i }).click();
-
-  const messageInput = anonPage.getByTestId('message-input');
-  await expect(messageInput).toBeEnabled({ timeout: 15000 });
-
-  const aiMessages = anonPage.getByTestId('ai-message');
-  const initialAiCount = await aiMessages.count();
-
-  await messageInput.fill('I need help with a divorce and custody issue. I am in Austin, TX.');
-  await anonPage.getByRole('button', { name: /send message/i }).click();
-
-  const expectedCount = initialAiCount + 1;
-  await expect(aiMessages).toHaveCount(expectedCount, { timeout: 30000 });
-  const latestAiText = await aiMessages.nth(expectedCount - 1).innerText();
-  if (latestAiText.includes('I wasn\'t able to generate a response')) {
-    await testInfo.attach('ai-fallback', { body: latestAiText, contentType: 'text/plain' });
-    if (consoleLogs.length) {
-      await testInfo.attach('console-logs', { body: consoleLogs.join('\n'), contentType: 'text/plain' });
+    const captureLeadFlowState = async () => {
+      return anonPage.evaluate(() => {
+        const bodyText = document.body?.innerText ?? '';
+        const allButtons = Array.from(document.querySelectorAll('button'))
+          .map((el) => (el.textContent ?? '').trim())
+          .filter(Boolean)
+          .slice(-20);
+        const aiMessages = Array.from(document.querySelectorAll('[data-testid="ai-message"]'))
+          .map((el) => (el.textContent ?? '').trim())
+          .slice(-5);
+        const systemMessages = Array.from(document.querySelectorAll('[data-testid="system-message"]'))
+          .map((el) => (el.textContent ?? '').trim())
+          .slice(-5);
+        const userMessages = Array.from(document.querySelectorAll('[data-testid="user-message"]'))
+          .map((el) => (el.textContent ?? '').trim())
+          .slice(-5);
+        return {
+          url: window.location.href,
+          title: document.title,
+          bodySnippet: bodyText.slice(-1500),
+          buttons: allButtons,
+          recentMessages: { userMessages, aiMessages, systemMessages },
+        };
+      });
+    };
+    try {
+      await expect(messageInput).toBeEnabled({ timeout: 45000 });
+    } catch (error) {
+      const entryDebug = await captureLeadFlowState();
+      console.log('[lead-flow] Entry debug:', JSON.stringify(entryDebug, null, 2));
+      await testInfo.attach('lead-flow-entry-debug.json', {
+        body: JSON.stringify(entryDebug, null, 2),
+        contentType: 'application/json',
+      });
+      throw error;
     }
+    const bodyLocator = anonPage.locator('body');
+    const submitNowButton = anonPage.getByRole('button', { name: /submit request/i });
+    const buildBriefButton = anonPage.getByRole('button', { name: /build stronger brief/i });
+    const aiTranscript: Array<{ prompt?: string; user: string; contentType: string; replyText: string }> = [];
+
+    const sendAndAwaitAi = async (text: string) => {
+      const aiLocator = anonPage.locator('[data-testid="ai-message"], [data-testid="system-message"]');
+      const streamingLocator = anonPage.locator('[id^="message-streaming-"]');
+      const getLatestMeaningfulAiText = async () => {
+        const texts = await aiLocator.evaluateAll((els) => els.map((el) => (el.textContent ?? '').trim()));
+        for (let i = texts.length - 1; i >= 0; i -= 1) {
+          const candidate = texts[i]?.trim() ?? '';
+          if (!candidate) continue;
+          if (/loading markdown/i.test(candidate)) continue;
+          return candidate;
+        }
+        return texts[texts.length - 1] ?? '';
+      };
+      const aiSignatureBefore = JSON.stringify(
+        await aiLocator.evaluateAll((els) => els.map((el) => (el.textContent ?? '').trim()))
+      );
+      const responsePromise = anonPage.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST'
+          && response.url().includes('/api/ai/chat')
+          && response.status() === 200,
+        { timeout: LEAD_TURN_TIMEOUT_MS }
+      );
+      await messageInput.fill(text);
+      await anonPage.getByRole('button', { name: /send message/i }).click();
+      const response = await responsePromise;
+      const contentType = response.headers()['content-type'] ?? '';
+      const responseTextPromise = !contentType.includes('application/json')
+        ? response.text().catch(() => '')
+        : Promise.resolve('');
+      const body = contentType.includes('application/json')
+        ? await response.json().catch(() => null) as { reply?: string; message?: { content?: string } } | null
+        : null;
+      if (!contentType.includes('application/json')) {
+        try {
+          await expect
+            .poll(
+              async () => {
+                const [aiSignature, streamingCount] = await Promise.all([
+                  aiLocator.evaluateAll((els) => JSON.stringify(els.map((el) => (el.textContent ?? '').trim()))),
+                  streamingLocator.count(),
+                ]);
+                return { aiSignature, streamingCount };
+              },
+              {
+                timeout: LEAD_TURN_TIMEOUT_MS,
+                message: 'Expected streaming bubble or rendered AI/system message after SSE response started.',
+              }
+            )
+            .not.toEqual({ aiSignature: aiSignatureBefore, streamingCount: 0 });
+        } catch (error) {
+          const sseBody = await responseTextPromise;
+          throw new Error(
+            `SSE response started but no UI progress within ${LEAD_TURN_TIMEOUT_MS}ms.\n` +
+            `SSE body (tail): ${sseBody.slice(-800)}\n` +
+            `Original error: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
+      const visibleAiMessages = aiLocator;
+      const visibleAiCount = await aiLocator.count();
+      let latestVisibleAiText = visibleAiCount > 0 ? await getLatestMeaningfulAiText() : '';
+      if (!contentType.includes('application/json') && /loading markdown/i.test(latestVisibleAiText)) {
+        await expect
+          .poll(
+            getLatestMeaningfulAiText,
+            {
+              timeout: LEAD_TURN_TIMEOUT_MS,
+              message: 'AI reply stayed on "Loading markdown..." and never settled.',
+            }
+          )
+          .not.toContain('Loading markdown');
+        latestVisibleAiText = await getLatestMeaningfulAiText();
+      }
+      if (!contentType.includes('application/json')) {
+        // Ensure the SSE turn settles into a non-placeholder rendered reply.
+        await expect
+          .poll(
+            getLatestMeaningfulAiText,
+            {
+              timeout: LEAD_TURN_TIMEOUT_MS,
+              message: 'SSE AI reply did not settle into a rendered non-empty message.',
+            }
+          )
+          .not.toMatch(/^\s*$|loading markdown/i);
+        latestVisibleAiText = await getLatestMeaningfulAiText();
+      }
+      return {
+        response,
+        contentType,
+        responseText: contentType.includes('application/json') ? '' : await responseTextPromise,
+        replyText: body?.reply ?? body?.message?.content ?? latestVisibleAiText,
+      };
+    };
+
+    const getLatestAiPromptText = async () => {
+      const aiLocator = anonPage.locator('[data-testid="ai-message"], [data-testid="system-message"]');
+      const count = await aiLocator.count();
+      if (count === 0) return '';
+      return (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+    };
+
+    const answered = new Set<string>();
+    const defaultSituation =
+      'I am going through a divorce and my wife is asking for most of our money and assets. I need help protecting my finances and getting a fair outcome.';
+
+    const pickAnswerForPrompt = (rawPrompt: string): string => {
+      const prompt = rawPrompt.toLowerCase();
+      if (/ready to submit|submit your request|continue now/.test(prompt)) return 'Submit request';
+      if (/legal situation|what'?s going on|describe what'?s going on|tell me a bit/.test(prompt)) {
+        answered.add('situation');
+        return defaultSituation;
+      }
+      if (/city and state|what city|where.*(located|live)|what state/.test(prompt)) {
+        answered.add('location');
+        return 'durham nc';
+      }
+      if (/deadline|court date/.test(prompt)) {
+        answered.add('deadlines');
+        return 'not that i know of';
+      }
+      if (/another party involved|other party involved/.test(prompt)) {
+        answered.add('party-involved');
+        return 'yes, my wife ashley luke';
+      }
+      if (/only other party|only party involved/.test(prompt)) {
+        answered.add('party-only');
+        return 'yes, only my wife';
+      }
+      if (/what outcome|hoping for|what do you want/.test(prompt)) {
+        answered.add('outcome');
+        return 'I want to protect my assets and keep as much of my money as possible';
+      }
+      if (/documents|paperwork|files/.test(prompt)) {
+        answered.add('documents');
+        return 'not yet';
+      }
+      if (/anything else|other details|add anything/.test(prompt)) {
+        answered.add('other-details');
+        return 'No, that covers the main issue right now.';
+      }
+      if (!answered.has('situation')) {
+        answered.add('situation');
+        return defaultSituation;
+      }
+      if (!answered.has('location')) {
+        answered.add('location');
+        return 'durham nc';
+      }
+      if (!answered.has('deadlines')) {
+        answered.add('deadlines');
+        return 'not that i know of';
+      }
+      if (!answered.has('party-involved')) {
+        answered.add('party-involved');
+        return 'yes, my wife ashley luke';
+      }
+      if (!answered.has('outcome')) {
+        answered.add('outcome');
+        return 'I want to protect my assets and keep as much of my money as possible';
+      }
+      return 'No additional details right now.';
+    };
+
+    let reachedSubmitReady = false;
+    const MAX_INTAKE_TURNS = 12;
+    for (let index = 0; index < MAX_INTAKE_TURNS; index += 1) {
+      const submitVisibleBefore = await submitNowButton.isVisible().catch(() => false);
+      const buildVisibleBefore = await buildBriefButton.isVisible().catch(() => false);
+      const bodyTextBefore = await bodyLocator.innerText().catch(() => '');
+      const readyPromptBefore = /ready to submit|submit your request|would you like to continue now/i.test(bodyTextBefore);
+      if (submitVisibleBefore || (buildVisibleBefore && readyPromptBefore)) {
+        reachedSubmitReady = true;
+        break;
+      }
+
+      const promptText = await getLatestAiPromptText();
+      const answer = pickAnswerForPrompt(promptText);
+      let aiStep;
+      try {
+        aiStep = await sendAndAwaitAi(answer);
+      } catch (error) {
+        const debug = await captureLeadFlowState();
+        await testInfo.attach(`lead-flow-step-${index + 1}-debug.json`, {
+          body: JSON.stringify({ step: index + 1, promptText, answer, debug, aiTranscript }, null, 2),
+          contentType: 'application/json',
+        });
+        console.log('[lead-flow] Step failure:', JSON.stringify({ step: index + 1, promptText, answer, debug, aiTranscript }, null, 2));
+        throw error;
+      }
+      aiTranscript.push({
+        prompt: promptText,
+        user: answer,
+        contentType: aiStep.contentType,
+        replyText: aiStep.replyText,
+      });
+      if (aiStep.replyText && aiStep.replyText.includes("I wasn't able to generate a response")) {
+        throw new Error(`AI fallback response detected: ${aiStep.replyText}`);
+      }
+
+      const submitVisible = await submitNowButton.isVisible().catch(() => false);
+      const buildVisible = await buildBriefButton.isVisible().catch(() => false);
+      const bodyText = await bodyLocator.innerText().catch(() => '');
+      const readyPrompt = /ready to submit|submit your request|would you like to continue now/i.test(bodyText);
+      if (submitVisible || (buildVisible && readyPrompt)) {
+        reachedSubmitReady = true;
+        break;
+      }
+    }
+
+    if (!reachedSubmitReady) {
+      const debug = await captureLeadFlowState();
+      await testInfo.attach('lead-flow-cta-debug.json', {
+        body: JSON.stringify(debug, null, 2),
+        contentType: 'application/json',
+      });
+      await testInfo.attach('lead-flow-ai-transcript.json', {
+        body: JSON.stringify(aiTranscript, null, 2),
+        contentType: 'application/json',
+      });
+      console.log('[lead-flow] CTA debug:', JSON.stringify(debug, null, 2));
+      console.log('[lead-flow] AI transcript:', JSON.stringify(aiTranscript, null, 2));
+      throw new Error('Intake did not reach a submit-ready CTA state after scripted intake answers.');
+    }
+
+    await expect(submitNowButton).toBeVisible({ timeout: 10000 });
+    const buildBriefVisibleAtSubmit = await buildBriefButton.isVisible().catch(() => false);
+    if (!buildBriefVisibleAtSubmit) {
+      console.log('[lead-flow] Build stronger brief CTA not visible in this run (submit CTA present).');
+    }
+
+    await submitNowButton.click();
+
+    // Deterministic CTA path should advance to auth/save flow (modal/overlay) or auth route.
+    // We intentionally avoid hardcoding a single UI variant because this path may be modal
+    // or route-based depending on environment/widget context.
+    await expect
+      .poll(
+        async () => {
+          const state = await captureLeadFlowState();
+          const body = (state.bodySnippet || '').toLowerCase();
+          const href = (state.url || '').toLowerCase();
+          const buttons = (state.buttons || []).join(' | ').toLowerCase();
+          const authOverlay = body.includes('save your conversation') || buttons.includes('sign up / sign in');
+          const authForm = body.includes('continue with google') || body.includes('continue with email');
+          const authRoute = href.includes('/auth');
+          return authOverlay || authForm || authRoute;
+        },
+        {
+          timeout: 15000,
+          message:
+            'Submit request CTA did not advance to auth/save flow. ' +
+            'Expected auth overlay/modal or auth route after clicking Submit request.',
+        }
+      )
+      .toBe(true);
+
     if (consoleErrors.length) {
       await testInfo.attach('console-errors', { body: consoleErrors.join('\n'), contentType: 'text/plain' });
     }
-    throw new Error('AI fallback response detected during intake flow.');
-  }
-
-  const readyButton = anonPage.getByRole('button', { name: /yes, i'm ready/i });
-  await expect(readyButton).toBeVisible({ timeout: 30000 });
-  await readyButton.click();
-
-  await expect(anonPage.getByTestId('address-experience-form')).toBeVisible({ timeout: 15000 });
-
-  const uniqueId = randomUUID().slice(0, 8);
-  const email = `e2e+${uniqueId}@example.com`;
-  const password = `Test${uniqueId}!23`;
-
-  await anonPage.getByLabel('Name').fill(`E2E Lead ${uniqueId}`);
-  await anonPage.getByLabel('Email').fill(email);
-  await anonPage.getByLabel('Phone').fill('555-555-1212');
-  await anonPage.getByLabel('City').fill('Austin');
-  await anonPage.getByLabel('State').fill('TX');
-
-    const inviteResponsePromise = anonPage.waitForResponse((response) => (
-      response.request().method() === 'POST'
-      && response.url().includes('/api/practice/client-intakes/')
-      && response.url().endsWith('/invite')
-    ), { timeout: 30000 });
-
-  await anonPage.getByTestId('contact-form-submit-footer').click();
-
-    await expect(anonPage.getByText('Contact Information:', { exact: false })).toBeVisible({ timeout: 15000 });
-    await expect(anonPage.getByRole('button', { name: 'Continue to finish intake' })).toBeVisible({ timeout: 15000 });
-
-    await anonPage.getByRole('button', { name: 'Continue to finish intake' }).click();
-
-    await expect(
-      anonPage.getByLabel(/full name|name/i)
-    ).toBeVisible({ timeout: 15000 });
-
-    await anonPage.getByLabel(/name/i).fill(`E2E ${uniqueId}`);
-    await anonPage.getByLabel(/email/i).fill(email);
-    await anonPage.getByLabel(/password/i).first().fill(password);
-    await anonPage.getByLabel(/confirm/i).fill(password);
-    await anonPage.getByTestId('signup-submit-button').click();
-
-    await anonPage.waitForURL(/\/auth\/awaiting-invite/);
-
-    const inviteResponse = await inviteResponsePromise;
-    if (!inviteResponse.ok()) {
-      const bodyText = await inviteResponse.text().catch(() => '');
-      throw new Error(`Invite trigger failed: ${inviteResponse.status()} ${bodyText}`);
+    if (pageErrors.length) {
+      await testInfo.attach('page-errors', { body: pageErrors.join('\n'), contentType: 'text/plain' });
     }
+
+    expect(
+      pageErrors.filter((e) => !e.includes('Chat connection closed')),
+      `Unexpected page errors:\n${pageErrors.join('\n')}`
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request consultation now opens in a modal dialog and shows the slim contact form there; in-modal flow replaces the prior drawer path and hides the in-frame composer when active.
  * AI streaming adds per-read timeouts and automatic fallback replies when streams stall.

* **Bug Fixes**
  * Prevents duplicate streaming message bubbles via upsert behavior.
  * Conversation metadata updates now only change local mode for specific consult/question modes; consult flows explicitly mark mode and always start fresh while other flows may reuse recent conversations.

* **Tests**
  * Expanded e2e lead intake tests to cover widget-based slim-form flows with enhanced debugging and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->