### PR TITLE
Unify invoice record UX across create/detail/new

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -47,7 +47,7 @@ import {
   peekPostAuthConversationContext,
 } from '@/shared/utils/anonymousIdentity';
 import type { SettingsView } from '@/features/settings/pages/SettingsContent';
-import { InformationCircleIcon } from '@heroicons/react/24/outline';
+import { InformationCircleIcon, PaperAirplaneIcon } from '@heroicons/react/24/outline';
 import { PlusIcon } from '@heroicons/react/24/solid';
 import { Button } from '@/shared/ui/Button';
 import { Icon } from '@/shared/ui/Icon';
@@ -57,6 +57,7 @@ import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
 import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { resolveStrengthStyle, resolveStrengthTier } from '@/shared/utils/intakeStrength';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
+import { INVOICE_CREATE_SEND_EVENT } from '@/features/invoices/utils/invoicePageConfig';
 
 // ─── types ────────────────────────────────────────────────────────────────────
 
@@ -71,7 +72,6 @@ type WorkspaceView = 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'c
 export type LayoutMode = 'widget' | 'mobile' | 'desktop';
 
 const WorkspaceSubviewFallback = () => <LoadingBlock className="p-6" />;
-
 // ─── component ────────────────────────────────────────────────────────────────
 
 export function MainApp({
@@ -1119,6 +1119,12 @@ export function MainApp({
               onClick: () => navigate(`${practiceMattersPath}/new`),
               icon: PlusIcon,
             }
+          : resolvedWorkspaceView === 'invoiceCreate' && isPracticeWorkspace
+            ? {
+                label: 'Send Invoice',
+                onClick: () => window.dispatchEvent(new CustomEvent(INVOICE_CREATE_SEND_EVENT)),
+                icon: PaperAirplaneIcon,
+              }
           : (resolvedWorkspaceView === 'invoices' || resolvedWorkspaceView === 'invoiceDetail') && isPracticeWorkspace && practiceInvoicesPath
             ? {
                 label: 'New Invoice',

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -3,7 +3,7 @@ import type { ComponentChildren } from 'preact';
 import { useMemo, useRef, useState, useEffect, useCallback } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import axios from 'axios';
-import { Bars3Icon } from '@heroicons/react/24/outline';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { PlusIcon } from '@heroicons/react/24/solid';
 import { useNavigation } from '@/shared/utils/navigation';
 import { signOut } from '@/shared/utils/auth';
@@ -194,7 +194,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   workspace = 'public',
   settingsView = 'general',
   settingsAppId,
-  routeInvoiceId,
+  routeInvoiceId: _routeInvoiceId,
   onStartNewConversation,
   activeConversationId = null,
   chatView,
@@ -479,11 +479,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     if (view === 'clients' && selectedClientIdFromPath) {
       return { entityType: 'client' as const, entityId: selectedClientIdFromPath };
     }
-    if (view === 'invoiceDetail' && routeInvoiceId) {
-      return { entityType: 'invoice' as const, entityId: routeInvoiceId };
-    }
     return null;
-  }, [activeConversationId, routeInvoiceId, selectedClientIdFromPath, selectedMatterIdFromPath, view, workspaceSection]);
+  }, [activeConversationId, selectedClientIdFromPath, selectedMatterIdFromPath, view, workspaceSection]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const handleOpenInspector = () => {
@@ -1528,7 +1525,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       size="icon-sm"
       onClick={primaryCreateAction.onClick}
       aria-label={primaryCreateAction.label}
-      icon={PlusIcon} iconClassName="h-5 w-5"
+      icon={primaryCreateAction.icon ?? PlusIcon}
+      iconClassName="h-5 w-5"
     />
   ) : null;
   const desktopCreateButton = primaryCreateAction ? (
@@ -1538,7 +1536,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       size="icon-sm"
       onClick={primaryCreateAction.onClick}
       aria-label={primaryCreateAction.label}
-      icon={PlusIcon} iconClassName="h-5 w-5"
+      icon={primaryCreateAction.icon ?? PlusIcon}
+      iconClassName="h-5 w-5"
     />
   ) : null;
   const detailInspectorOpen = Boolean(inspectorTarget) && isInspectorOpen;
@@ -1728,6 +1727,43 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       />
     )
     : undefined;
