### PR TITLE
chore: rename user-details to clients API

### DIFF
--- a/docs/blawby-system-current-vs-goal.md
+++ b/docs/blawby-system-current-vs-goal.md
@@ -32,7 +32,7 @@ At a high level:
 - The frontend talks same-origin to the worker.
 - The worker handles conversations, realtime chat, AI routes, file/media helpers, and notification queueing.
 - The worker proxies most business endpoints to the backend.
-- The backend is the source of truth for auth, practices, intakes, matters, subscriptions, uploads, invoices, onboarding, user details, and most Stripe-backed business logic.
+- The backend is the source of truth for auth, practices, intakes, matters, subscriptions, uploads, invoices, onboarding, clients, and most Stripe-backed business logic.
 
 ### Repo Roles
 

--- a/docs/blawby-system-current-vs-goal.md
+++ b/docs/blawby-system-current-vs-goal.md
@@ -80,7 +80,7 @@ Backend-proxied responsibilities:
 - `/api/matters`
 - `/api/invoices`
 - `/api/practice/client-intakes`
-- `/api/user-details`
+- `/api/clients`
 - `/api/practice/*` except worker-local practice details helpers
 - `/api/preferences`
 - `/api/subscriptions`

--- a/public/widget-loader.js
+++ b/public/widget-loader.js
@@ -1,3 +1,4 @@
+/* global window, document, console, fetch, URL, URLSearchParams, CustomEvent, setTimeout */
 /**
  * Blawby Website Messenger — Widget Loader
  *
@@ -77,7 +78,7 @@
         if (!trimmed) return;
         out[key] = trimmed;
       });
-    } catch (_) { /* ignore malformed query params */ }
+    } catch { /* ignore malformed query params */ }
     return out;
   }
 
@@ -302,7 +303,7 @@
     if (!hasAttributionParams) return;
     try {
       w.sessionStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(attributionParams));
-    } catch (_) { /* storage may be unavailable in privacy contexts */ }
+    } catch { /* storage may be unavailable in privacy contexts */ }
   }
 
   function getAttributionPayload() {
@@ -313,7 +314,7 @@
       var parsed = JSON.parse(raw);
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
       return parsed;
-    } catch (_) {
+    } catch {
       return null;
     }
   }
@@ -439,7 +440,7 @@
       if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(JSON.stringify(msg), BASE_ORIGIN);
       }
-    } catch (_) { /* cross-origin post may fail; safe to ignore */ }
+    } catch { /* cross-origin post may fail; safe to ignore */ }
   }
 
   function addListener(eventName, callback) {
@@ -523,7 +524,7 @@
 
     try {
       w.dispatchEvent(new CustomEvent('blawby:widget-event', { detail: payload }));
-    } catch (_) { /* CustomEvent may fail in legacy contexts; ignore */ }
+    } catch { /* CustomEvent may fail in legacy contexts; ignore */ }
   }
 
   /* ── postMessage bridge ──────────────────────────────────────────────── */
@@ -534,7 +535,7 @@
     var data;
     try {
       data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
-    } catch (_) { return; }
+    } catch { return; }
 
     if (!data || typeof data.type !== 'string') return;
 

--- a/src/app/SEOHead.tsx
+++ b/src/app/SEOHead.tsx
@@ -9,36 +9,6 @@ interface SEOHeadProps {
   currentUrl?: string;
 }
 
-/**
- * Truncates text to a maximum length while preserving word boundaries.
- * If truncation occurs mid-word, cuts back to the last space.
- */
-function truncateToWordBoundary(text: string, maxLength: number): string {
-  if (!text || text.length <= maxLength) {
-    return text;
-  }
-  
-  const trimmed = text.trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-  
-  // Find the last space before maxLength
-  const truncated = trimmed.substring(0, maxLength);
-  const lastSpaceIndex = truncated.lastIndexOf(' ');
-  
-  // Minimum allowed length to avoid extremely short truncations
-  const MINIMUM_ALLOWED = 10;
-  
-  // If we found a space and it's not below the minimum threshold, use it
-  // This preserves word boundaries whenever possible
-  if (lastSpaceIndex !== -1 && lastSpaceIndex >= MINIMUM_ALLOWED) {
-    return truncated.substring(0, lastSpaceIndex).trim();
-  }
-  
-  // Fallback: just truncate at maxLength (word might be longer than maxLength)
-  return truncated.trim();
-}
 
 /**
  * Generates a safe, SEO-friendly page title with proper fallbacks.

--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -33,7 +33,7 @@
  *   /api/subscription/*            - Subscription management
  *   /api/members/*                 - Member management
  *   /api/practice/client-intakes/* - Intake settings, status, creation
- *   /api/user-details/*            - Client user details & memos
+ *   /api/clients/*                 - Client user details & memos
  *   /api/conversations/:id/link    - Conversation link generation
  */
 

