### PR TITLE
Remove intake submission fallback

### DIFF
--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -827,12 +827,8 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
                     const leadReview = resolveLeadReview(message);
                     const authCta = resolveAuthCta(message);
 
-                    const quickReplies = isLast
-                        ? (Array.isArray(intakeConversationState?.quickReplies)
-                            ? intakeConversationState.quickReplies
-                            : Array.isArray(message.metadata?.quickReplies)
-                                ? message.metadata.quickReplies.filter((value: unknown): value is string => typeof value === 'string')
-                                : undefined)
+                    const quickReplies = isLast && Array.isArray(message.metadata?.quickReplies)
+                        ? message.metadata.quickReplies.filter((value: unknown): value is string => typeof value === 'string')
                         : undefined;
                     const onboardingMetaFromMessage = (
                         message.metadata && typeof message.metadata.onboardingProfile === 'object' && message.metadata.onboardingProfile

--- a/worker/routes/aiChat.ts
+++ b/worker/routes/aiChat.ts
@@ -604,7 +604,7 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
       if (isIntakeMode) {
         const mergedForConversation = mergeIntakeState(storedIntakeState, intakeFields);
         const conversationSystemPrompt = [
-          buildIntakeConversationPrompt(servicesForPrompt, mergedForConversation, body.messages.length),
+          buildIntakeConversationPrompt(servicesForPrompt, mergedForConversation),
           `PRACTICE_CONTEXT: ${JSON.stringify(aiDetails)}`,
           body.additionalContext ? `SEARCH_CONTEXT: ${body.additionalContext}` : null,
         ].filter(Boolean).join('\n\n');

--- a/worker/routes/aiChatIntake.ts
+++ b/worker/routes/aiChatIntake.ts
@@ -71,8 +71,7 @@ Rules:
 
 export const buildIntakeConversationPrompt = (
   services: Array<{ name: string; key: string }>,
-  mergedState: Record<string, unknown> | null,
-  messageCount: number
+  mergedState: Record<string, unknown> | null
 ): string => {
   const knownFields: string[] = [];
   if (mergedState) {
@@ -92,7 +91,7 @@ export const buildIntakeConversationPrompt = (
 
   const isReadyToSubmit = shouldShowDeterministicIntakeCta(mergedState);
 
-  const ctaInstruction = isReadyToSubmit || messageCount >= 8
+  const ctaInstruction = isReadyToSubmit
     ? `\nThe intake brief is complete. Do not ask any more questions. Summarize what you know in 2-3 sentences and ask if the user is ready to submit to the firm.`
     : `\nAsk exactly ONE focused question about the single most important missing piece of information. Priority: situation description → city and state → opposing party → urgency → desired outcome → documents.`;
 


### PR DESCRIPTION
Removes the message-count fallback that was pushing the intake flow into submission mode too early, and keeps quick replies tied to the current assistant message metadata only. Also updates the intake conversation prompt call site to the new signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
* Streamlined quick reply sourcing: message response options are now exclusively derived from message metadata for more predictable chat interactions
* Enhanced intake submission prompts: call-to-action messages now activate based on form completion status only, eliminating automatic triggers based on message count thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->