+  const invoiceCreateTopBar = view === 'invoiceCreate' ? (
+    <WorkspaceListHeader
+      leftControls={(
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="icon"
+            size="icon-sm"
+            aria-label="Close invoice composer"
+            onClick={() => {
+              if (workspace === 'practice' && practiceSlug) {
+                navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices`);
+                return;
+              }
+              if (workspace === 'client' && practiceSlug) {
+                navigate(`/client/${encodeURIComponent(practiceSlug)}/invoices`);
+              }
+            }}
+            icon={XMarkIcon}
+            iconClassName="h-5 w-5"
+          />
+          <div className="h-5 w-px bg-line-glass/30" aria-hidden="true" />
+        </div>
+      )}
+      title={<h1 className="workspace-header__title">Create Invoice</h1>}
+      controls={primaryCreateAction ? (
+        <Button
+          type="button"
+          size="sm"
+          onClick={primaryCreateAction.onClick}
+        >
+          {primaryCreateAction.label}
+        </Button>
+      ) : undefined}
+      className={layoutMode === 'desktop' ? 'px-4 py-2' : 'px-1 py-1'}
+    />
+  ) : undefined;
   const sectionContent = (() => {
     switch (view) {
       case 'setup':
@@ -1765,7 +1801,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       invoiceListIsEmpty={invoiceListIsEmpty}
       chatView={chatView}
       content={sectionContent}
-      topBar={layoutMode === 'desktop' ? undefined : mobileSectionTopBar}
+      topBar={invoiceCreateTopBar ?? (layoutMode === 'desktop' ? undefined : mobileSectionTopBar)}
       bottomNav={bottomNav}
       sectionPlaceholderAction={
         layoutMode === 'desktop' && (view === 'matters' || view === 'invoices') ? primaryCreateAction ?? undefined : undefined

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1743,7 +1743,9 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
               }
               if (workspace === 'client' && practiceSlug) {
                 navigate(`/client/${encodeURIComponent(practiceSlug)}/invoices`);
+                return;
               }
+              navigate('/dashboard');
             }}
             icon={XMarkIcon}
             iconClassName="h-5 w-5"

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'preact/hooks';
+import { useCallback, useMemo, useState } from 'preact/hooks';
+import { forwardRef, useImperativeHandle } from 'preact/compat';
 import { Button } from '@/shared/ui/Button';
 import { Combobox, Input, Textarea } from '@/shared/ui/input';
 import { asMajor, safeAdd } from '@/shared/utils/money';
@@ -7,11 +8,13 @@ import { useToastContext } from '@/shared/contexts/ToastContext';
 import type { MatterDetail } from '@/features/matters/data/matterTypes';
 import type { Invoice, InvoiceLineItem } from '@/features/matters/types/billing.types';
 import { createInvoice, sendInvoice, updateInvoice } from '@/features/invoices/services/invoicesService';
-import { LineItemsBuilder } from '@/features/invoices/components/LineItemsBuilder';
+import { InvoiceLineItemsForm } from '@/features/invoices/components/InvoiceLineItemsForm';
 import { InvoicePreview } from '@/features/invoices/components/InvoicePreview';
 import { SendInvoiceDialog } from '@/features/invoices/components/SendInvoiceDialog';
+import type { InvoicePageMode } from '@/features/invoices/utils/invoicePageConfig';
 
-type InvoiceBuilderProps = {
+type InvoiceFormProps = {
+  mode?: InvoicePageMode;
   practiceId: string;
   matter?: MatterDetail | null;
   connectedAccountId?: string | null;
@@ -25,6 +28,8 @@ type InvoiceBuilderProps = {
   initialMemo?: string;
   initialInvoiceType?: Invoice['invoice_type'];
   editMode?: boolean;
+  readOnly?: boolean;
+  hideFooterActions?: boolean;
   invoiceContext?: 'default' | 'milestone' | 'retainer';
   existingInvoiceId?: string;
   closeAfterSuccess?: boolean;
@@ -40,6 +45,10 @@ type InvoiceBuilderProps = {
   billingIncrementMinutes?: number | null;
 };
 
+export type InvoiceFormHandle = {
+  requestSend: () => void;
+};
+
 type InvoiceUpdatePayload = {
   due_date?: string;
   notes?: string;
@@ -52,7 +61,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 const buildDefaultDueDate = () => {
   const next = new Date();
-  next.setDate(next.getDate() + 30);
+  next.setDate(next.getDate() + 1);
   const year = next.getFullYear();
   const month = String(next.getMonth() + 1).padStart(2, '0');
   const day = String(next.getDate()).padStart(2, '0');
@@ -108,7 +117,8 @@ const buildInvoiceUpdatePayload = ({
 
 const serializeInvoiceUpdatePayload = (payload: InvoiceUpdatePayload) => JSON.stringify(payload);
 
-export const InvoiceBuilder = ({
+export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
+  mode,
   practiceId,
   matter = null,
   connectedAccountId = null,
@@ -122,6 +132,8 @@ export const InvoiceBuilder = ({
   initialMemo,
   initialInvoiceType,
   editMode = false,
+  readOnly = false,
+  hideFooterActions = false,
   invoiceContext = 'default',
   existingInvoiceId,
   closeAfterSuccess = true,
@@ -131,8 +143,18 @@ export const InvoiceBuilder = ({
   practiceLogoUrl = null,
   practiceEmail = null,
   billingIncrementMinutes = null,
-}: InvoiceBuilderProps) => {
+}, ref) => {
   const { showError } = useToastContext();
+  const resolvedMode: InvoicePageMode = useMemo(() => {
+    if (mode) return mode;
+    if (readOnly) return 'readOnly';
+    if (editMode) return 'edit';
+    return 'create';
+  }, [editMode, mode, readOnly]);
+  const resolvedReadOnly = resolvedMode === 'readOnly' || readOnly;
+  const resolvedEditMode = resolvedMode === 'edit' || resolvedMode === 'readOnly' || editMode;
+  const resolvedHideFooterActions = hideFooterActions || resolvedMode === 'create';
+
   const defaultInvoiceType = detectDefaultInvoiceType(
     initialLineItems,
     invoiceContext,
@@ -144,15 +166,20 @@ export const InvoiceBuilder = ({
   const [lineItems, setLineItems] = useState<InvoiceLineItem[]>(initialLineItems);
   const [notes, setNotes] = useState(initialNotes ?? '');
   const [memo, setMemo] = useState(initialMemo ?? '');
-  const [dueDate, setDueDate] = useState(initialDueDate ?? buildDefaultDueDate());
-  const [isSaving, setIsSaving] = useState(false);
+  const defaultDueDate = useMemo(() => buildDefaultDueDate(), []);
+  const [dueDate, setDueDate] = useState(initialDueDate ?? defaultDueDate);
+  const [dueDateMode, setDueDateMode] = useState<'tomorrow' | 'custom'>(() => {
+    const initial = initialDueDate ?? defaultDueDate;
+    return initial === defaultDueDate ? 'tomorrow' : 'custom';
+  });
+  const isSaving = false;
   const [isSending, setIsSending] = useState(false);
   const [showSendDialog, setShowSendDialog] = useState(false);
   const [createdInvoiceId, setCreatedInvoiceId] = useState<string | null>(
-    editMode ? existingInvoiceId ?? null : null
+    resolvedEditMode ? existingInvoiceId ?? null : null
   );
   const [lastPersistedSnapshot, setLastPersistedSnapshot] = useState<string | null>(() => (
-    editMode && existingInvoiceId
+    resolvedEditMode && existingInvoiceId
       ? serializeInvoiceUpdatePayload(
           buildInvoiceUpdatePayload({
             dueDate: initialDueDate ?? buildDefaultDueDate(),
@@ -217,11 +244,29 @@ export const InvoiceBuilder = ({
     () => Boolean(connectedAccountId && UUID_REGEX.test(connectedAccountId)),
     [connectedAccountId]
   );
-  const disableActions = isSaving || isSending || !isValidConnectedAccount || lineItems.length === 0;
+  const disableActions = isSaving || isSending || resolvedReadOnly || !isValidConnectedAccount || lineItems.length === 0;
+
+  const openSendDialog = useCallback(() => {
+    if (resolvedReadOnly) return;
+    if (!isValidConnectedAccount) {
+      showError('Cannot send invoice', 'Complete Stripe onboarding before sending invoices.');
+      return;
+    }
+    if (!resolvedClientId) {
+      showError('Cannot send invoice', 'Choose a person first.');
+      return;
+    }
+    if (lineItems.length === 0) {
+      showError('Cannot send invoice', 'Add at least one line item.');
+      return;
+    }
+    if (isSaving || isSending) return;
+    setShowSendDialog(true);
+  }, [isSaving, isSending, isValidConnectedAccount, lineItems.length, resolvedClientId, resolvedReadOnly, showError]);
 
   const logInvoiceAction = (action: string, details: Record<string, unknown>) => {
     if (import.meta.env.DEV) {
-      console.info('[Billing][InvoiceBuilder]', action, details);
+      console.info('[Billing][InvoiceForm]', action, details);
     }
   };
 
@@ -243,47 +288,6 @@ export const InvoiceBuilder = ({
     }
   };
 
-  const handleSaveDraft = async () => {
-    if (!resolvedClientId) {
-      showError('Could not save invoice', 'Choose a person before creating the invoice.');
-      return;
-    }
-    if (disableActions || !connectedAccountId) return;
-    setIsSaving(true);
-    setSendError(null);
-    try {
-      const targetInvoiceId = existingInvoiceId ?? createdInvoiceId;
-      let nextInvoiceId: string | null = targetInvoiceId;
-      if (targetInvoiceId) {
-        const payload = currentUpdatePayload;
-        logInvoiceAction('update-draft', {
-          invoiceId: targetInvoiceId,
-          invoiceType: payload.invoice_type
-        });
-        const updated = await updateInvoice(practiceId, targetInvoiceId, payload);
-        nextInvoiceId = updated?.id ?? targetInvoiceId;
-        setCreatedInvoiceId(nextInvoiceId);
-        setLastPersistedSnapshot(currentUpdateSnapshot);
-      } else {
-        const payload = buildCreatePayload(connectedAccountId);
-        logInvoiceAction('create-draft', {
-          connectedAccountId: payload.connected_account_id,
-          invoiceType: payload.invoice_type,
-          lineItemCount: payload.line_items.length
-        });
-        const created = await createInvoice(practiceId, payload);
-        nextInvoiceId = created?.id ?? null;
-        setCreatedInvoiceId(nextInvoiceId);
-        setLastPersistedSnapshot(currentUpdateSnapshot);
-      }
-      await finalizeSuccess(nextInvoiceId);
-    } catch (error) {
-      showError('Could not save invoice', error instanceof Error ? error.message : 'Please try again.');
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
   const handleSendInvoice = async () => {
     if (!resolvedClientId) {
       showError('Could not send invoice', 'Choose a person before creating the invoice.');
@@ -294,7 +298,7 @@ export const InvoiceBuilder = ({
     setSendError(null);
     let invoiceId = createdInvoiceId;
     try {
-      if (editMode && existingInvoiceId) {
+      if (resolvedEditMode && existingInvoiceId) {
         const payload = currentUpdatePayload;
         logInvoiceAction('update-before-send', {
           invoiceId: existingInvoiceId,
@@ -346,13 +350,17 @@ export const InvoiceBuilder = ({
     }
   };
 
+  useImperativeHandle(ref, () => ({
+    requestSend: openSendDialog,
+  }), [openSendDialog]);
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
       <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
         <div className="grid min-h-0 flex-1 gap-8 lg:grid-cols-[minmax(0,1fr)_520px] lg:gap-10">
           <div className="min-h-0 overflow-y-auto">
             <div className="space-y-5">
-              {!isValidConnectedAccount ? (
+              {!resolvedReadOnly && !isValidConnectedAccount ? (
                 <div className="status-warning rounded-xl px-4 py-3 text-sm">
                   Complete Stripe onboarding to enable invoicing.
                 </div>
@@ -365,6 +373,7 @@ export const InvoiceBuilder = ({
                     onChange={handleClientChange}
                     options={clientOptions}
                     placeholder="Choose a person"
+                    disabled={resolvedReadOnly}
                   />
                   <Combobox
                     label="Matter (optional)"
@@ -379,7 +388,7 @@ export const InvoiceBuilder = ({
                       label: option.label,
                     }))}
                     placeholder={clientId ? 'Link a matter' : 'Choose a person first'}
-                    disabled={!clientId}
+                    disabled={resolvedReadOnly || !clientId}
                     clearable
                   />
                   <Combobox
@@ -389,6 +398,7 @@ export const InvoiceBuilder = ({
                     options={INVOICE_TYPE_OPTIONS}
                     searchable={false}
                     clearable={false}
+                    disabled={resolvedReadOnly}
                   />
                 </div>
               ) : (
@@ -399,21 +409,58 @@ export const InvoiceBuilder = ({
                   options={INVOICE_TYPE_OPTIONS}
                   searchable={false}
                   clearable={false}
+                  disabled={resolvedReadOnly}
                 />
               )}
-              <LineItemsBuilder 
+              <InvoiceLineItemsForm
                 lineItems={lineItems} 
                 onChange={setLineItems} 
                 billingIncrementMinutes={billingIncrementMinutes} 
+                readOnly={resolvedReadOnly}
               />
-              <Input
-                label="Due date"
-                type="date"
-                value={dueDate}
-                onChange={setDueDate}
-              />
-              <Textarea label="Notes to client" value={notes} onChange={setNotes} rows={3} />
-              <Textarea label="Internal memo" value={memo} onChange={setMemo} rows={2} />
+              <section className="space-y-3">
+                <h3 className="text-sm font-semibold text-input-text">Request payment</h3>
+                <p className="text-xs text-input-placeholder">
+                  Choose when this invoice should be due.
+                </p>
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm text-input-text">
+                    <input
+                      type="radio"
+                      name="due-date-mode"
+                      checked={dueDateMode === 'tomorrow'}
+                      onChange={() => {
+                        setDueDateMode('tomorrow');
+                        setDueDate(defaultDueDate);
+                      }}
+                      disabled={resolvedReadOnly}
+                    />
+                    <span>Due tomorrow ({defaultDueDate})</span>
+                  </label>
+                  <label className="flex items-center gap-2 text-sm text-input-text">
+                    <input
+                      type="radio"
+                      name="due-date-mode"
+                      checked={dueDateMode === 'custom'}
+                      onChange={() => setDueDateMode('custom')}
+                      disabled={resolvedReadOnly}
+                    />
+                    <span>Custom due date</span>
+                  </label>
+                </div>
+                {dueDateMode === 'custom' ? (
+                  <Input
+                    label="Due date"
+                    type="date"
+                    value={dueDate}
+                    onChange={setDueDate}
+                    disabled={resolvedReadOnly}
+                    min={defaultDueDate}
+                  />
+                ) : null}
+              </section>
+              <Textarea label="Notes to client" value={notes} onChange={setNotes} rows={3} disabled={resolvedReadOnly} />
+              <Textarea label="Internal memo" value={memo} onChange={setMemo} rows={2} disabled={resolvedReadOnly} />
               {sendError ? (
                 <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
                   <p>{sendError}</p>
@@ -447,48 +494,53 @@ export const InvoiceBuilder = ({
           </div>
         </div>
 
-        <footer className="flex flex-col gap-3 py-4 lg:flex-row lg:items-center lg:justify-between">
-          <p className="text-sm font-semibold text-input-text">
-            Total: {formatCurrency(total)}
-          </p>
-          {!isValidConnectedAccount ? (
-            <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
-              <strong className="block font-semibold">Payment account not connected.</strong>
-              Finish Stripe onboarding to save or send invoices.
+        {!resolvedHideFooterActions ? (
+          <footer className="flex flex-col gap-3 py-4 lg:flex-row lg:items-center lg:justify-between">
+            <p className="text-sm font-semibold text-input-text">
+              Total: {formatCurrency(total)}
+            </p>
+            {!resolvedReadOnly && !isValidConnectedAccount ? (
+              <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+                <strong className="block font-semibold">Payment account not connected.</strong>
+                Finish Stripe onboarding to save or send invoices.
+              </div>
+            ) : null}
+            <div className="flex items-center gap-2">
+              <Button variant="secondary" onClick={onClose} disabled={isSaving || isSending}>
+                {resolvedReadOnly ? 'Back' : 'Cancel'}
+              </Button>
+              {!resolvedReadOnly ? (
+                <>
+                  <Button onClick={openSendDialog} disabled={disableActions}>
+                    Send invoice
+                  </Button>
+                </>
+              ) : null}
             </div>
-          ) : null}
-          <div className="flex items-center gap-2">
-            <Button variant="secondary" onClick={onClose} disabled={isSaving || isSending}>
-              Cancel
-            </Button>
-            <Button variant="secondary" onClick={() => void handleSaveDraft()} disabled={disableActions}>
-              {isSaving ? 'Saving...' : 'Save draft'}
-            </Button>
-            <Button onClick={() => setShowSendDialog(true)} disabled={disableActions}>
-              Send invoice
-            </Button>
-          </div>
-        </footer>
+          </footer>
+        ) : null}
       </div>
 
-      <SendInvoiceDialog
-        isOpen={showSendDialog}
-        totalAmount={total}
-        onConfirm={handleSendInvoice}
-        onCancel={() => setShowSendDialog(false)}
-        loading={isSending}
-        lineItems={lineItems}
-        dueDate={dueDate}
-        previewTitle={previewTitle}
-        previewReferenceLabel={previewReferenceLabel}
-        previewIssueDate={previewIssueDate}
-        practiceName={practiceName}
-        practiceLogoUrl={practiceLogoUrl}
-        practiceEmail={practiceEmail}
-        clientName={resolvedClientLabel || null}
-        clientEmail={resolvedClientEmail}
-        billingIncrementMinutes={billingIncrementMinutes}
-      />
+      {!resolvedReadOnly ? (
+        <SendInvoiceDialog
+          isOpen={showSendDialog}
+          totalAmount={total}
+          onConfirm={handleSendInvoice}
+          onCancel={() => setShowSendDialog(false)}
+          loading={isSending}
+          lineItems={lineItems}
+          dueDate={dueDate}
+          previewTitle={previewTitle}
+          previewReferenceLabel={previewReferenceLabel}
+          previewIssueDate={previewIssueDate}
+          practiceName={practiceName}
+          practiceLogoUrl={practiceLogoUrl}
+          practiceEmail={practiceEmail}
+          clientName={resolvedClientLabel || null}
+          clientEmail={resolvedClientEmail}
+          billingIncrementMinutes={billingIncrementMinutes}
+        />
+      ) : null}
     </div>
   );
-};
+});

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -172,7 +172,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
     const initial = initialDueDate ?? defaultDueDate;
     return initial === defaultDueDate ? 'tomorrow' : 'custom';
   });
-  const isSaving = false;
+  const [isSaving, setIsSaving] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [showSendDialog, setShowSendDialog] = useState(false);
   const [createdInvoiceId, setCreatedInvoiceId] = useState<string | null>(
@@ -235,10 +235,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
     () => serializeInvoiceUpdatePayload(currentUpdatePayload),
     [currentUpdatePayload]
   );
-  const previewIssueDate = useMemo(() => {
-    const explicitIssueDate = (currentUpdatePayload as { issue_date?: string | Date | null }).issue_date;
-    return explicitIssueDate ?? new Date();
-  }, [currentUpdatePayload]);
+  const previewIssueDate = useMemo(() => new Date(), []);
 
   const isValidConnectedAccount = useMemo(
     () => Boolean(connectedAccountId && UUID_REGEX.test(connectedAccountId)),
@@ -294,6 +291,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
       return;
     }
     if (disableActions || !connectedAccountId) return;
+    setIsSaving(true);
     setIsSending(true);
     setSendError(null);
     let invoiceId = createdInvoiceId;
@@ -346,6 +344,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
       );
     } finally {
       setIsSending(false);
+      setIsSaving(false);
       setShowSendDialog(false);
     }
   };

--- a/src/features/invoices/components/InvoiceLineItemsForm.tsx
+++ b/src/features/invoices/components/InvoiceLineItemsForm.tsx
@@ -7,10 +7,11 @@ import { asMajor, safeMultiply, getMajorAmountValue } from '@/shared/utils/money
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import type { InvoiceLineItem } from '@/features/matters/types/billing.types';
 
-type LineItemsBuilderProps = {
+type InvoiceLineItemsFormProps = {
   lineItems: InvoiceLineItem[];
   onChange: (lineItems: InvoiceLineItem[]) => void;
   billingIncrementMinutes?: number | null;
+  readOnly?: boolean;
 };
 
 const newLineItem = (): InvoiceLineItem => ({
@@ -104,7 +105,7 @@ const LineItemDialog = ({ isOpen, item, onSave, onClose, billingIncrementMinutes
   );
 };
 
-export const LineItemsBuilder = ({ lineItems, onChange, billingIncrementMinutes }: LineItemsBuilderProps) => {
+export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinutes, readOnly = false }: InvoiceLineItemsFormProps) => {
   const [editingItem, setEditingItem] = useState<{ item: InvoiceLineItem | null, index: number } | null>(null);
   const [isAddMode, setIsAddMode] = useState(false);
 
@@ -134,28 +135,32 @@ export const LineItemsBuilder = ({ lineItems, onChange, billingIncrementMinutes 
         <div>
           <h3 className="text-sm font-semibold text-input-text">Line items</h3>
         </div>
-        <Button 
-          size="xs" 
-          variant="secondary" 
-          onClick={() => setIsAddMode(true)}
-          icon={PlusIcon}
-          iconClassName="h-3.5 w-3.5 mr-1"
-        >
-          Add line item
-        </Button>
+        {!readOnly ? (
+          <Button 
+            size="xs" 
+            variant="secondary" 
+            onClick={() => setIsAddMode(true)}
+            icon={PlusIcon}
+            iconClassName="h-3.5 w-3.5 mr-1"
+          >
+            Add line item
+          </Button>
+        ) : null}
       </div>
 
       {lineItems.length === 0 ? (
         <div className="rounded-xl border border-dashed border-line-glass/30 p-8 text-center bg-white/[0.02]">
            <p className="text-sm text-input-placeholder">No line items added yet.</p>
-           <Button 
-            size="sm" 
-            variant="ghost" 
-            onClick={() => setIsAddMode(true)}
-            className="mt-2"
-          >
-            Click to add your first item
-          </Button>
+           {!readOnly ? (
+             <Button 
+              size="sm" 
+              variant="ghost" 
+              onClick={() => setIsAddMode(true)}
+              className="mt-2"
+            >
+              Click to add your first item
+            </Button>
+           ) : null}
         </div>
       ) : (
         <div className="overflow-hidden rounded-xl border border-line-glass/30 bg-white/[0.02]">
@@ -166,7 +171,7 @@ export const LineItemsBuilder = ({ lineItems, onChange, billingIncrementMinutes 
                 <th className="px-5 py-3 w-20 text-right font-medium">Qty</th>
                 <th className="px-5 py-3 w-28 text-right font-medium">Unit Price</th>
                 <th className="px-5 py-3 w-32 text-right font-medium">Amount</th>
-                <th className="px-5 py-3 w-28 text-right font-medium">Actions</th>
+                {!readOnly ? <th className="px-5 py-3 w-28 text-right font-medium">Actions</th> : null}
               </tr>
             </thead>
             <tbody className="divide-y divide-line-glass/20">
@@ -196,26 +201,28 @@ export const LineItemsBuilder = ({ lineItems, onChange, billingIncrementMinutes 
                         {formatCurrency(itemTotal)}
                       </span>
                     </td>
-                    <td className="px-5 py-4 text-right">
-                      <div className="flex justify-end gap-1">
-                        <Button
-                          size="icon-xs"
-                          variant="ghost"
-                          onClick={() => setEditingItem({ item, index })}
-                          icon={PencilSquareIcon} 
-                          iconClassName="h-4 w-4 text-input-placeholder hover:text-accent-400"
-                          title="Edit item"
-                        />
-                        <Button
-                          size="icon-xs"
-                          variant="ghost"
-                          onClick={() => removeItem(index)}
-                          icon={TrashIcon} 
-                          iconClassName="h-4 w-4 text-input-placeholder hover:text-red-400"
-                          title="Delete item"
-                        />
-                      </div>
-                    </td>
+                    {!readOnly ? (
+                      <td className="px-5 py-4 text-right">
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            size="icon-xs"
+                            variant="ghost"
+                            onClick={() => setEditingItem({ item, index })}
+                            icon={PencilSquareIcon} 
+                            iconClassName="h-4 w-4 text-input-placeholder hover:text-accent-400"
+                            title="Edit item"
+                          />
+                          <Button
+                            size="icon-xs"
+                            variant="ghost"
+                            onClick={() => removeItem(index)}
+                            icon={TrashIcon} 
+                            iconClassName="h-4 w-4 text-input-placeholder hover:text-red-400"
+                            title="Delete item"
+                          />
+                        </div>
+                      </td>
+                    ) : null}
                   </tr>
                 );
               })}
@@ -225,23 +232,27 @@ export const LineItemsBuilder = ({ lineItems, onChange, billingIncrementMinutes 
       )}
 
       {/* Logic for Dialogs */}
-      <LineItemDialog 
-        key={`add-${isAddMode}`}
-        isOpen={isAddMode} 
-        item={null}
-        onSave={handleSaveItem}
-        onClose={() => setIsAddMode(false)}
-        billingIncrementMinutes={billingIncrementMinutes}
-      />
+      {!readOnly ? (
+        <>
+          <LineItemDialog 
+            key={`add-${isAddMode}`}
+            isOpen={isAddMode} 
+            item={null}
+            onSave={handleSaveItem}
+            onClose={() => setIsAddMode(false)}
+            billingIncrementMinutes={billingIncrementMinutes}
+          />
 
-      <LineItemDialog 
-        key={editingItem?.item?.id ?? 'none'}
-        isOpen={!!editingItem} 
-        item={editingItem?.item || null}
-        onSave={handleSaveItem}
-        onClose={() => setEditingItem(null)}
-        billingIncrementMinutes={billingIncrementMinutes}
-      />
+          <LineItemDialog 
+            key={editingItem?.item?.id ?? 'none'}
+            isOpen={!!editingItem} 
+            item={editingItem?.item || null}
+            onSave={handleSaveItem}
+            onClose={() => setEditingItem(null)}
+            billingIncrementMinutes={billingIncrementMinutes}
+          />
+        </>
+      ) : null}
     </section>
   );
 };

--- a/src/features/invoices/components/SendInvoiceDialog.tsx
+++ b/src/features/invoices/components/SendInvoiceDialog.tsx
@@ -62,11 +62,12 @@ export const SendInvoiceDialog = ({
 
       <div className="space-y-4">
         <div className="rounded-xl border border-line-glass/10 bg-white/[0.03] p-4">
-          <p className="text-sm text-white/70">
-            You are about to send this invoice to the client.
-          </p>
+          <p className="text-sm text-white/70">Send this invoice now?</p>
           <p className="mt-1 text-base font-semibold text-white">
             Total due: {formatCurrency(totalAmount)}
+          </p>
+          <p className="mt-2 text-xs text-white/60">
+            You can update invoices until they are paid. The client will receive a receipt after payment.
           </p>
         </div>
 

--- a/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
@@ -1,9 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useStore } from '@nanostores/preact';
 import { useLocation } from 'preact-iso';
-import { Breadcrumbs } from '@/shared/ui/navigation';
 import { Page } from '@/shared/ui/layout/Page';
-import { PageHeader } from '@/shared/ui/layout/PageHeader';
 import { Panel } from '@/shared/ui/layout/Panel';
 import { useNavigation } from '@/shared/utils/navigation';
 import { useToastContext } from '@/shared/contexts/ToastContext';
@@ -13,11 +11,13 @@ import {
   type UserDetailRecord,
 } from '@/shared/lib/apiClient';
 import { listMatters, type BackendMatter, updateMatterMilestone } from '@/features/matters/services/mattersApi';
-import { InvoiceBuilder } from '@/features/invoices/components/InvoiceBuilder';
+import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
+import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
 import {
   clearPendingInvoiceDraftContext,
   readPendingInvoiceDraftContext,
 } from '@/features/invoices/utils/invoiceDraftContext';
+import { INVOICE_CREATE_SEND_EVENT } from '@/features/invoices/utils/invoicePageConfig';
 import { practiceDetailsStore } from '@/shared/stores/practiceDetailsStore';
 import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 
@@ -90,6 +90,7 @@ export function PracticeInvoiceCreatePage({
   const [connectedAccountId, setConnectedAccountId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const builderRef = useRef<InvoiceFormHandle | null>(null);
 
   // Read cached practice identity — no extra requests; usePracticeManagement uses shared snapshot cache
   const { currentPractice } = usePracticeManagement({
@@ -114,14 +115,10 @@ export function PracticeInvoiceCreatePage({
     return `/practice/${encodeURIComponent(practiceSlug)}/invoices`;
   }, [practiceSlug]);
   const returnPath = draftContext?.returnPath?.trim() || invoicesPath;
-  const breadcrumbLabel = draftContext?.returnLabel?.trim() || 'Invoices';
   const missingDraftError = draftId && !draftContext
     ? 'Invoice draft context was not found. Start invoice creation from the matter or invoices page again.'
     : null;
   const displayError = loadError ?? missingDraftError;
-  const pageSubtitle = draftContext?.matterId
-    ? 'Draft a new invoice for this matter, review the preview, and send it when ready.'
-    : 'Draft a new invoice, choose who it belongs to, and optionally link it to a matter.';
 
   useEffect(() => {
     if (!practiceId) return;
@@ -171,6 +168,14 @@ export function PracticeInvoiceCreatePage({
 
     return () => controller.abort();
   }, [practiceId]);
+
+  useEffect(() => {
+    const handleSendRequest = () => {
+      builderRef.current?.requestSend();
+    };
+    window.addEventListener(INVOICE_CREATE_SEND_EVENT, handleSendRequest);
+    return () => window.removeEventListener(INVOICE_CREATE_SEND_EVENT, handleSendRequest);
+  }, []);
 
   const clientOptions = useMemo(() => {
     return clients.map((client) => ({
@@ -235,14 +240,6 @@ export function PracticeInvoiceCreatePage({
   return (
     <Page className="min-h-full">
       <div className="mx-auto flex max-w-7xl flex-col gap-6">
-        <Breadcrumbs
-          items={[{ label: breadcrumbLabel, href: returnPath ?? undefined }, { label: 'Create invoice' }]}
-          onNavigate={navigate}
-        />
-        <PageHeader
-          title="Create Invoice"
-          subtitle={pageSubtitle}
-        />
         {displayError ? (
           <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
             {displayError}
@@ -253,7 +250,9 @@ export function PracticeInvoiceCreatePage({
             <div className="text-sm text-input-placeholder">Loading invoice builder...</div>
           </Panel>
         ) : missingDraftError || !practiceId ? null : (
-          <InvoiceBuilder
+          <InvoiceForm
+            ref={builderRef}
+            mode="create"
             practiceId={practiceId}
             connectedAccountId={connectedAccountId}
             clientOptions={clientOptions}

--- a/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
@@ -1,28 +1,28 @@
 import type { ComponentChildren } from 'preact';
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import Modal from '@/shared/components/Modal';
 import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
-import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useNavigation } from '@/shared/utils/navigation';
-import { getMajorAmountValue } from '@/shared/utils/money';
-import { LineItemsBuilder } from '@/features/invoices/components/LineItemsBuilder';
+import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
+import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
 import {
-  deleteInvoice,
   getInvoice,
-  sendInvoice,
   syncInvoice,
-  updateInvoice,
   voidInvoice,
 } from '@/features/invoices/services/invoicesService';
-import { InvoiceStatusBadge } from '@/features/invoices/components/InvoiceStatusBadge';
 import type { InvoiceDetail } from '@/features/invoices/types';
-import type { InvoiceLineItem } from '@/features/matters/types/billing.types';
+import { resolveInvoicePageMode } from '@/features/invoices/utils/invoicePageConfig';
 
 const isActionableOpenStatus = (status: string): boolean => {
   return ['sent', 'pending', 'open', 'overdue'].includes(status);
+};
+
+const isRefundEligibleStatus = (status: string): boolean => {
+  return !['draft', 'void', 'cancelled'].includes(status);
 };
 
 const renderEventDate = (value: string | null): string => {
@@ -47,16 +47,16 @@ export function PracticeInvoiceDetailPage({
   showBack?: boolean;
 }) {
   const { navigate } = useNavigation();
-  const { showError, showSuccess, showInfo } = useToastContext();
+  const { showError, showInfo, showSuccess } = useToastContext();
   const [detail, setDetail] = useState<InvoiceDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [editing, setEditing] = useState(false);
-  const [savingEdit, setSavingEdit] = useState(false);
-  const [lineItems, setLineItems] = useState<InvoiceLineItem[]>([]);
-  const [notes, setNotes] = useState('');
-  const [memo, setMemo] = useState('');
-  const [dueDate, setDueDate] = useState('');
+
+  const [refundModalOpen, setRefundModalOpen] = useState(false);
+  const [refundReason, setRefundReason] = useState('');
+  const [refundAmount, setRefundAmount] = useState('');
+  const [submittingMockRefund, setSubmittingMockRefund] = useState(false);
+  const formRef = useRef<InvoiceFormHandle | null>(null);
 
   const loadDetail = useCallback((signal?: AbortSignal) => {
     if (!practiceId || !invoiceId) return Promise.resolve();
@@ -71,10 +71,6 @@ export function PracticeInvoiceDetailPage({
           return;
         }
         setDetail(result);
-        setLineItems(result.lineItems);
-        setNotes(result.notes ?? '');
-        setMemo(result.memo ?? '');
-        setDueDate(result.dueDate ? result.dueDate.slice(0, 10) : '');
       })
       .catch((err) => {
         if (err.name === 'AbortError') return;
@@ -91,8 +87,22 @@ export function PracticeInvoiceDetailPage({
   }, [loadDetail]);
 
   const status = useMemo(() => (detail?.status ?? 'draft').toLowerCase(), [detail?.status]);
-
+  const mode = useMemo(() => resolveInvoicePageMode(status), [status]);
+  const isDraft = mode === 'edit';
   const hasHostedUrl = Boolean(detail?.stripeHostedInvoiceUrl);
+  const canMockRefund = Boolean(detail && isRefundEligibleStatus(status) && detail.amountPaid > 0);
+
+  const builderClientOptions = useMemo(() => {
+    if (!detail) return [];
+    const label = detail.clientName?.trim() || 'Person';
+    return [{ value: detail.sourceInvoice.client_id, label }];
+  }, [detail]);
+
+  const builderMatterOptions = useMemo(() => {
+    if (!detail?.sourceInvoice.matter_id) return [];
+    const label = detail.matterTitle?.trim() || 'Matter';
+    return [{ value: detail.sourceInvoice.matter_id, label, meta: detail.sourceInvoice.client_id }];
+  }, [detail]);
 
   const handleOpenHostedInvoice = useCallback(() => {
     if (!detail?.stripeHostedInvoiceUrl) {
@@ -107,16 +117,14 @@ export function PracticeInvoiceDetailPage({
     navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices`);
   }, [navigate, practiceSlug]);
 
-  const handleSend = useCallback(async () => {
-    if (!practiceId || !invoiceId) return;
-    try {
-      await sendInvoice(practiceId, invoiceId);
-      showSuccess('Invoice sent', 'The invoice was sent successfully.');
-      await loadDetail();
-    } catch (err) {
-      showError('Invoice send failed', err instanceof Error ? err.message : 'Failed to send invoice');
+  const handleBuilderSuccess = useCallback(async (updatedInvoiceId?: string | null) => {
+    const safeInvoiceId = updatedInvoiceId?.trim();
+    if (safeInvoiceId && safeInvoiceId !== detail?.id && practiceSlug) {
+      navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices/${encodeURIComponent(safeInvoiceId)}`);
+      return;
     }
-  }, [invoiceId, loadDetail, practiceId, showError, showSuccess]);
+    await loadDetail();
+  }, [detail?.id, loadDetail, navigate, practiceSlug]);
 
   const handleSync = useCallback(async () => {
     if (!practiceId || !invoiceId) return;
@@ -143,59 +151,35 @@ export function PracticeInvoiceDetailPage({
     }
   }, [invoiceId, loadDetail, practiceId, showError, showSuccess]);
 
-  const handleDelete = useCallback(async () => {
-    if (!practiceId || !invoiceId) return;
-    const confirmed = window.confirm('Delete this draft invoice?');
-    if (!confirmed) return;
-
-    try {
-      await deleteInvoice(practiceId, invoiceId);
-      showSuccess('Invoice deleted', 'Draft invoice deleted.');
-      handleBackToList();
-    } catch (err) {
-      showError('Invoice delete failed', err instanceof Error ? err.message : 'Failed to delete invoice');
+  const handleSubmitMockRefund = useCallback(async () => {
+    if (!detail) return;
+    if (!refundReason.trim()) {
+      showError('Refund request', 'Please provide a reason.');
+      return;
     }
-  }, [handleBackToList, invoiceId, practiceId, showError, showSuccess]);
-  const handleCancelEdit = useCallback(() => {
-    if (detail) {
-      setLineItems(detail.lineItems);
-      setNotes(detail.notes ?? '');
-      setMemo(detail.memo ?? '');
-      setDueDate(detail.dueDate ? detail.dueDate.slice(0, 10) : '');
+
+    const parsedAmount = refundAmount.trim().length > 0 ? Number(refundAmount) : undefined;
+    if (parsedAmount !== undefined && (!Number.isFinite(parsedAmount) || parsedAmount <= 0)) {
+      showError('Refund request', 'Amount must be a positive number.');
+      return;
     }
-    setEditing(false);
-  }, [detail]);
 
-  const handleSaveEdit = useCallback(async () => {
-    if (!practiceId || !invoiceId || !detail) return;
-    setSavingEdit(true);
+    if (parsedAmount !== undefined && parsedAmount > detail.amountPaid) {
+      showError('Refund request', 'Amount cannot be greater than the amount paid.');
+      return;
+    }
+
+    setSubmittingMockRefund(true);
     try {
-      let localDueDate: string | undefined;
-      const dueDateTrimmed = dueDate.trim();
-      if (dueDateTrimmed) {
-        const parts = dueDateTrimmed.split('-').map(Number);
-        if (parts.length === 3 && parts.every((p) => !Number.isNaN(p))) {
-          const [year, month, day] = parts;
-          localDueDate = new Date(year, month - 1, day).toISOString();
-        }
-      }
-
-      await updateInvoice(practiceId, invoiceId, {
-        line_items: lineItems,
-        notes: notes.trim() || undefined,
-        memo: memo.trim() || undefined,
-        due_date: localDueDate,
-        invoice_type: detail.sourceInvoice.invoice_type,
-      });
-      showSuccess('Invoice updated', 'Draft invoice has been updated.');
-      setEditing(false);
-      await loadDetail();
-    } catch (err) {
-      showError('Invoice update failed', err instanceof Error ? err.message : 'Failed to update invoice');
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      showSuccess('Refund request queued', 'Mock refund flow: request captured locally while backend endpoints are in progress.');
+      setRefundReason('');
+      setRefundAmount('');
+      setRefundModalOpen(false);
     } finally {
-      setSavingEdit(false);
+      setSubmittingMockRefund(false);
     }
-  }, [detail, dueDate, invoiceId, lineItems, loadDetail, memo, notes, practiceId, showError, showSuccess]);
+  }, [detail, refundAmount, refundReason, showError, showSuccess]);
 
   if (loading) {
     return <div className="p-6 text-sm text-input-placeholder">Loading invoice...</div>;
@@ -207,6 +191,10 @@ export function PracticeInvoiceDetailPage({
 
   if (!detail) {
     return <div className="p-6 text-sm text-input-placeholder">Invoice not found.</div>;
+  }
+
+  if (!practiceId) {
+    return <div className="p-6 text-sm text-red-300">Practice context is missing from this route.</div>;
   }
 
   return (
@@ -221,11 +209,11 @@ export function PracticeInvoiceDetailPage({
         inspectorOpen={inspectorOpen}
         actions={(
           <div className="flex flex-wrap items-center gap-2">
-            {status === 'draft' ? (
+            {isDraft ? (
               <>
-                <Button variant="secondary" onClick={() => setEditing((prev) => !prev)}>{editing ? 'Close edit' : 'Edit'}</Button>
-                <Button onClick={() => void handleSend()}>Send</Button>
-                <Button variant="danger-ghost" onClick={() => void handleDelete()}>Delete</Button>
+                <Button onClick={() => formRef.current?.requestSend()}>
+                  Send invoice
+                </Button>
               </>
             ) : null}
             {isActionableOpenStatus(status) ? (
@@ -238,128 +226,72 @@ export function PracticeInvoiceDetailPage({
             {status === 'paid' ? (
               <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
             ) : null}
+            {canMockRefund ? (
+              <Button variant="secondary" onClick={() => setRefundModalOpen(true)}>Issue refund (Mock)</Button>
+            ) : null}
           </div>
         )}
       />
-      <div className="mt-1">
-        <InvoiceStatusBadge status={detail.status} />
-      </div>
 
-      <div className="grid gap-3 sm:grid-cols-3">
-        <div className="glass-panel p-4">
-          <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Total</p>
-          <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.total)}</p>
-        </div>
-        <div className="glass-panel p-4">
-          <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Amount paid</p>
-          <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.amountPaid)}</p>
-        </div>
-        <div className="glass-panel p-4">
-          <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Amount due</p>
-          <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.amountDue)}</p>
-        </div>
-      </div>
+      <InvoiceForm
+        ref={formRef}
+        mode={mode}
+        practiceId={practiceId}
+        connectedAccountId={detail.sourceInvoice.connected_account_id}
+        clientOptions={builderClientOptions}
+        matterOptions={builderMatterOptions}
+        initialClientId={detail.sourceInvoice.client_id}
+        initialMatterId={detail.sourceInvoice.matter_id ?? undefined}
+        initialLineItems={detail.lineItems}
+        initialDueDate={detail.dueDate ? detail.dueDate.slice(0, 10) : undefined}
+        initialNotes={detail.notes ?? undefined}
+        initialMemo={detail.memo ?? undefined}
+        initialInvoiceType={detail.sourceInvoice.invoice_type}
+        existingInvoiceId={detail.id}
+        closeAfterSuccess={false}
+        hideFooterActions
+        onClose={handleBackToList}
+        onSuccess={handleBuilderSuccess}
+      />
 
-      {editing ? (
-        <div className="glass-panel p-4">
-          <h2 className="text-base font-semibold text-input-text">Edit draft invoice</h2>
-          <p className="mt-1 text-sm text-input-placeholder">Inline editing for draft invoices.</p>
-          <div className="mt-4 space-y-4">
-            <LineItemsBuilder lineItems={lineItems} onChange={setLineItems} />
-            <Input type="date" label="Due date" value={dueDate} onChange={setDueDate} />
-            <Textarea label="Notes" value={notes} onChange={setNotes} rows={3} />
-            <Textarea label="Memo" value={memo} onChange={setMemo} rows={2} />
-            <div className="flex justify-end gap-2">
-              <Button variant="secondary" onClick={handleCancelEdit}>Cancel</Button>
-              <Button onClick={() => void handleSaveEdit()} disabled={savingEdit}>{savingEdit ? 'Saving...' : 'Save changes'}</Button>
-            </div>
+      <Modal
+        isOpen={refundModalOpen}
+        onClose={() => setRefundModalOpen(false)}
+        title="Issue refund (Mock)"
+        contentClassName="max-w-xl"
+        disableBackdropClick={submittingMockRefund}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-input-placeholder">
+            This flow is currently mocked and does not execute a real backend refund.
+          </p>
+          <Input
+            type="number"
+            label="Amount"
+            value={refundAmount}
+            onChange={setRefundAmount}
+            min={0}
+            step={0.01}
+            placeholder={`Up to ${detail.amountPaid}`}
+            disabled={submittingMockRefund}
+          />
+          <Textarea
+            label="Reason"
+            value={refundReason}
+            onChange={setRefundReason}
+            rows={3}
+            disabled={submittingMockRefund}
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setRefundModalOpen(false)} disabled={submittingMockRefund}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleSubmitMockRefund()} disabled={submittingMockRefund}>
+              {submittingMockRefund ? 'Submitting...' : 'Queue refund request'}
+            </Button>
           </div>
         </div>
-      ) : null}
-
-      <div className="glass-panel overflow-hidden">
-        <div className="border-b border-line-glass/30 px-4 py-3">
-          <h2 className="text-base font-semibold text-input-text">Line items</h2>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead className="border-b border-line-glass/30 text-xs uppercase tracking-[0.08em] text-input-placeholder">
-              <tr>
-                <th className="px-4 py-3 text-left">Description</th>
-                <th className="px-4 py-3 text-left">Type</th>
-                <th className="px-4 py-3 text-right">Qty</th>
-                <th className="px-4 py-3 text-right">Unit</th>
-                <th className="px-4 py-3 text-right">Total</th>
-              </tr>
-            </thead>
-            <tbody>
-              {detail.lineItems.map((item) => (
-                <tr key={item.id} className="border-b border-line-glass/20 last:border-b-0">
-                  <td className="px-4 py-3 text-input-text">{item.description || '—'}</td>
-                  <td className="px-4 py-3 text-input-text">{item.type}</td>
-                  <td className="px-4 py-3 text-right text-input-text">{item.quantity}</td>
-                  <td className="px-4 py-3 text-right text-input-text">{formatCurrency(getMajorAmountValue(item.unit_price))}</td>
-                  <td className="px-4 py-3 text-right font-semibold text-input-text">{formatCurrency(getMajorAmountValue(item.line_total))}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="glass-panel p-4">
-          <h3 className="text-sm font-semibold text-input-text">Activity & payments</h3>
-          {detail.payments.length === 0 ? (
-            <p className="mt-2 text-sm text-input-placeholder">No payment history.</p>
-          ) : (
-            <ul className="mt-2 space-y-2 text-sm">
-              {detail.payments.map((payment) => (
-                <li key={payment.id} className="rounded-lg border border-line-glass/20 px-3 py-2">
-                  <p className="font-medium text-input-text">{formatCurrency(payment.amount)} • {payment.status}</p>
-                  <p className="text-xs text-input-placeholder">{renderEventDate(payment.paidAt)}</p>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        <div className="glass-panel p-4">
-          <h3 className="text-sm font-semibold text-input-text">Refund history</h3>
-          {detail.refunds.length === 0 ? (
-            <p className="mt-2 text-sm text-input-placeholder">No refunds on this invoice.</p>
-          ) : (
-            <ul className="mt-2 space-y-2 text-sm">
-              {detail.refunds.map((refund) => (
-                <li key={refund.id} className="rounded-lg border border-line-glass/20 px-3 py-2">
-                  <p className="font-medium text-input-text">{formatCurrency(refund.amount)} • {refund.status}</p>
-                  <p className="text-xs text-input-placeholder">{renderEventDate(refund.createdAt)}</p>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        <div className="glass-panel p-4">
-          <h3 className="text-sm font-semibold text-input-text">Refund tooling</h3>
-          <p className="mt-2 text-sm text-input-placeholder">
-            Direct refund actions are disabled until backend refund execution endpoints are available.
-          </p>
-          <Button variant="secondary" size="sm" className="mt-3" disabled>
-            Issue refund (Unavailable)
-          </Button>
-          {detail.refundRequests.length > 0 ? (
-            <ul className="mt-3 space-y-2 text-sm">
-              {detail.refundRequests.map((request) => (
-                <li key={request.id} className="rounded-lg border border-line-glass/20 px-3 py-2">
-                  <p className="font-medium text-input-text">{request.status}</p>
-                  <p className="text-xs text-input-placeholder">{renderEventDate(request.createdAt)}</p>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-      </div>
+      </Modal>
     </div>
   );
 }

--- a/src/features/invoices/utils/invoicePageConfig.ts
+++ b/src/features/invoices/utils/invoicePageConfig.ts
@@ -1,0 +1,11 @@
+export type InvoicePageMode = 'create' | 'edit' | 'readOnly';
+
+export const INVOICE_CREATE_SEND_EVENT = 'blawby:invoice-create-send';
+
+export const resolveInvoicePageMode = (status?: string | null): InvoicePageMode => {
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  if (normalized === 'draft') {
+    return 'edit';
+  }
+  return 'readOnly';
+};

--- a/src/features/matters/services/invoicesApi.ts
+++ b/src/features/matters/services/invoicesApi.ts
@@ -4,7 +4,6 @@ import { urls } from '@/config/urls';
 import {
   assertMajorUnits,
   asMajor,
-  _safeMultiply,
   toMajorUnits,
   toMinorUnitsValue,
   type MajorAmount

--- a/src/shared/ui/input/Textarea.tsx
+++ b/src/shared/ui/input/Textarea.tsx
@@ -67,6 +67,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
   autoFocus,
   onKeyDown
 }, ref) => {
+  const localTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   // Generate stable ID for accessibility
   const generatedId = useUniqueId('textarea');
   const textareaId = id || generatedId;
@@ -157,6 +158,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
   const isNearLimit = maxLength && currentLength > maxLength * 0.8;
   const isOverLimit = maxLength && currentLength > maxLength;
 
+  useEffect(() => {
+    if (!autoFocus || disabled) return;
+    localTextareaRef.current?.focus();
+  }, [autoFocus, disabled]);
+
   return (
     <div className="w-full">
       {displayLabel && (
@@ -168,7 +174,16 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
       
       <textarea
         id={textareaId}
-        ref={ref}
+        ref={(node) => {
+          localTextareaRef.current = node;
+          if (typeof ref === 'function') {
+            ref(node);
+            return;
+          }
+          if (ref && typeof ref === 'object') {
+            (ref as { current: HTMLTextAreaElement | null }).current = node;
+          }
+        }}
         value={actualValue}
         onChange={(e) => {
           const newValue = (e.target as HTMLTextAreaElement).value;
@@ -201,7 +216,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
         disabled={disabled}
         required={required}
         rows={rows}
-        autoFocus={autoFocus}
         onKeyDown={onKeyDown}
         maxLength={enforceMaxLength === 'soft' ? undefined : maxLength}
         className={textareaClasses}


### PR DESCRIPTION
## Summary
- unify invoice create/detail/new behavior around a shared mode-driven invoice form
- align header-driven actions and remove duplicated footer actions in create/detail
- remove legacy hero metrics and copy/share/detail extras to match intended flow
- rename invoice components for consistency (`InvoiceForm`, `InvoiceLineItemsForm`)
- centralize invoice mode and create-send event in shared config

## Validation
- npm run type-check
- npm run lint (passes with 1 existing warning in `src/shared/ui/input/Textarea.tsx` about `autoFocus`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New invoice creation interface with streamlined send workflow
  * Support for multiple invoice modes (create, edit, read-only) to accommodate different workflows
  * Refund processing capability for invoices marked as paid

* **Improvements**
  * Clearer invoice confirmation messaging
  * Better focus behavior in form inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->