### PR TITLE
Match thinking dot animation to ChatGPT

### DIFF
--- a/src/features/chat/components/AIThinkingIndicator.tsx
+++ b/src/features/chat/components/AIThinkingIndicator.tsx
@@ -52,17 +52,14 @@ export function AIThinkingIndicator({
 
   // For thinking indicators, use the full wrapper
   return (
-    <div 
+    <div
       className={`flex items-center gap-2 min-h-4 ${className}`}
       role="status"
       aria-live="polite"
       aria-busy="true"
       aria-atomic="true"
     >
-      <span className="relative flex h-2.5 w-2.5">
-        <span className="absolute inline-flex h-full w-full rounded-full bg-accent-500/30 animate-ping" />
-        <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-accent-500 shadow-lg shadow-accent-500/20" />
-      </span>
+      <span className="ai-thinking-indicator__dot" aria-hidden="true" />
       <span className="sr-only">{displayMessage}</span>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -273,6 +273,15 @@
     box-shadow: var(--glass-rim-medium);
   }
 
+  .ai-thinking-indicator__dot {
+    @apply inline-flex h-3 w-3 rounded-full bg-accent-500;
+    transform-origin: 50% center;
+    backface-visibility: hidden;
+    will-change: transform;
+    transform: translateZ(0);
+    animation: ai-thinking-dot-pulse 1.25s ease-in-out infinite;
+  }
+
   /* ============================================================
      BUTTON SYSTEM
      All button visual styles are defined here as component
@@ -1345,6 +1354,17 @@
 
   .animate-float-in {
     animation: float-in 600ms ease-out both;
+  }
+
+  @keyframes ai-thinking-dot-pulse {
+    0%,
+    100% {
+      transform: translateZ(0) scale(1);
+    }
+
+    50% {
+      transform: translateZ(0) scale(1.25);
+    }
   }
 
   @keyframes workspace-header-progress {

--- a/tests/component/ai-thinking-indicator.test.tsx
+++ b/tests/component/ai-thinking-indicator.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/preact';
+import { describe, expect, it, vi } from 'vitest';
+import { AIThinkingIndicator } from '@/features/chat/components/AIThinkingIndicator';
+
+vi.mock('@/features/chat/components/ChatMarkdown', () => ({
+  default: ({ text }: { text: string }) => <div data-testid="chat-markdown">{text}</div>
+}));
+
+describe('AIThinkingIndicator', () => {
+  it('renders a single pulsing thinking dot with accessible status text', () => {
+    const { container } = render(
+      <AIThinkingIndicator toolMessage="Working through the response" />
+    );
+
+    const status = screen.getByRole('status');
+    const dot = container.querySelector('.ai-thinking-indicator__dot');
+
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+    expect(status).toHaveAttribute('aria-atomic', 'true');
+    expect(status).toHaveTextContent('Working through the response');
+    expect(dot).not.toBeNull();
+    expect(container.querySelector('.ai-thinking-indicator__glow')).toBeNull();
+    expect(container.querySelector('.ai-thinking-indicator__core')).toBeNull();
+    expect(container.querySelector('.animate-ping')).toBeNull();
+  });
+
+  it('keeps the streaming content path unchanged and does not render the thinking dot', () => {
+    const { container } = render(
+      <AIThinkingIndicator content="Streaming draft content" className="custom-class" />
+    );
+
+    expect(screen.getByTestId('chat-markdown')).toHaveTextContent('Streaming draft content');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector('.ai-thinking-indicator__dot')).toBeNull();
+    expect(container.querySelector('.animate-ping')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the thinking indicator halo with a single pulsing dot
- match ChatGPT's current pulse timing and size growth while keeping Blawby's accent color
- add focused component coverage for the loading and streaming branches

## Testing
- npm run type-check
- npm run test:component -- tests/component/ai-thinking-indicator.test.tsx

Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined the AI thinking indicator with an enhanced pulsing animation effect to provide clearer visual feedback when the AI is processing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->