--- a/src/features/chat/components/ChatContainer.tsx
+++ b/src/features/chat/components/ChatContainer.tsx
@@ -5,13 +5,12 @@ import VirtualMessageList from './VirtualMessageList';
 import MessageComposer from './MessageComposer';
 import { ChatMessageUI } from '../../../../worker/types';
 import { FileAttachment } from '../../../../worker/types';
-import { ContactData, ContactForm } from '@/features/intake/components/ContactForm';
+import { ContactData } from '@/features/intake/components/ContactForm';
 import { isValidStripePaymentLink, type IntakePaymentRequest } from '@/shared/utils/intakePayments';
 import { createKeyPressHandler } from '@/shared/utils/keyboard';
 import type { UploadingFile } from '@/shared/hooks/useFileUpload';
 import type { ConversationMode } from '@/shared/types/conversation';
 import type { ReplyTarget } from '@/features/chat/types';
-import { useTranslation } from '@/shared/i18n/hooks';
 import type { LayoutMode } from '@/app/MainApp';
 import type { IntakeConversationState } from '@/shared/types/intake';
 import { isIntakeSubmittable } from '@/shared/utils/consultationState';
@@ -182,7 +181,6 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   mentionCandidates = [],
   onRegisterOpenPayment,
 }) => {
-  const { t } = useTranslation('common');
   const [inputValue, setInputValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [paymentRequest, setPaymentRequest] = useState<IntakePaymentRequest | null>(null);

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -453,7 +453,6 @@ const MessageComposer = ({
                     onKeyDown(event, sanitizedMentionIds);
                   }}
                   aria-label="Message input"
-                  aria-expanded={mentionMenuOpen}
                   aria-controls={mentionMenuOpen ? "mention-listbox" : undefined}
                   aria-activedescendant={mentionMenuOpen ? `mention-option-${mentionFocusIndex}` : undefined}
                   disabled={isComposerDisabled}

--- a/src/features/clients/pages/PracticeClientsPage.tsx
+++ b/src/features/clients/pages/PracticeClientsPage.tsx
@@ -121,7 +121,7 @@ const resolveUserDetailAddressValue = (detail: PersonRecord): unknown => {
     return nestedAddress;
   }
 
-  // Some user-details responses include flattened address fields instead of a nested object.
+  // Some clients responses include flattened address fields instead of a nested object.
   const flattened: Record<string, unknown> = {};
   const line1 = typeof detailRecord.line1 === 'string'
     ? detailRecord.line1

--- a/src/features/invoices/pages/ClientInvoicesPage.tsx
+++ b/src/features/invoices/pages/ClientInvoicesPage.tsx
@@ -37,7 +37,6 @@ export function ClientInvoicesPage({
 }) {
   const { navigate } = useNavigation();
   const { showError } = useToastContext();
-  const isListOnly = renderMode === 'listOnly';
 
   const {
     items: invoices,

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -47,7 +47,6 @@ export function PracticeInvoicesPage({
 }) {
   const { navigate } = useNavigation();
   const { showError } = useToastContext();
-  const isListOnly = renderMode === 'listOnly';
 
   const {
     items: invoices,

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -23,7 +23,6 @@ import {
   PencilSquareIcon,
   PlusIcon
 } from '@heroicons/react/24/outline';
-import { Icon } from '@/shared/ui/Icon';
 import { MATTER_STATUS_LABELS, type MatterStatus } from '@/shared/types/matterStatus';
 import {
   type MatterDetail,
@@ -303,7 +302,7 @@ export const PracticeMattersPage = ({
     () => resolveQueryValue(location.query?.convertIntake),
     [location.query?.convertIntake]
   );
-  const navigate = (path: string) => location.route(path);
+  const navigate = useCallback((path: string) => location.route(path), [location]);
   const goToList = () => navigate(basePath);
   const goToDetail = (id: string, section: Exclude<DetailSectionId, 'overview'> | null = null) =>
     navigate(section ? `${basePath}/${encodeURIComponent(id)}/${section}` : `${basePath}/${encodeURIComponent(id)}`);
@@ -335,9 +334,9 @@ export const PracticeMattersPage = ({
   const [noteRecords, setNoteRecords] = useState<BackendMatterNote[]>([]);
   const [activityLoading, setActivityLoading] = useState(false);
   const [activityError, setActivityError] = useState<string | null>(null);
-  const [noteLoading, setNoteLoading] = useState(false);
-  const [noteError, setNoteError] = useState<string | null>(null);
-  const [noteRetryCount, setNoteRetryCount] = useState(0);
+  const [_noteLoading, setNoteLoading] = useState(false);
+  const [_noteError, setNoteError] = useState<string | null>(null);
+  const [_noteRetryCount, _setNoteRetryCount] = useState(0);
   const [activityRetryCount, setActivityRetryCount] = useState(0);
 
   // ── Sub-resource state ────────────────────────────────────────────────────
@@ -368,7 +367,7 @@ export const PracticeMattersPage = ({
   const [connectedAccountId, setConnectedAccountId] = useState<string | null>(null);
   const [stripeAccountId, setStripeAccountId] = useState<string | null>(null);
   const [onboardingUrl, setOnboardingUrl] = useState<string | null>(null);
-  const [quickTimeEntryKey, setQuickTimeEntryKey] = useState(0);
+  const [_quickTimeEntryKey, _setQuickTimeEntryKey] = useState(0);
   const [isDescriptionEditing, setIsDescriptionEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
   const [descriptionDraft, setDescriptionDraft] = useState('');
@@ -762,7 +761,7 @@ export const PracticeMattersPage = ({
       });
 
     return () => controller.abort();
-  }, [activePracticeId, selectedMatterId, noteRetryCount]);
+  }, [activePracticeId, selectedMatterId, _noteRetryCount]);
 
   // ── Data fetching: time stats (used by summary cards) ────────────────────
   useEffect(() => {
@@ -2222,7 +2221,7 @@ export const PracticeMattersPage = ({
             contentClassName="max-w-2xl"
           >
             <TimeEntryForm
-              key={`quick-time-${quickTimeEntryKey}`}
+              key={`quick-time-${_quickTimeEntryKey}`}
               onSubmit={handleQuickTimeSubmit}
               onCancel={() => setIsQuickTimeEntryOpen(false)}
             />

--- a/src/features/matters/services/invoicesApi.ts
+++ b/src/features/matters/services/invoicesApi.ts
@@ -4,7 +4,7 @@ import { urls } from '@/config/urls';
 import {
   assertMajorUnits,
   asMajor,
-  safeMultiply,
+  _safeMultiply,
   toMajorUnits,
   toMinorUnitsValue,
   type MajorAmount

--- a/src/features/settings/components/SettingsSubheader.tsx
+++ b/src/features/settings/components/SettingsSubheader.tsx
@@ -13,8 +13,8 @@ export const SettingsSubheader = ({
   variant = 'default'
 }: SettingsSubheaderProps) => {
   const variantClasses = {
-    default: 'text-[11px] font-semibold uppercase tracking-wide text-input-placeholder',
-    section: 'text-sm font-semibold text-input-text'
+    default: 'text-xs font-medium text-input-placeholder tracking-tight',
+    section: 'text-base font-semibold text-input-text pt-4 pb-2'
   };
 
   return (

--- a/src/features/settings/pages/NotificationsPage.tsx
+++ b/src/features/settings/pages/NotificationsPage.tsx
@@ -382,7 +382,7 @@ export const NotificationsPage = ({
 
       <SectionDivider />
 
-      <SettingsSubheader variant="section" className="px-1 pb-2 text-left">
+      <SettingsSubheader variant="section" className="text-left">
         {t('settings:notifications.inApp.sectionTitle', { defaultValue: 'In-app bot messages' })}
       </SettingsSubheader>
 

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -31,7 +31,7 @@ import { getFrontendHost } from '@/config/urls';
 import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { FormGrid, SectionDivider } from '@/shared/ui/layout';
 import { ContentPageLayout } from '@/shared/ui/layout';
-import { SettingsSubheader } from '@/features/settings/components/SettingsSubheader';
+import { _SettingsSubheader } from '@/features/settings/components/SettingsSubheader';
 import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { SettingRow } from '@/features/settings/components/SettingRow';
@@ -110,7 +110,7 @@ const resolveOnboardingData = (practice: Practice | null, details: PracticeDetai
   return { ...baseFromPractice, ...baseFromDetails };
 };
 
-const truncateText = (value: string, maxLength: number) => {
+const _truncateText = (value: string, maxLength: number) => {
   if (value.length <= maxLength) return value;
   return `${value.slice(0, maxLength).trim()}...`;
 };

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -31,7 +31,6 @@ import { getFrontendHost } from '@/config/urls';
 import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { FormGrid, SectionDivider } from '@/shared/ui/layout';
 import { ContentPageLayout } from '@/shared/ui/layout';
-import { _SettingsSubheader } from '@/features/settings/components/SettingsSubheader';
 import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { SettingRow } from '@/features/settings/components/SettingRow';
@@ -110,10 +109,6 @@ const resolveOnboardingData = (practice: Practice | null, details: PracticeDetai
   return { ...baseFromPractice, ...baseFromDetails };
 };
 
-const _truncateText = (value: string, maxLength: number) => {
-  if (value.length <= maxLength) return value;
-  return `${value.slice(0, maxLength).trim()}...`;
-};
 
 const isValidHttpUrl = (value: string): boolean => {
   try {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -93,7 +93,7 @@ export function App() {
 }
 
 function AppShell() {
-  const { isDark } = useTheme();
+  useTheme();
   const location = useLocation();
   const { navigate } = useNavigation();
   const { session, isPending: sessionPending } = useSessionContext();
@@ -798,7 +798,7 @@ function PublicPracticeRoute({
 function WidgetRoute({
   practiceSlug,
   conversationId,
-  workspaceView = 'home'
+  workspaceView: _workspaceView = 'home'
 }: {
   practiceSlug: string;
   conversationId?: string;
@@ -926,7 +926,13 @@ function AppWithProviders() {
 }
 
 async function mountClientApp() {
-  const savedTheme = localStorage.getItem('theme');
+  let savedTheme: string | null = null;
+  try {
+    savedTheme = localStorage.getItem('theme');
+  } catch (_error) {
+    // Session storage or local storage may be unavailable (private mode, iframe restrictions, etc.)
+  }
+
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const shouldBeDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
 

--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -75,10 +75,8 @@ export const buildFileUrl = (value: string): string => {
   if (ABSOLUTE_URL_PATTERN.test(trimmed) || trimmed.startsWith('data:') || trimmed.startsWith('blob:')) return trimmed;
   if (trimmed.startsWith('/')) return trimmed;
   
-  // Check cache first
-  if (fileUrlCache.has(trimmed)) {
-    return fileUrlCache.get(trimmed)!;
-  }
+  const cached = fileUrlCache.get(trimmed);
+  if (cached) return cached;
   
   // Build and cache URL
   const url = `${getWorkerApiUrl()}/api/files/${encodeURIComponent(trimmed)}`;

--- a/src/shared/hooks/useConversationSetup.ts
+++ b/src/shared/hooks/useConversationSetup.ts
@@ -3,7 +3,6 @@ import { getConversationEndpoint, getConversationsEndpoint } from '@/config/api'
 import type { ConversationMode } from '@/shared/types/conversation';
 import { logConversationEvent, updateConversationMetadata } from '@/shared/lib/conversationApi';
 import type { SessionContextValue } from '@/shared/contexts/SessionContext';
-import { rememberConversationAnonymousParticipant } from '@/shared/utils/anonymousIdentity';
 import { withWidgetAuthHeaders } from '@/shared/utils/widgetAuth';
 import { clearConsultationMetadata } from '@/shared/utils/consultationState';
 
@@ -155,7 +154,7 @@ export function useConversationSetup({
       setIsCreatingConversation(false);
       creationPromiseRef.current = null;
     }
-  }, [isPracticeWorkspace, isPublicWorkspace, practiceId, currentUserId, setConversationIdWithRef]);
+  }, [isPracticeWorkspace, practiceId, currentUserId, setConversationIdWithRef]);
 
   const ensureConversation = useCallback(async (options?: { forceNew?: boolean; waitForSessionReadyMs?: number }): Promise<string | null> => {
     // Read from ref to get latest value and avoid stale closure

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -785,7 +785,7 @@ export function useIntakeFlow({
     intakeConversationState,
   ]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   finalizeRef.current = handleFinalizeSubmit as (options?: { generatePaymentLinkOnly?: boolean }) => Promise<{ paymentLinkUrl: string | null }>;
 
   // Cancel any in-flight payment polling when the hook unmounts.
@@ -796,7 +796,7 @@ export function useIntakeFlow({
         paymentPollingTimerRef.current = null;
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   }, []);
 
   /** Backward-compat alias for callers that don't have a payment UI wired */

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -5,7 +5,7 @@ import { fetchIntakePaymentStatus, isPaidIntakeStatus, isTerminalUnpaidStatus } 
 import type { IntakePaymentRequest } from '@/shared/utils/intakePayments';
 import type { ContactData } from '@/features/intake/components/ContactForm';
 import type { ConversationMetadata, ConversationMessage } from '@/shared/types/conversation';
-import type { FileAttachment, MinorAmount } from '../../../worker/types';
+import type { FileAttachment } from '../../../worker/types';
 import {
   initialIntakeState,
   type IntakeConversationState,
@@ -192,7 +192,7 @@ export function useIntakeFlow({
   sendMessage,
   sendMessageOverWs,
   onError,
-  onOpenPayment,
+  onOpenPayment: _onOpenPayment,
 }: UseIntakeFlowOptions): UseIntakeFlowResult {
   const { session, isAnonymous } = useSessionContext();
   const currentUserId = session?.user?.id ?? null;

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -854,7 +854,7 @@ export async function listUserDetails(
   }
   const { signal, ...queryParams } = params ?? {};
   const response = await apiClient.get(
-    `/api/user-details/${encodeURIComponent(practiceId)}`,
+    `/api/clients/${encodeURIComponent(practiceId)}`,
     { params: queryParams, signal }
   );
   const payload = response.data;
@@ -879,7 +879,7 @@ export async function getUserDetail(
     throw new Error('practiceId and userDetailId are required');
   }
   const response = await apiClient.get(
-    `/api/user-details/${encodeURIComponent(practiceId)}`,
+    `/api/clients/${encodeURIComponent(practiceId)}`,
     // Backend contract uses `client_id` even though this record is presented as Person in UI.
     { params: { client_id: userDetailId }, signal: config?.signal }
   );
@@ -902,7 +902,7 @@ export async function getUserDetailAddressById(
     throw new Error('practiceId and addressId are required');
   }
   const response = await apiClient.get(
-    `/api/user-details/${encodeURIComponent(practiceId)}/addresses/${encodeURIComponent(addressId)}`,
+    `/api/clients/${encodeURIComponent(practiceId)}/addresses/${encodeURIComponent(addressId)}`,
     { signal: config?.signal }
   );
   const payload = unwrapApiData(response.data);
@@ -1035,7 +1035,7 @@ export async function updateUserDetail(
   const { address, name, email, phone, status, currency, event_name, ...rest } = payload;
   const normalized = normalizeUserDetailPayload({ address, name, email, phone, status, currency, event_name });
   const response = await apiClient.patch(
-    `/api/user-details/${encodeURIComponent(practiceId)}/update/${encodeURIComponent(userDetailId)}`,
+    `/api/clients/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}`,
     { ...rest, ...normalized }
   );
   const data = response.data;
@@ -1053,7 +1053,7 @@ export async function deleteUserDetail(
     throw new Error('practiceId and userDetailId are required');
   }
   await apiClient.delete(
-    `/api/user-details/${encodeURIComponent(practiceId)}/delete/${encodeURIComponent(userDetailId)}`
+    `/api/clients/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}`
   );
 }
 
@@ -1080,7 +1080,7 @@ export async function listUserDetailMemos(
     throw new Error('practiceId and userDetailId are required');
   }
   const response = await apiClient.get(
-    `/api/user-details/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos`
+    `/api/clients/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos`
   );
   const payload = response.data;
   if (isRecord(payload) && Array.isArray(payload.data)) {
@@ -1101,7 +1101,7 @@ export async function createUserDetailMemo(
     throw new Error('practiceId and userDetailId are required');
   }
   const response = await apiClient.post(
-    `/api/user-details/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos`,
+    `/api/clients/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos`,
     payload
   );
   const data = response.data;
@@ -1121,7 +1121,7 @@ export async function updateUserDetailMemo(
     throw new Error('practiceId, userDetailId, and memoId are required');
   }
   const response = await apiClient.patch(
-    `/api/user-details/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos/update/${encodeURIComponent(memoId)}`,
+    `/api/clients/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos/${encodeURIComponent(memoId)}`,
     payload
   );
   const data = response.data;
@@ -1140,7 +1140,7 @@ export async function deleteUserDetailMemo(
     throw new Error('practiceId, userDetailId, and memoId are required');
   }
   await apiClient.delete(
-    `/api/user-details/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos/delete/${encodeURIComponent(memoId)}`
+    `/api/clients/${encodeURIComponent(practiceId)}/${encodeURIComponent(userDetailId)}/memos/${encodeURIComponent(memoId)}`
   );
 }
 

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -20,7 +20,7 @@ import {
   InspectorHeaderPerson,
   InspectorHeaderHero,
 } from './InspectorPrimitives';
-import { XMarkIcon, PhoneIcon, EnvelopeIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { PERSON_RELATIONSHIP_STATUS_LABELS } from '@/shared/domain/people';
 import type { Address } from '@/shared/types/address';
@@ -327,7 +327,7 @@ export const InspectorPanel = ({
             try {
               const practiceDetail = await getPracticeDetails(practiceId, { signal: controller.signal });
               setPracticeDetail(practiceDetail);
-            } catch (error) {
+            } catch {
               setPracticeDetail(null);
             }
           } else {
@@ -874,7 +874,7 @@ export const InspectorPanel = ({
                                       options={intakeServiceOptions}
                                       placeholder="Select Practice Area"
                                       searchable
-                                      autoFocus
+                                      
                                     />
                                   </InspectorEditableRow>
                                 </InspectorGroup>
@@ -895,7 +895,7 @@ export const InspectorPanel = ({
                                   value={localIntakeDraft ?? intakeConversationState.city ?? ''}
                                   onChange={setLocalIntakeDraft}
                                   placeholder="City"
-                                  autoFocus
+                                  
                                   className="w-full"
                                   onBlur={() => {
                                     if (skipBlurRef.current) {
@@ -937,7 +937,7 @@ export const InspectorPanel = ({
                                   options={STATE_OPTIONS}
                                   placeholder="Select State"
                                   searchable
-                                  autoFocus
+                                  
                                 />
                               </InspectorEditableRow>
                             </InspectorGroup>
@@ -957,7 +957,7 @@ export const InspectorPanel = ({
                                   value={localIntakeDraft ?? intakeConversationState.opposingParty ?? ''}
                                   onChange={setLocalIntakeDraft}
                                   placeholder="Opposing party"
-                                  autoFocus
+                                  
                                   className="w-full"
                                   onBlur={() => {
                                     if (skipBlurRef.current) {
@@ -997,7 +997,7 @@ export const InspectorPanel = ({
                                   value={localIntakeDraft ?? intakeConversationState.desiredOutcome ?? ''}
                                   onChange={setLocalIntakeDraft}
                                   placeholder="Desired outcome"
-                                  autoFocus
+                                  
                                   className="w-full"
                                   rows={3}
                                   onBlur={() => {
@@ -1038,7 +1038,7 @@ export const InspectorPanel = ({
                                   value={localIntakeDraft ?? intakeConversationState.description ?? ''}
                                   onChange={setLocalIntakeDraft}
                                   placeholder="Summary of the situation"
-                                  autoFocus
+                                  
                                   className="w-full"
                                   rows={4}
                                   onBlur={() => {
@@ -1104,7 +1104,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleConversationMatterChange(value); }}
                       options={matterOptions}
                       searchable
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Search matters"
@@ -1133,7 +1133,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleConversationAssignmentChange(value); }}
                       options={assignedToOptions}
                       searchable
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Assign owner"
@@ -1161,7 +1161,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleConversationPriorityChange(value); }}
                       options={priorityOptions}
                       searchable={false}
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       disabled={isSavingPriority}
@@ -1191,7 +1191,7 @@ export const InspectorPanel = ({
                       onChange={(values) => { void handleConversationTagsChange(values); }}
                       options={tagOptions}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Add tags"
@@ -1235,7 +1235,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterStatusChange(value); }}
                       options={matterStatusOptions}
                       searchable={false}
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Select status"
@@ -1264,7 +1264,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ clientId: value === '' ? null : value }); }}
                       options={matterClientOptionsWithNone}
                       searchable
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Select client"
@@ -1293,7 +1293,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ responsibleAttorneyId: value === '' ? null : value }); }}
                       options={[{ value: '', label: 'Not set' }, ...matterAssigneeOptions]}
                       searchable
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Select attorney"
@@ -1322,7 +1322,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ originatingAttorneyId: value === '' ? null : value }); }}
                       options={[{ value: '', label: 'Not set' }, ...matterAssigneeOptions]}
                       searchable
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       placeholder="Select attorney"
@@ -1351,7 +1351,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ urgency: value === '' ? null : value }); }}
                       options={urgencyOptions}
                       searchable={false}
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       disabled={isSavingMatterField || !canEditMatterFields}
@@ -1379,7 +1379,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ caseNumber: value }); }}
                       options={[]}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       addNewLabel="Set case number"
@@ -1409,7 +1409,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ matterType: value }); }}
                       options={[]}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       addNewLabel="Set matter type"
@@ -1439,7 +1439,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ court: value }); }}
                       options={[]}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       addNewLabel="Set court"
@@ -1469,7 +1469,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ judge: value }); }}
                       options={[]}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       addNewLabel="Set judge"
@@ -1499,7 +1499,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ opposingParty: value }); }}
                       options={[]}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       addNewLabel="Set opposing party"
@@ -1529,7 +1529,7 @@ export const InspectorPanel = ({
                       onChange={(value) => { void handleMatterPatchChange({ opposingCounsel: value }); }}
                       options={[]}
                       allowCustomValues
-                      autoFocus
+                      
                       defaultOpen
                       hideTrigger
                       addNewLabel="Set opposing counsel"

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -327,8 +327,12 @@ export const InspectorPanel = ({
             try {
               const practiceDetail = await getPracticeDetails(practiceId, { signal: controller.signal });
               setPracticeDetail(practiceDetail);
-            } catch {
-              setPracticeDetail(null);
+            } catch (err: unknown) {
+              const error = err as Error;
+              // Only clear state for real errors, not aborted requests
+              if (!controller.signal.aborted && error?.name !== 'AbortError') {
+                setPracticeDetail(null);
+              }
             }
           } else {
             // Client view - set null if no prop details provided

--- a/tests/e2e/clients.spec.ts
+++ b/tests/e2e/clients.spec.ts
@@ -43,7 +43,7 @@ test.describe('Clients', () => {
     }
 
     const createResponsePromise = page.waitForResponse((response) => {
-      return response.url().includes('/api/user-details/practice/') && response.request().method() === 'POST';
+      return response.url().includes('/api/clients/') && response.request().method() === 'POST';
     });
     await page.getByRole('button', { name: 'Add Client' }).last().click();
     const createResponse = await createResponsePromise;
@@ -58,7 +58,7 @@ test.describe('Clients', () => {
     const memoEdit = `E2E memo updated ${suffix}`;
     await page.getByLabel('Add your comment').fill(memo);
     const memoCreateResponsePromise = page.waitForResponse((response) => {
-      return response.url().includes('/api/user-details/practice/') &&
+      return response.url().includes('/api/clients/') &&
         response.url().includes('/memos') &&
         response.request().method() === 'POST';
     });
@@ -71,9 +71,9 @@ test.describe('Clients', () => {
     await memoItem.getByRole('button', { name: 'Edit' }).click();
     await memoItem.getByRole('textbox').fill(memoEdit);
     const memoUpdateResponsePromise = page.waitForResponse((response) => {
-      return response.url().includes('/api/user-details/practice/') &&
+      return response.url().includes('/api/clients/') &&
         response.url().includes('/memos') &&
-        response.request().method() === 'PUT';
+        response.request().method() === 'PATCH';
     });
     await memoItem.getByRole('button', { name: 'Save' }).click();
     const memoUpdateResponse = await memoUpdateResponsePromise;
@@ -82,7 +82,7 @@ test.describe('Clients', () => {
 
     const updatedMemoItem = page.locator('li', { hasText: memoEdit }).first();
     const memoDeleteResponsePromise = page.waitForResponse((response) => {
-      return response.url().includes('/api/user-details/practice/') &&
+      return response.url().includes('/api/clients/') &&
         response.url().includes('/memos') &&
         response.request().method() === 'DELETE';
     });
@@ -118,7 +118,7 @@ test.describe('Clients', () => {
       }
     }
     const clientUpdateResponsePromise = page.waitForResponse((response) => {
-      return response.url().includes('/api/user-details/practice/') && response.request().method() === 'PUT';
+      return response.url().includes('/api/clients/') && response.request().method() === 'PATCH';
     });
     await page.getByRole('button', { name: 'Save Changes' }).click();
     const clientUpdateResponse = await clientUpdateResponsePromise;
@@ -128,7 +128,7 @@ test.describe('Clients', () => {
     await page.getByLabel('Open client actions').click();
     page.once('dialog', (dialog) => dialog.accept());
     const clientDeleteResponsePromise = page.waitForResponse((response) => {
-      return response.url().includes('/api/user-details/practice/') && response.request().method() === 'DELETE';
+      return response.url().includes('/api/clients/') && response.request().method() === 'DELETE';
     });
     await actionsDropdown.getByRole('button', { name: 'Delete' }).click();
     const clientDeleteResponse = await clientDeleteResponsePromise;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -170,7 +170,7 @@ const fixDecodeNamedCharacterReference = (): Plugin => {
 				}
 			};
 		},
-		resolveId(id, importer) {
+		resolveId(id, _importer) {
 			if (id === 'decode-named-character-reference') {
 				// Dynamically resolve the package entry instead of hardcoding a pnpm path.
 				// We want the non-DOM build (default export) so use Node resolution with
@@ -225,7 +225,7 @@ const serveStaticHtmlPlugin = (): Plugin => {
 								res.setHeader('Content-Type', urlPath.endsWith('.js') ? 'application/javascript' : 'text/html');
 								res.end(content);
 								return;
-							} catch (e) {
+							} catch (_e) {
 								// File not found in public/, let Vite handle it (SPA fallback or 404)
 							}
 						}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -112,7 +112,7 @@ const workerEndpoints = [
 	'status',
 	'ai',
 	'practices',
-	'user-details',
+	'clients',
 	'onboarding',
 	'practice',
 	'preferences',

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -73,7 +73,7 @@ async function handleRequestInternal(request: Request, env: Env, _ctx: Execution
       path.startsWith('/api/matters') ||
       path.startsWith('/api/invoices') ||
       path.startsWith('/api/practice/client-intakes') ||
-      path.startsWith('/api/user-details') ||
+      path.startsWith('/api/clients') ||
       ((path === '/api/practice' || path.startsWith('/api/practice/')) &&
         !path.startsWith('/api/practice/details/') &&
         !path.startsWith('/api/practices')) ||

--- a/worker/routes/authProxy.ts
+++ b/worker/routes/authProxy.ts
@@ -28,7 +28,7 @@ const BACKEND_PATH_PREFIXES = [
   '/api/subscriptions',
   '/api/subscription',
   '/api/uploads',
-  '/api/user-details'
+  '/api/clients'
 ];
 
 const getBaseDomain = (host: string): string | null => {

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -378,7 +378,7 @@ export async function handleSubmitIntake(
           clientMergedIntakeState = sanitizeMergedIntakeState(body.mergedIntakeState);
         }
       }
-    } catch (e) {
+    } catch (_e) {
       // Ignore parse errors, fallback to DB only
     }
   }


### PR DESCRIPTION
Matches the backend team's update to the API endpoint name from user-details to clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched backend routing and proxying for user-detail flows to a unified "clients" route.

* **Documentation**
  * Updated internal docs and in-app routing notes to reference the "clients" endpoint.

* **Tests**
  * Updated end-to-end tests to align with the new API routes and adjusted HTTP methods.

* **UX**
  * Removed several automatic input autofocuses to reduce unexpected focus jumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->