### PR TITLE
Standardize Heroicon rendering through shared Icon

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -603,7 +603,7 @@ export function MainApp({
           window.dispatchEvent(new CustomEvent('workspace:open-inspector'));
         }}
         aria-label="Open inspector"
-        icon={<InformationCircleIcon className="h-5 w-5" />}
+        icon={InformationCircleIcon} iconClassName="h-5 w-5"
       />
     );
     if (isPracticeWorkspace) {

--- a/src/features/chat/components/BriefStrengthIndicator.tsx
+++ b/src/features/chat/components/BriefStrengthIndicator.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'preact';
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -121,7 +122,7 @@ const BriefStrengthIndicator: FunctionComponent<BriefStrengthIndicatorProps> = (
               />
             </svg>
             <span className="absolute inset-0 flex items-center justify-center">
-              <InformationCircleIcon className="h-3.5 w-3.5 text-input-text/80" aria-hidden="true" />
+              <Icon icon={InformationCircleIcon} className="h-3.5 w-3.5 text-input-text/80" aria-hidden="true"  />
             </span>
           </span>
         </Button>

--- a/src/features/chat/components/LinkMatterModal.tsx
+++ b/src/features/chat/components/LinkMatterModal.tsx
@@ -3,6 +3,7 @@ import Modal from '@/shared/components/Modal';
 import { Button } from '@/shared/ui/Button';
 import { Combobox } from '@/shared/ui/input/Combobox';
 import { FolderIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { listMatters, getMatter } from '@/features/matters/services/mattersApi';
 import { updateConversationMatter } from '@/shared/lib/apiClient';
 import type { Conversation } from '@/shared/types/conversation';
@@ -231,8 +232,8 @@ export const LinkMatterModal = ({
             options={matterOptions}
             onChange={setSelectedMatterId}
             disabled={saving || loadingState === 'loading'}
-            leading={() => <FolderIcon className="h-4 w-4 text-input-placeholder" />}
-            optionLeading={() => <FolderIcon className="h-4 w-4 text-input-placeholder" />}
+            leading={() => <Icon icon={FolderIcon} className="h-4 w-4 text-input-placeholder"  />}
+            optionLeading={() => <Icon icon={FolderIcon} className="h-4 w-4 text-input-placeholder"  />}
           />
           {loadingState === 'loading' && (
             <div className="text-xs text-gray-500 dark:text-gray-400">Loading matters…</div>

--- a/src/features/chat/components/Message.tsx
+++ b/src/features/chat/components/Message.tsx
@@ -10,6 +10,7 @@ import { MessageAttachments } from './MessageAttachments';
 import { MessageActions } from './MessageActions';
 import type { ReplyTarget } from '@/features/chat/types';
 import { ArrowUturnLeftIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { chatTypography } from '@/features/chat/styles/chatTypography';
 import type { IntakeConversationState } from '@/shared/types/intake';
@@ -241,7 +242,7 @@ const Message: FunctionComponent<MessageProps> = memo(({
 							aria-label="Reply to message"
 							onClick={onReply}
 						>
-							<ArrowUturnLeftIcon className="h-4 w-4" />
+							<Icon icon={ArrowUturnLeftIcon} className="h-4 w-4"  />
 						</button>
 					)}
 				</div>

--- a/src/features/chat/components/MessageActions.tsx
+++ b/src/features/chat/components/MessageActions.tsx
@@ -6,6 +6,7 @@ import type { IntakePaymentRequest } from '@/shared/utils/intakePayments';
 import DocumentChecklist from '@/features/intake/components/DocumentChecklist';
 import MatterCanvas from '@/features/matters/components/MatterCanvas';
 import { DocumentIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { formatDocumentIconSize } from '@/features/chat/utils/fileUtils';
 import { Button } from '@/shared/ui/Button';
 import type { IntakeConversationState } from '@/shared/types/intake';
@@ -334,7 +335,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 				<div className="my-2">
 					<div className="flex items-center gap-2 p-3 rounded-lg glass-panel">
 						<div className="w-8 h-8 rounded bg-white/10 flex items-center justify-center flex-shrink-0">
-							<DocumentIcon className="w-4 h-4 text-input-text" />
+							<Icon icon={DocumentIcon} className="w-4 h-4 text-input-text"  />
 						</div>
 						<div className="flex-1 min-w-0">
 							<div className="text-sm font-medium text-input-text whitespace-nowrap overflow-hidden text-ellipsis" title={generatedPDF.filename}>

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -188,7 +188,7 @@ const MessageComposer = ({
                 className="h-6 w-6 rounded-full"
                 aria-label="Cancel reply"
                 onClick={() => onCancelReply?.()}
-                icon={<XMarkIcon className="h-4 w-4" />}
+                icon={XMarkIcon} iconClassName="h-4 w-4"
               />
             </div>
           )}
@@ -266,7 +266,7 @@ const MessageComposer = ({
                         ? 'Send message (disabled)'
                         : 'Send message')}
                 className={`w-8 h-8 p-0 rounded-full shrink-0 ${isInputExpanded ? 'self-end' : 'self-center'} transition ${isInputFocused && !sendDisabled ? 'ring-2 ring-accent-500/50 shadow-[0_0_0_2px_rgba(255,196,0,0.15)]' : ''}`}
-                icon={<ArrowUpIcon className="w-3.5 h-3.5" aria-hidden="true" />}
+                icon={ArrowUpIcon} iconClassName="w-3.5 h-3.5"
                 data-testid="message-send-button"
               />
             </div>

--- a/src/features/chat/components/PracticeConversationHeaderMenu.tsx
+++ b/src/features/chat/components/PracticeConversationHeaderMenu.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, Fragment } from 'preact';
 import { useState } from 'preact/hooks';
 import { LinkIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -40,7 +41,7 @@ const PracticeConversationHeaderMenu: FunctionComponent<PracticeConversationHead
             className="border border-line-glass/30 bg-white/[0.08] hover:bg-white/[0.12]"
             aria-label="Conversation actions"
           >
-            <LinkIcon className="h-4 w-4" aria-hidden="true" />
+            <Icon icon={LinkIcon} className="h-4 w-4" aria-hidden="true"  />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect, useState, useCallback, useLayoutEffect, useMemo } fr
 import Message from './Message';
 import { memo } from 'preact/compat';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { debounce } from '@/shared/utils/debounce';
 import { ErrorBoundary } from '@/app/ErrorBoundary';
 import { ChatMessageUI } from '../../../../worker/types';
@@ -940,7 +941,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
                 onClick={scrollToBottom}
                 aria-label="Scroll to latest message"
             >
-                <ChevronDownIcon className="h-5 w-5" />
+                <Icon icon={ChevronDownIcon} className="h-5 w-5"  />
             </button>
         )}
         </div>

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1503,7 +1503,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       size="icon-sm"
       onClick={() => setIsMobileNavOpen(true)}
       aria-label="Open navigation menu"
-      icon={<Bars3Icon className="h-5 w-5" />}
+      icon={Bars3Icon} iconClassName="h-5 w-5"
     />
   ) : null;
   const inspectorToggleButton = inspectorTarget ? (
@@ -1513,7 +1513,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       size="icon-sm"
       onClick={() => setIsInspectorOpen(true)}
       aria-label="Open inspector"
-      icon={<InformationCircleIcon className="h-5 w-5" />}
+      icon={InformationCircleIcon} iconClassName="h-5 w-5"
     />
   ) : null;
   const mobileConversationHeaderLeftControl = layoutMode !== 'desktop' && mobileMenuButton

--- a/src/features/chat/utils/fileUtils.tsx
+++ b/src/features/chat/utils/fileUtils.tsx
@@ -4,6 +4,7 @@ import {
 	MusicalNoteIcon,
 	VideoCameraIcon
 } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { FileAttachment } from '../../../../worker/types';
 import type { VNode } from 'preact';
 
@@ -24,7 +25,7 @@ export const getDocumentIcon = (file: FileAttachment): VNode => {
 	// PDF icon
 	if (file.type === 'application/pdf' || ext === 'pdf') {
 		return (
-			<DocumentIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+			<Icon icon={DocumentIcon} className="w-4 h-4 text-gray-600 dark:text-gray-400"  />
 		);
 	}
 
@@ -33,7 +34,7 @@ export const getDocumentIcon = (file: FileAttachment): VNode => {
 		file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
 		ext === 'doc' || ext === 'docx') {
 		return (
-			<DocumentIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+			<Icon icon={DocumentIcon} className="w-4 h-4 text-gray-600 dark:text-gray-400"  />
 		);
 	}
 
@@ -42,27 +43,27 @@ export const getDocumentIcon = (file: FileAttachment): VNode => {
 		file.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
 		ext === 'xls' || ext === 'xlsx' || ext === 'csv') {
 		return (
-			<TableCellsIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+			<Icon icon={TableCellsIcon} className="w-4 h-4 text-gray-600 dark:text-gray-400"  />
 		);
 	}
 
 	// Audio file icon
 	if (file.type?.startsWith('audio/')) {
 		return (
-			<MusicalNoteIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+			<Icon icon={MusicalNoteIcon} className="w-4 h-4 text-gray-600 dark:text-gray-400"  />
 		);
 	}
 
 	// Video file icon
 	if (file.type?.startsWith('video/')) {
 		return (
-			<VideoCameraIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+			<Icon icon={VideoCameraIcon} className="w-4 h-4 text-gray-600 dark:text-gray-400"  />
 		);
 	}
 
 	// Default file icon
 	return (
-		<DocumentIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+		<Icon icon={DocumentIcon} className="w-4 h-4 text-gray-600 dark:text-gray-400"  />
 	);
 };
 

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, type ComponentChildren } from 'preact';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeftIcon, PaperAirplaneIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Avatar } from '@/shared/ui/profile/atoms/Avatar';
 import { Button } from '@/shared/ui/Button';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
@@ -102,7 +103,7 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
               className="workspace-header__icon"
               aria-label={t('common.back')}
             >
-              <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
+              <Icon icon={ChevronLeftIcon} className="h-4 w-4" aria-hidden="true"  />
             </Button>
           ) : null}
           {showTitle ? (
@@ -217,7 +218,7 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
             variant="primary"
             size="lg"
             className="w-full"
-            icon={<PaperAirplaneIcon className="h-4 w-4" aria-hidden="true" />}
+            icon={PaperAirplaneIcon} iconClassName="h-4 w-4"
             iconPosition="right"
             onClick={onSendMessage}
           >

--- a/src/features/chat/views/WorkspaceDashboardView.tsx
+++ b/src/features/chat/views/WorkspaceDashboardView.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircleIcon,
   ChartBarIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Button } from '@/shared/ui/Button';
 
 type IconComponent = typeof ChatBubbleLeftRightIcon;
@@ -110,7 +111,7 @@ export const WorkspaceDashboardView: FunctionComponent<{
             </div>
             <div className="p-12 text-center">
               <div className="w-16 h-16 bg-surface-panel/40 rounded-full flex items-center justify-center mx-auto mb-4">
-                <CheckCircleIcon className="w-8 h-8 text-input-placeholder" />
+                <Icon icon={CheckCircleIcon} className="w-8 h-8 text-input-placeholder"  />
               </div>
               <p className="text-input-placeholder text-sm">No recent activity found. Once you share your intake link, you&apos;ll see updates here.</p>
             </div>

--- a/src/features/chat/views/WorkspaceHomeView.tsx
+++ b/src/features/chat/views/WorkspaceHomeView.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'preact';
 import { useTranslation } from 'react-i18next';
 import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Avatar } from '@/shared/ui/profile/atoms/Avatar';
 import { Button } from '@/shared/ui/Button';
 
@@ -123,7 +124,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
             className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-accent-500 text-[rgb(var(--accent-foreground))] pointer-events-none transition-all duration-300 group-hover:scale-110 group-hover:shadow-accent-500/40"
             aria-hidden="true"
           >
-            <PaperAirplaneIcon className="h-5 w-5" aria-hidden="true" />
+            <Icon icon={PaperAirplaneIcon} className="h-5 w-5" aria-hidden="true"  />
           </span>
         </button>
 

--- a/src/features/clients/pages/PracticeClientsPage.tsx
+++ b/src/features/clients/pages/PracticeClientsPage.tsx
@@ -44,6 +44,7 @@ import {
   UserIcon,
   DocumentTextIcon as DocumentTextOutlineIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 
 const STATUS_LABELS: Record<UserDetailStatus, string> = {
   lead: 'Lead',
@@ -100,17 +101,17 @@ const EmptyState = ({ onAddClient }: { onAddClient: () => void }) => (
   <div className="flex h-full items-center justify-center p-6">
     <div className="max-w-md text-center">
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/5 border border-white/10">
-        <UserIcon className="h-6 w-6 text-input-placeholder" aria-hidden="true" />
+        <Icon icon={UserIcon} className="h-6 w-6 text-input-placeholder" aria-hidden="true"  />
       </div>
       <h3 className="mt-4 text-sm font-semibold text-input-text">No clients yet</h3>
       <p className="mt-2 text-sm text-input-placeholder">
         Get started by creating a new client or importing your existing clients.
       </p>
       <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
-        <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={onAddClient}>
+        <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={onAddClient}>
           Add Client
         </Button>
-        <Button size="sm" variant="secondary" icon={<ArrowUpTrayIcon className="h-4 w-4" />} disabled>
+        <Button size="sm" variant="secondary" icon={ArrowUpTrayIcon} iconClassName="h-4 w-4" disabled>
           Import Clients
         </Button>
       </div>
@@ -191,13 +192,13 @@ const ClientDetailPanel = ({
     <div className="divide-y divide-line-default">
       <div className="pb-6">
         <div className="flex flex-wrap items-center gap-2">
-          <Button size="sm" icon={<DocumentTextOutlineIcon className="h-4 w-4" />}>
+          <Button size="sm" icon={DocumentTextOutlineIcon} iconClassName="h-4 w-4">
             Generate Invoice
           </Button>
           <Button
             variant="secondary"
             size="sm"
-            icon={<ChatBubbleLeftRightIcon className="h-4 w-4" />}
+            icon={ChatBubbleLeftRightIcon} iconClassName="h-4 w-4"
             disabled={!client.phone}
           >
             Send message
@@ -207,7 +208,7 @@ const ClientDetailPanel = ({
               <Button
                 variant="secondary"
                 size="icon"
-                icon={<EllipsisVerticalIcon className="h-5 w-5" />}
+                icon={EllipsisVerticalIcon} iconClassName="h-5 w-5"
                 aria-label="Open client actions"
               />
             </DropdownMenuTrigger>
@@ -903,7 +904,7 @@ export const PracticeClientsPage = ({
     <div className="h-full flex items-center justify-center">
       <div className="text-center">
         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-light-hover dark:bg-dark-hover">
-          <UserIcon className="h-6 w-6 text-input-text/70" aria-hidden="true" />
+          <Icon icon={UserIcon} className="h-6 w-6 text-input-text/70" aria-hidden="true"  />
         </div>
         <h3 className="mt-4 text-sm font-semibold text-input-text">Select a client</h3>
         <p className="mt-2 text-sm text-input-placeholder">
@@ -1044,10 +1045,10 @@ export const PracticeClientsPage = ({
               subtitle="A unified list of client relationships tied to conversations and matters."
               actions={(
                 <div className="flex items-center gap-2">
-                  <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={handleOpenAddClient}>
+                  <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={handleOpenAddClient}>
                     Add Client
                   </Button>
-                  <Button size="sm" variant="secondary" icon={<ArrowUpTrayIcon className="h-4 w-4" />} disabled>
+                  <Button size="sm" variant="secondary" icon={ArrowUpTrayIcon} iconClassName="h-4 w-4" disabled>
                     Import
                   </Button>
                 </div>

--- a/src/features/intake/components/DocumentChecklist.tsx
+++ b/src/features/intake/components/DocumentChecklist.tsx
@@ -8,6 +8,7 @@ import {
   CloudArrowUpIcon,
   XMarkIcon
 } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 
 interface DocumentItem {
   id: string;
@@ -67,13 +68,13 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
   const getStatusIcon = (status: DocumentItem['status'], required: boolean) => {
     switch (status) {
       case 'uploaded':
-        return <CheckCircleIcon className="w-5 h-5 text-green-500" />;
+        return <Icon icon={CheckCircleIcon} className="w-5 h-5 text-green-500"  />;
       case 'pending':
-        return <ExclamationTriangleIcon className="w-5 h-5 text-yellow-500" />;
+        return <Icon icon={ExclamationTriangleIcon} className="w-5 h-5 text-yellow-500"  />;
       case 'missing':
         return required ?
-          <ExclamationTriangleIcon className="w-5 h-5 text-red-500" /> :
-          <DocumentIcon className="w-5 h-5 text-gray-400" />;
+          <Icon icon={ExclamationTriangleIcon} className="w-5 h-5 text-red-500"  /> :
+          <Icon icon={DocumentIcon} className="w-5 h-5 text-gray-400"  />;
     }
   };
 
@@ -171,7 +172,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                       <Button
                         variant="secondary"
                         size="sm"
-                        icon={<CloudArrowUpIcon className="w-4 h-4" />}
+                        icon={CloudArrowUpIcon} iconClassName="w-4 h-4"
                       >
                         Choose Document
                       </Button>
@@ -185,14 +186,14 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                 {/* Uploaded DocumentIcon Display */}
                 {doc.status === 'uploaded' && doc.file && (
                   <div className="flex items-center gap-2 mt-2">
-                    <DocumentIcon className="w-4 h-4 text-emerald-400" />
+                    <Icon icon={DocumentIcon} className="w-4 h-4 text-emerald-400"  />
                     <span className="text-sm text-input-text">
                       {doc.file.name}
                     </span>
                     <Button
                       variant="danger-ghost"
                       size="sm"
-                      icon={<XMarkIcon className="w-4 h-4" />}
+                      icon={XMarkIcon} iconClassName="w-4 h-4"
                       aria-label={`Remove ${doc.name ?? 'document'}`}
                       onClick={() => onDocumentRemove(doc.id)}
                     />

--- a/src/features/intake/components/PrivacySupportSidebar.tsx
+++ b/src/features/intake/components/PrivacySupportSidebar.tsx
@@ -3,6 +3,7 @@ import {
   QuestionMarkCircleIcon,
   ArrowTopRightOnSquareIcon
 } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/shared/ui/Accordion';
 
 interface PrivacySupportSidebarProps {
@@ -23,9 +24,9 @@ const PrivacySupportSidebar = ({ className }: PrivacySupportSidebarProps) => {
               rel="noopener noreferrer"
               className="flex items-center gap-2 text-xs sm:text-sm text-gray-600 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors duration-200"
             >
-              <ShieldCheckIcon className="w-4 h-4" />
+              <Icon icon={ShieldCheckIcon} className="w-4 h-4"  />
               Privacy Policy
-              <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+              <Icon icon={ArrowTopRightOnSquareIcon} className="w-3 h-3"  />
             </a>
             <a
               href="https://blawby.com/help"
@@ -33,9 +34,9 @@ const PrivacySupportSidebar = ({ className }: PrivacySupportSidebarProps) => {
               rel="noopener noreferrer"
               className="flex items-center gap-2 text-xs sm:text-sm text-gray-600 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors duration-200"
             >
-              <QuestionMarkCircleIcon className="w-4 h-4" />
+              <Icon icon={QuestionMarkCircleIcon} className="w-4 h-4"  />
               Help & Support
-              <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+              <Icon icon={ArrowTopRightOnSquareIcon} className="w-3 h-3"  />
             </a>
           </div>
         </AccordionContent>

--- a/src/features/matters/components/ActivityTimeline.tsx
+++ b/src/features/matters/components/ActivityTimeline.tsx
@@ -15,6 +15,7 @@ import {
   DocumentIcon,
   LinkIcon
 } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { useActivity } from '@/shared/hooks/useActivity';
 
 interface ActivityTimelineProps {
@@ -153,7 +154,7 @@ const ActivityTimeline: FunctionComponent<ActivityTimelineProps> = ({
               {/* Empty state */}
               {!error && events.length === 0 && (
                 <div className="text-center py-6 text-gray-500 dark:text-gray-400">
-                  <ClockIcon className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                  <Icon icon={ClockIcon} className="w-8 h-8 mx-auto mb-2 opacity-50"  />
                   <p className="text-sm">No activity yet</p>
                   <p className="text-xs mt-1">Activity will appear here as you use the system</p>
                 </div>

--- a/src/features/matters/components/MatterCanvas.tsx
+++ b/src/features/matters/components/MatterCanvas.tsx
@@ -1,5 +1,6 @@
 import { FunctionalComponent } from 'preact';
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { analyzeMissingInfo } from '@/shared/utils/matterAnalysis';
 import { MatterStatusBadge, type MatterWorkflowStatus } from './StatusBadge';
 
@@ -59,7 +60,7 @@ const MatterCanvas: FunctionalComponent<MatterCanvasProps> = ({
         {missingInfo.length > 0 && (
           <div className="missing-info-section">
             <div className="missing-info-header">
-              <ExclamationTriangleIcon className="w-4 h-4" />
+              <Icon icon={ExclamationTriangleIcon} className="w-4 h-4"  />
               <span>Missing Information</span>
             </div>
             <div className="missing-info-list">

--- a/src/features/matters/components/MatterCreateModal.tsx
+++ b/src/features/matters/components/MatterCreateModal.tsx
@@ -27,6 +27,7 @@ import {
   ArrowUturnRightIcon
 } from '@heroicons/react/24/outline';
 import { PlusIcon } from '@heroicons/react/24/solid';
+import { Icon } from '@/shared/ui/Icon';
 import { formatDateOnlyUtc } from '@/shared/utils/dateOnly';
 import { asMajor, type MajorAmount } from '@/shared/utils/money';
 import { FormGrid } from '@/shared/ui/layout/FormGrid';
@@ -336,12 +337,12 @@ const MatterFormModalInner = ({
               const selectedStatus = (selectedOption?.value ?? formState.status) as MatterStatus;
               const StatusIcon = STATUS_ICON[selectedStatus] ?? ScaleIcon;
               return (
-                <StatusIcon className="h-4 w-4 text-input-placeholder" aria-hidden="true" />
+                <Icon icon={StatusIcon} className="h-4 w-4 text-input-placeholder" />
               );
             }}
             optionLeading={(option) => {
               const StatusIcon = STATUS_ICON[option.value as MatterStatus] ?? ScaleIcon;
-              return <StatusIcon className="h-4 w-4 text-input-placeholder" aria-hidden="true" />;
+              return <Icon icon={StatusIcon} className="h-4 w-4 text-input-placeholder" />;
             }}
             onChange={(value) => updateForm('status', value as MatterStatus)}
           />
@@ -358,7 +359,7 @@ const MatterFormModalInner = ({
                   return renderUserAvatar(client.name, client.image, 'sm');
                 }
               }
-              return buildLeadingIcon(<UserIcon className="h-4 w-4" />);
+              return buildLeadingIcon(<Icon icon={UserIcon} className="h-4 w-4"  />);
             }}
             optionLeading={(option) => {
               const client = clientById.get(option.value);
@@ -377,7 +378,7 @@ const MatterFormModalInner = ({
             placeholder={practiceAreasLoading ? 'Loading services...' : 'Select practice area'}
             value={formState.practiceAreaId}
             options={practiceAreaOptions}
-            leading={buildLeadingIcon(<ScaleIcon className="h-4 w-4" />)}
+            leading={buildLeadingIcon(<Icon icon={ScaleIcon} className="h-4 w-4"  />)}
             onChange={(value) => updateForm('practiceAreaId', value)}
             disabled={practiceAreasLoading}
           />
@@ -398,7 +399,7 @@ const MatterFormModalInner = ({
               onChange={(value) => updateForm('matterType', value)}
               placeholder="e.g. Contract dispute"
               options={[]}
-              leading={buildLeadingIcon(<BriefcaseIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={BriefcaseIcon} className="h-4 w-4"  />)}
               allowCustomValues
               addNewLabel="Add matter type"
             />
@@ -425,7 +426,7 @@ const MatterFormModalInner = ({
               onChange={(value) => updateForm('court', value)}
               placeholder="e.g. Superior Court of CA"
               options={[]}
-              leading={buildLeadingIcon(<ScaleIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={ScaleIcon} className="h-4 w-4"  />)}
               allowCustomValues
               addNewLabel="Add court"
             />
@@ -437,7 +438,7 @@ const MatterFormModalInner = ({
               onChange={(values) => updateForm('judge', serializeMultiValueText(values))}
               placeholder="e.g. Hon. A. Smith"
               options={[]}
-              leading={buildLeadingIcon(<UserIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={UserIcon} className="h-4 w-4"  />)}
               multiple
               allowCustomValues
               addNewLabel="Add judge"
@@ -448,7 +449,7 @@ const MatterFormModalInner = ({
               onChange={(values) => updateForm('opposingParty', serializeMultiValueText(values))}
               placeholder="Enter opposing party"
               options={[]}
-              leading={buildLeadingIcon(<UserIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={UserIcon} className="h-4 w-4"  />)}
               multiple
               allowCustomValues
               addNewLabel="Add opposing party"
@@ -461,7 +462,7 @@ const MatterFormModalInner = ({
               onChange={(values) => updateForm('opposingCounsel', serializeMultiValueText(values))}
               placeholder="Enter opposing counsel"
               options={[]}
-              leading={buildLeadingIcon(<UserIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={UserIcon} className="h-4 w-4"  />)}
               multiple
               allowCustomValues
               addNewLabel="Add opposing counsel"
@@ -485,7 +486,7 @@ const MatterFormModalInner = ({
               placeholder="Select attorney"
               value={formState.responsibleAttorneyId}
               options={assigneeOptions}
-              leading={buildLeadingIcon(<UserIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={UserIcon} className="h-4 w-4"  />)}
               optionLeading={(option) => {
                 const assignee = assigneeById.get(option.value);
                 if (!assignee) return null;
@@ -499,7 +500,7 @@ const MatterFormModalInner = ({
               placeholder="Select attorney"
               value={formState.originatingAttorneyId}
               options={assigneeOptions}
-              leading={buildLeadingIcon(<UserIcon className="h-4 w-4" />)}
+              leading={buildLeadingIcon(<Icon icon={UserIcon} className="h-4 w-4"  />)}
               optionLeading={(option) => {
                 const assignee = assigneeById.get(option.value);
                 if (!assignee) return null;
@@ -643,7 +644,7 @@ const MatterFormModalInner = ({
                       type="button"
                       onClick={() => setIsMilestoneFormVisible(true)}
                       icon={
-                        <PlusIcon className="h-4 w-4" aria-hidden="true" />
+                        <Icon icon={PlusIcon} className="h-4 w-4" aria-hidden="true"  />
                       }
                     >
                       Add Milestone
@@ -681,7 +682,7 @@ const MatterFormModalInner = ({
         ) : null}
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="flex items-center gap-2 text-xs text-input-placeholder">
-            <ShieldCheckIcon className="h-4 w-4 text-input-placeholder" />
+            <Icon icon={ShieldCheckIcon} className="h-4 w-4 text-input-placeholder"  />
             <span>
               Payments are built for securing IOLTA compliance.{' '}
               <a

--- a/src/features/matters/components/MatterCreateModal.tsx
+++ b/src/features/matters/components/MatterCreateModal.tsx
@@ -643,9 +643,8 @@ const MatterFormModalInner = ({
                       size="sm"
                       type="button"
                       onClick={() => setIsMilestoneFormVisible(true)}
-                      icon={
-                        <Icon icon={PlusIcon} className="h-4 w-4" aria-hidden="true"  />
-                      }
+                      icon={PlusIcon}
+                      iconClassName="h-4 w-4"
                     >
                       Add Milestone
                     </Button>

--- a/src/features/matters/components/MatterDetailPanel.tsx
+++ b/src/features/matters/components/MatterDetailPanel.tsx
@@ -170,14 +170,14 @@ const SectionHeader = ({
           variant="ghost"
           onClick={onCancel}
           disabled={isSaving}
-          icon={<XMarkIcon className="h-3.5 w-3.5" />}
+          icon={XMarkIcon} iconClassName="h-3.5 w-3.5"
           aria-label="Cancel editing"
         />
         <Button
           size="xs"
           onClick={onSave}
           disabled={isSaving}
-          icon={<CheckIcon className="h-3.5 w-3.5" />}
+          icon={CheckIcon} iconClassName="h-3.5 w-3.5"
           aria-label="Save changes"
         >
           {isSaving ? 'Saving…' : 'Save'}
@@ -189,7 +189,7 @@ const SectionHeader = ({
         variant="icon"
         size="icon-sm"
         onClick={onEdit}
-        icon={<PencilIcon className="h-4 w-4" />}
+        icon={PencilIcon} iconClassName="h-4 w-4"
         className={cn(
           'text-input-placeholder/80 transition-colors',
           'hover:text-input-text focus-visible:text-input-text'
@@ -605,7 +605,7 @@ export const MatterDetailsPanel = ({
                 size="sm"
                 variant="outline"
                 onClick={() => startEdit(group.key)}
-                icon={<PlusIcon className="h-3.5 w-3.5" />}
+                icon={PlusIcon} iconClassName="h-3.5 w-3.5"
                 className="rounded-full"
               >
                 {group.label}

--- a/src/features/matters/components/MatterStatusPopover.tsx
+++ b/src/features/matters/components/MatterStatusPopover.tsx
@@ -203,7 +203,13 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
                     : 'text-input-text hover:bg-white/10'
                 )}
               >
-                <Icon icon={statusIcon} className="h-4 w-4 shrink-0 text-input-placeholder" />
+                <Icon
+                  icon={statusIcon}
+                  className={cn(
+                    'h-4 w-4 shrink-0',
+                    isSelected ? 'text-[rgb(var(--accent-foreground))]' : 'text-input-placeholder'
+                  )}
+                />
                 <span className="flex-1">{MATTER_STATUS_LABELS[status]}</span>
                 {isSelected && <Icon icon={CheckIcon} className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--accent-foreground))]" aria-hidden  />}
               </button>

--- a/src/features/matters/components/MatterStatusPopover.tsx
+++ b/src/features/matters/components/MatterStatusPopover.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDownIcon
 } from '@heroicons/react/24/outline';
 import { CheckIcon } from '@heroicons/react/24/solid';
+import { Icon } from '@/shared/ui/Icon';
 import {
   MATTER_STATUS_LABELS,
   MATTER_WORKFLOW_STATUSES,
@@ -157,12 +158,12 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
           colorClasses
         )}
       >
-        <StatusIcon className="h-4 w-4 shrink-0" aria-hidden />
+        <Icon icon={StatusIcon} className="h-4 w-4 shrink-0" />
         {MATTER_STATUS_LABELS[currentStatus]}
-        <ChevronDownIcon
+        <Icon icon={ChevronDownIcon}
           className={cn('h-3.5 w-3.5 shrink-0 transition-transform duration-150', open && 'rotate-180')}
           aria-hidden
-        />
+         />
       </button>
 
       {open && (
@@ -179,7 +180,7 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
           )}
         >
           {MATTER_WORKFLOW_STATUSES.map((status, index) => {
-            const Icon = (STATUS_ICON[status] as preact.ComponentType<{ className?: string; 'aria-hidden'?: boolean }>) ?? ScaleIcon;
+            const statusIcon = (STATUS_ICON[status] as preact.ComponentType<{ className?: string; 'aria-hidden'?: boolean }>) ?? ScaleIcon;
             const isSelected = status === currentStatus;
             const isFocused = index === focusedIndex;
             return (
@@ -202,9 +203,9 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
                     : 'text-input-text hover:bg-white/10'
                 )}
               >
-                <Icon className="h-4 w-4 shrink-0 text-input-placeholder" aria-hidden />
+                <Icon icon={statusIcon} className="h-4 w-4 shrink-0 text-input-placeholder" />
                 <span className="flex-1">{MATTER_STATUS_LABELS[status]}</span>
-                {isSelected && <CheckIcon className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--accent-foreground))]" aria-hidden />}
+                {isSelected && <Icon icon={CheckIcon} className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--accent-foreground))]" aria-hidden  />}
               </button>
             );
           })}

--- a/src/features/matters/components/MatterTab.tsx
+++ b/src/features/matters/components/MatterTab.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircleIcon,
   ExclamationTriangleIcon
 } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { MatterData, MatterStatus } from '@/shared/types/matter';
 import { getDefaultDocumentSuggestions } from '@/shared/hooks/useMatterState';
 import type { DocumentIconAttachment } from '../../../../worker/types';
@@ -119,7 +120,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
   if (status === 'empty') {
     return (
       <div>
-        <DocumentIcon />
+        <Icon icon={DocumentIcon}  />
         <h3>No Matter Yet</h3>
         <p>Start a chat to create your matter</p>
         <Button onClick={onStartChat} variant="primary" size="sm">
@@ -185,7 +186,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
       {missingInfo.length > 0 && (
         <div>
           <div>
-            <ExclamationTriangleIcon />
+            <Icon icon={ExclamationTriangleIcon}  />
             <h4>Missing Information</h4>
           </div>
           <ul>
@@ -205,7 +206,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
       {/* Document Suggestions */}
       <div>
         <div>
-          <DocumentIcon />
+          <Icon icon={DocumentIcon}  />
           <h4>Suggested Documents</h4>
         </div>
         <div>
@@ -213,9 +214,9 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
             <div key={doc.id}>
               <div>
                 {doc.status === 'uploaded' ? (
-                  <CheckCircleIcon />
+                  <Icon icon={CheckCircleIcon}  />
                 ) : (
-                  <DocumentIcon />
+                  <Icon icon={DocumentIcon}  />
                 )}
                 <div>
                   <p>{doc.name}</p>
@@ -245,7 +246,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
       {status === 'ready' && (
         <div>
           <div>
-            <CheckCircleIcon />
+            <Icon icon={CheckCircleIcon}  />
             <h4>Matter Complete</h4>
           </div>
           <p>All required information has been provided</p>

--- a/src/features/matters/components/MatterTab.tsx
+++ b/src/features/matters/components/MatterTab.tsx
@@ -120,7 +120,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
   if (status === 'empty') {
     return (
       <div>
-        <Icon icon={DocumentIcon}  />
+        <Icon icon={DocumentIcon} className="h-4 w-4" />
         <h3>No Matter Yet</h3>
         <p>Start a chat to create your matter</p>
         <Button onClick={onStartChat} variant="primary" size="sm">
@@ -186,7 +186,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
       {missingInfo.length > 0 && (
         <div>
           <div>
-            <Icon icon={ExclamationTriangleIcon}  />
+            <Icon icon={ExclamationTriangleIcon} className="h-4 w-4" />
             <h4>Missing Information</h4>
           </div>
           <ul>
@@ -206,7 +206,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
       {/* Document Suggestions */}
       <div>
         <div>
-          <Icon icon={DocumentIcon}  />
+          <Icon icon={DocumentIcon} className="h-4 w-4" />
           <h4>Suggested Documents</h4>
         </div>
         <div>
@@ -214,9 +214,9 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
             <div key={doc.id}>
               <div>
                 {doc.status === 'uploaded' ? (
-                  <Icon icon={CheckCircleIcon}  />
+                  <Icon icon={CheckCircleIcon} className="h-4 w-4" />
                 ) : (
-                  <Icon icon={DocumentIcon}  />
+                  <Icon icon={DocumentIcon} className="h-4 w-4" />
                 )}
                 <div>
                   <p>{doc.name}</p>
@@ -246,7 +246,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
       {status === 'ready' && (
         <div>
           <div>
-            <Icon icon={CheckCircleIcon}  />
+            <Icon icon={CheckCircleIcon} className="h-4 w-4" />
             <h4>Matter Complete</h4>
           </div>
           <p>All required information has been provided</p>

--- a/src/features/matters/components/billing/LineItemsBuilder.tsx
+++ b/src/features/matters/components/billing/LineItemsBuilder.tsx
@@ -135,7 +135,7 @@ export const LineItemsBuilder = ({ lineItems, onChange }: LineItemsBuilderProps)
                         variant="danger-ghost"
                         onClick={() => removeItem(index)}
                         disabled={disableRemoval}
-                        icon={<TrashIcon className="h-4 w-4" />}
+                        icon={TrashIcon} iconClassName="h-4 w-4"
                         aria-label="Remove line item"
                       />
                     </td>

--- a/src/features/matters/components/expenses/MatterExpensesPanel.tsx
+++ b/src/features/matters/components/expenses/MatterExpensesPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'preact/hooks';
 import { EllipsisVerticalIcon, PlusIcon, TrashIcon, PencilIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { ulid } from 'ulid';
 import { format, parseISO } from 'date-fns';
 import Modal from '@/shared/components/Modal';
@@ -178,7 +179,7 @@ export const MatterExpensesPanel = ({
             {sortedExpenses.length} recorded · {formatCurrency(totalExpenses)} total · {formatCurrency(billableTotal)} billable
           </p>
         </div>
-        <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={openNewExpense} disabled={!canCreate}>
+        <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={openNewExpense} disabled={!canCreate}>
           Add expense
         </Button>
       </header>
@@ -243,20 +244,20 @@ export const MatterExpensesPanel = ({
                         variant="ghost"
                         size="sm"
                         aria-label="Open expense actions"
-                        icon={<EllipsisVerticalIcon className="h-4 w-4" />}
+                        icon={EllipsisVerticalIcon} iconClassName="h-4 w-4"
                       />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-32">
                       <div className="py-1">
                         <DropdownMenuItem onSelect={() => openEditExpense(expense)}>
                           <span className="flex items-center gap-2">
-                            <PencilIcon className="h-4 w-4" />
+                            <Icon icon={PencilIcon} className="h-4 w-4"  />
                             Edit
                           </span>
                         </DropdownMenuItem>
                         <DropdownMenuItem onSelect={() => confirmDelete(expense)}>
                           <span className="flex items-center gap-2 text-red-600 dark:text-red-400">
-                            <TrashIcon className="h-4 w-4" />
+                            <Icon icon={TrashIcon} className="h-4 w-4"  />
                             Delete
                           </span>
                         </DropdownMenuItem>

--- a/src/features/matters/components/milestones/MatterMilestonesPanel.tsx
+++ b/src/features/matters/components/milestones/MatterMilestonesPanel.tsx
@@ -186,7 +186,7 @@ export const MatterMilestonesPanel = ({
             {resolvedMilestones.length} milestones tracked
           </p>
         </div>
-        <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={openForm} disabled={!canCreate}>
+        <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={openForm} disabled={!canCreate}>
           Add milestone
         </Button>
       </header>
@@ -231,7 +231,7 @@ export const MatterMilestonesPanel = ({
                       <Button
                         variant="ghost"
                         size="sm"
-                        icon={<PencilIcon className="h-4 w-4" />}
+                        icon={PencilIcon} iconClassName="h-4 w-4"
                         onClick={() => openEditForm(milestone)}
                         aria-label="Edit milestone"
                       />
@@ -240,7 +240,7 @@ export const MatterMilestonesPanel = ({
                       <Button
                         variant="ghost"
                         size="sm"
-                        icon={<TrashIcon className="h-4 w-4" />}
+                        icon={TrashIcon} iconClassName="h-4 w-4"
                         onClick={() => confirmDelete(milestone)}
                         aria-label="Delete milestone"
                       />
@@ -251,14 +251,14 @@ export const MatterMilestonesPanel = ({
                       <Button
                         variant="ghost"
                         size="sm"
-                        icon={<ArrowUpIcon className="h-4 w-4" />}
+                        icon={ArrowUpIcon} iconClassName="h-4 w-4"
                         onClick={() => moveMilestone(index, -1)}
                         aria-label="Move milestone up"
                       />
                       <Button
                         variant="ghost"
                         size="sm"
-                        icon={<ArrowDownIcon className="h-4 w-4" />}
+                        icon={ArrowDownIcon} iconClassName="h-4 w-4"
                         onClick={() => moveMilestone(index, 1)}
                         aria-label="Move milestone down"
                       />

--- a/src/features/matters/components/notes/MatterNotesPanel.tsx
+++ b/src/features/matters/components/notes/MatterNotesPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'preact/hooks';
 import { EllipsisVerticalIcon, PencilIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { format, parseISO } from 'date-fns';
 import { ulid } from 'ulid';
 import Modal from '@/shared/components/Modal';
@@ -168,7 +169,7 @@ export const MatterNotesPanel = ({
             {sortedNotes.length} notes recorded
           </p>
         </div>
-        <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={openNewNote} disabled={!canCreate}>
+        <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={openNewNote} disabled={!canCreate}>
           Add note
         </Button>
       </header>
@@ -229,7 +230,7 @@ export const MatterNotesPanel = ({
                       variant="ghost"
                       size="sm"
                       aria-label="Open note actions"
-                      icon={<EllipsisVerticalIcon className="h-4 w-4" />}
+                      icon={EllipsisVerticalIcon} iconClassName="h-4 w-4"
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-32">
@@ -237,7 +238,7 @@ export const MatterNotesPanel = ({
                       {canEdit ? (
                         <DropdownMenuItem onSelect={() => openEditNote(note)}>
                           <span className="flex items-center gap-2">
-                            <PencilIcon className="h-4 w-4" />
+                            <Icon icon={PencilIcon} className="h-4 w-4"  />
                             Edit
                           </span>
                         </DropdownMenuItem>
@@ -245,7 +246,7 @@ export const MatterNotesPanel = ({
                       {canDelete ? (
                         <DropdownMenuItem onSelect={() => confirmDelete(note)}>
                           <span className="flex items-center gap-2 text-red-600 dark:text-red-400">
-                            <TrashIcon className="h-4 w-4" />
+                            <Icon icon={TrashIcon} className="h-4 w-4"  />
                             Delete
                           </span>
                         </DropdownMenuItem>

--- a/src/features/matters/components/tasks/MatterTasksPanel.tsx
+++ b/src/features/matters/components/tasks/MatterTasksPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'preact/hooks';
 import { EllipsisVerticalIcon, PencilIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import Modal from '@/shared/components/Modal';
 import { Button } from '@/shared/ui/Button';
 import {
@@ -158,7 +159,7 @@ export const MatterTasksPanel = ({
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={openCreate}>
+          <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={openCreate}>
             Add task
           </Button>
         </div>
@@ -259,20 +260,20 @@ export const MatterTasksPanel = ({
                           variant="ghost"
                           size="sm"
                           aria-label="Open task actions"
-                          icon={<EllipsisVerticalIcon className="h-4 w-4" />}
+                          icon={EllipsisVerticalIcon} iconClassName="h-4 w-4"
                         />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-32">
                         <div className="py-1">
                           <DropdownMenuItem onSelect={() => openEdit(task)}>
                             <span className="flex items-center gap-2">
-                              <PencilIcon className="h-4 w-4" />
+                              <Icon icon={PencilIcon} className="h-4 w-4"  />
                               Edit
                             </span>
                           </DropdownMenuItem>
                           <DropdownMenuItem onSelect={() => setDeleteTarget(task)}>
                             <span className="flex items-center gap-2 text-red-600 dark:text-red-400">
-                              <TrashIcon className="h-4 w-4" />
+                              <Icon icon={TrashIcon} className="h-4 w-4"  />
                               Delete
                             </span>
                           </DropdownMenuItem>

--- a/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
+++ b/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
@@ -152,7 +152,7 @@ export const TimeEntriesPanel = ({
                 <p className="text-sm font-semibold text-input-text">{weekRangeLabel}</p>
               </div>
             </div>
-            <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={() => openNewEntry()}>
+            <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={() => openNewEntry()}>
               Add time entry
             </Button>
           </header>

--- a/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
+++ b/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
@@ -99,7 +99,7 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
           variant="ghost"
           size="sm"
           aria-label="Previous month"
-          icon={<ChevronLeftIcon className="h-4 w-4" />}
+          icon={ChevronLeftIcon} iconClassName="h-4 w-4"
           onClick={handlePrevMonth}
         />
         <div className="text-sm font-semibold text-input-text">{monthLabel}</div>
@@ -107,7 +107,7 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
           variant="ghost"
           size="sm"
           aria-label="Next month"
-          icon={<ChevronRightIcon className="h-4 w-4" />}
+          icon={ChevronRightIcon} iconClassName="h-4 w-4"
           onClick={handleNextMonth}
         />
       </div>

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -13,6 +13,7 @@ import { CurrencyInput } from '@/shared/ui/input';
 import { ActivityTimeline, type TimelineItem, type TimelinePerson } from '@/shared/ui/activity/ActivityTimeline';
 import Modal from '@/shared/components/Modal';
 import { FolderIcon, PencilIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { MATTER_STATUS_LABELS, type MatterStatus } from '@/shared/types/matterStatus';
 import {
   type MatterDetail,
@@ -121,14 +122,14 @@ const EmptyState = ({ onCreate, disableCreate }: { onCreate?: () => void; disabl
   <div className="flex h-full items-center justify-center p-8">
     <div className="max-w-md text-center">
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/[0.08] ring-1 ring-white/[0.12]">
-        <FolderIcon className="h-6 w-6 text-input-text/70" aria-hidden="true" />
+        <Icon icon={FolderIcon} className="h-6 w-6 text-input-text/70" aria-hidden="true"  />
       </div>
       <h3 className="mt-4 text-sm font-semibold text-input-text">No matters yet</h3>
       <p className="mt-2 text-sm text-input-placeholder">
         Create your first matter to start tracking progress and milestones.
       </p>
       <div className="mt-6 flex justify-center">
-        <Button size="sm" icon={<PlusIcon className="h-4 w-4" />} onClick={onCreate} disabled={disableCreate}>
+        <Button size="sm" icon={PlusIcon} iconClassName="h-4 w-4" onClick={onCreate} disabled={disableCreate}>
           Add Matter
         </Button>
       </div>
@@ -1748,7 +1749,7 @@ export const PracticeMattersPage = ({
                     size="icon-sm"
                     variant="icon"
                     onClick={startDescriptionEdit}
-                    icon={<PencilIcon className="h-4 w-4" />}
+                    icon={PencilIcon} iconClassName="h-4 w-4"
                     aria-label="Edit description"
                     className="shrink-0"
                   />
@@ -2045,7 +2046,7 @@ export const PracticeMattersPage = ({
           actions={
             <Button
               size="sm"
-              icon={<PlusIcon className="h-4 w-4" />}
+              icon={PlusIcon} iconClassName="h-4 w-4"
               onClick={() => navigate(`${basePath}/new`)}
               disabled={!activePracticeId}
             >

--- a/src/features/media/components/AudioRecordingUI.tsx
+++ b/src/features/media/components/AudioRecordingUI.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'preact';
 import { useEffect, useState, useRef, useCallback } from 'preact/hooks';
 import { XMarkIcon, CheckIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { Button } from '@/shared/ui/Button';
 
 // Type-safe interface for AudioContext globals
@@ -329,7 +330,7 @@ const AudioRecordingUI: FunctionComponent<AudioRecordingUIProps> = ({
                 title="Cancel recording"
                 className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-all duration-200 text-input-placeholder hover:text-red-400 bg-white/5 hover:bg-red-500/10 animate-zoom-in"
             >
-                <XMarkIcon className="w-5 h-5" aria-hidden="true" />
+                <Icon icon={XMarkIcon} className="w-5 h-5" aria-hidden="true"  />
             </Button>
             <div className="flex-1 flex items-center gap-4 h-8 animate-zoom-in bg-transparent" aria-live="polite">
                 <canvas ref={canvasRef} width="300" height="40" aria-hidden="true" className="flex-1 h-8 rounded-lg block image-rendering-crisp-edges image-rendering-webkit-optimize-contrast bg-white/5" />
@@ -349,7 +350,7 @@ const AudioRecordingUI: FunctionComponent<AudioRecordingUIProps> = ({
                 ref={confirmBtnRef}
                 className="flex items-center justify-center w-8 h-8 p-1.5 rounded-full shadow-lg shadow-accent-500/20 cursor-pointer transition-all duration-200 animate-zoom-in hover:scale-110 active:scale-95"
             >
-                <CheckIcon className="w-5 h-5" aria-hidden="true" />
+                <Icon icon={CheckIcon} className="w-5 h-5" aria-hidden="true"  />
             </Button>
         </div>
     );

--- a/src/features/media/components/DragDropOverlay.tsx
+++ b/src/features/media/components/DragDropOverlay.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'preact';
 import { useEffect, useRef, useCallback } from 'preact/hooks';
 import { CloudArrowUpIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 
 interface DragDropOverlayProps {
   isVisible: boolean;
@@ -41,7 +42,7 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
       aria-modal="true"
     >
       <div className="flex flex-col items-center justify-center gap-3 text-input-text text-lg sm:text-xl lg:text-2xl text-center p-6 sm:p-10 rounded-2xl bg-surface-overlay/80 shadow-2xl border border-line-default max-w-[90%] relative z-[10000]">
-        <CloudArrowUpIcon className="w-10 h-10 sm:w-14 sm:h-14 text-amber-500 mb-1" aria-hidden="true" />
+        <Icon icon={CloudArrowUpIcon} className="w-10 h-10 sm:w-14 sm:h-14 text-amber-500 mb-1" aria-hidden="true"  />
         <h3 className="text-lg sm:text-2xl lg:text-3xl font-semibold m-0 text-input-text">Drop Files to Upload</h3>
         <p className="text-xs sm:text-sm lg:text-base opacity-80 m-0 text-gray-600 dark:text-gray-300">We accept images, videos, and document files</p>
       </div>

--- a/src/features/media/components/FileMenu.tsx
+++ b/src/features/media/components/FileMenu.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'preact';
 import { useState, useRef, useEffect, useCallback } from 'preact/hooks';
 import { PlusIcon, PhotoIcon, CameraIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { Button } from '@/shared/ui/Button';
 import CameraModal from '@/features/modals/components/CameraModal';
 import { THEME } from '@/shared/utils/constants';
@@ -146,7 +147,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
             ? 'bg-white/20 border-white/35'
             : 'bg-white/10 border-white/20 hover:bg-white/20 hover:border-white/30 hover:scale-105'
         }`}
-        icon={<PlusIcon className="w-5 h-5" aria-hidden="true" />}
+        icon={PlusIcon} iconClassName="w-5 h-5"
       />
 
       {(isOpen || isClosing) && (
@@ -170,7 +171,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
             className="file-menu-item py-3 text-xs sm:text-sm"
           >
             <span>Add photos &amp; files</span>
-            <PhotoIcon className="w-5 h-5" aria-hidden="true" />
+            <Icon icon={PhotoIcon} className="w-5 h-5" aria-hidden="true"  />
           </Button>
 
           <Button
@@ -182,7 +183,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
             className="file-menu-item py-3 border-t border-white/10 text-xs sm:text-sm"
           >
             <span>Take Photo</span>
-            <CameraIcon className="w-5 h-5" aria-hidden="true" />
+            <Icon icon={CameraIcon} className="w-5 h-5" aria-hidden="true"  />
           </Button>
         </div>
       )}
@@ -201,7 +202,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
               className="p-1 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-200 transition-colors"
               aria-label="Dismiss error message"
             >
-              <XMarkIcon className="w-4 h-4" />
+              <Icon icon={XMarkIcon} className="w-4 h-4"  />
             </button>
           </div>
         </div>

--- a/src/features/media/components/MediaContent.tsx
+++ b/src/features/media/components/MediaContent.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
 import { PlayIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { type AggregatedMedia } from '@/shared/utils/mediaAggregation';
 
 interface MediaContentProps {
@@ -40,7 +41,7 @@ const MediaContent: FunctionComponent<MediaContentProps> = ({ media }) => {
                                 playsInline
                             />
                             <div className="absolute inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center gap-2">
-                                <PlayIcon className="text-white w-12 h-12" />
+                                <Icon icon={PlayIcon} className="text-white w-12 h-12"  />
                                 <p className="text-white text-sm font-medium">Click to play</p>
                             </div>
                         </div>

--- a/src/features/media/components/MediaControls.tsx
+++ b/src/features/media/components/MediaControls.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'preact';
 import { useState, useRef, useEffect } from 'preact/hooks';
 import AudioRecordingUI from './AudioRecordingUI';
 import { MicrophoneIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { features } from '@/config/features';
 import { Button } from '@/shared/ui/Button';
 
@@ -163,7 +164,7 @@ const MediaControls: FunctionComponent<MediaControlsProps> = ({
 				disabled={permissionDenied}
 				className="w-8 h-8 p-0 rounded-full"
 			>
-				<MicrophoneIcon className="w-4 h-4" aria-hidden="true" />
+				<Icon icon={MicrophoneIcon} className="w-4 h-4" aria-hidden="true"  />
 			</Button>
 			{permissionDenied && (
 				<div className="sr-only" role="alert">

--- a/src/features/media/components/MediaSidebar.tsx
+++ b/src/features/media/components/MediaSidebar.tsx
@@ -3,6 +3,7 @@ import {
   PhotoIcon,
   ArrowDownTrayIcon
 } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { 
   aggregateMediaFromMessages, 
   formatFileSize, 
@@ -64,7 +65,7 @@ export default function MediaSidebar({ messages }: MediaSidebarProps) {
           <AccordionTrigger>Media, DocumentIcons, and Links</AccordionTrigger>
           <AccordionContent>
             <div className="flex flex-col items-center justify-center text-center py-6">
-              <PhotoIcon className="w-6 h-6 sm:w-8 sm:h-8 text-input-placeholder/50 mb-2" />
+              <Icon icon={PhotoIcon} className="w-6 h-6 sm:w-8 sm:h-8 text-input-placeholder/50 mb-2"  />
               <p className="text-sm font-medium mb-1 text-input-text">No files shared yet</p>
               <p className="text-xs text-input-placeholder">Files you share in the conversation will appear here</p>
             </div>
@@ -141,7 +142,7 @@ export default function MediaSidebar({ messages }: MediaSidebarProps) {
                                     title="Download file"
                                     className="p-1.5 surface-hover rounded-lg text-input-placeholder hover:text-input-text"
                                   >
-                                    <ArrowDownTrayIcon className="w-3.5 h-3.5" />
+                                    <Icon icon={ArrowDownTrayIcon} className="w-3.5 h-3.5"  />
                                   </Button>
                                 </div>
                               </div>

--- a/src/features/modals/components/CameraCaptureButton.tsx
+++ b/src/features/modals/components/CameraCaptureButton.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'preact';
 import { CameraIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 
 interface CameraCaptureButtonProps {
   onClick: () => void;
@@ -17,7 +18,7 @@ const CameraCaptureButton: FunctionComponent<CameraCaptureButtonProps> = ({ onCl
       className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full glass-panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-white/[0.04] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
       aria-label="Take photo"
     >
-      <CameraIcon className="w-16 h-16 text-input-text" />
+      <Icon icon={CameraIcon} className="w-16 h-16 text-input-text"  />
     </button>
   );
 };

--- a/src/features/onboarding/components/PersonalInfoStep.tsx
+++ b/src/features/onboarding/components/PersonalInfoStep.tsx
@@ -94,7 +94,8 @@ const PersonalInfoStep = ({
                           value={(value as string) || ''}
                           onChange={(value) => onChange(value)}
                           placeholder={t('onboarding.step1.fullNamePlaceholder')}
-                          icon={<UserIcon className="h-5 w-5 text-input-placeholder" />}
+                          icon={UserIcon}
+                          iconClassName="h-5 w-5 text-input-placeholder"
                           error={error?.message}
                         />
                       </FormControl>

--- a/src/features/onboarding/components/UseCaseStep.tsx
+++ b/src/features/onboarding/components/UseCaseStep.tsx
@@ -10,6 +10,7 @@ import {
   EllipsisHorizontalIcon,
   CheckIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
 import { Textarea } from '@/shared/ui/input';
 
@@ -129,7 +130,7 @@ const UseCaseStep = ({ data, onComplete, isSubmitting: parentSubmitting = false 
               className="grid gap-3 sm:grid-cols-2"
             >
               {useCaseOptions.map((option) => {
-                const Icon = option.icon;
+                const optionIcon = option.icon;
                 const isSelected = selectedUseCases.includes(option.id);
 
                 return (
@@ -147,7 +148,7 @@ const UseCaseStep = ({ data, onComplete, isSubmitting: parentSubmitting = false 
                   >
                     <div className="flex items-center justify-between">
                       <div className="flex items-center space-x-3">
-                        <Icon className={`h-6 w-6 ${
+                        <Icon icon={optionIcon} className={`h-6 w-6 ${
                           isSelected 
                             ? 'text-[rgb(var(--accent-foreground))]' 
                             : 'text-input-placeholder'
@@ -161,7 +162,7 @@ const UseCaseStep = ({ data, onComplete, isSubmitting: parentSubmitting = false 
                         </span>
                       </div>
                       {isSelected && (
-                        <CheckIcon className="h-5 w-5 text-[rgb(var(--accent-foreground))]" />
+                        <Icon icon={CheckIcon} className="h-5 w-5 text-[rgb(var(--accent-foreground))]"  />
                       )}
                     </div>
                   </button>

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'preact';
 import { ArrowDownCircleIcon, ArrowPathIcon, ArrowUpCircleIcon } from '@heroicons/react/20/solid';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatDate } from '@/shared/utils/dateTime';
@@ -100,8 +101,8 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                           <td className="relative py-5 pr-6">
                             <div className="flex gap-x-6">
                               {(() => {
-                                const Icon = statusIcon(entry.status);
-                                return <Icon aria-hidden="true" className="hidden h-6 w-5 flex-none text-input-placeholder sm:block" />;
+                                const activityIcon = statusIcon(entry.status);
+                                return <Icon icon={activityIcon} className="hidden h-6 w-5 flex-none text-input-placeholder sm:block" />;
                               })()}
                               <div className="flex-auto">
                                 <div className="flex items-start gap-x-3">

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -1,4 +1,5 @@
 import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/shared/ui/dropdown';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatDate } from '@/shared/utils/dateTime';
@@ -67,7 +68,7 @@ export const RecentClientsGrid = ({
                       aria-label={`Client actions for ${client.name}`}
                     >
                       <span className="absolute -inset-2.5" />
-                      <EllipsisHorizontalIcon className="h-5 w-5" />
+                      <Icon icon={EllipsisHorizontalIcon} className="h-5 w-5"  />
                     </button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="min-w-[140px]">

--- a/src/features/practice-onboarding/components/OnboardingChat.tsx
+++ b/src/features/practice-onboarding/components/OnboardingChat.tsx
@@ -9,6 +9,7 @@ import { FunctionComponent } from 'preact';
 import { useCallback } from 'preact/hooks';
 import { useMemo } from 'preact/hooks';
 import { SparklesIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import ChatContainer from '@/features/chat/components/ChatContainer';
 import ConversationalCorrection from './ConversationalCorrection';
 import type { ChatMessageUI } from '../../../../worker/types';
@@ -194,7 +195,7 @@ const OnboardingChat: FunctionComponent<OnboardingChatProps> = ({
             headerContent={
               <div className="flex items-center justify-between mb-2 gap-3 px-4 pt-3">
                 <div className="flex items-center gap-2">
-                  <SparklesIcon className="w-4 h-4 text-accent-500" />
+                  <Icon icon={SparklesIcon} className="w-4 h-4 text-accent-500"  />
                   <div>
                     <div className="text-sm font-semibold">Setup assistant</div>
                     {status.needsSetup ? (

--- a/src/features/practice/components/PracticeProfile.tsx
+++ b/src/features/practice/components/PracticeProfile.tsx
@@ -1,4 +1,5 @@
 import { FaceSmileIcon, CheckBadgeIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { useTranslation } from 'react-i18next';
 
 interface PracticeProfileProps {
@@ -30,7 +31,7 @@ export default function PracticeProfile({
 					/>
 				) : (
 					<div className="flex items-center justify-center rounded-lg bg-surface-subtle border border-line-glass/30 w-12 h-12">
-						<FaceSmileIcon className="w-8 h-8 text-input-placeholder" />
+						<Icon icon={FaceSmileIcon} className="w-8 h-8 text-input-placeholder"  />
 					</div>
 				)}
 			</div>
@@ -39,7 +40,7 @@ export default function PracticeProfile({
 			<div className="flex items-center justify-center gap-2 w-full">
 				<h3 className="text-base sm:text-lg font-semibold text-center m-0 text-input-text leading-tight truncate min-w-0" title={name}>{name}</h3>
 				{showVerified && (
-					<CheckBadgeIcon className="w-4 h-4 sm:w-5 sm:h-5 text-accent-500 flex-shrink-0" aria-label={t('profile.verified')} title={t('profile.verified')} />
+					<Icon icon={CheckBadgeIcon} className="w-4 h-4 sm:w-5 sm:h-5 text-accent-500 flex-shrink-0" aria-label={t('profile.verified')} title={t('profile.verified')}  />
 				)}
 			</div>
 

--- a/src/features/pricing/components/PricingView.tsx
+++ b/src/features/pricing/components/PricingView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '@/shared/i18n/hooks';
 import { Button } from '@/shared/ui/Button';
 import { SegmentedToggle } from '@/shared/ui/input';
 import { CheckIcon } from '@heroicons/react/20/solid';
+import { Icon } from '@/shared/ui/Icon';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { fetchPlans, type SubscriptionPlan } from '@/shared/utils/fetchPlans';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
@@ -183,7 +184,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
               <ul className="space-y-3 text-base text-input-placeholder">
                 {features.map((feature) => (
                   <li key={feature} className="flex items-start gap-2">
-                    <CheckIcon className="mt-0.5 h-5 w-5 flex-none text-accent-500" />
+                    <Icon icon={CheckIcon} className="mt-0.5 h-5 w-5 flex-none text-accent-500"  />
                     <span>{feature}</span>
                   </li>
                 ))}

--- a/src/features/services/components/ServiceCard.tsx
+++ b/src/features/services/components/ServiceCard.tsx
@@ -1,5 +1,6 @@
 
 import type { ComponentChildren, ComponentType, JSX } from 'preact';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 
 interface ServiceCardProps {
@@ -23,7 +24,6 @@ export function ServiceCard({
   headerActions,
   className = ''
 }: ServiceCardProps) {
-  const Icon = icon;
   const rightContent = headerActions ? (
     <div className="flex items-center gap-2">
       {headerActions}
@@ -32,12 +32,12 @@ export function ServiceCard({
   const content = (
     <div className="flex items-start justify-between gap-3">
       <div className="flex items-start gap-3">
-        {Icon && (
+        {icon && (
           <span className={cn(
             'mt-0.5 transition-colors',
             selected ? 'text-accent-500' : 'text-input-text/70'
           )}>
-            <Icon className="h-5 w-5" />
+            <Icon icon={icon} className="h-5 w-5" />
           </span>
         )}
         <div>

--- a/src/features/services/components/ServicesList.tsx
+++ b/src/features/services/components/ServicesList.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'preact/hooks';
 import { TrashIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Button } from '@/shared/ui/Button';
 import Modal from '@/shared/components/Modal';
 import type { Service } from '../types';
@@ -65,7 +66,7 @@ export function ServicesList({
                   onClick={() => onRemoveService(service.id)}
                   aria-label={`Remove ${service.title}`}
                 >
-                  <TrashIcon className="w-4 h-4" />
+                  <Icon icon={TrashIcon} className="w-4 h-4"  />
                 </Button>
               </>
             )}

--- a/src/features/settings/components/AppConnectionModal.tsx
+++ b/src/features/settings/components/AppConnectionModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'preact/hooks';
 import Modal from '@/shared/components/Modal';
 import { Button } from '@/shared/ui/Button';
 import { XMarkIcon, ShieldCheckIcon, LockClosedIcon, ExclamationTriangleIcon, PuzzlePieceIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { useTranslation } from '@/shared/i18n/hooks';
 import type { App } from '../pages/appsData';
 import { SectionDivider } from '@/shared/ui/layout';
@@ -100,7 +101,7 @@ export const AppConnectionModal: FunctionComponent<AppConnectionModalProps> = ({
         <div className="flex items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
             <div className="glass-input w-10 h-10 rounded-lg flex items-center justify-center">
-              <PuzzlePieceIcon className="w-6 h-6 text-gray-700 dark:text-gray-200" aria-hidden="true" />
+              <Icon icon={PuzzlePieceIcon} className="w-6 h-6 text-gray-700 dark:text-gray-200" aria-hidden="true"  />
             </div>
             <h2 id={titleId} className="text-lg font-semibold text-input-text">
               {t('settings:apps.clio.connectModal.title', { app: app.name })}
@@ -112,7 +113,7 @@ export const AppConnectionModal: FunctionComponent<AppConnectionModalProps> = ({
             onClick={onClose}
             ref={closeButtonRef}
             aria-label="Close"
-            icon={<XMarkIcon className="w-5 h-5" />}
+            icon={XMarkIcon} iconClassName="w-5 h-5"
           />
         </div>
         <SectionDivider />
@@ -123,7 +124,7 @@ export const AppConnectionModal: FunctionComponent<AppConnectionModalProps> = ({
             label={t('settings:apps.clio.connectModal.permissions.title')}
             labelNode={(
               <div className="flex items-center gap-2">
-                <ShieldCheckIcon className="w-5 h-5 text-gray-700 dark:text-gray-300" aria-hidden="true" />
+                <Icon icon={ShieldCheckIcon} className="w-5 h-5 text-gray-700 dark:text-gray-300" aria-hidden="true"  />
                 <span className="text-sm font-semibold text-input-text">
                   {t('settings:apps.clio.connectModal.permissions.title')}
                 </span>
@@ -138,7 +139,7 @@ export const AppConnectionModal: FunctionComponent<AppConnectionModalProps> = ({
             label={t('settings:apps.clio.connectModal.control.title')}
             labelNode={(
               <div className="flex items-center gap-2">
-                <LockClosedIcon className="w-5 h-5 text-gray-700 dark:text-gray-300" aria-hidden="true" />
+                <Icon icon={LockClosedIcon} className="w-5 h-5 text-gray-700 dark:text-gray-300" aria-hidden="true"  />
                 <span className="text-sm font-semibold text-input-text">
                   {t('settings:apps.clio.connectModal.control.title')}
                 </span>
@@ -165,7 +166,7 @@ export const AppConnectionModal: FunctionComponent<AppConnectionModalProps> = ({
             label={t('settings:apps.clio.connectModal.risk.title')}
             labelNode={(
               <div className="flex items-center gap-2">
-                <ExclamationTriangleIcon className="w-5 h-5 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+                <Icon icon={ExclamationTriangleIcon} className="w-5 h-5 text-amber-600 dark:text-amber-400" aria-hidden="true"  />
                 <span className="text-sm font-semibold text-input-text">
                   {t('settings:apps.clio.connectModal.risk.title')}
                 </span>

--- a/src/features/settings/components/EmailSettingsSection.tsx
+++ b/src/features/settings/components/EmailSettingsSection.tsx
@@ -1,4 +1,5 @@
 import { EnvelopeIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { SettingSection } from './SettingSection';
 
 export interface EmailSettingsSectionProps {
@@ -24,7 +25,7 @@ export const EmailSettingsSection = ({
     <SettingSection title={title} className={className}>
       {/* Email Address */}
       <div className="flex items-center gap-3 py-3">
-        <EnvelopeIcon className="w-4 h-4 text-input-placeholder" />
+        <Icon icon={EnvelopeIcon} className="w-4 h-4 text-input-placeholder"  />
         <span className="text-sm text-input-text">
           {email}
         </span>

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -21,6 +21,7 @@ import { getCurrentSubscription, type CurrentSubscription } from '@/shared/lib/a
 import { uploadWithProgress } from '@/shared/services/upload/UploadTransport';
 import { ChevronDownIcon, XMarkIcon, GlobeAltIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { CheckIcon } from '@heroicons/react/20/solid';
+import { Icon } from '@/shared/ui/Icon';
 import type { UserLinks, EmailSettings } from '@/shared/types/user';
 import { SettingRow } from '@/features/settings/components/SettingRow';
 import { SettingSection } from '@/features/settings/components/SettingSection';
@@ -742,7 +743,7 @@ export const AccountPage = ({
                         variant="secondary"
                         size="sm"
                         disabled={submitting}
-                        icon={<ChevronDownIcon className="w-4 h-4" />}
+                        icon={ChevronDownIcon} iconClassName="w-4 h-4"
                         iconPosition="right"
                       >
                         {t('settings:account.plan.manage')}
@@ -766,7 +767,7 @@ export const AccountPage = ({
                         }}
                       >
                         <span className="flex items-center gap-2 whitespace-nowrap text-red-600 dark:text-red-400">
-                          <XMarkIcon className="h-4 w-4" />
+                          <Icon icon={XMarkIcon} className="h-4 w-4"  />
                           {t('settings:account.plan.cancelSubscription')}
                         </span>
                       </DropdownMenuItem>
@@ -903,7 +904,7 @@ export const AccountPage = ({
               label={t('settings:account.links.domainLabel')}
               labelNode={
                 <div className="flex items-center gap-3">
-                  <GlobeAltIcon className="w-5 h-5 text-input-placeholder" />
+                  <Icon icon={GlobeAltIcon} className="w-5 h-5 text-input-placeholder"  />
                   <FormLabel>{t('settings:account.links.domainLabel')}</FormLabel>
                 </div>
               }
@@ -938,7 +939,7 @@ export const AccountPage = ({
                 variant="secondary"
                 size="sm"
                 onClick={handleAddLinkedIn}
-                icon={<PlusIcon className="w-4 h-4" />}
+                icon={PlusIcon} iconClassName="w-4 h-4"
                 iconPosition="right"
               >
                 {t('settings:account.links.addButton')}
@@ -963,7 +964,7 @@ export const AccountPage = ({
                 variant="secondary"
                 size="sm"
                 onClick={handleAddGitHub}
-                icon={<PlusIcon className="w-4 h-4" />}
+                icon={PlusIcon} iconClassName="w-4 h-4"
                 iconPosition="right"
               >
                 {t('settings:account.links.addButton')}

--- a/src/features/settings/pages/AppDetailPage.tsx
+++ b/src/features/settings/pages/AppDetailPage.tsx
@@ -16,6 +16,7 @@ import { formatDate } from '@/shared/utils/dateTime';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/shared/ui/dropdown';
 import { useWorkspaceResolver } from '@/shared/hooks/useWorkspaceResolver';
 import { DocumentDuplicateIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 
 interface AppDetailPageProps {
   app: App;
@@ -122,7 +123,7 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
           size="icon"
           onClick={onBack}
           aria-label={t('settings:navigation.backToSettings')}
-          icon={<ArrowLeftIcon className="w-5 h-5" />}
+          icon={ArrowLeftIcon} iconClassName="w-5 h-5"
         />
       )}
     >
@@ -140,7 +141,7 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
                     loading="lazy"
                   />
                 ) : (
-                  <PuzzlePieceIcon className="w-8 h-8 text-input-text/80" aria-hidden="true" />
+                  <Icon icon={PuzzlePieceIcon} className="w-8 h-8 text-input-text/80" aria-hidden="true"  />
                 )}
               </div>
               <div className="flex items-center gap-2">
@@ -179,13 +180,13 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
                   variant="ghost"
                   size="sm"
                   aria-label="More options"
-                  icon={<EllipsisVerticalIcon className="w-5 h-5" />}
+                  icon={EllipsisVerticalIcon} iconClassName="w-5 h-5"
                 />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onSelect={handleOpenSettings}>
                   <div className="flex items-center gap-2">
-                    <Cog6ToothIcon className="w-4 h-4" aria-hidden="true" />
+                    <Icon icon={Cog6ToothIcon} className="w-4 h-4" aria-hidden="true"  />
                     <span>{t('settings:apps.clio.settings')}</span>
                   </div>
                 </DropdownMenuItem>
@@ -221,7 +222,7 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
                   size="sm"
                   disabled={!slug}
                   className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity bg-elevation-3 hover:bg-elevation-4 border-line-glass/30"
-                  icon={copiedScript ? <CheckIcon className="w-4 h-4 text-green-500" /> : <DocumentDuplicateIcon className="w-4 h-4" />}
+                  icon={copiedScript ? <Icon icon={CheckIcon} className="w-4 h-4 text-green-500"  /> : <Icon icon={DocumentDuplicateIcon} className="w-4 h-4"  />}
                   onClick={copySnippet}
                 >
                   {copiedScript ? t('settings:apps.copied') : t('settings:apps.copy')}
@@ -263,7 +264,7 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
                 className="inline-flex items-center gap-1 text-accent-600 dark:text-accent-400"
               >
                 {app.website}
-                <GlobeAltIcon className="w-4 h-4" aria-hidden="true" />
+                <Icon icon={GlobeAltIcon} className="w-4 h-4" aria-hidden="true"  />
               </a>
             }
           />
@@ -277,7 +278,7 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
                 className="inline-flex items-center gap-1 text-accent-600 dark:text-accent-400"
               >
                 {app.privacyPolicy}
-                <GlobeAltIcon className="w-4 h-4" aria-hidden="true" />
+                <Icon icon={GlobeAltIcon} className="w-4 h-4" aria-hidden="true"  />
               </a>
             }
           />

--- a/src/features/settings/pages/AppsPage.tsx
+++ b/src/features/settings/pages/AppsPage.tsx
@@ -4,6 +4,7 @@ import { SettingsBadge } from '@/features/settings/components/SettingsBadge';
 import { SectionDivider } from '@/shared/ui/layout';
 import { SettingsPageLayout } from '@/features/settings/components/SettingsPageLayout';
 import { ChevronRightIcon, PuzzlePieceIcon, CheckBadgeIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { useTranslation } from '@/shared/i18n/hooks';
 
 interface AppsPageProps {
@@ -41,7 +42,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
                         loading="lazy"
                       />
                     ) : (
-                      <PuzzlePieceIcon className="w-6 h-6 text-input-text/70" aria-hidden="true" />
+                      <Icon icon={PuzzlePieceIcon} className="w-6 h-6 text-input-text/70" aria-hidden="true"  />
                     )}
                   </div>
                   <div className="flex-1 min-w-0">
@@ -49,7 +50,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
                       <p className="text-base font-medium text-input-text truncate">{app.name}</p>
                       {app.connected && (
                         <SettingsBadge variant="success">
-                          <CheckBadgeIcon className="w-4 h-4" aria-hidden="true" />
+                          <Icon icon={CheckBadgeIcon} className="w-4 h-4" aria-hidden="true"  />
                           {t('settings:apps.clio.connected')}
                         </SettingsBadge>
                       )}
@@ -63,7 +64,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
                 </div>
               )}
             >
-              <ChevronRightIcon className="w-5 h-5 text-input-placeholder" aria-hidden="true" />
+              <Icon icon={ChevronRightIcon} className="w-5 h-5 text-input-placeholder" aria-hidden="true"  />
             </SettingRow>
           </button>
           {index < apps.length - 1 && <SectionDivider />}

--- a/src/features/settings/pages/MFAEnrollmentPage.tsx
+++ b/src/features/settings/pages/MFAEnrollmentPage.tsx
@@ -202,7 +202,7 @@ export const MFAEnrollmentPage = ({
           size="icon"
           onClick={() => navigate(toSettingsPath('security'))}
           aria-label={t('settings:mfa.back')}
-          icon={<ArrowLeftIcon className="w-5 h-5" />}
+          icon={ArrowLeftIcon} iconClassName="w-5 h-5"
         />
       )}
     >

--- a/src/features/settings/pages/PayoutsPage.tsx
+++ b/src/features/settings/pages/PayoutsPage.tsx
@@ -23,6 +23,7 @@ import {
   ShieldCheckIcon,
   UserCircleIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 
 const maskStripeAccountId = (value?: string | null) => {
   if (!value) return 'Not created';
@@ -238,7 +239,7 @@ export const PayoutsPage = ({ className = '' }: { className?: string }) => {
           <div className="space-y-4">
             <div className="flex items-start gap-3 text-sm text-input-placeholder">
               <span className="mt-0.5 flex h-8 w-8 items-center justify-center">
-                <ShieldCheckIcon className="h-5 w-5 text-input-placeholder" />
+                <Icon icon={ShieldCheckIcon} className="h-5 w-5 text-input-placeholder"  />
               </span>
               <p>
                 Information about your business, and authorized representative(s) of your business, will need to be verified to comply with the law. This may require you to provide documents such as government-issued identification.
@@ -246,7 +247,7 @@ export const PayoutsPage = ({ className = '' }: { className?: string }) => {
             </div>
             <div className="flex items-start gap-3 text-sm text-input-placeholder">
               <span className="mt-0.5 flex h-8 w-8 items-center justify-center">
-                <UserCircleIcon className="h-5 w-5 text-input-placeholder" />
+                <Icon icon={UserCircleIcon} className="h-5 w-5 text-input-placeholder"  />
               </span>
               <p>
                 It&apos;s recommended that the person filling out the information is either the owner of the business, or someone with a significant role in the business, such as a director or executive.
@@ -254,7 +255,7 @@ export const PayoutsPage = ({ className = '' }: { className?: string }) => {
             </div>
             <div className="flex items-start gap-3 text-sm text-input-placeholder">
               <span className="mt-0.5 flex h-8 w-8 items-center justify-center">
-                <LockClosedIcon className="h-5 w-5 text-input-placeholder" />
+                <Icon icon={LockClosedIcon} className="h-5 w-5 text-input-placeholder"  />
               </span>
               <p>
                 Any information and documentation you submit will be securely handled in accordance with Blawby&apos;s Privacy Policy, and may be used to create a faster onboarding experience for you if you choose to use other Blawby products.
@@ -263,7 +264,7 @@ export const PayoutsPage = ({ className = '' }: { className?: string }) => {
             {missingBusinessEmail && (
               <div className="flex items-start gap-3 text-sm text-input-placeholder">
                 <span className="mt-0.5 flex h-8 w-8 items-center justify-center">
-                  <ExclamationTriangleIcon className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+                  <Icon icon={ExclamationTriangleIcon} className="h-5 w-5 text-amber-600 dark:text-amber-400"  />
                 </span>
                 <p>
                   Add a business email in your practice contact settings before starting Stripe verification.

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -6,6 +6,7 @@ import {
   PhoneIcon,
   TrashIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { usePracticeManagement, type Practice } from '@/shared/hooks/usePracticeManagement';
 import { Button } from '@/shared/ui/Button';
 import { FormActions } from '@/shared/ui/form';
@@ -696,15 +697,15 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                     <h3 className="text-sm font-semibold text-input-text">Contact</h3>
                     <div className="mt-2 space-y-2">
                       <div className="flex items-start gap-2">
-                        <GlobeAltIcon className="w-4 h-4 text-input-placeholder mt-0.5" aria-hidden="true" />
+                        <Icon icon={GlobeAltIcon} className="w-4 h-4 text-input-placeholder mt-0.5" aria-hidden="true"  />
                         <SettingsHelperText>{websiteValue || 'Not set'}</SettingsHelperText>
                       </div>
                       <div className="flex items-start gap-2">
-                        <PhoneIcon className="w-4 h-4 text-input-placeholder mt-0.5" aria-hidden="true" />
+                        <Icon icon={PhoneIcon} className="w-4 h-4 text-input-placeholder mt-0.5" aria-hidden="true"  />
                         <SettingsHelperText>{phoneValue || 'Not set'}</SettingsHelperText>
                       </div>
                       <div className="flex items-start gap-2">
-                        <MapPinIcon className="w-4 h-4 text-input-placeholder mt-0.5" aria-hidden="true" />
+                        <Icon icon={MapPinIcon} className="w-4 h-4 text-input-placeholder mt-0.5" aria-hidden="true"  />
                         <SettingsHelperText>{addressSummary || 'Not set'}</SettingsHelperText>
                       </div>
                     </div>
@@ -726,7 +727,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                     onClick={openContactModal}
                     className="sm:hidden"
                     aria-label="Manage contact details"
-                    icon={<ChevronRightIcon className="w-5 h-5" aria-hidden="true" />}
+                    icon={ChevronRightIcon} iconClassName="w-5 h-5"
                   />
                 </div>
               </SettingRow>
@@ -767,7 +768,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                     onClick={() => navigateTo(toSettingsPath('practice/services'))}
                     className="sm:hidden"
                     aria-label="Manage services"
-                    icon={<ChevronRightIcon className="w-5 h-5" aria-hidden="true" />}
+                    icon={ChevronRightIcon} iconClassName="w-5 h-5"
                   />
                 </div>
               </SettingRow>
@@ -800,7 +801,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                     onClick={() => navigateTo(toSettingsPath('practice/pricing'))}
                     className="sm:hidden"
                     aria-label="Manage pricing"
-                    icon={<ChevronRightIcon className="w-5 h-5" aria-hidden="true" />}
+                    icon={ChevronRightIcon} iconClassName="w-5 h-5"
                   />
                 </div>
               </SettingRow>
@@ -845,7 +846,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                       : toSettingsPath('practice/team'))}
                     className="sm:hidden"
                     aria-label={members.length === 0 ? 'Invite team members' : 'Manage team members'}
-                    icon={<ChevronRightIcon className="w-5 h-5" aria-hidden="true" />}
+                    icon={ChevronRightIcon} iconClassName="w-5 h-5"
                   />
                 </div>
               </SettingRow>
@@ -907,7 +908,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
                         onClick={() => setShowDeleteModal(true)}
                         data-testid="practice-delete-action"
                       >
-                        <TrashIcon className="w-4 h-4 mr-2" />
+                        <Icon icon={TrashIcon} className="w-4 h-4 mr-2"  />
                         Delete
                       </Button>
                     )}

--- a/src/features/settings/pages/PracticePricingPage.tsx
+++ b/src/features/settings/pages/PracticePricingPage.tsx
@@ -237,7 +237,7 @@ export const PracticePricingPage = ({ className }: PracticePricingPageProps) => 
           size="icon"
           onClick={() => navigate(toSettingsPath('practice'))}
           aria-label="Back to practice settings"
-          icon={<ArrowLeftIcon className="w-5 h-5" />}
+          icon={ArrowLeftIcon} iconClassName="w-5 h-5"
         />
       )}
     >

--- a/src/features/settings/pages/PracticeServicesPage.tsx
+++ b/src/features/settings/pages/PracticeServicesPage.tsx
@@ -92,7 +92,7 @@ export const PracticeServicesPage = ({ onNavigate, className }: PracticeServices
           size="icon"
           onClick={() => navigate(toSettingsPath('practice'))}
           aria-label="Back to practice settings"
-          icon={<ArrowLeftIcon className="w-5 h-5" />}
+          icon={ArrowLeftIcon} iconClassName="w-5 h-5"
         />
       )}
     >

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { ArrowLeftIcon, UserPlusIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { usePracticeManagement, type Role } from '@/shared/hooks/usePracticeManagement';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { usePaymentUpgrade } from '@/shared/hooks/usePaymentUpgrade';
@@ -192,7 +193,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
           size="icon"
           onClick={() => navigate(toSettingsPath('practice'))}
           aria-label="Back to practice settings"
-          icon={<ArrowLeftIcon className="w-5 h-5" />}
+          icon={ArrowLeftIcon} iconClassName="w-5 h-5"
         />
       )}
     >
@@ -211,7 +212,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
               size="sm"
               onClick={() => setIsInvitingMember(!isInvitingMember)}
             >
-              <UserPlusIcon className="w-4 h-4 mr-2" />
+              <Icon icon={UserPlusIcon} className="w-4 h-4 mr-2"  />
               {isInvitingMember ? 'Cancel' : 'Invite'}
             </Button>
           )}

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -8,6 +8,7 @@ import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { authClient } from '@/shared/lib/authClient';
 import Modal from '@/shared/components/Modal';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { useTranslation } from '@/shared/i18n/hooks';
 import type { SecuritySettings } from '@/shared/types/user';
 import { SettingSection } from '@/features/settings/components/SettingSection';
@@ -431,7 +432,7 @@ export const SecurityPage = ({
             <div className="space-y-4">
               <div className="flex items-start gap-3">
                 <div className="flex-shrink-0">
-                  <ExclamationTriangleIcon className="w-6 h-6 text-orange-500" />
+                  <Icon icon={ExclamationTriangleIcon} className="w-6 h-6 text-orange-500"  />
                 </div>
                 <div className="flex-1">
                   <h3 className="text-lg font-semibold text-input-text mb-2">

--- a/src/features/workspace/views/WorkspaceConversationListView.tsx
+++ b/src/features/workspace/views/WorkspaceConversationListView.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from '@/shared/ui/layout/PageHeader';
 import { Button } from '@/shared/ui/Button';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { ChatBubbleLeftRightIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import type { Conversation } from '@/shared/types/conversation';
 import type { Practice } from '@/shared/hooks/usePracticeManagement';
 
@@ -85,7 +86,7 @@ const WorkspaceConversationListView: FunctionComponent<WorkspaceConversationList
             disabled={!practice}
             className="flex items-center gap-2"
           >
-            <PlusIcon className="w-4 h-4" />
+            <Icon icon={PlusIcon} className="w-4 h-4"  />
             New Conversation
           </Button>
         }
@@ -108,7 +109,7 @@ const WorkspaceConversationListView: FunctionComponent<WorkspaceConversationList
           </div>
         ) : sortedConversations.length === 0 ? (
           <div className="glass-card p-8 text-center">
-            <ChatBubbleLeftRightIcon className="w-16 h-16 mx-auto mb-4 text-input-placeholder opacity-50" />
+            <Icon icon={ChatBubbleLeftRightIcon} className="w-16 h-16 mx-auto mb-4 text-input-placeholder opacity-50"  />
             <h3 className="text-lg font-semibold text-input-text mb-2">No conversations yet</h3>
             <p className="text-input-placeholder mb-6">
               Start your first conversation to begin helping clients
@@ -138,7 +139,7 @@ const WorkspaceConversationListView: FunctionComponent<WorkspaceConversationList
               >
                 <div className="flex items-center gap-4">
                   <div className="w-12 h-12 bg-accent-100 rounded-full flex items-center justify-center">
-                    <ChatBubbleLeftRightIcon className="w-6 h-6 text-accent-600" />
+                    <Icon icon={ChatBubbleLeftRightIcon} className="w-6 h-6 text-accent-600"  />
                   </div>
                   
                   <div className="flex-1 min-w-0">

--- a/src/features/workspace/views/WorkspaceConversationView.tsx
+++ b/src/features/workspace/views/WorkspaceConversationView.tsx
@@ -11,6 +11,7 @@ import { Page } from '@/shared/ui/layout/Page';
 import { PageHeader } from '@/shared/ui/layout/PageHeader';
 import { Button } from '@/shared/ui/Button';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import type { ChatMessageUI } from '../../../../worker/types';
 import type { Practice } from '@/shared/hooks/usePracticeManagement';
 
@@ -62,7 +63,7 @@ const WorkspaceConversationView: FunctionComponent<WorkspaceConversationViewProp
           subtitle="Error loading conversation"
           actions={
             <Button onClick={handleBack} variant="secondary" className="flex items-center gap-2">
-              <ArrowLeftIcon className="w-4 h-4" />
+              <Icon icon={ArrowLeftIcon} className="w-4 h-4"  />
               Back
             </Button>
           }
@@ -86,7 +87,7 @@ const WorkspaceConversationView: FunctionComponent<WorkspaceConversationViewProp
         subtitle={`${messageCount} message${messageCount !== 1 ? 's' : ''} • ${practiceName}`}
         actions={
           <Button onClick={handleBack} variant="secondary" className="flex items-center gap-2">
-            <ArrowLeftIcon className="w-4 h-4" />
+            <Icon icon={ArrowLeftIcon} className="w-4 h-4"  />
             Back
           </Button>
         }

--- a/src/features/workspace/views/WorkspaceHomeView.tsx
+++ b/src/features/workspace/views/WorkspaceHomeView.tsx
@@ -11,6 +11,7 @@ import { Page } from '@/shared/ui/layout/Page';
 import { PageHeader } from '@/shared/ui/layout/PageHeader';
 import { Button } from '@/shared/ui/Button';
 import { SparklesIcon, ChatBubbleLeftRightIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import type { Practice } from '@/shared/hooks/usePracticeManagement';
 import type { PracticeDetails } from '@/shared/lib/apiClient';
 
@@ -66,7 +67,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
         <section className="glass-card p-6 sm:p-8">
           <div className="flex items-center gap-4 mb-4">
             <div className="p-3 bg-accent-100 rounded-full">
-              <SparklesIcon className="w-6 h-6 text-accent-600" />
+              <Icon icon={SparklesIcon} className="w-6 h-6 text-accent-600"  />
             </div>
             <div>
               <h2 className="text-2xl font-bold text-input-text">Practice Dashboard</h2>
@@ -127,7 +128,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
         <section className="glass-card p-6">
           <h3 className="text-lg font-semibold text-input-text mb-4">Recent Activity</h3>
           <div className="text-center py-8 text-input-placeholder">
-            <ChatBubbleLeftRightIcon className="w-12 h-12 mx-auto mb-3 opacity-50" />
+            <Icon icon={ChatBubbleLeftRightIcon} className="w-12 h-12 mx-auto mb-3 opacity-50"  />
             <p>No recent conversations</p>
             <p className="text-sm mt-2">Start a new conversation to see activity here</p>
           </div>

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -120,7 +120,7 @@ const AuthPage = ({ mode = 'signin', onSuccess, redirectDelay = 1000 }: AuthPage
               size="sm"
               onClick={handleBackToHome}
               className="text-sm text-input-placeholder hover:text-input-text"
-              icon={<ArrowLeftIcon className="h-4 w-4" />}
+              icon={ArrowLeftIcon} iconClassName="h-4 w-4"
               iconPosition="left"
             >
               {t('navigation.backToHome')}

--- a/src/pages/DebugConversationsPage.tsx
+++ b/src/pages/DebugConversationsPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'preact/hooks';
 import { ChatBubbleLeftRightIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Button } from '@/shared/ui/Button';
 import WorkspacePage from '@/features/chat/pages/WorkspacePage';
 import WorkspaceConversationHeader from '@/features/chat/components/WorkspaceConversationHeader';
@@ -38,8 +39,6 @@ const PRACTICE_ID = 'debug-practice';
 const PRACTICE_SLUG = 'debug-practice';
 const PRACTICE_NAME = 'Blawby Family Law';
 const PRACTICE_LOGO = null;
-const PRACTICE_CLIENTS_PATH = `/practice/${encodeURIComponent(PRACTICE_SLUG)}/clients`;
-
 const practiceSeeds: SeedConversation[] = [
   {
     id: 'practice-conv-1',
@@ -372,7 +371,7 @@ export default function DebugConversationsPage() {
                   aria-label="Open conversation details"
                   onClick={() => setIsConversationDetailsOpen(true)}
                 >
-                  <InformationCircleIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={InformationCircleIcon} className="h-4 w-4" aria-hidden="true"  />
                 </Button>
                 <PracticeConversationHeaderMenu practiceId={PRACTICE_ID} conversationId={activeConversation?.id} />
               </div>
@@ -386,7 +385,7 @@ export default function DebugConversationsPage() {
                 aria-label="Open conversation details"
                 onClick={() => setIsConversationDetailsOpen(true)}
               >
-                <InformationCircleIcon className="h-4 w-4" aria-hidden="true" />
+                <Icon icon={InformationCircleIcon} className="h-4 w-4" aria-hidden="true"  />
               </Button>
             )}
         />
@@ -414,7 +413,7 @@ export default function DebugConversationsPage() {
     <main className="mx-auto max-w-[1480px] space-y-4 p-4 md:p-6">
       <header className="space-y-2">
         <div className="flex flex-wrap items-center gap-2">
-          <ChatBubbleLeftRightIcon className="h-6 w-6 text-accent-500" aria-hidden="true" />
+          <Icon icon={ChatBubbleLeftRightIcon} className="h-6 w-6 text-accent-500" aria-hidden="true"  />
           <h1 className="text-2xl font-semibold text-input-text">Debug Conversations</h1>
           <span className="rounded-full border border-line-glass/30 bg-surface-panel/60 px-2.5 py-1 text-xs font-medium text-input-placeholder">
             No API
@@ -449,7 +448,6 @@ export default function DebugConversationsPage() {
           view={isPractice ? 'conversation' : clientView}
           practiceId={PRACTICE_ID}
           practiceSlug={PRACTICE_SLUG}
-          practiceClientsPath={PRACTICE_CLIENTS_PATH}
           practiceName={PRACTICE_NAME}
           practiceLogo={PRACTICE_LOGO}
           messages={activeMessages}

--- a/src/pages/DebugMatterPage.tsx
+++ b/src/pages/DebugMatterPage.tsx
@@ -426,7 +426,7 @@ export default function DebugMatterPage() {
                           size="icon-sm"
                           variant="icon"
                           onClick={startDescriptionEdit}
-                          icon={<PencilIcon className="h-4 w-4" />}
+                          icon={PencilIcon} iconClassName="h-4 w-4"
                           aria-label="Edit description"
                           className="shrink-0"
                         />

--- a/src/pages/DebugStylesPage.tsx
+++ b/src/pages/DebugStylesPage.tsx
@@ -6,6 +6,7 @@ import { CurrencyInput } from '@/shared/ui/input/CurrencyInput';
 import { DatePicker } from '@/shared/ui/input/DatePicker';
 import { Textarea } from '@/shared/ui/input/Textarea';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 
 const buttonVariants = [
   'primary',
@@ -225,7 +226,7 @@ export default function DebugStylesPage() {
               options={comboboxOptions}
               value={comboboxValue}
               onChange={setComboboxValue}
-              leading={<UserCircleIcon className="h-4 w-4 text-input-placeholder" />}
+              leading={<Icon icon={UserCircleIcon} className="h-4 w-4 text-input-placeholder"  />}
             />
           </div>
           <div className="glass-panel relative z-30 rounded-xl p-4 overflow-visible">
@@ -237,7 +238,7 @@ export default function DebugStylesPage() {
               onChange={setComboboxMultiOnlyValue}
               multiple
               searchable={false}
-              leading={<UserCircleIcon className="h-4 w-4 text-input-placeholder" />}
+              leading={<Icon icon={UserCircleIcon} className="h-4 w-4 text-input-placeholder"  />}
             />
           </div>
           <div className="glass-panel relative z-30 rounded-xl p-4 overflow-visible">
@@ -249,7 +250,7 @@ export default function DebugStylesPage() {
               onChange={setComboboxMultiValue}
               multiple
               allowCustomValues
-              leading={<UserCircleIcon className="h-4 w-4 text-input-placeholder" />}
+              leading={<Icon icon={UserCircleIcon} className="h-4 w-4 text-input-placeholder"  />}
             />
           </div>
         </div>

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -65,7 +65,7 @@ const PricingPage = () => {
               size="sm"
               onClick={handleClose}
               className="text-sm text-input-placeholder hover:text-input-text"
-              icon={<ArrowLeftIcon className="h-4 w-4" />}
+              icon={ArrowLeftIcon} iconClassName="h-4 w-4"
               iconPosition="left"
             >
               Back

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -308,7 +308,7 @@ const AuthForm = ({
                           setFormData(prev => ({ ...prev, name: String(value) }));
                         }}
                         placeholder={t('signup.fullNamePlaceholder')}
-                        icon={<UserIcon className="h-5 w-5 text-input-placeholder" />}
+                        icon={UserIcon} iconClassName="h-5 w-5 text-input-placeholder"
                         error={fieldError?.message}
                         data-testid="signup-name-input"
                       />

--- a/src/shared/components/ConfirmationDialog.tsx
+++ b/src/shared/components/ConfirmationDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'preact/hooks';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import Modal from '@/shared/components/Modal';
 import { FormActions } from '@/shared/ui/form';
 import { handleError } from '@/shared/utils/errorHandler';
@@ -114,7 +115,7 @@ export default function ConfirmationDialog({
           {/* Warning Content */}
           <div className="flex items-start gap-3">
             <div className="flex-shrink-0">
-              <ExclamationTriangleIcon className="w-6 h-6 text-red-500" />
+              <Icon icon={ExclamationTriangleIcon} className="w-6 h-6 text-red-500"  />
             </div>
             <div className="flex-1">
               <p className="text-sm text-input-placeholder mb-4">

--- a/src/shared/components/MobileTopNav.tsx
+++ b/src/shared/components/MobileTopNav.tsx
@@ -35,7 +35,7 @@ const MobileTopNav = ({
                 variant="ghost"
                 size="md"
                 onClick={onOpenSidebar}
-                icon={<Bars3Icon className="w-5 h-5" aria-hidden="true" focusable="false" />}
+                icon={Bars3Icon} iconClassName="w-5 h-5"
                 aria-label="Open menu"
               />
               
@@ -45,7 +45,7 @@ const MobileTopNav = ({
                   variant="primary"
                   size="md"
                   onClick={onPlusClick}
-                  icon={<SparklesIcon className="w-4 h-4" />}
+                  icon={SparklesIcon} iconClassName="w-4 h-4"
                   aria-label="Get Plus"
                 >
                   Get Plus

--- a/src/shared/components/Modal.tsx
+++ b/src/shared/components/Modal.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'preact';
 import { createPortal } from 'preact/compat';
 import { useEffect, useState } from 'preact/hooks';
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/shared/ui/Button';
 import { THEME } from '@/shared/utils/constants';
@@ -141,7 +142,7 @@ const Modal: FunctionComponent<ModalProps> = ({
                                         className="text-input-placeholder hover:text-input-text hover:bg-white/5"
                                         aria-label="Close modal"
                                         icon={
-                                            <XMarkIcon className="w-6 h-6" />
+                                            <Icon icon={XMarkIcon} className="w-6 h-6"  />
                                         }
                                     />
                                 )}
@@ -157,7 +158,7 @@ const Modal: FunctionComponent<ModalProps> = ({
                                 className="absolute top-4 right-4 w-10 h-10 border-none bg-black bg-opacity-50 text-white rounded-full hover:bg-black hover:bg-opacity-70 hover:scale-110 z-10 transition-all duration-200"
                                 aria-label="Close modal"
                                 icon={
-                                    <XMarkIcon className="w-6 h-6" />
+                                    <Icon icon={XMarkIcon} className="w-6 h-6"  />
                                 }
                             />
                         )}

--- a/src/shared/components/Toast.tsx
+++ b/src/shared/components/Toast.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'preact';
 import { useEffect, useRef, useCallback } from 'preact/hooks';
 import { motion } from 'framer-motion';
 import { CheckCircleIcon, ExclamationTriangleIcon, InformationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from '@/shared/ui/Icon';
 
 export interface Toast {
   id: string;
@@ -38,14 +39,14 @@ const ToastComponent: FunctionComponent<ToastProps> = ({ toast, onRemove }) => {
   const getIcon = () => {
     switch (toast.type) {
       case 'success':
-        return <CheckCircleIcon className="h-5 w-5 text-green-500" />;
+        return <Icon icon={CheckCircleIcon} className="h-5 w-5 text-green-500"  />;
       case 'error':
-        return <ExclamationTriangleIcon className="h-5 w-5 text-red-500" />;
+        return <Icon icon={ExclamationTriangleIcon} className="h-5 w-5 text-red-500"  />;
       case 'warning':
-        return <ExclamationTriangleIcon className="h-5 w-5 text-yellow-500" />;
+        return <Icon icon={ExclamationTriangleIcon} className="h-5 w-5 text-yellow-500"  />;
       case 'info':
       default:
-        return <InformationCircleIcon className="h-5 w-5 text-accent-400" />;
+        return <Icon icon={InformationCircleIcon} className="h-5 w-5 text-accent-400"  />;
     }
   };
 
@@ -90,7 +91,7 @@ const ToastComponent: FunctionComponent<ToastProps> = ({ toast, onRemove }) => {
             onClick={handleRemove}
             className="inline-flex text-input-placeholder hover:text-input-text transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-accent-500 rounded-sm focus:outline-none"
           >
-            <XMarkIcon className="h-4 w-4" />
+            <Icon icon={XMarkIcon} className="h-4 w-4"  />
           </button>
         </div>
       </div>

--- a/src/shared/ui/Accordion.tsx
+++ b/src/shared/ui/Accordion.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, ComponentChildren, createContext } from "preact"
 import { useState, useContext } from "preact/hooks"
 import { ChevronDownIcon } from "@heroicons/react/24/outline"
+import { Icon } from '@/shared/ui/Icon'
 
 // Utility function for className merging (following codebase pattern)
 function cn(...classes: (string | undefined | null | false)[]): string {
@@ -178,7 +179,7 @@ const AccordionTrigger: FunctionComponent<AccordionTriggerProps> = ({
         type="button"
       >
         {children}
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 transition-transform duration-200" />
+        <Icon icon={ChevronDownIcon} className="text-muted-foreground pointer-events-none size-4 shrink-0 transition-transform duration-200" />
       </button>
     </div>
   )

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,6 +1,7 @@
 import { ComponentChildren, toChildArray, cloneElement } from 'preact';
 import type { JSX } from 'preact';
 import { forwardRef } from 'preact/compat';
+import { Icon, type IconComponent } from '@/shared/ui/Icon';
 
 type ButtonVariant =
   | 'primary'
@@ -27,6 +28,8 @@ type ButtonSize =
   | 'icon-md'
   | 'icon-lg';
 
+type ButtonIcon = IconComponent | ComponentChildren;
+
 interface ButtonProps extends JSX.HTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
@@ -36,7 +39,8 @@ interface ButtonProps extends JSX.HTMLAttributes<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset';
   form?: string;
   style?: JSX.CSSProperties;
-  icon?: ComponentChildren;
+  icon?: ButtonIcon;
+  iconClassName?: string;
   iconPosition?: 'left' | 'right';
   'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false';
   'aria-pressed'?: boolean | 'true' | 'false' | 'mixed';
@@ -56,6 +60,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   type = 'button',
   style,
   icon,
+  iconClassName = '',
   iconPosition = 'left',
   'aria-current': ariaCurrent,
   'aria-pressed': ariaPressed,
@@ -116,40 +121,49 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     className
   ].filter(Boolean).join(' ');
 
+  const makeIconDecorative = (iconElement: ComponentChildren) => {
+    if (typeof iconElement === 'object' && iconElement !== null && 'type' in iconElement) {
+      return cloneElement(iconElement as JSX.Element, {
+        'aria-hidden': 'true',
+        focusable: 'false'
+      });
+    }
+    return <span aria-hidden="true">{iconElement}</span>;
+  };
+
+  const renderIcon = () => {
+    if (!icon) {
+      return null;
+    }
+
+    if (isIconComponent(icon)) {
+      return <Icon icon={icon} className={iconClassName} />;
+    }
+
+    return makeIconDecorative(icon);
+  };
+
   const renderContent = () => {
     if (isIconOnly) {
-      return icon;
+      return renderIcon();
     }
-    
+
     if (!icon) {
       return children;
     }
-    
-    // Helper function to make icon decorative
-    const makeIconDecorative = (iconElement: ComponentChildren) => {
-      if (typeof iconElement === 'object' && iconElement !== null && 'type' in iconElement) {
-        // If it's a Preact element, clone it with decorative attributes
-        return cloneElement(iconElement as JSX.Element, { 
-          'aria-hidden': 'true', 
-          focusable: 'false' 
-        });
-      }
-      // If it's a string or other type, wrap it in a span with decorative attributes
-      return <span aria-hidden="true">{iconElement}</span>;
-    };
-    
+
     if (iconPosition === 'right') {
       return (
         <>
           {children}
-          <span className={variant === 'menu-item' ? '' : 'ml-2'}>{makeIconDecorative(icon)}</span>
+          <span className={variant === 'menu-item' ? '' : 'ml-2'}>{renderIcon()}</span>
         </>
       );
     }
-    
+
     return (
       <>
-        <span className={variant === 'menu-item' ? '' : 'mr-2'}>{makeIconDecorative(icon)}</span>
+        <span className={variant === 'menu-item' ? '' : 'mr-2'}>{renderIcon()}</span>
         {children}
       </>
     );
@@ -174,3 +188,5 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     </button>
   );
 }); 
+  const isIconComponent = (iconValue: ButtonIcon | undefined): iconValue is IconComponent =>
+    typeof iconValue === 'function';

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -187,6 +187,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       {renderContent()}
     </button>
   );
-}); 
-  const isIconComponent = (iconValue: ButtonIcon | undefined): iconValue is IconComponent =>
-    typeof iconValue === 'function';
+});
+
+const isIconComponent = (iconValue: ButtonIcon | undefined): iconValue is IconComponent =>
+  typeof iconValue === 'function'
+  || (
+    typeof iconValue === 'object'
+    && iconValue !== null
+    && !('type' in iconValue)
+    && ('$$typeof' in iconValue || 'render' in iconValue)
+  );

--- a/src/shared/ui/CopyButton.tsx
+++ b/src/shared/ui/CopyButton.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'preact/hooks';
 import { ClipboardIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Button } from './Button';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 
@@ -57,7 +58,7 @@ export const CopyButton = ({ text, label, className = '', disabled = false }: Co
       aria-label={copied ? 'Copied!' : 'Copy to clipboard'}
       className={className}
     >
-      <ClipboardIcon className="w-4 h-4" />
+      <Icon icon={ClipboardIcon} className="w-4 h-4"  />
       {copied ? 'Copied!' : (label || 'Copy')}
     </Button>
   );

--- a/src/shared/ui/Icon.tsx
+++ b/src/shared/ui/Icon.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType, JSX } from 'preact';
-type IconComponent = ComponentType<JSX.SVGAttributes<SVGSVGElement>>;
+
+export type IconComponent = ComponentType<JSX.SVGAttributes<SVGSVGElement>>;
 
 interface IconProps extends JSX.SVGAttributes<SVGSVGElement> {
   icon: IconComponent;

--- a/src/shared/ui/activity/ActivityTimeline.tsx
+++ b/src/shared/ui/activity/ActivityTimeline.tsx
@@ -6,6 +6,7 @@ import {
   PlusCircleIcon,
   PaperAirplaneIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { Avatar } from '@/shared/ui/profile';
 import { Button } from '@/shared/ui/Button';
 import { cn } from '@/shared/utils/cn';
@@ -65,10 +66,10 @@ const DEFAULT_ACTIONS: Record<TimelineItem['type'], string> = {
 };
 
 const TYPE_ICONS: Partial<Record<TimelineItem['type'], (props: { className?: string }) => JSX.Element>> = {
-  created: (props) => <PlusCircleIcon {...props} />,
-  edited: (props) => <PencilSquareIcon {...props} />,
-  sent: (props) => <PaperAirplaneIcon {...props} />,
-  viewed: (props) => <EyeIcon {...props} />
+  created: (props) => <Icon icon={PlusCircleIcon} {...props}  />,
+  edited: (props) => <Icon icon={PencilSquareIcon} {...props}  />,
+  sent: (props) => <Icon icon={PaperAirplaneIcon} {...props}  />,
+  viewed: (props) => <Icon icon={EyeIcon} {...props}  />
 };
 
 export const ActivityTimeline = ({
@@ -176,13 +177,13 @@ export const ActivityTimeline = ({
                     className="ring-1 ring-black/10 bg-white/10 text-input-text dark:ring-white/20"
                   />
                   <span className="absolute -right-1 -bottom-1 flex h-5 w-5 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-glass/30 shadow-sm">
-                    <ChatBubbleLeftRightIcon className="h-3 w-3" aria-hidden="true" />
+                    <Icon icon={ChatBubbleLeftRightIcon} className="h-3 w-3" aria-hidden="true"  />
                   </span>
                 </div>
               ) : (
                 <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-glass/30 shadow-sm">
                   {item.type === 'paid' ? (
-                    <CheckCircleIcon aria-hidden="true" className="h-5 w-5 text-emerald-500" />
+                    <Icon icon={CheckCircleIcon} aria-hidden="true" className="h-5 w-5 text-emerald-500"  />
                   ) : TYPE_ICONS[item.type] ? (
                     (() => {
                       const Icon = TYPE_ICONS[item.type];

--- a/src/shared/ui/badges/OnboardingStatusBadge.tsx
+++ b/src/shared/ui/badges/OnboardingStatusBadge.tsx
@@ -6,6 +6,7 @@
  */
 
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import type { ComponentChildren } from 'preact';
 
@@ -49,7 +50,7 @@ export const OnboardingStatusBadge = ({
     if (variant === 'compact') {
       return (
         <>
-          {status !== 'completed' && <ExclamationTriangleIcon className="w-3 h-3 mr-1" />}
+          {status !== 'completed' && <Icon icon={ExclamationTriangleIcon} className="w-3 h-3 mr-1"  />}
           Setup
         </>
       );

--- a/src/shared/ui/input/Combobox.tsx
+++ b/src/shared/ui/input/Combobox.tsx
@@ -21,6 +21,7 @@ import {
   XMarkIcon,
   PlusIcon,
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 
 // ---------------------------------------------------------------------------
@@ -112,7 +113,7 @@ function Chip({
         className="ml-0.5 rounded hover:text-red-400 transition-colors"
         aria-label={`Remove ${label}`}
       >
-        <XMarkIcon className="h-3 w-3" />
+        <Icon icon={XMarkIcon} className="h-3 w-3"  />
       </button>
     </span>
   );
@@ -170,7 +171,7 @@ function DropdownOption({
           <span className="text-xs text-input-placeholder">{resolvedOptionMeta}</span>
         )}
         {isSelected && (
-          <CheckIcon className="h-4 w-4 text-accent-400" aria-hidden="true" />
+          <Icon icon={CheckIcon} className="h-4 w-4 text-accent-400" aria-hidden="true"  />
         )}
       </span>
     </button>
@@ -481,13 +482,13 @@ export function Combobox({
           className="flex-shrink-0 text-input-placeholder hover:text-input-text transition-colors"
           aria-label="Clear selection"
         >
-          <XMarkIcon className="h-4 w-4" />
+          <Icon icon={XMarkIcon} className="h-4 w-4"  />
         </button>
       ) : (
         <span className="flex-shrink-0 text-input-placeholder pointer-events-none">
           {searchable
-            ? <ChevronUpDownIcon className="h-4 w-4" />
-            : <ChevronDownIcon className={cn('h-4 w-4 transition-transform', isOpen && 'rotate-180')} />
+            ? <Icon icon={ChevronUpDownIcon} className="h-4 w-4"  />
+            : <Icon icon={ChevronDownIcon} className={cn('h-4 w-4 transition-transform', isOpen && 'rotate-180')}  />
           }
         </span>
       )}
@@ -604,7 +605,7 @@ export function Combobox({
                 )}
               >
                 <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-accent-500/20 text-accent-400">
-                  <PlusIcon className="h-3.5 w-3.5" />
+                  <Icon icon={PlusIcon} className="h-3.5 w-3.5"  />
                 </span>
                 <span>
                   {addNewLabel}{' '}

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'preact/compat';
 import { EnvelopeIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
@@ -125,7 +126,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
       
       <div className="relative">
         <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-          <EnvelopeIcon className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+          <Icon icon={EnvelopeIcon} className="w-4 h-4 text-gray-400 dark:text-gray-500"  />
         </div>
         
         <input
@@ -147,9 +148,9 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
         {showValidationIcon && (
           <div className="absolute inset-y-0 right-0 flex items-center pr-3">
             {isEmailValid ? (
-              <CheckIcon className="w-4 h-4 text-green-600 dark:text-green-400" />
+              <Icon icon={CheckIcon} className="w-4 h-4 text-green-600 dark:text-green-400"  />
             ) : (
-              <XMarkIcon className="w-4 h-4 text-red-600 dark:text-red-400" />
+              <Icon icon={XMarkIcon} className="w-4 h-4 text-red-600 dark:text-red-400"  />
             )}
           </div>
         )}

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -1,8 +1,11 @@
 import { forwardRef } from 'preact/compat';
 import { ComponentChildren, JSX } from 'preact';
+import { Icon, type IconComponent } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useTranslation } from '@/shared/i18n/hooks';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
+
+type InputIcon = IconComponent | ComponentChildren;
 
 export interface InputProps extends Omit<JSX.IntrinsicElements['input'], 'type' | 'value' | 'onChange' | 'onBlur' | 'size'> {
   type?: 'text' | 'password' | 'email' | 'tel' | 'url' | 'number' | 'search' | 'date';
@@ -15,7 +18,8 @@ export interface InputProps extends Omit<JSX.IntrinsicElements['input'], 'type' 
   className?: string;
   size?: 'sm' | 'md' | 'lg';
   variant?: 'default' | 'error' | 'success';
-  icon?: ComponentChildren;
+  icon?: InputIcon;
+  iconClassName?: string;
   iconPosition?: 'left' | 'right';
   label?: string;
   description?: string;
@@ -43,6 +47,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   size = 'md',
   variant = 'default',
   icon,
+  iconClassName = '',
   iconPosition = 'left',
   label,
   description,
@@ -72,6 +77,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   const displayDescription = descriptionKey ? t(descriptionKey) : description;
   const displayPlaceholder = placeholderKey ? t(placeholderKey) : placeholder;
   const displayError = errorKey ? t(errorKey) : error;
+  const isIconComponent = (iconValue: InputIcon | undefined): iconValue is IconComponent =>
+    typeof iconValue === 'function';
 
   // Generate stable IDs for description and error elements
   const descriptionId = displayDescription ? `${inputId}-description` : undefined;
@@ -113,6 +120,20 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
     className
   );
 
+  const renderIcon = () => {
+    if (!icon) return null;
+
+    if (isIconComponent(icon)) {
+      return <Icon icon={icon} className={cn('w-4 h-4 text-gray-400 dark:text-gray-500', iconClassName)} />;
+    }
+
+    return (
+      <div className="w-4 h-4 text-gray-400 dark:text-gray-500">
+        {icon}
+      </div>
+    );
+  };
+
   return (
     <div className="w-full">
       {displayLabel && (
@@ -125,9 +146,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
       <div className="relative">
         {icon && iconPosition === 'left' && (
           <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-            <div className="w-4 h-4 text-gray-400 dark:text-gray-500">
-              {icon}
-            </div>
+            {renderIcon()}
           </div>
         )}
         
@@ -151,9 +170,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
         
         {icon && iconPosition === 'right' && (
           <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-            <div className="w-4 h-4 text-gray-400 dark:text-gray-500">
-              {icon}
-            </div>
+            {renderIcon()}
           </div>
         )}
       </div>

--- a/src/shared/ui/input/MarkdownUploadTextarea.tsx
+++ b/src/shared/ui/input/MarkdownUploadTextarea.tsx
@@ -8,6 +8,7 @@ import {
   ListBulletIcon,
   NumberedListIcon
 } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { uploadWithProgress, validateFile } from '@/shared/services/upload/UploadTransport';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
@@ -301,28 +302,28 @@ export const MarkdownUploadTextarea = ({
                   <span className="text-xs italic leading-none">I</span>
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Quote" onClick={() => prependToLine('> ', 'Quoted text')}>
-                  <Bars3BottomLeftIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={Bars3BottomLeftIcon} className="h-4 w-4" aria-hidden="true"  />
                 </button>
               </div>
               <div className="h-4 w-px bg-line-glass/50" />
               <div className="flex items-center gap-1">
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Code block" onClick={() => replaceSelection('```\n', '\n```', 'code')}>
-                  <CodeBracketIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={CodeBracketIcon} className="h-4 w-4" aria-hidden="true"  />
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Insert link" onClick={() => replaceSelection('[', '](https://)', 'link text')}>
-                  <LinkIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={LinkIcon} className="h-4 w-4" aria-hidden="true"  />
                 </button>
               </div>
               <div className="h-4 w-px bg-line-glass/50" />
               <div className="flex items-center gap-1">
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Bulleted list" onClick={() => prependToLine('- ', 'List item')}>
-                  <ListBulletIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={ListBulletIcon} className="h-4 w-4" aria-hidden="true"  />
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Numbered list" onClick={() => prependToLine('1. ', 'List item')}>
-                  <NumberedListIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={NumberedListIcon} className="h-4 w-4" aria-hidden="true"  />
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Task list" onClick={() => prependToLine('- [ ] ', 'Task')}>
-                  <DocumentTextIcon className="h-4 w-4" aria-hidden="true" />
+                  <Icon icon={DocumentTextIcon} className="h-4 w-4" aria-hidden="true"  />
                 </button>
               </div>
             </div>
@@ -413,7 +414,7 @@ export const MarkdownUploadTextarea = ({
         {showFooter ? (
           <div className="flex flex-wrap items-center justify-between gap-2 border-t border-line-glass/30 px-4 py-2 text-sm">
             <div className="flex items-center gap-2 text-input-placeholder">
-              <CloudArrowUpIcon className="h-4 w-4" aria-hidden="true" />
+              <Icon icon={CloudArrowUpIcon} className="h-4 w-4" aria-hidden="true"  />
               <button
                 type="button"
                 className="hover:text-input-text"
@@ -446,7 +447,7 @@ export const MarkdownUploadTextarea = ({
         <div className="space-y-1 rounded-xl border border-line-glass/30 bg-surface-overlay/50 px-3 py-2">
           {uploadItems.map((item) => (
             <div key={item.id} className="flex items-center gap-2 text-xs text-input-placeholder">
-              <DocumentTextIcon className="h-4 w-4" aria-hidden="true" />
+              <Icon icon={DocumentTextIcon} className="h-4 w-4" aria-hidden="true"  />
               <span className="truncate">{item.name}</span>
               {item.status === 'uploading' && <span>{item.progress}%</span>}
               {item.status === 'uploaded' && <span className="text-emerald-300">uploaded</span>}

--- a/src/shared/ui/input/NumberInput.tsx
+++ b/src/shared/ui/input/NumberInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback } from 'preact/compat';
 import { PlusIcon, MinusIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
@@ -191,7 +192,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
                 'rounded-tr-lg'
               )}
             >
-              <PlusIcon className="w-3 h-3" />
+              <Icon icon={PlusIcon} className="w-3 h-3"  />
             </button>
             <button
               type="button"
@@ -205,7 +206,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
                 'rounded-br-lg'
               )}
             >
-              <MinusIcon className="w-3 h-3" />
+              <Icon icon={MinusIcon} className="w-3 h-3"  />
             </button>
           </div>
         )}

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useState } from 'preact/compat';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
@@ -180,9 +181,9 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
           className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 focus:ring-2 focus:ring-accent-500 focus:ring-offset-1 focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-1"
         >
           {showPassword ? (
-            <EyeSlashIcon className="w-4 h-4" />
+            <Icon icon={EyeSlashIcon} className="w-4 h-4"  />
           ) : (
-            <EyeIcon className="w-4 h-4" />
+            <Icon icon={EyeIcon} className="w-4 h-4"  />
           )}
         </button>
       </div>

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useState, useEffect, useRef } from 'preact/compat';
 import { PhoneIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
@@ -267,7 +268,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
             >
               <span className="text-base mr-1">{currentCountry.emoji}</span>
               <span className="text-sm">{currentCountry.code}</span>
-              <ChevronDownIcon className="w-3 h-3 ml-1" />
+              <Icon icon={ChevronDownIcon} className="w-3 h-3 ml-1"  />
             </button>
             
             {isDropdownOpen && (
@@ -304,7 +305,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         
         <div className="relative flex-1">
           <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-            <PhoneIcon className="w-4 h-4 text-input-placeholder" />
+            <Icon icon={PhoneIcon} className="w-4 h-4 text-input-placeholder"  />
           </div>
           
           <input

--- a/src/shared/ui/input/URLInput.tsx
+++ b/src/shared/ui/input/URLInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback } from 'preact/compat';
 import { LinkIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
@@ -256,7 +257,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
       
       <div className="relative">
         <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-          <LinkIcon className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+          <Icon icon={LinkIcon} className="w-4 h-4 text-gray-400 dark:text-gray-500"  />
         </div>
         
         <input
@@ -276,9 +277,9 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
         {showValidationIcon && (
           <div className="absolute inset-y-0 right-0 flex items-center pr-3">
             {isURLValid ? (
-              <CheckIcon className="w-4 h-4 text-green-600 dark:text-green-400" />
+              <Icon icon={CheckIcon} className="w-4 h-4 text-green-600 dark:text-green-400"  />
             ) : (
-              <XMarkIcon className="w-4 h-4 text-red-600 dark:text-red-400" />
+              <Icon icon={XMarkIcon} className="w-4 h-4 text-red-600 dark:text-red-400"  />
             )}
           </div>
         )}

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -200,7 +200,7 @@ export const InspectorPanel = ({
           size="icon-sm"
           onClick={onClose}
           aria-label="Close inspector"
-          icon={<XMarkIcon className="h-4 w-4" />}
+          icon={XMarkIcon} iconClassName="h-4 w-4"
         />
       </div>
 

--- a/src/shared/ui/layout/DetailHeader.tsx
+++ b/src/shared/ui/layout/DetailHeader.tsx
@@ -37,7 +37,7 @@ export const DetailHeader = ({
             size="icon-sm"
             onClick={onBack}
             aria-label="Back"
-            icon={<ChevronLeftIcon className="h-4 w-4" />}
+            icon={ChevronLeftIcon} iconClassName="h-4 w-4"
           />
         </div>
       ) : null}
@@ -55,7 +55,7 @@ export const DetailHeader = ({
               size="icon-sm"
               onClick={onInspector}
               aria-label={inspectorOpen ? 'Close inspector' : 'Open inspector'}
-              icon={<InformationCircleIcon className="h-5 w-5" />}
+              icon={InformationCircleIcon} iconClassName="h-5 w-5"
             />
           ) : null}
         </div>

--- a/src/shared/ui/markdown/markdownComponents.tsx
+++ b/src/shared/ui/markdown/markdownComponents.tsx
@@ -2,6 +2,7 @@ import type { Components } from 'react-markdown';
 import { useState, useRef, useEffect } from 'preact/hooks';
 import type { ComponentChildren, VNode } from 'preact';
 import { ClipboardDocumentCheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 
 /**
  * Shared react-markdown component overrides used across chat bubbles
@@ -61,12 +62,12 @@ const CopyButton = ({ text }: { text: string }) => {
     >
       {copied ? (
         <>
-          <ClipboardDocumentCheckIcon className="h-4 w-4" aria-hidden="true" />
+          <Icon icon={ClipboardDocumentCheckIcon} className="h-4 w-4" aria-hidden="true"  />
           Copied
         </>
       ) : (
         <>
-          <ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" />
+          <Icon icon={ClipboardDocumentIcon} className="h-4 w-4" aria-hidden="true"  />
           Copy
         </>
       )}

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -1,12 +1,13 @@
-import type { ComponentType, FunctionComponent, JSX } from 'preact';
+import type { FunctionComponent } from 'preact';
 import { useLocation } from 'preact-iso';
+import { Icon, type IconComponent } from '@/shared/ui/Icon';
 import { useNavigation } from '@/shared/utils/navigation';
 import { cn } from '@/shared/utils/cn';
 
 export interface NavRailItem {
   id: string;
   label: string;
-  icon: ComponentType<JSX.SVGAttributes<SVGSVGElement>>;
+  icon: IconComponent;
   href: string;
   badge?: number | null;
   variant?: 'default' | 'danger';
@@ -68,7 +69,7 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
   return (
     <div className={cn(containerClass, className)}>
       {items.map((item) => {
-        const Icon = item.icon;
+        const icon = item.icon;
         const isActive = !item.isAction && activeItemId === item.id;
         const isDanger = item.variant === 'danger';
 
@@ -107,7 +108,7 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
               onItemActivate?.();
             }}
           >
-            <Icon className="h-5 w-5" aria-hidden="true" />
+            <Icon icon={icon} className="h-5 w-5" />
             {variant === 'bottom' && showLabels ? <span className="truncate max-w-full">{item.label}</span> : null}
             {item.badge && item.badge > 0 ? (
               <span className="absolute -right-1 -top-1 min-w-[1.125rem] rounded-full bg-accent-600 px-1.5 py-0.5 text-[10px] font-bold leading-none text-[rgb(var(--accent-foreground))]">

--- a/src/shared/ui/profile/atoms/ProfileIcon.tsx
+++ b/src/shared/ui/profile/atoms/ProfileIcon.tsx
@@ -5,10 +5,10 @@
  * No interactions, no state. Just renders an icon with consistent sizing.
  */
 
-import type { ComponentChildren } from 'preact';
+import { Icon, type IconComponent } from '@/shared/ui/Icon';
 
 interface ProfileIconProps {
-  icon: ComponentChildren;
+  icon: IconComponent;
   className?: string;
 }
 
@@ -17,8 +17,8 @@ export const ProfileIcon = ({
   className = ''
 }: ProfileIconProps) => {
   return (
-    <span className={`w-4 h-4 flex-shrink-0 ${className}`}>
-      {icon}
+    <span className={`flex-shrink-0 ${className}`}>
+      <Icon icon={icon} className="w-4 h-4" />
     </span>
   );
 };

--- a/src/shared/ui/profile/atoms/ProfileIcon.tsx
+++ b/src/shared/ui/profile/atoms/ProfileIcon.tsx
@@ -18,7 +18,7 @@ export const ProfileIcon = ({
 }: ProfileIconProps) => {
   return (
     <span className={`flex-shrink-0 ${className}`}>
-      <Icon icon={icon} className="w-4 h-4" />
+      <Icon icon={icon} className="w-4 h-4" aria-hidden="true" />
     </span>
   );
 };

--- a/src/shared/ui/profile/molecules/ProfileDropdown.tsx
+++ b/src/shared/ui/profile/molecules/ProfileDropdown.tsx
@@ -39,7 +39,7 @@ export const ProfileDropdown = ({
     >
       {/* Settings */}
       <ProfileMenuItem
-        icon={<Cog6ToothIcon />}
+        icon={Cog6ToothIcon}
         label={t('profile:menu.settings')}
         onClick={onSettings}
       />
@@ -49,14 +49,14 @@ export const ProfileDropdown = ({
       
       {/* Help */}
       <ProfileMenuItem
-        icon={<QuestionMarkCircleIcon />}
+        icon={QuestionMarkCircleIcon}
         label={t('profile:menu.help')}
         onClick={onHelp}
       />
       
       {/* Log out */}
       <ProfileMenuItem
-        icon={<ArrowRightOnRectangleIcon />}
+        icon={ArrowRightOnRectangleIcon}
         label={t('profile:menu.signOut')}
         onClick={onLogout}
       />

--- a/src/shared/ui/profile/molecules/ProfileMenuItem.tsx
+++ b/src/shared/ui/profile/molecules/ProfileMenuItem.tsx
@@ -6,10 +6,10 @@
  */
 
 import { ProfileIcon } from '../atoms/ProfileIcon';
-import type { ComponentChildren } from 'preact';
+import type { IconComponent } from '@/shared/ui/Icon';
 
 interface ProfileMenuItemProps {
-  icon: ComponentChildren;
+  icon: IconComponent;
   label: string;
   onClick: () => void;
   isActive?: boolean;

--- a/src/shared/ui/profile/organisms/UserProfileDisplay.tsx
+++ b/src/shared/ui/profile/organisms/UserProfileDisplay.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useRef } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { UserIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { ProfileButton } from '../molecules/ProfileButton';
 import { ProfileDropdown } from '../molecules/ProfileDropdown';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
@@ -156,7 +157,7 @@ export const UserProfileDisplay = ({
       <div className={`p-2 border-t border-line-glass/30`}>
         <div className={`flex items-center ${isCollapsed ? 'justify-center py-2' : 'gap-3 px-3 py-2'}`}>
           <div className="w-8 h-8 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center flex-shrink-0">
-            <UserIcon className="w-4 h-4 text-red-600 dark:text-red-400" />
+            <Icon icon={UserIcon} className="w-4 h-4 text-red-600 dark:text-red-400"  />
           </div>
           {!isCollapsed && (
             <div className="flex-1 min-w-0">
@@ -186,7 +187,7 @@ export const UserProfileDisplay = ({
           title={isCollapsed ? t('profile:menu.signIn') : undefined}
           aria-label={t('profile:aria.signInButton')}
         >
-          <UserIcon className="w-5 h-5 flex-shrink-0" />
+          <Icon icon={UserIcon} className="w-5 h-5 flex-shrink-0"  />
           {!isCollapsed && <span className="text-sm font-medium">{t('profile:menu.signIn')}</span>}
         </button>
       </div>

--- a/src/shared/ui/sidebar/atoms/CollapsibleToggle.tsx
+++ b/src/shared/ui/sidebar/atoms/CollapsibleToggle.tsx
@@ -6,20 +6,22 @@
  */
 
 import { Button } from '../../Button';
-import type { ComponentChildren } from 'preact';
+import type { IconComponent } from '@/shared/ui/Icon';
 
 interface CollapsibleToggleProps {
-  icon: ComponentChildren;
+  icon: IconComponent;
   onClick: () => void;
   ariaLabel: string;
   className?: string;
+  iconClassName?: string;
 }
 
 export const CollapsibleToggle = ({ 
   icon, 
   onClick, 
   ariaLabel,
-  className = ''
+  className = '',
+  iconClassName = ''
 }: CollapsibleToggleProps) => {
   return (
     <Button
@@ -27,6 +29,7 @@ export const CollapsibleToggle = ({
       size="sm"
       onClick={onClick}
       icon={icon}
+      iconClassName={iconClassName}
       aria-label={ariaLabel}
       className={`w-8 h-8 p-0 ${className}`}
     />

--- a/src/shared/ui/sidebar/atoms/NavigationIcon.tsx
+++ b/src/shared/ui/sidebar/atoms/NavigationIcon.tsx
@@ -5,10 +5,10 @@
  * Just renders an icon with consistent sizing and styling.
  */
 
-import type { ComponentChildren } from 'preact';
+import { Icon, type IconComponent } from '@/shared/ui/Icon';
 
 interface NavigationIconProps {
-  icon: ComponentChildren;
+  icon: IconComponent;
   size?: 'sm' | 'md' | 'lg';
   className?: string;
 }
@@ -25,8 +25,8 @@ export const NavigationIcon = ({
   };
 
   return (
-    <span className={`flex-shrink-0 ${sizeClasses[size]} ${className}`}>
-      {icon}
+    <span className={`flex-shrink-0 ${className}`}>
+      <Icon icon={icon} className={sizeClasses[size]} />
     </span>
   );
 };

--- a/src/shared/ui/sidebar/molecules/NavigationItem.tsx
+++ b/src/shared/ui/sidebar/molecules/NavigationItem.tsx
@@ -9,7 +9,7 @@ import { NavigationIcon } from '../atoms/NavigationIcon';
 import { StatusDot } from '../atoms/StatusDot';
 import { NotificationDot } from '../atoms/NotificationDot';
 import { MatterStatus } from '@/shared/types/matter';
-import type { ComponentChildren } from 'preact';
+import type { IconComponent } from '@/shared/ui/Icon';
 
 /**
  * Translates matter status to user-friendly screen reader text
@@ -30,7 +30,7 @@ const translateMatterStatus = (status: MatterStatus | null | undefined): string 
 };
 
 interface NavigationItemProps {
-  icon: ComponentChildren;
+  icon: IconComponent;
   label: string;
   isActive: boolean;
   onClick: () => void;

--- a/src/shared/ui/sidebar/molecules/SidebarHeader.tsx
+++ b/src/shared/ui/sidebar/molecules/SidebarHeader.tsx
@@ -47,7 +47,8 @@ export const SidebarHeader = ({
           ) : (
             // Visible, focusable fallback when no profile image
             <CollapsibleToggle
-              icon={<Bars3Icon className="w-4 h-4" />}
+              icon={Bars3Icon}
+              iconClassName="w-4 h-4"
               onClick={() => onToggleCollapse()}
               ariaLabel="Expand sidebar"
             />
@@ -56,7 +57,8 @@ export const SidebarHeader = ({
           {practiceConfig?.profileImage && (
             <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none group-hover:pointer-events-auto">
               <CollapsibleToggle
-                icon={<Bars3Icon className="w-4 h-4" />}
+                icon={Bars3Icon}
+                iconClassName="w-4 h-4"
                 onClick={() => onToggleCollapse()}
                 ariaLabel="Expand sidebar"
               />
@@ -78,13 +80,15 @@ export const SidebarHeader = ({
       )}
       {onClose ? (
         <CollapsibleToggle
-          icon={<XMarkIcon className="w-5 h-5" />}
+          icon={XMarkIcon}
+          iconClassName="w-5 h-5"
           onClick={onClose}
           ariaLabel="Close sidebar"
         />
       ) : (
         <CollapsibleToggle
-          icon={<Bars3Icon className="w-5 h-5" />}
+          icon={Bars3Icon}
+          iconClassName="w-5 h-5"
           onClick={onToggleCollapse}
           ariaLabel="Collapse sidebar"
         />

--- a/src/shared/ui/sidebar/organisms/SidebarContent.tsx
+++ b/src/shared/ui/sidebar/organisms/SidebarContent.tsx
@@ -9,13 +9,13 @@ import { SidebarHeader } from '../molecules/SidebarHeader';
 import { NavigationList } from '../molecules/NavigationList';
 import { NavigationItem } from '../molecules/NavigationItem';
 import UserProfile from '@/shared/components/UserProfile';
-import type { ComponentChildren } from 'preact';
+import type { IconComponent } from '@/shared/ui/Icon';
 import type { MatterStatus } from '@/shared/types/matter';
 
 export interface SidebarNavItem {
   id: string;
   label: string;
-  icon: ComponentChildren;
+  icon: IconComponent;
   isActive: boolean;
   onClick: () => void;
   matterStatus?: MatterStatus;

--- a/tests/component/icon-standardization.test.tsx
+++ b/tests/component/icon-standardization.test.tsx
@@ -1,0 +1,65 @@
+import type { JSX } from 'preact';
+import { fireEvent, render, screen } from '@testing-library/preact';
+import { describe, expect, it, vi } from 'vitest';
+import { Button } from '@/shared/ui/Button';
+import { ProfileMenuItem } from '@/shared/ui/profile/molecules/ProfileMenuItem';
+
+const TestIcon = (props: JSX.SVGAttributes<SVGSVGElement>) => (
+  <svg data-testid="test-icon" {...props} />
+);
+
+describe('Icon standardization', () => {
+  it('renders icon components through Button with shared icon styling', () => {
+    render(
+      <Button
+        icon={TestIcon}
+        iconClassName="h-4 w-4 text-input-text"
+        aria-label="Open inspector"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Open inspector' });
+    const icon = screen.getByTestId('test-icon');
+
+    expect(button).toHaveClass('btn-icon-md');
+    expect(icon).toHaveClass('shrink-0', 'h-4', 'w-4', 'text-input-text');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).toHaveAttribute('focusable', 'false');
+  });
+
+  it('preserves JSX icon children for Button compatibility', () => {
+    render(
+      <Button
+        icon={<svg data-testid="custom-icon" className="custom-svg" />}
+        aria-label="Open custom"
+      />
+    );
+
+    const icon = screen.getByTestId('custom-icon');
+    expect(icon).toHaveClass('custom-svg');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).toHaveAttribute('focusable', 'false');
+  });
+
+  it('renders profile menu icons from icon component props without changing behavior', () => {
+    const onClick = vi.fn();
+
+    render(
+      <ProfileMenuItem
+        icon={TestIcon}
+        label="Settings"
+        onClick={onClick}
+        isActive
+      />
+    );
+
+    const button = screen.getByRole('menuitem', { name: 'Settings' });
+    const icon = screen.getByTestId('test-icon');
+
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(button).toHaveClass('font-semibold');
+    expect(icon).toHaveClass('shrink-0', 'w-4', 'h-4');
+  });
+});


### PR DESCRIPTION
## Summary
- route production Heroicon rendering through the shared `Icon` wrapper
- expand shared icon-bearing APIs like `Button` and `Input` to accept icon component types
- add focused regression coverage for icon component rendering

Closes #285

## Verification
- npm run lint
- npm run type-check
- npm run test:component -- tests/component/icon-standardization.test.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized icon rendering across the app with a shared Icon wrapper for consistent visuals.
  * Updated Button and Input to accept icon components plus a separate sizing prop, simplifying icon usage and harmonizing icon styling across UI.

* **Tests**
  * Added tests validating the new icon rendering and sizing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->