### PR TITLE
Refactor practice team read model

### DIFF
--- a/public/widget-test.html
+++ b/public/widget-test.html
@@ -315,6 +315,7 @@
       var baseUrlInput = document.getElementById('base-url');
       var primaryColorInput = document.getElementById('primary-color');
 
+      var MAX_DEBUG_EVENTS = 200;
       var debugState = {
         events: [],
         network: [],
@@ -362,6 +363,9 @@
           pushDataLayerOnChatStart: true,
           onEvent: function (eventPayload) {
             debugState.events.unshift(eventPayload);
+            if (debugState.events.length > MAX_DEBUG_EVENTS) {
+              debugState.events.pop();
+            }
             appendLog(eventLogEl, 'onEvent', eventPayload);
             if (eventPayload && eventPayload.type === 'theme_applied') {
               debugState.themeEvent = eventPayload;
@@ -415,7 +419,15 @@
         setText(containerCssVarEl, cssVar || 'Widget container not mounted yet');
 
         if (cssVar) {
-          resolvedThemeColorEl.innerHTML = '<span class="badge"><span class="swatch" style="background:' + cssVar + ';"></span>' + cssVar + '</span>';
+          resolvedThemeColorEl.textContent = '';
+          var badge = document.createElement('span');
+          badge.className = 'badge';
+          var swatch = document.createElement('span');
+          swatch.className = 'swatch';
+          swatch.style.background = cssVar;
+          badge.appendChild(swatch);
+          badge.appendChild(document.createTextNode(cssVar));
+          resolvedThemeColorEl.appendChild(badge);
         } else {
           setText(resolvedThemeColorEl, 'Waiting for widget…');
         }

--- a/public/widget-test.html
+++ b/public/widget-test.html
@@ -440,7 +440,11 @@
         if (payload && payload.accentColor) {
           var colorBadge = document.createElement('div');
           colorBadge.className = 'badge';
-          colorBadge.innerHTML = '<span class="swatch" style="background:' + payload.accentColor + ';"></span>accentColor: ' + payload.accentColor;
+          var swatch = document.createElement('span');
+          swatch.className = 'swatch';
+          swatch.style.background = payload.accentColor;
+          colorBadge.appendChild(swatch);
+          colorBadge.appendChild(document.createTextNode('accentColor: ' + payload.accentColor));
           practiceFetchBadgesEl.appendChild(colorBadge);
         }
       }

--- a/public/widget-test.html
+++ b/public/widget-test.html
@@ -1,220 +1,564 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Widget Test — Mock Practice Site</title>
+  <title>Widget Debug</title>
   <style>
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
-
+    * { box-sizing: border-box; }
     body {
-      font-family: system-ui, -apple-system, sans-serif;
-      background: linear-gradient(135deg, #f0f4ff 0%, #e8f5f0 100%);
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #08101d 0%, #0f172a 100%);
+      color: #e5edf7;
       min-height: 100vh;
-      display: flex;
-      align-items: flex-start;
-      justify-content: center;
-      padding: 40px 20px;
     }
-
     .page {
-      max-width: 760px;
-      width: 100%;
+      width: min(1200px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 32px 0 120px;
     }
-
+    .hero {
+      margin-bottom: 24px;
+    }
     h1 {
+      margin: 0 0 8px;
       font-size: 2rem;
-      font-weight: 700;
-      color: #1a1a2e;
-      margin-bottom: 8px;
+      line-height: 1.1;
     }
-
-    p {
-      color: #555;
+    .lead {
+      margin: 0;
+      color: #9fb0c6;
       line-height: 1.6;
-      margin-bottom: 16px;
-      font-size: 1rem;
+      max-width: 72ch;
     }
-
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      gap: 16px;
+    }
     .card {
-      background: white;
-      border-radius: 12px;
-      padding: 28px;
-      margin-top: 24px;
-      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-    }
-
-    .card h2 {
-      font-size: 1.25rem;
-      color: #1a1a2e;
-      margin-bottom: 12px;
-    }
-
-    code {
-      background: #f4f4f8;
-      padding: 2px 6px;
-      border-radius: 4px;
-      font-size: 0.875rem;
-    }
-
-    pre {
-      background: #1a1a2e;
-      color: #a8ff78;
+      grid-column: span 12;
+      background: rgba(15, 23, 42, 0.78);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      border-radius: 18px;
       padding: 20px;
-      border-radius: 8px;
-      overflow-x: auto;
-      font-size: 0.85rem;
-      line-height: 1.6;
-      margin: 16px 0;
+      box-shadow: 0 14px 40px rgba(0, 0, 0, 0.24);
+      backdrop-filter: blur(12px);
     }
-
+    .card h2 {
+      margin: 0 0 12px;
+      font-size: 1rem;
+      color: #f8fafc;
+      letter-spacing: 0.01em;
+    }
+    .card p {
+      margin: 0 0 12px;
+      color: #9fb0c6;
+      line-height: 1.5;
+    }
+    .card-half { grid-column: span 6; }
+    .card-third { grid-column: span 4; }
     .controls {
       display: flex;
-      gap: 10px;
       flex-wrap: wrap;
-      margin-top: 16px;
+      gap: 10px;
+      margin-top: 14px;
     }
-
     button {
-      padding: 10px 20px;
-      border-radius: 8px;
-      border: 1.5px solid #10B981;
-      background: transparent;
-      color: #10B981;
+      appearance: none;
+      border: 1px solid rgba(212, 175, 55, 0.45);
+      background: rgba(212, 175, 55, 0.12);
+      color: #f8fafc;
+      border-radius: 999px;
+      padding: 10px 16px;
       font-size: 0.9rem;
       font-weight: 600;
       cursor: pointer;
-      transition: background 0.15s;
+      transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
     }
-
     button:hover {
-      background: #10B981;
-      color: white;
+      transform: translateY(-1px);
+      background: rgba(212, 175, 55, 0.2);
+      border-color: rgba(212, 175, 55, 0.7);
     }
-
-    .notice {
-      background: #fff8e1;
-      border-left: 4px solid #f59e0b;
-      padding: 12px 16px;
-      border-radius: 0 6px 6px 0;
-      font-size: 0.875rem;
-      color: #78350f;
-      margin-top: 12px;
+    button.secondary {
+      border-color: rgba(148, 163, 184, 0.3);
+      background: rgba(148, 163, 184, 0.08);
     }
-
-    .events {
-      margin-top: 16px;
-      padding: 12px;
-      background: #f8fafc;
-      border: 1px solid #e2e8f0;
-      border-radius: 8px;
-      max-height: 220px;
-      overflow: auto;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    .fields {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 14px;
+    }
+    label {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #cbd5e1;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    input {
+      width: 100%;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 12px;
+      background: rgba(15, 23, 42, 0.9);
+      color: #f8fafc;
+      padding: 11px 12px;
+      font-size: 0.95rem;
+    }
+    input:focus {
+      outline: 2px solid rgba(212, 175, 55, 0.6);
+      outline-offset: 1px;
+    }
+    .kv {
+      display: grid;
+      grid-template-columns: 180px minmax(0, 1fr);
+      gap: 10px 16px;
+      align-items: start;
+      font-size: 0.92rem;
+    }
+    .kv dt {
+      color: #94a3b8;
+      font-weight: 600;
+    }
+    .kv dd {
+      margin: 0;
+      color: #f8fafc;
+      word-break: break-word;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.12);
+      color: #e2e8f0;
+      font-size: 0.82rem;
+      margin-right: 8px;
+      margin-bottom: 8px;
+    }
+    .swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      flex-shrink: 0;
+    }
+    pre {
+      margin: 0;
+      padding: 14px;
+      border-radius: 14px;
+      background: rgba(2, 6, 23, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.14);
+      color: #d9f99d;
       font-size: 12px;
-      line-height: 1.45;
-      color: #0f172a;
+      line-height: 1.5;
       white-space: pre-wrap;
+      word-break: break-word;
+      overflow: auto;
+      min-height: 110px;
+      max-height: 320px;
+    }
+    .log {
+      min-height: 180px;
+      max-height: 360px;
+    }
+    .muted {
+      color: #94a3b8;
+    }
+    .notice {
+      margin-top: 12px;
+      padding: 12px 14px;
+      border-radius: 12px;
+      background: rgba(251, 191, 36, 0.12);
+      border: 1px solid rgba(251, 191, 36, 0.24);
+      color: #fde68a;
+      font-size: 0.88rem;
+      line-height: 1.5;
+    }
+    @media (max-width: 900px) {
+      .card-half, .card-third { grid-column: span 12; }
+      .fields { grid-template-columns: 1fr; }
+      .kv { grid-template-columns: 1fr; }
     }
   </style>
 </head>
-
 <body>
   <script>
-    // Forcibly remove any lingering PWA Service Workers from previous dev sessions
-    // that might intercept this HTML file and route it to the SPA.
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.getRegistrations().then(function (registrations) {
-        for (let registration of registrations) {
+        registrations.forEach(function (registration) {
           registration.unregister();
-          console.log('Unregistered stale service worker.');
-        }
+        });
       });
     }
   </script>
-  <div class="page">
-    <h1>⚖️ Park & Associates</h1>
-    <p>Expert legal counsel in employment law, corporate litigation, and estate planning. Serving the greater
-      metropolitan area for over 20 years.</p>
-    <p>Have a legal question? Chat with our AI assistant below — click the green button in the bottom-right corner to
-      get started.</p>
 
-    <div class="card">
-      <h2>Widget Integration Code</h2>
-      <p>Paste this snippet into your website to activate the Blawby Messenger:</p>
-      <pre id="snippet-preview"></pre>
-      <p class="notice">
-        ⚠️ This test page loads the widget against <code>localhost:5173</code>. Update <code>baseUrl</code> to
-        <code>https://ai.blawby.com</code> for production.
+  <div class="page">
+    <div class="hero">
+      <h1>Widget Debug</h1>
+      <p class="lead">
+        This page shows the actual widget config and runtime state being used locally:
+        loader source, resolved iframe URL, fetched practice details, CSS theme vars, and emitted widget events.
       </p>
-      <div class="controls">
-        <button onclick="window.BlawbyWidget.open()">Open Widget</button>
-        <button onclick="window.BlawbyWidget.close()">Close Widget</button>
-        <button onclick="window.BlawbyWidget.toggle()">Toggle Widget</button>
-      </div>
-      <div id="event-log" class="events">Widget events will appear here…</div>
+    </div>
+
+    <div class="grid">
+      <section class="card">
+        <h2>Runtime Controls</h2>
+        <p>Edit the debug config below, then reload the widget to see exactly what code and runtime values are being used.</p>
+        <div class="fields">
+          <div>
+            <label for="practice-slug">Practice Slug</label>
+            <input id="practice-slug" type="text" value="paul-yahoo" />
+          </div>
+          <div>
+            <label for="base-url">Base URL</label>
+            <input id="base-url" type="text" value="" />
+          </div>
+          <div>
+            <label for="primary-color">Primary Color Override</label>
+            <input id="primary-color" type="text" value="" placeholder="Optional hex, e.g. #D4AF37" />
+          </div>
+        </div>
+        <div class="controls">
+          <button id="reload-widget" type="button">Reload Widget</button>
+          <button id="open-widget" type="button" class="secondary">Open</button>
+          <button id="close-widget" type="button" class="secondary">Close</button>
+          <button id="toggle-widget" type="button" class="secondary">Toggle</button>
+          <button id="refresh-debug" type="button" class="secondary">Refresh Debug Data</button>
+        </div>
+        <div class="notice">
+          The effective embed snippet below is generated from the current inputs, not a hardcoded demo string.
+        </div>
+      </section>
+
+      <section class="card card-half">
+        <h2>Effective Embed Snippet</h2>
+        <pre id="effective-snippet"></pre>
+      </section>
+
+      <section class="card card-half">
+        <h2>Runtime Snapshot</h2>
+        <dl class="kv">
+          <dt>Loader Script URL</dt>
+          <dd id="loader-script-url" class="muted">Waiting for loader…</dd>
+          <dt>Configured Base URL</dt>
+          <dd id="configured-base-url" class="muted">—</dd>
+          <dt>Configured Practice Slug</dt>
+          <dd id="configured-practice-slug" class="muted">—</dd>
+          <dt>Configured Primary Color</dt>
+          <dd id="configured-primary-color" class="muted">—</dd>
+          <dt>Widget Iframe URL</dt>
+          <dd id="iframe-url" class="muted">Waiting for iframe…</dd>
+          <dt>Resolved Theme Color</dt>
+          <dd id="resolved-theme-color" class="muted">Waiting for widget…</dd>
+          <dt>Theme Source</dt>
+          <dd id="resolved-theme-source" class="muted">Waiting for theme_applied…</dd>
+          <dt>Container CSS Var</dt>
+          <dd id="container-css-var" class="muted">Waiting for widget…</dd>
+        </dl>
+      </section>
+
+      <section class="card card-third">
+        <h2>Practice Details Fetch</h2>
+        <div id="practice-fetch-badges"></div>
+        <pre id="practice-fetch-payload">No fetch captured yet.</pre>
+      </section>
+
+      <section class="card card-third">
+        <h2>Configured Widget Object</h2>
+        <pre id="widget-config-payload">Waiting for config…</pre>
+      </section>
+
+      <section class="card card-third">
+        <h2>Last Theme Event</h2>
+        <pre id="theme-event-payload">No theme event yet.</pre>
+      </section>
+
+      <section class="card card-half">
+        <h2>Widget Events</h2>
+        <pre id="event-log" class="log">Widget events will appear here…</pre>
+      </section>
+
+      <section class="card card-half">
+        <h2>Network / Debug Log</h2>
+        <pre id="network-log" class="log">Debug log will appear here…</pre>
+      </section>
     </div>
   </div>
 
   <script>
-    // ── Widget configuration ──────────────────────────────────────────────
-    // In a real website, replace this with your actual practice slug.
-    // The practiceSlug is shown in Settings → Practice → Workspace URL.
-    var PRACTICE_SLUG = 'paul-yahoo'; // <-- replace with your slug
-    var eventLogEl = document.getElementById('event-log');
-    window.dataLayer = window.dataLayer || [];
-    var originalDataLayerPush = window.dataLayer.push.bind(window.dataLayer);
+    (function () {
+      var eventLogEl = document.getElementById('event-log');
+      var networkLogEl = document.getElementById('network-log');
+      var snippetEl = document.getElementById('effective-snippet');
+      var widgetConfigEl = document.getElementById('widget-config-payload');
+      var practiceFetchEl = document.getElementById('practice-fetch-payload');
+      var practiceFetchBadgesEl = document.getElementById('practice-fetch-badges');
+      var themeEventEl = document.getElementById('theme-event-payload');
+      var loaderScriptUrlEl = document.getElementById('loader-script-url');
+      var configuredBaseUrlEl = document.getElementById('configured-base-url');
+      var configuredPracticeSlugEl = document.getElementById('configured-practice-slug');
+      var configuredPrimaryColorEl = document.getElementById('configured-primary-color');
+      var iframeUrlEl = document.getElementById('iframe-url');
+      var resolvedThemeColorEl = document.getElementById('resolved-theme-color');
+      var resolvedThemeSourceEl = document.getElementById('resolved-theme-source');
+      var containerCssVarEl = document.getElementById('container-css-var');
 
-    function appendEvent(prefix, payload) {
-      var line = '[' + new Date().toISOString() + '] ' + prefix + ': ' + JSON.stringify(payload);
-      console.log(line);
-      if (eventLogEl) {
-        eventLogEl.textContent = line + '\n' + eventLogEl.textContent;
+      var slugInput = document.getElementById('practice-slug');
+      var baseUrlInput = document.getElementById('base-url');
+      var primaryColorInput = document.getElementById('primary-color');
+
+      var debugState = {
+        events: [],
+        network: [],
+        practiceFetch: null,
+        themeEvent: null
+      };
+
+      function appendLog(el, prefix, payload) {
+        var line = '[' + new Date().toISOString() + '] ' + prefix + ': ' + JSON.stringify(payload, null, 2);
+        el.textContent = line + '\n\n' + el.textContent;
       }
-    }
 
-    window.dataLayer.push = function (payload) {
-      appendEvent('dataLayer', payload);
-      return originalDataLayerPush(payload);
-    };
-
-    window.BlawbyWidget = {
-      practiceSlug: PRACTICE_SLUG,
-      // Override baseUrl to point at local dev server for testing.
-      // Remove this line (or set to 'https://ai.blawby.com') in production.
-      baseUrl: window.location.origin,
-      position: 'bottom-right',
-      pushDataLayerOnChatStart: true,
-      onEvent: function (eventPayload) {
-        appendEvent('onEvent', eventPayload);
-      },
-      onChatStart: function (eventPayload) {
-        appendEvent('onChatStart', eventPayload);
+      function setText(idOrElement, value) {
+        var el = typeof idOrElement === 'string' ? document.getElementById(idOrElement) : idOrElement;
+        if (!el) return;
+        el.textContent = value;
       }
-    };
 
-    window.addEventListener('blawby:widget-event', function (event) {
-      appendEvent('dom-event', event.detail);
-    });
+      function renderJson(el, payload) {
+        el.textContent = JSON.stringify(payload, null, 2);
+      }
 
-    // Show the snippet in the card
-    var snippetEl = document.getElementById('snippet-preview');
-    snippetEl.textContent = [
-      '<script>',
-      '  window.BlawbyWidget = {',
-      '    practiceSlug: \'' + PRACTICE_SLUG + '\'',
-      '  };',
-      '<\/script>',
-      '<script src="https://ai.blawby.com/widget-loader.js" defer><\/script>',
-    ].join('\n');
+      function normalizeHexColor(value) {
+        if (typeof value !== 'string') return null;
+        var trimmed = value.trim();
+        if (!trimmed) return null;
+        if (!/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(trimmed)) return null;
+        if (trimmed.length === 4) {
+          return '#' + trimmed[1] + trimmed[1] + trimmed[2] + trimmed[2] + trimmed[3] + trimmed[3];
+        }
+        return trimmed;
+      }
+
+      function getBaseUrl() {
+        var raw = (baseUrlInput.value || '').trim();
+        return raw || window.location.origin;
+      }
+
+      function getConfig() {
+        return {
+          practiceSlug: (slugInput.value || '').trim() || 'paul-yahoo',
+          baseUrl: getBaseUrl(),
+          position: 'bottom-right',
+          primaryColor: normalizeHexColor(primaryColorInput.value),
+          pushDataLayerOnChatStart: true,
+          onEvent: function (eventPayload) {
+            debugState.events.unshift(eventPayload);
+            appendLog(eventLogEl, 'onEvent', eventPayload);
+            if (eventPayload && eventPayload.type === 'theme_applied') {
+              debugState.themeEvent = eventPayload;
+              renderJson(themeEventEl, eventPayload);
+              setText(resolvedThemeSourceEl, eventPayload.source || 'unknown');
+            }
+            refreshRuntimeSnapshot();
+          },
+          onChatStart: function (eventPayload) {
+            appendLog(eventLogEl, 'onChatStart', eventPayload);
+          }
+        };
+      }
+
+      function renderSnippet() {
+        var cfg = getConfig();
+        var lines = [
+          '<script>',
+          '  window.BlawbyWidget = {',
+          '    practiceSlug: ' + JSON.stringify(cfg.practiceSlug) + ',',
+          '    baseUrl: ' + JSON.stringify(cfg.baseUrl) + (cfg.primaryColor ? ',' : '')
+        ];
+        if (cfg.primaryColor) {
+          lines.push('    primaryColor: ' + JSON.stringify(cfg.primaryColor));
+        }
+        lines.push('  };');
+        lines.push('<\/script>');
+        lines.push('<script src="' + cfg.baseUrl.replace(/\/+$/, '') + '/widget-loader.js" defer><\/script>');
+        snippetEl.textContent = lines.join('\n');
+      }
+
+      function refreshRuntimeSnapshot() {
+        var cfg = getConfig();
+        var loaderScript = document.getElementById('widget-loader-script');
+        var iframe = document.querySelector('iframe[id^="blawby-widget-"][id$="-iframe"]');
+        var container = document.querySelector('div[id^="blawby-widget-"][id$="-container"]');
+        var cssVar = container ? getComputedStyle(container).getPropertyValue('--blawby-widget-primary-color').trim() : '';
+
+        renderJson(widgetConfigEl, {
+          practiceSlug: cfg.practiceSlug,
+          baseUrl: cfg.baseUrl,
+          primaryColor: cfg.primaryColor,
+          position: cfg.position,
+          pushDataLayerOnChatStart: cfg.pushDataLayerOnChatStart
+        });
+        setText(loaderScriptUrlEl, loaderScript ? loaderScript.src : 'Loader script not mounted');
+        setText(configuredBaseUrlEl, cfg.baseUrl);
+        setText(configuredPracticeSlugEl, cfg.practiceSlug);
+        setText(configuredPrimaryColorEl, cfg.primaryColor || '(none)');
+        setText(iframeUrlEl, iframe && iframe.getAttribute('src') ? iframe.getAttribute('src') : 'Iframe not loaded yet');
+        setText(containerCssVarEl, cssVar || 'Widget container not mounted yet');
+
+        if (cssVar) {
+          resolvedThemeColorEl.innerHTML = '<span class="badge"><span class="swatch" style="background:' + cssVar + ';"></span>' + cssVar + '</span>';
+        } else {
+          setText(resolvedThemeColorEl, 'Waiting for widget…');
+        }
+
+        if (!debugState.themeEvent) {
+          setText(resolvedThemeSourceEl, 'Waiting for theme_applied…');
+        }
+      }
+
+      function renderPracticeFetch(payload) {
+        debugState.practiceFetch = payload;
+        renderJson(practiceFetchEl, payload);
+        practiceFetchBadgesEl.innerHTML = '';
+
+        if (payload && payload.url) {
+          var urlBadge = document.createElement('div');
+          urlBadge.className = 'badge';
+          urlBadge.textContent = 'URL: ' + payload.url;
+          practiceFetchBadgesEl.appendChild(urlBadge);
+        }
+
+        if (payload && payload.accentColor) {
+          var colorBadge = document.createElement('div');
+          colorBadge.className = 'badge';
+          colorBadge.innerHTML = '<span class="swatch" style="background:' + payload.accentColor + ';"></span>accentColor: ' + payload.accentColor;
+          practiceFetchBadgesEl.appendChild(colorBadge);
+        }
+      }
+
+      function captureFetch() {
+        var originalFetch = window.fetch.bind(window);
+        window.fetch = function (input, init) {
+          var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
+          return originalFetch(input, init).then(function (response) {
+            if (url.indexOf('/api/widget/practice-details/') !== -1) {
+              response.clone().json().then(function (payload) {
+                renderPracticeFetch({
+                  url: url,
+                  ok: response.ok,
+                  status: response.status,
+                  accentColor: payload && (payload.accentColor || payload.accent_color) || null,
+                  payload: payload
+                });
+                appendLog(networkLogEl, 'practice-details', {
+                  url: url,
+                  status: response.status,
+                  payload: payload
+                });
+              }).catch(function (error) {
+                appendLog(networkLogEl, 'practice-details-error', {
+                  url: url,
+                  status: response.status,
+                  error: String(error)
+                });
+              });
+            }
+            return response;
+          });
+        };
+      }
+
+      function installDataLayerDebug() {
+        window.dataLayer = window.dataLayer || [];
+        var originalPush = window.dataLayer.push.bind(window.dataLayer);
+        window.dataLayer.push = function (payload) {
+          appendLog(networkLogEl, 'dataLayer', payload);
+          return originalPush(payload);
+        };
+      }
+
+      function mountWidget() {
+        window.BlawbyWidget = getConfig();
+        renderSnippet();
+        refreshRuntimeSnapshot();
+
+        var existingScript = document.getElementById('widget-loader-script');
+        if (existingScript) {
+          existingScript.remove();
+        }
+
+        var existingContainer = document.querySelector('div[id^="blawby-widget-"][id$="-container"]');
+        if (existingContainer) {
+          existingContainer.remove();
+        }
+
+        var script = document.createElement('script');
+        script.id = 'widget-loader-script';
+        script.src = getBaseUrl().replace(/\/+$/, '') + '/widget-loader.js?v=debug-' + Date.now();
+        script.defer = true;
+        script.onload = function () {
+          appendLog(networkLogEl, 'loader', { src: script.src, status: 'loaded' });
+          setTimeout(refreshRuntimeSnapshot, 50);
+          setTimeout(refreshRuntimeSnapshot, 250);
+          setTimeout(refreshRuntimeSnapshot, 1000);
+        };
+        script.onerror = function () {
+          appendLog(networkLogEl, 'loader', { src: script.src, status: 'failed' });
+          refreshRuntimeSnapshot();
+        };
+        document.body.appendChild(script);
+      }
+
+      document.getElementById('reload-widget').addEventListener('click', function () {
+        mountWidget();
+      });
+      document.getElementById('refresh-debug').addEventListener('click', function () {
+        refreshRuntimeSnapshot();
+      });
+      document.getElementById('open-widget').addEventListener('click', function () {
+        if (window.BlawbyWidget && typeof window.BlawbyWidget.open === 'function') {
+          window.BlawbyWidget.open();
+          setTimeout(refreshRuntimeSnapshot, 50);
+        }
+      });
+      document.getElementById('close-widget').addEventListener('click', function () {
+        if (window.BlawbyWidget && typeof window.BlawbyWidget.close === 'function') {
+          window.BlawbyWidget.close();
+          setTimeout(refreshRuntimeSnapshot, 50);
+        }
+      });
+      document.getElementById('toggle-widget').addEventListener('click', function () {
+        if (window.BlawbyWidget && typeof window.BlawbyWidget.toggle === 'function') {
+          window.BlawbyWidget.toggle();
+          setTimeout(refreshRuntimeSnapshot, 50);
+        }
+      });
+
+      window.addEventListener('blawby:widget-event', function (event) {
+        appendLog(eventLogEl, 'dom-event', event.detail);
+        if (event.detail && event.detail.type === 'theme_applied') {
+          debugState.themeEvent = event.detail;
+          renderJson(themeEventEl, event.detail);
+          setText(resolvedThemeSourceEl, event.detail.source || 'unknown');
+        }
+        refreshRuntimeSnapshot();
+      });
+
+      captureFetch();
+      installDataLayerDebug();
+      baseUrlInput.value = window.location.origin;
+      renderSnippet();
+      mountWidget();
+    })();
   </script>
-  <!-- Widget loader — in production use src="https://ai.blawby.com/widget-loader.js" -->
-  <script src="/widget-loader.js?v=2" defer></script>
 </body>
-
 </html>

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -516,7 +516,7 @@ export function MainApp({
       try {
         const participants = await getConversationParticipants(activeConversationId, practiceId, { signal: controller.signal });
         const nextMentionCandidates = participants
-          .filter((participant) => participant.role !== 'client')
+          .filter((participant) => participant.canMentionInternally === true)
           .map((participant) => ({
             userId: participant.userId,
             name: (participant.name ?? '').trim(),

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -499,6 +499,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
       </>
     );
   }, [closeButton, conversationStrengthAction, isEmbedded]);
+  const showWidgetBottomNav = view !== 'chat';
 
   useEffect(() => {
     const isDark = true; // Handle dark mode state if needed
@@ -684,13 +685,13 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
           </>
         )}
         
-        <div className="mt-auto">
-          <NavRail
-            items={navItems}
-            activeHref={view === 'home' ? '/home' : '/list'}
-            variant="bottom"
-          />
-        </div>
+        <NavRail
+          items={navItems}
+          activeHref={view === 'home' ? '/home' : '/list'}
+          variant="bottom"
+          hidden={!showWidgetBottomNav}
+          className="mt-auto"
+        />
       </div>
     </>
   );

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -687,7 +687,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
         
         <NavRail
           items={navItems}
-          activeHref={view === 'home' ? '#home' : '#list'}
+          activeHref={view === 'home' ? '/home' : '/list'}
           variant="bottom"
           hidden={!showWidgetBottomNav}
           className="mt-auto"

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -687,7 +687,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
         
         <NavRail
           items={navItems}
-          activeHref={view === 'home' ? '/home' : '/list'}
+          activeHref={view === 'home' ? '#home' : '#list'}
           variant="bottom"
           hidden={!showWidgetBottomNav}
           className="mt-auto"

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1075,8 +1075,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     forcePreviewReload();
   }, [forcePreviewReload, updateSetupDetails]);
 
-  const workspacePracticeId = currentPractice?.id ?? practiceId;
-  const organizationId = currentPractice?.id ?? null;
+  const workspacePracticeId = practiceId ?? currentPractice?.id ?? null;
+  const organizationId = practiceId ?? currentPractice?.id ?? null;
   const { members: practiceMembers } = usePracticeTeam(
     workspacePracticeId,
     session?.user?.id ?? null,

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -38,6 +38,7 @@ import { resolveConversationDisplayTitle } from '@/shared/utils/conversationDisp
 import { resolveConsultationState } from '@/shared/utils/consultationState';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
 import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 import { useMattersData } from '@/shared/hooks/useMattersData';
 import { useClientsData } from '@/shared/hooks/useClientsData';
@@ -893,7 +894,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     };
   }, [practiceLogo, practiceName, conversationPreviews, resolvedConversations, filteredMessages]);
 
-  const { currentPractice, updatePractice, getMembers, fetchMembers } = usePracticeManagement({ fetchOnboardingStatus: false });
+  const { currentPractice, updatePractice } = usePracticeManagement({ fetchOnboardingStatus: false });
   const { showSuccess, showError } = useToastContext();
   const handleOnboardingMessageError = useCallback((error: unknown) => {
     const message = error instanceof Error ? error.message : 'Onboarding chat error';
@@ -1075,10 +1076,14 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   }, [forcePreviewReload, updateSetupDetails]);
 
   const organizationId = currentPractice?.id ?? null;
-  const practiceMembers = useMemo(() => getMembers(practiceId), [getMembers, practiceId]);
+  const { members: practiceMembers } = usePracticeTeam(
+    practiceId,
+    session?.user?.id ?? null,
+    { enabled: isPracticeWorkspace && Boolean(practiceId) }
+  );
   const conversationMemberOptions = useMemo(
     () => practiceMembers
-      .filter((member) => member.role !== 'client')
+      .filter((member) => member.canMentionInternally)
       .map((member) => ({
         userId: member.userId,
         name: member.name?.trim() ?? '',
@@ -1096,13 +1101,6 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     })),
     [conversationMemberOptions]
   );
-
-  useEffect(() => {
-    if (!isPracticeWorkspace || !practiceId) return;
-    void fetchMembers(practiceId).catch((error) => {
-      console.warn('[WorkspacePage] Failed to fetch members for inspector', error);
-    });
-  }, [fetchMembers, isPracticeWorkspace, practiceId]);
   const [stripeStatus, setStripeStatus] = useState<StripeConnectStatus | null>(null);
   const [isStripeLoading, setIsStripeLoading] = useState(false);
   const [isStripeSubmitting, setIsStripeSubmitting] = useState(false);

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1075,11 +1075,12 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     forcePreviewReload();
   }, [forcePreviewReload, updateSetupDetails]);
 
+  const workspacePracticeId = currentPractice?.id ?? practiceId;
   const organizationId = currentPractice?.id ?? null;
   const { members: practiceMembers } = usePracticeTeam(
-    practiceId,
+    workspacePracticeId,
     session?.user?.id ?? null,
-    { enabled: isPracticeWorkspace && Boolean(practiceId) }
+    { enabled: isPracticeWorkspace && Boolean(workspacePracticeId) }
   );
   const conversationMemberOptions = useMemo(
     () => practiceMembers
@@ -1813,7 +1814,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       key={`${inspectorTarget.entityType}:${inspectorTarget.entityId}`}
       entityType={inspectorTarget.entityType}
       entityId={inspectorTarget.entityId}
-      practiceId={practiceId}
+      practiceId={workspacePracticeId}
       conversation={selectedConversation}
       conversationMembers={isPracticeWorkspace ? conversationMemberOptions : []}
       isClientView={!isPracticeWorkspace}
@@ -1826,7 +1827,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       onConversationAssignedToChange={isPracticeWorkspace ? async (assignedTo) => {
         if (!selectedConversation?.id) return;
         try {
-          await updateConversationTriage(selectedConversation.id, practiceId, { assignedTo });
+          await updateConversationTriage(selectedConversation.id, workspacePracticeId, { assignedTo });
           await refreshConversations();
         } catch (error) {
           console.error('[WorkspacePage] Failed to update assignment:', error);
@@ -1836,7 +1837,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       onConversationPriorityChange={isPracticeWorkspace ? async (priority) => {
         if (!selectedConversation?.id) return;
         try {
-          await updateConversationTriage(selectedConversation.id, practiceId, { priority });
+          await updateConversationTriage(selectedConversation.id, workspacePracticeId, { priority });
           await refreshConversations();
         } catch (error) {
           console.error('[WorkspacePage] Failed to update priority:', error);
@@ -1852,10 +1853,10 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
           const toRemove = [...current].filter((tag) => !next.has(tag));
           
           for (const tag of toAdd) {
-            await addConversationTag(selectedConversation.id, practiceId, tag);
+            await addConversationTag(selectedConversation.id, workspacePracticeId, tag);
           }
           for (const tag of toRemove) {
-            await removeConversationTag(selectedConversation.id, practiceId, tag);
+            await removeConversationTag(selectedConversation.id, workspacePracticeId, tag);
           }
           
           await refreshConversations();

--- a/src/features/clients/pages/PracticeClientsPage.tsx
+++ b/src/features/clients/pages/PracticeClientsPage.tsx
@@ -14,6 +14,8 @@ import { ActivityTimeline, type TimelineItem } from '@/shared/ui/activity/Activi
 import { formatDate } from '@/shared/utils/dateTime';
 import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 import { useToastContext } from '@/shared/contexts/ToastContext';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
 import type { Address } from '@/shared/types/address';
 import {
   listUserDetailMemos,
@@ -333,15 +335,13 @@ export const PracticeClientsPage = ({
   showDetailBackButton?: boolean;
 }) => {
   const location = useLocation();
-  const { currentPractice, fetchMembers, getMembers } = usePracticeManagement();
+  const { currentPractice } = usePracticeManagement();
+  const { session } = useSessionContext();
   const { showError, showSuccess } = useToastContext();
   const [memoTimeline, setMemoTimeline] = useState<Record<string, TimelineItem[]>>({});
   const [memoSubmitting, setMemoSubmitting] = useState(false);
   const [memoActionId, setMemoActionId] = useState<string | null>(null);
   const [sendMessagePending, setSendMessagePending] = useState(false);
-  const [isFetchingMembers, setIsFetchingMembers] = useState(false);
-  const [teamMembersLoaded, setTeamMembersLoaded] = useState(false);
-  const [teamMembersError, setTeamMembersError] = useState<string | null>(null);
   const [hydratedAddressByDetailId, setHydratedAddressByDetailId] = useState<Record<string, unknown>>({});
   const processedDetailIdsRef = useRef<Set<string>>(new Set());
   const [addClientSubmitting, setAddClientSubmitting] = useState(false);
@@ -389,6 +389,12 @@ export const PracticeClientsPage = ({
   const listRef = useRef<HTMLDivElement>(null);
   const [currentLetter, setCurrentLetter] = useState('');
   const activePracticeId = routePracticeId === undefined ? (currentPractice?.id ?? null) : routePracticeId;
+  const {
+    members: teamMembersData,
+    isLoaded: teamMembersLoaded,
+    isLoading: isFetchingMembers,
+    error: teamMembersError,
+  } = usePracticeTeam(activePracticeId, session?.user?.id ?? null, { enabled: Boolean(activePracticeId) });
 
   const buildClientRecord = useCallback((detail: PersonRecord): DirectoryRecord => {
     const name = detail.user?.name?.trim() || detail.user?.email?.trim() || 'Unknown person';
@@ -470,10 +476,7 @@ export const PracticeClientsPage = ({
     };
   }, [activePracticeId, prefetchedItems]);
   const teamMembers = useMemo(() => {
-    if (!activePracticeId) return [];
-    return getMembers(activePracticeId)
-      .filter((member) => member.role !== 'client')
-      .map<DirectoryRecord>((member) => ({
+    return teamMembersData.map<DirectoryRecord>((member) => ({
         id: `team:${member.userId}`,
         kind: 'team',
         userId: member.userId,
@@ -482,30 +485,7 @@ export const PracticeClientsPage = ({
         phone: null,
         teamRole: member.role
       }));
-  }, [activePracticeId, getMembers]);
-  useEffect(() => {
-    if (!activePracticeId) {
-      setIsFetchingMembers(false);
-      setTeamMembersLoaded(false);
-      setTeamMembersError(null);
-      return;
-    }
-    setIsFetchingMembers(true);
-    setTeamMembersLoaded(false);
-    setTeamMembersError(null);
-    fetchMembers(activePracticeId)
-      .then(() => {
-        setTeamMembersLoaded(true);
-      })
-      .catch((error) => {
-        console.error('[People] Failed to load team members', error);
-        setTeamMembersLoaded(false);
-        setTeamMembersError(error instanceof Error ? error.message : 'Failed to load team members');
-      })
-      .finally(() => {
-        setIsFetchingMembers(false);
-      });
-  }, [activePracticeId, fetchMembers]);
+  }, [teamMembersData]);
   const clients = useMemo(() => {
     const peopleItems = prefetchedItems.map(buildClientRecord);
     if (isArchivedListRoute) {

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -437,8 +437,8 @@ export const PracticeMattersPage = ({
   }, [teamMembers]);
 
   const assigneeNameById = useMemo(
-    () => new Map(assigneeOptions.map((a) => [a.id, a.name])),
-    [assigneeOptions]
+    () => new Map(teamMembers.map((m) => [m.userId, m.name ?? m.email])),
+    [teamMembers]
   );
 
   const serviceNameById = useMemo(

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -44,7 +44,7 @@ import { UnbilledSummaryCard } from '@/features/matters/components/billing/Unbil
 import { MatterSummaryCards } from '@/features/matters/components/MatterSummaryCards';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useToastContext } from '@/shared/contexts/ToastContext';
-import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
 import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 import { asMajor, getMajorAmountValue, safeAdd, safeDivide, safeMultiply, type MajorAmount } from '@/shared/utils/money';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
@@ -314,9 +314,10 @@ export const PracticeMattersPage = ({
   }, [basePath]);
 
   // ── External hooks ────────────────────────────────────────────────────────
-  const { getMembers, fetchMembers } = usePracticeManagement({
-    autoFetchPractices: false,
-    fetchPracticeDetails: false
+  const {
+    members: teamMembers,
+  } = usePracticeTeam(activePracticeId, session?.user?.id ?? null, {
+    enabled: Boolean(activePracticeId)
   });
   const {
     details: practiceDetails,
@@ -424,9 +425,8 @@ export const PracticeMattersPage = ({
   }, [practiceDetails?.services]);
 
   const assigneeOptions = useMemo<MatterOption[]>(() => {
-    if (!activePracticeId) return [];
-    return getMembers(activePracticeId)
-      .filter((m) => m.role !== 'member' && m.role !== 'client')
+    return teamMembers
+      .filter((member) => member.canAssignToMatter)
       .map((m) => ({
         id: m.userId,
         name: m.name ?? m.email,
@@ -434,7 +434,7 @@ export const PracticeMattersPage = ({
         image: m.image ?? undefined,
         role: m.role
       }));
-  }, [activePracticeId, getMembers]);
+  }, [teamMembers]);
 
   const assigneeNameById = useMemo(
     () => new Map(assigneeOptions.map((a) => [a.id, a.name])),
@@ -464,14 +464,14 @@ export const PracticeMattersPage = ({
   }, [clientNameById, selectedMatterDetailState, serviceNameById]);
 
   const membersById = useMemo(() => {
-    if (!activePracticeId) return new Map<string, { name: string; email?: string | null; image?: string | null }>();
+    if (teamMembers.length === 0) return new Map<string, { name: string; email?: string | null; image?: string | null }>();
     return new Map(
-      getMembers(activePracticeId).map((m) => [
+      teamMembers.map((m) => [
         m.userId,
         { name: m.name ?? '', email: m.email ?? null, image: m.image }
       ])
     );
-  }, [activePracticeId, getMembers]);
+  }, [teamMembers]);
 
   const matterContext = useMemo(() => ({
     title: selectedMatterDetail?.title ?? null,
@@ -545,12 +545,6 @@ export const PracticeMattersPage = ({
       buildNoteTimelineItem(note, resolvePerson),
     [resolvePerson]
   );
-
-  // ── Data fetching: members ────────────────────────────────────────────────
-  useEffect(() => {
-    if (!activePracticeId) return;
-    void fetchMembers(activePracticeId, { force: false });
-  }, [activePracticeId, fetchMembers]);
 
   // ── Data fetching: people (paginated) ─────────────────────────────────────
   const buildClientOption = useCallback((detail: UserDetailRecord): MatterOption => ({

--- a/src/features/settings/hooks/usePracticePageEffects.ts
+++ b/src/features/settings/hooks/usePracticePageEffects.ts
@@ -17,14 +17,10 @@ export const useLeadQueueAutoLoad = (loadLeadQueue: () => Promise<void> | void) 
 
 export const usePracticeMembersSync = ({
   practice,
-  setEditPracticeForm,
-  fetchMembers,
-  showError
+  setEditPracticeForm
 }: {
   practice: Practice | null;
   setEditPracticeForm: Dispatch<StateUpdater<EditPracticeFormState>>;
-  fetchMembers: (practiceId: string) => Promise<void>;
-  showError: ShowToast;
 }) => {
   useEffect(() => {
     if (!practice) return;
@@ -33,18 +29,7 @@ export const usePracticeMembersSync = ({
       slug: practice.slug || '',
       logo: practice.logo || ''
     });
-
-    const fetchMembersData = async () => {
-      try {
-        await fetchMembers(practice.id);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        showError(message || 'Failed to fetch practice members');
-      }
-    };
-
-    void fetchMembersData();
-  }, [practice, fetchMembers, setEditPracticeForm, showError]);
+  }, [practice, setEditPracticeForm]);
 };
 
 export const usePracticeSyncParamRefetch = ({

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { Icon } from '@/shared/ui/Icon';
 import { usePracticeManagement, type Practice } from '@/shared/hooks/usePracticeManagement';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
 import { Button } from '@/shared/ui/Button';
 import { FormActions } from '@/shared/ui/form';
 import type { Address } from '@/shared/types/address';
@@ -146,13 +147,11 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
   const { session, isPending: sessionPending, activeMemberRole } = useSessionContext();
   const { 
     currentPractice,
-    getMembers,
     loading, 
     error,
     updatePractice,
     createPractice,
     deletePractice,
-    fetchMembers,
     refetch,
   } = usePracticeManagement({ fetchPracticeDetails: true });
   const activePracticeId = currentPractice?.id ?? null;
@@ -192,7 +191,14 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
 
   const practice = currentPractice ?? null;
   const hasPractice = !!practice;
-  const members = useMemo(() => practice ? getMembers(practice.id) : [], [practice, getMembers]);
+  const {
+    members,
+    refetch: refetchTeam,
+  } = usePracticeTeam(
+    practice?.id ?? null,
+    session?.user?.id ?? null,
+    { enabled: Boolean(practice?.id) }
+  );
   
   // Better approach - get role directly from current practice context
   const currentMember = useMemo(() => {
@@ -316,21 +322,19 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
 
   // Current user email is now derived from session - removed redirect to keep practice settings accessible
 
-  // Initialize form with current practice data
-  // Note: usePracticeManagement already fetches practice details during initialization,
-  // so we only need to fetch members here. Details are available via practiceDetailsStore.
+  // Initialize form with current practice data. Practice details are hydrated elsewhere.
   usePracticeMembersSync({
     practice,
-    setEditPracticeForm,
-    fetchMembers,
-    showError
+    setEditPracticeForm
   });
 
   // Refetch after return from portal
   usePracticeSyncParamRefetch({
     location,
     practiceId: practice?.id ?? null,
-    refetch,
+    refetch: async () => {
+      await Promise.all([refetch(), refetchTeam()]);
+    },
     showSuccess
   });
 

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -42,7 +42,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
     acceptInvitation,
     declineInvitation,
   } = usePracticeInvitations(currentPractice?.id ?? null);
-  const { showSuccess, showError } = useToastContext();
+  const { showSuccess, showError, showWarning } = useToastContext();
   const { openBillingPortal, submitting } = usePaymentUpgrade();
   const { navigate: baseNavigate } = useNavigation();
   const { t } = useTranslation(['settings']);
@@ -136,10 +136,15 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
 
     try {
       await updateMemberRole(currentPractice.id, editMemberData.userId, editMemberData.role);
-      await refetchTeam();
       showSuccess('Member role updated successfully!');
       setEditMemberData(null);
       setIsEditingMember(false);
+      try {
+        await refetchTeam();
+      } catch (refetchErr) {
+        console.warn('[PracticeTeamPage] Failed to refresh team — changes were saved.', refetchErr);
+        showWarning('Failed to refresh team — changes were saved.');
+      }
     } catch (err) {
       showError(err instanceof Error ? err.message : 'Failed to update member role');
     }
@@ -154,10 +159,15 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
 
     try {
       await removeMember(currentPractice.id, member.userId);
-      await refetchTeam();
       showSuccess('Member removed successfully!');
       setEditMemberData(null);
       setIsEditingMember(false);
+      try {
+        await refetchTeam();
+      } catch (refetchErr) {
+        console.warn('[PracticeTeamPage] Failed to refresh team — changes were saved.', refetchErr);
+        showWarning('Failed to refresh team — changes were saved.');
+      }
     } catch (err) {
       showError(err instanceof Error ? err.message : 'Failed to remove member');
     }
@@ -166,8 +176,13 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
   const handleAcceptInvitation = async (invitationId: string) => {
     try {
       await acceptInvitation(invitationId);
-      await refetchTeam();
       showSuccess('Invitation accepted!');
+      try {
+        await refetchTeam();
+      } catch (refetchErr) {
+        console.warn('[PracticeTeamPage] Failed to refresh team — changes were saved.', refetchErr);
+        showWarning('Failed to refresh team — changes were saved.');
+      }
     } catch (err) {
       showError(err instanceof Error ? err.message : 'Failed to accept invitation');
     }

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
-import { ArrowLeftIcon, UserPlusIcon } from '@heroicons/react/24/outline';
+import { ArrowLeftIcon, UserPlusIcon, DocumentDuplicateIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { Icon } from '@/shared/ui/Icon';
 import { usePracticeManagement, type Role } from '@/shared/hooks/usePracticeManagement';
 import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
@@ -8,7 +8,7 @@ import { usePracticeInvitations } from '@/shared/hooks/usePracticeInvitations';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { usePaymentUpgrade } from '@/shared/hooks/usePaymentUpgrade';
 import { Button } from '@/shared/ui/Button';
-import { Input } from '@/shared/ui/input';
+import { EmailInput } from '@/shared/ui/input';
 import { FormLabel } from '@/shared/ui/form/FormLabel';
 import { Combobox } from '@/shared/ui/input/Combobox';
 import { useToastContext } from '@/shared/contexts/ToastContext';
@@ -22,6 +22,7 @@ import { ContentPageLayout } from '@/shared/ui/layout';
 import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { buildSettingsPath, resolveSettingsBasePath } from '@/shared/utils/workspace';
+import { Avatar } from '@/shared/ui/profile';
 
 interface PracticeTeamPageProps {
   onNavigate?: (path: string) => void;
@@ -41,6 +42,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
     sendInvitation: sendPracticeInvitation,
     acceptInvitation,
     declineInvitation,
+    cancelInvitation,
   } = usePracticeInvitations(currentPractice?.id ?? null);
   const { showSuccess, showError, showWarning } = useToastContext();
   const { openBillingPortal, submitting } = usePaymentUpgrade();
@@ -197,6 +199,30 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
     }
   };
 
+  const handleCancelInvitation = async (invitationId: string) => {
+    try {
+      await cancelInvitation(invitationId);
+      showSuccess('Invitation canceled successfully!');
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to cancel invitation');
+    }
+  };
+
+  const buildInvitationLink = (invitationId: string) => {
+    const path = `/auth/accept-invitation?invitationId=${encodeURIComponent(invitationId)}`;
+    return origin ? `${origin}${path}` : path;
+  };
+
+  const copyInvitationLink = async (invitationId: string) => {
+    const link = buildInvitationLink(invitationId);
+    try {
+      await navigator.clipboard.writeText(link);
+      showSuccess('Invite link copied', link);
+    } catch (err) {
+      showError('Failed to copy invite link', err instanceof Error ? err.message : 'Unknown error');
+    }
+  };
+
   if (!currentPractice) {
     return (
       <div className="h-full flex items-center justify-center">
@@ -273,13 +299,20 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
           <div className="space-y-3">
             {members.map((member) => (
               <div key={member.userId} className="flex items-center justify-between py-2">
-                <div className="flex-1">
-                  <p className="text-sm font-medium text-input-text">
-                    {member.name || member.email}
-                  </p>
-                  <SettingsHelperText>
-                    {member.email} • {getPracticeRoleLabel(member.role)}
-                  </SettingsHelperText>
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <Avatar
+                    src={member.image ?? null}
+                    name={member.name || member.email || member.userId}
+                    size="md"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-input-text">
+                      {member.name || member.email || member.userId}
+                    </p>
+                    <SettingsHelperText className="truncate">
+                      {member.email || member.userId} • {getPracticeRoleLabel(member.role)}
+                    </SettingsHelperText>
+                  </div>
                 </div>
                 {isAdmin && member.role !== 'owner' && (
                   <Button
@@ -311,12 +344,12 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
             <FormGrid>
               <div>
                 <FormLabel htmlFor="invite-email">Email Address</FormLabel>
-                <Input
-                  id="invite-email"
-                  type="email"
+                <EmailInput
                   value={inviteForm.email}
                   onChange={(value) => setInviteForm(prev => ({ ...prev, email: value }))}
                   placeholder="colleague@lawfirm.com"
+                  showValidation
+                  required
                 />
               </div>
 
@@ -394,21 +427,53 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
             <div className="space-y-3">
               {invitations.map(inv => (
                 <div key={inv.id} className="flex items-center justify-between py-2">
-                  <div className="flex-1">
-                    <p className="text-sm font-medium text-input-text">
-                      {inv.practiceName || inv.practiceId}
-                    </p>
-                    <SettingsHelperText>
-                      Role: {getPracticeRoleLabel(inv.role)} • Expires: {formatDate(new Date(inv.expiresAt * 1000))}
-                    </SettingsHelperText>
+                  <div className="flex min-w-0 flex-1 items-center gap-3">
+                    <Avatar
+                      name={inv.email}
+                      size="md"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-input-text">
+                      {inv.email}
+                      </p>
+                      <SettingsHelperText className="truncate">
+                        Role: {getPracticeRoleLabel(inv.role)} • Expires: {formatDate(new Date(inv.expiresAt))}
+                      </SettingsHelperText>
+                    </div>
                   </div>
                   <div className="flex gap-2">
-                    <Button size="sm" onClick={() => handleAcceptInvitation(inv.id)}>
-                      Accept
-                    </Button>
-                    <Button size="sm" variant="secondary" onClick={() => handleDeclineInvitation(inv.id)}>
-                      Decline
-                    </Button>
+                    {inv.email.toLowerCase() === currentUserEmail.toLowerCase() ? (
+                      <>
+                        <Button size="sm" onClick={() => handleAcceptInvitation(inv.id)}>
+                          Accept
+                        </Button>
+                        <Button size="sm" variant="secondary" onClick={() => handleDeclineInvitation(inv.id)}>
+                          Decline
+                        </Button>
+                      </>
+                    ) : isAdmin ? (
+                      <>
+                        <Button
+                          variant="icon"
+                          size="icon-sm"
+                          onClick={() => void copyInvitationLink(inv.id)}
+                          aria-label={`Copy invite link for ${inv.email}`}
+                          title="Copy invite link"
+                          icon={DocumentDuplicateIcon}
+                          iconClassName="h-4 w-4"
+                        />
+                        <Button
+                          variant="icon"
+                          size="icon-sm"
+                          onClick={() => handleCancelInvitation(inv.id)}
+                          aria-label={`Cancel invitation for ${inv.email}`}
+                          title="Cancel invitation"
+                          icon={XMarkIcon}
+                          iconClassName="h-4 w-4"
+                        />
+                      </>
+                    ) : null
+                    }
                   </div>
                 </div>
               ))}

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -345,6 +345,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
               <div>
                 <FormLabel htmlFor="invite-email">Email Address</FormLabel>
                 <EmailInput
+                  id="invite-email"
                   value={inviteForm.email}
                   onChange={(value) => setInviteForm(prev => ({ ...prev, email: value }))}
                   placeholder="colleague@lawfirm.com"

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -77,6 +77,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
   const currentUserRole = normalizedActiveRole ?? roleFromMembers ?? 'member';
   const isOwner = currentUserRole === 'owner';
   const isAdmin = currentUserRole === 'admin' || isOwner;
+  const isMembershipResolved = !teamLoading && !teamError;
   const isMember = Boolean(normalizedActiveRole ?? roleFromMembers);
   const teamRoleOptions = PRACTICE_ROLE_OPTIONS.filter(option => option.value !== 'owner');
 
@@ -109,7 +110,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
     showError(teamError);
   }, [showError, teamError]);
 
-  if (currentPractice && !activeMemberRoleLoading && !isMember) {
+  if (currentPractice && !activeMemberRoleLoading && isMembershipResolved && !isMember) {
     return (
       <div className="h-full flex items-center justify-center">
         <p className="text-sm text-input-placeholder">You are not a member of this practice.</p>

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -3,10 +3,10 @@ import { useLocation } from 'preact-iso';
 import { ArrowLeftIcon, UserPlusIcon } from '@heroicons/react/24/outline';
 import { Icon } from '@/shared/ui/Icon';
 import { usePracticeManagement, type Role } from '@/shared/hooks/usePracticeManagement';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
 import { usePracticeInvitations } from '@/shared/hooks/usePracticeInvitations';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { usePaymentUpgrade } from '@/shared/hooks/usePaymentUpgrade';
-import { normalizeSeats } from '@/shared/utils/subscription';
 import { Button } from '@/shared/ui/Button';
 import { Input } from '@/shared/ui/input';
 import { FormLabel } from '@/shared/ui/form/FormLabel';
@@ -32,8 +32,6 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
   const { session, activeMemberRole, activeMemberRoleLoading } = useSessionContext();
   const {
     currentPractice,
-    getMembers,
-    fetchMembers,
     updateMemberRole,
     removeMember,
     loading
@@ -54,9 +52,16 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
   const toSettingsPath = (subPath?: string) => buildSettingsPath(settingsBasePath, subPath);
 
   const currentUserEmail = session?.user?.email || '';
-  const members = useMemo(
-    () => (currentPractice ? getMembers(currentPractice.id) : []),
-    [currentPractice, getMembers]
+  const {
+    members,
+    summary,
+    isLoading: teamLoading,
+    error: teamError,
+    refetch: refetchTeam,
+  } = usePracticeTeam(
+    currentPractice?.id ?? null,
+    session?.user?.id ?? null,
+    { enabled: Boolean(currentPractice?.id) }
   );
 
   const currentMember = useMemo(() => {
@@ -98,11 +103,9 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
   }, [location.query]);
 
   useEffect(() => {
-    if (!currentPractice) return;
-    fetchMembers(currentPractice.id).catch((err) => {
-      showError(err?.message || String(err) || 'Failed to fetch practice members');
-    });
-  }, [currentPractice, fetchMembers, showError]);
+    if (!teamError) return;
+    showError(teamError);
+  }, [showError, teamError]);
 
   if (currentPractice && !activeMemberRoleLoading && !isMember) {
     return (
@@ -133,6 +136,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
 
     try {
       await updateMemberRole(currentPractice.id, editMemberData.userId, editMemberData.role);
+      await refetchTeam();
       showSuccess('Member role updated successfully!');
       setEditMemberData(null);
       setIsEditingMember(false);
@@ -150,6 +154,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
 
     try {
       await removeMember(currentPractice.id, member.userId);
+      await refetchTeam();
       showSuccess('Member removed successfully!');
       setEditMemberData(null);
       setIsEditingMember(false);
@@ -161,6 +166,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
   const handleAcceptInvitation = async (invitationId: string) => {
     try {
       await acceptInvitation(invitationId);
+      await refetchTeam();
       showSuccess('Invitation accepted!');
     } catch (err) {
       showError(err instanceof Error ? err.message : 'Failed to accept invitation');
@@ -207,7 +213,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
               Manage access to your practice workspace.
             </p>
             <SettingsHelperText className="mt-2">
-              Seats used: {members.length} / {normalizeSeats(currentPractice?.seats)}
+              Seats used: {summary.seatsUsed} / {summary.seatsIncluded}
             </SettingsHelperText>
           </div>
           {isAdmin && (
@@ -222,10 +228,10 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
         </div>
       </div>
 
-        {members.length > normalizeSeats(currentPractice?.seats) && (
+        {summary.seatsUsed > summary.seatsIncluded && (
           <SettingsNotice variant="warning" className="mb-4" role="status" aria-live="polite">
             <p className="text-sm">
-              You&apos;re using {members.length} seats but your plan includes {normalizeSeats(currentPractice?.seats)}. The billing owner can increase seats in Stripe.
+              You&apos;re using {summary.seatsUsed} seats but your plan includes {summary.seatsIncluded}. The billing owner can increase seats in Stripe.
               {isOwner && (
                 <Button
                   variant="ghost"
@@ -246,7 +252,7 @@ export const PracticeTeamPage = ({ onNavigate, className }: PracticeTeamPageProp
           </SettingsNotice>
         )}
 
-      {members.length === 0 && loading ? (
+      {members.length === 0 && (loading || teamLoading) ? (
         <SettingsHelperText>Loading members...</SettingsHelperText>
       ) : members.length > 0 ? (
           <div className="space-y-3">

--- a/src/shared/hooks/__tests__/usePracticeTeam.test.ts
+++ b/src/shared/hooks/__tests__/usePracticeTeam.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/preact';
+import { usePracticeTeam } from '../usePracticeTeam';
+import { resetPracticeTeamStore } from '@/shared/stores/practiceTeamStore';
+
+if (typeof globalThis.requestAnimationFrame !== 'function') {
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => (
+    window.setTimeout(() => callback(Date.now()), 0)
+  )) as typeof globalThis.requestAnimationFrame;
+}
+
+if (typeof globalThis.cancelAnimationFrame !== 'function') {
+  globalThis.cancelAnimationFrame = ((handle: number) => {
+    window.clearTimeout(handle);
+  }) as typeof globalThis.cancelAnimationFrame;
+}
+
+const mocks = vi.hoisted(() => ({
+  listPracticeTeamMock: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({
+  listPracticeTeam: mocks.listPracticeTeamMock,
+}));
+
+describe('usePracticeTeam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPracticeTeamStore();
+    mocks.listPracticeTeamMock.mockResolvedValue({
+      members: [
+        {
+          userId: 'staff-1',
+          email: 'staff@example.com',
+          name: 'Staff Member',
+          image: null,
+          role: 'admin',
+          createdAt: 123,
+          canAssignToMatter: true,
+          canMentionInternally: true,
+        },
+      ],
+      summary: {
+        seatsIncluded: 2,
+        seatsUsed: 1,
+      },
+    });
+  });
+
+  it('loads and caches the team response by user and practice', async () => {
+    const first = renderHook(() => usePracticeTeam('practice-1', 'user-1'));
+
+    await waitFor(() => {
+      expect(first.result.current.members).toHaveLength(1);
+    });
+
+    expect(first.result.current.summary).toEqual({
+      seatsIncluded: 2,
+      seatsUsed: 1,
+    });
+    expect(mocks.listPracticeTeamMock).toHaveBeenCalledTimes(1);
+
+    const second = renderHook(() => usePracticeTeam('practice-1', 'user-1'));
+
+    await waitFor(() => {
+      expect(second.result.current.members).toHaveLength(1);
+    });
+
+    expect(mocks.listPracticeTeamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('separates cache entries when the authenticated user changes', async () => {
+    mocks.listPracticeTeamMock
+      .mockResolvedValueOnce({
+        members: [
+          {
+            userId: 'staff-1',
+            email: 'staff@example.com',
+            name: 'Staff Member',
+            image: null,
+            role: 'admin',
+            createdAt: 123,
+            canAssignToMatter: true,
+            canMentionInternally: true,
+          },
+        ],
+        summary: {
+          seatsIncluded: 2,
+          seatsUsed: 1,
+        },
+      })
+      .mockResolvedValue({
+        members: [
+          {
+            userId: 'staff-2',
+            email: 'next@example.com',
+            name: 'Next User Team',
+            image: null,
+            role: 'member',
+            createdAt: 456,
+            canAssignToMatter: false,
+            canMentionInternally: true,
+          },
+        ],
+        summary: {
+          seatsIncluded: 5,
+          seatsUsed: 1,
+        },
+      });
+
+    const first = renderHook(() => usePracticeTeam('practice-1', 'user-1'));
+
+    await waitFor(() => {
+      expect(first.result.current.members).toHaveLength(1);
+    });
+
+    first.unmount();
+
+    const second = renderHook(() => usePracticeTeam('practice-1', 'user-2'));
+
+    await waitFor(() => {
+      expect(second.result.current.members).toHaveLength(1);
+    });
+
+    expect(second.result.current.members[0]).toMatchObject({
+      userId: 'staff-2',
+      email: 'next@example.com',
+      canAssignToMatter: false,
+    });
+    expect(second.result.current.summary).toEqual({
+      seatsIncluded: 5,
+      seatsUsed: 1,
+    });
+  });
+});

--- a/src/shared/hooks/usePracticeInvitations.ts
+++ b/src/shared/hooks/usePracticeInvitations.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'preact/hooks';
 import {
+  cancelPracticeInvitation,
   createPracticeInvitation,
   listPracticeInvitations,
   respondToPracticeInvitation,
@@ -16,6 +17,7 @@ interface UsePracticeInvitationsReturn {
   sendInvitation: (email: string, role: Role) => Promise<void>;
   acceptInvitation: (invitationId: string) => Promise<void>;
   declineInvitation: (invitationId: string) => Promise<void>;
+  cancelInvitation: (invitationId: string) => Promise<void>;
 }
 
 export const usePracticeInvitations = (practiceId: string | null | undefined): UsePracticeInvitationsReturn => {
@@ -106,6 +108,11 @@ export const usePracticeInvitations = (practiceId: string | null | undefined): U
     await fetchInvitations();
   }, [fetchInvitations]);
 
+  const cancelInvitation = useCallback(async (invitationId: string) => {
+    await cancelPracticeInvitation(invitationId);
+    await fetchInvitations();
+  }, [fetchInvitations]);
+
   useEffect(() => {
     const controller = new AbortController();
     void fetchInvitations(controller.signal);
@@ -120,5 +127,6 @@ export const usePracticeInvitations = (practiceId: string | null | undefined): U
     sendInvitation,
     acceptInvitation,
     declineInvitation,
+    cancelInvitation,
   };
 };

--- a/src/shared/hooks/usePracticeManagement.ts
+++ b/src/shared/hooks/usePracticeManagement.ts
@@ -1,6 +1,4 @@
 import axios, { type AxiosRequestConfig } from 'axios';
-import { atom } from 'nanostores';
-import { useStore } from '@nanostores/preact';
 import { useState, useCallback, useEffect, useRef, useContext } from 'preact/hooks';
 import { getPracticeWorkspaceEndpoint } from '@/config/api';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
@@ -16,7 +14,6 @@ import {
   getOnboardingStatusPayload,
   updatePracticeDetails as apiUpdatePracticeDetails,
   deletePractice as apiDeletePractice,
-  listPracticeMembers,
   updatePracticeMemberRole as apiUpdatePracticeMemberRole,
   deletePracticeMember as apiDeletePracticeMember,
   clearPublicPracticeDetailsCache
@@ -25,7 +22,7 @@ import { normalizeSubscriptionStatus as normalizePracticeStatus } from '@/shared
 import { resetPracticeDetailsStore, setPracticeDetailsEntry } from '@/shared/stores/practiceDetailsStore';
 import { invalidatePracticeTeamForPractice, resetPracticeTeamStore } from '@/shared/stores/practiceTeamStore';
 import { asMajor, type MajorAmount } from '@/shared/utils/money';
-import { normalizePracticeRole, type PracticeRole } from '@/shared/utils/practiceRoles';
+import { type PracticeRole } from '@/shared/utils/practiceRoles';
 
 const ENABLE_PAYOUT_STATUS = import.meta.env.VITE_ENABLE_PAYOUTS === 'true';
 
@@ -51,24 +48,6 @@ const resetSharedPracticeCache = () => {
   sharedPracticeIncludesDetails = false;
   practicesLoaded = false;
   practicesInFlight = null;
-};
-
-const membersStore = atom<Record<string, Member[]>>({});
-const membersLoaded = new Set<string>();
-const membersInFlight = new Map<string, Promise<Member[]>>();
-let membersCacheUserId: string | null = null;
-
-const resetMembersCache = () => {
-  membersStore.set({});
-  membersLoaded.clear();
-  membersInFlight.clear();
-  membersCacheUserId = null;
-};
-
-const setMembersForPractice = (practiceId: string, nextMembers: Member[]) => {
-  if (!practiceId) return;
-  const snapshot = membersStore.get();
-  membersStore.set({ ...snapshot, [practiceId]: nextMembers });
 };
 
 // Types
@@ -204,9 +183,6 @@ interface UsePracticeManagementReturn {
   updatePracticeDetails: (id: string, details: PracticeDetailsUpdate) => Promise<PracticeDetails | null>;
   deletePractice: (id: string) => Promise<void>;
   
-  // Team management
-  getMembers: (practiceId: string) => Member[];
-  fetchMembers: (practiceId: string, options?: { force?: boolean }) => Promise<void>;
   updateMemberRole: (practiceId: string, userId: string, role: Role) => Promise<void>;
   removeMember: (practiceId: string, userId: string) => Promise<void>;
   
@@ -552,7 +528,6 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
   const routePractice = useContext(RoutePracticeContext);
   const [practices, setPractices] = useState<Practice[]>([]);
   const [currentPractice, setCurrentPractice] = useState<Practice | null>(null);
-  const members = useStore(membersStore);
   const [workspaceData, setWorkspaceData] = useState<Record<string, Record<string, Record<string, unknown>[]>>>({});
   // Initialize loading to true when autoFetchPractices is enabled
   // This ensures the UI shows a loading state during the first render before the fetch effect runs
@@ -571,13 +546,13 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
   // Track if we've already fetched practices to prevent duplicate calls
   const practicesFetchedRef = useRef(false);
   const currentRequestRef = useRef<AbortController | null>(null);
+  const lastPracticeTeamUserIdRef = useRef<string | null>(null);
   const resolvedUserId = !session?.user || isAnonymous ? null : session.user.id;
 
   useEffect(() => {
-    if (membersCacheUserId !== resolvedUserId) {
-      resetMembersCache();
+    if (lastPracticeTeamUserIdRef.current !== resolvedUserId) {
       resetPracticeTeamStore();
-      membersCacheUserId = resolvedUserId;
+      lastPracticeTeamUserIdRef.current = resolvedUserId;
     }
   }, [resolvedUserId]);
 
@@ -624,12 +599,6 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
       throw error;
     }
   }, []);
-
-  // Helper functions to get data by practiceId
-  const getMembers = useCallback((practiceId: string): Member[] => {
-    return members[practiceId] || [];
-  }, [members]);
-
 
   const getWorkspaceData = useCallback((practiceId: string, resource: string): Record<string, unknown>[] => {
     return workspaceData[practiceId]?.[resource] || [];
@@ -1148,115 +1117,17 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
     await fetchPractices();
   }, [fetchPractices]);
 
-  // Fetch members
-  const fetchMembers = useCallback(async (
-    practiceId: string,
-    options: { force?: boolean } = {}
-  ): Promise<void> => {
-    if (!practiceId) return;
-
-    const force = options.force ?? false;
-    if (!force && membersLoaded.has(practiceId)) {
-      return;
-    }
-
-    const inFlight = membersInFlight.get(practiceId);
-    if (inFlight) {
-      await inFlight;
-      return;
-    }
-
-    const promise = (async () => {
-      const data = await listPracticeMembers(practiceId);
-      // Validate and normalize members manually
-    const validRoles: Role[] = ['owner', 'admin', 'attorney', 'paralegal', 'member', 'client'];
-
-      return (Array.isArray(data) ? data : [])
-        .map(m => {
-          if (!m || typeof m !== 'object') {
-            return null;
-          }
-          const member = m as Record<string, unknown>;
-          const userId = typeof member.userId === 'string'
-            ? member.userId
-            : (typeof member.user_id === 'string' ? member.user_id : null);
-          const normalizedRole = normalizePracticeRole(member.role);
-          const createdAtValue = member.createdAt ?? member.created_at ?? member.joined_at;
-          const createdAt = typeof createdAtValue === 'number'
-            ? createdAtValue
-            : (typeof createdAtValue === 'string' && createdAtValue.trim()
-              ? Number(createdAtValue)
-              : null);
-          const email = typeof member.email === 'string'
-            ? member.email
-            : (typeof (member.user as Record<string, unknown> | undefined)?.email === 'string'
-              ? (member.user as Record<string, unknown>).email as string
-              : '');
-          const userRecord = (member.user && typeof member.user === 'object')
-            ? (member.user as Record<string, unknown>)
-            : null;
-          const normalizedName = typeof member.name === 'string'
-            ? member.name
-            : (typeof userRecord?.name === 'string' ? userRecord.name : undefined);
-          const normalizedImage = typeof member.image === 'string'
-            ? member.image
-            : (typeof userRecord?.image === 'string' ? userRecord.image : undefined);
-
-          if (!userId) {
-            console.error('Invalid or missing member userId:', member);
-            return null;
-          }
-
-          if (!normalizedRole || !validRoles.includes(normalizedRole)) {
-            console.error('Invalid member role:', member.role, 'Expected one of:', validRoles, 'Member:', member);
-            return null;
-          }
-
-          if (typeof email !== 'string' || !email.trim()) {
-            console.error('Invalid or missing member email:', member.email, 'Member:', member);
-            return null;
-          }
-
-          return {
-            userId,
-            role: normalizedRole,
-            email,
-            name: normalizedName,
-            image: normalizedImage,
-            createdAt: Number.isFinite(createdAt ?? NaN) ? (createdAt as number) : Date.now(),
-          } as Member;
-        })
-        .filter((m): m is Member => m !== null);
-    })();
-
-    membersInFlight.set(practiceId, promise);
-    try {
-      const normalizedMembers = await promise;
-      membersLoaded.add(practiceId);
-      setMembersForPractice(practiceId, normalizedMembers);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch members');
-      membersLoaded.delete(practiceId);
-      setMembersForPractice(practiceId, []);
-      throw err;
-    } finally {
-      membersInFlight.delete(practiceId);
-    }
-  }, []);
-
   // Update member role
   const updateMemberRole = useCallback(async (practiceId: string, userId: string, role: Role): Promise<void> => {
     await apiUpdatePracticeMemberRole(practiceId, { userId, role });
     invalidatePracticeTeamForPractice(practiceId);
-    await fetchMembers(practiceId, { force: true });
-  }, [fetchMembers]);
+  }, []);
 
   // Remove member
   const removeMember = useCallback(async (practiceId: string, userId: string): Promise<void> => {
     await apiDeletePracticeMember(practiceId, userId);
     invalidatePracticeTeamForPractice(practiceId);
-    await fetchMembers(practiceId, { force: true });
-  }, [fetchMembers]);
+  }, []);
 
   // Fetch workspace data
   const fetchWorkspaceData = useCallback(async (practiceId: string, resource: string): Promise<void> => {
@@ -1311,8 +1182,6 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
     updatePractice,
     updatePracticeDetails,
     deletePractice,
-    getMembers,
-    fetchMembers,
     updateMemberRole,
     removeMember,
     getWorkspaceData,

--- a/src/shared/hooks/usePracticeManagement.ts
+++ b/src/shared/hooks/usePracticeManagement.ts
@@ -23,6 +23,7 @@ import {
 } from '@/shared/lib/apiClient';
 import { normalizeSubscriptionStatus as normalizePracticeStatus } from '@/shared/utils/subscription';
 import { resetPracticeDetailsStore, setPracticeDetailsEntry } from '@/shared/stores/practiceDetailsStore';
+import { invalidatePracticeTeamForPractice, resetPracticeTeamStore } from '@/shared/stores/practiceTeamStore';
 import { asMajor, type MajorAmount } from '@/shared/utils/money';
 import { normalizePracticeRole, type PracticeRole } from '@/shared/utils/practiceRoles';
 
@@ -575,6 +576,7 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
   useEffect(() => {
     if (membersCacheUserId !== resolvedUserId) {
       resetMembersCache();
+      resetPracticeTeamStore();
       membersCacheUserId = resolvedUserId;
     }
   }, [resolvedUserId]);
@@ -1245,12 +1247,14 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
   // Update member role
   const updateMemberRole = useCallback(async (practiceId: string, userId: string, role: Role): Promise<void> => {
     await apiUpdatePracticeMemberRole(practiceId, { userId, role });
+    invalidatePracticeTeamForPractice(practiceId);
     await fetchMembers(practiceId, { force: true });
   }, [fetchMembers]);
 
   // Remove member
   const removeMember = useCallback(async (practiceId: string, userId: string): Promise<void> => {
     await apiDeletePracticeMember(practiceId, userId);
+    invalidatePracticeTeamForPractice(practiceId);
     await fetchMembers(practiceId, { force: true });
   }, [fetchMembers]);
 

--- a/src/shared/hooks/usePracticeManagement.ts
+++ b/src/shared/hooks/usePracticeManagement.ts
@@ -20,7 +20,7 @@ import {
 } from '@/shared/lib/apiClient';
 import { normalizeSubscriptionStatus as normalizePracticeStatus } from '@/shared/utils/subscription';
 import { resetPracticeDetailsStore, setPracticeDetailsEntry } from '@/shared/stores/practiceDetailsStore';
-import { invalidatePracticeTeamForPractice, resetPracticeTeamStore } from '@/shared/stores/practiceTeamStore';
+import { ensurePracticeTeamCacheUserId, invalidatePracticeTeamForPractice, resetPracticeTeamStore } from '@/shared/stores/practiceTeamStore';
 import { asMajor, type MajorAmount } from '@/shared/utils/money';
 import { type PracticeRole } from '@/shared/utils/practiceRoles';
 
@@ -546,14 +546,10 @@ export function usePracticeManagement(options: UsePracticeManagementOptions = {}
   // Track if we've already fetched practices to prevent duplicate calls
   const practicesFetchedRef = useRef(false);
   const currentRequestRef = useRef<AbortController | null>(null);
-  const lastPracticeTeamUserIdRef = useRef<string | null>(null);
   const resolvedUserId = !session?.user || isAnonymous ? null : session.user.id;
 
   useEffect(() => {
-    if (lastPracticeTeamUserIdRef.current !== resolvedUserId) {
-      resetPracticeTeamStore();
-      lastPracticeTeamUserIdRef.current = resolvedUserId;
-    }
+    ensurePracticeTeamCacheUserId(resolvedUserId);
   }, [resolvedUserId]);
 
   // Helper for workspace/local endpoints still served by the Worker

--- a/src/shared/hooks/usePracticeTeam.ts
+++ b/src/shared/hooks/usePracticeTeam.ts
@@ -91,7 +91,7 @@ export const usePracticeTeam = (
         setIsLoading(false);
       }
     }
-  }, [cacheKey, enabled, practiceId]);
+  }, [cacheKey, enabled, practiceId, resolvedUserId]);
 
   useEffect(() => {
     if (!enabled || !practiceId || isLoaded) return;

--- a/src/shared/hooks/usePracticeTeam.ts
+++ b/src/shared/hooks/usePracticeTeam.ts
@@ -57,7 +57,8 @@ export const usePracticeTeam = (
         await existing;
       } catch (err) {
         if (!isMountedRef.current) return;
-        if (practiceTeamInFlight.get(cacheKey) !== existing) return;
+        const current = practiceTeamInFlight.get(cacheKey);
+        if (current !== undefined && current !== existing) return;
         if (err instanceof Error && err.name === 'AbortError') return;
 
         const nextLoaded = new Set(practiceTeamLoaded.get());

--- a/src/shared/hooks/usePracticeTeam.ts
+++ b/src/shared/hooks/usePracticeTeam.ts
@@ -51,6 +51,8 @@ export const usePracticeTeam = (
 
     const existing = practiceTeamInFlight.get(cacheKey);
     if (existing && !fetchOptions.force) {
+      setIsLoading(true);
+      setError(null);
       try {
         await existing;
       } catch (err) {
@@ -65,6 +67,10 @@ export const usePracticeTeam = (
         const message = err instanceof Error ? err.message : 'Failed to load team';
         setError(message);
         throw err;
+      } finally {
+        if (isMountedRef.current) {
+          setIsLoading(false);
+        }
       }
       return;
     }

--- a/src/shared/hooks/usePracticeTeam.ts
+++ b/src/shared/hooks/usePracticeTeam.ts
@@ -3,12 +3,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { listPracticeTeam } from '@/shared/lib/apiClient';
 import type { TeamSummary } from '@/shared/types/team';
 import {
-  markPracticeTeamCacheUserId,
-  practiceTeamCacheUserId,
+  ensurePracticeTeamCacheUserId,
   practiceTeamInFlight,
   practiceTeamLoaded,
   practiceTeamStore,
-  resetPracticeTeamStore,
   setPracticeTeamForKey,
 } from '@/shared/stores/practiceTeamStore';
 
@@ -48,15 +46,26 @@ export const usePracticeTeam = (
 
   const fetch = useCallback(async (fetchOptions: { force?: boolean; signal?: AbortSignal } = {}) => {
     if (!enabled || !practiceId) return;
-    if (practiceTeamCacheUserId !== resolvedUserId) {
-      resetPracticeTeamStore();
-      markPracticeTeamCacheUserId(resolvedUserId);
-    }
+    ensurePracticeTeamCacheUserId(resolvedUserId);
     if (!fetchOptions.force && practiceTeamLoaded.get().has(cacheKey)) return;
 
-    const inFlight = practiceTeamInFlight.get(cacheKey);
-    if (inFlight) {
-      await inFlight;
+    const existing = practiceTeamInFlight.get(cacheKey);
+    if (existing && !fetchOptions.force) {
+      try {
+        await existing;
+      } catch (err) {
+        if (!isMountedRef.current) return;
+        if (practiceTeamInFlight.get(cacheKey) !== existing) return;
+        if (err instanceof Error && err.name === 'AbortError') return;
+
+        const nextLoaded = new Set(practiceTeamLoaded.get());
+        nextLoaded.delete(cacheKey);
+        practiceTeamLoaded.set(nextLoaded);
+
+        const message = err instanceof Error ? err.message : 'Failed to load team';
+        setError(message);
+        throw err;
+      }
       return;
     }
 
@@ -68,7 +77,7 @@ export const usePracticeTeam = (
     try {
       const result = await promise;
       if (!isMountedRef.current) return;
-      if (!practiceTeamInFlight.has(cacheKey)) return;
+      if (practiceTeamInFlight.get(cacheKey) !== promise) return;
 
       const nextLoaded = new Set(practiceTeamLoaded.get());
       nextLoaded.add(cacheKey);
@@ -77,6 +86,7 @@ export const usePracticeTeam = (
     } catch (err) {
       if (!isMountedRef.current) return;
       if (err instanceof Error && err.name === 'AbortError') return;
+      if (practiceTeamInFlight.get(cacheKey) !== promise) return;
 
       const nextLoaded = new Set(practiceTeamLoaded.get());
       nextLoaded.delete(cacheKey);
@@ -86,7 +96,9 @@ export const usePracticeTeam = (
       setError(message);
       throw err;
     } finally {
-      practiceTeamInFlight.delete(cacheKey);
+      if (practiceTeamInFlight.get(cacheKey) === promise) {
+        practiceTeamInFlight.delete(cacheKey);
+      }
       if (isMountedRef.current) {
         setIsLoading(false);
       }

--- a/src/shared/hooks/usePracticeTeam.ts
+++ b/src/shared/hooks/usePracticeTeam.ts
@@ -1,0 +1,115 @@
+import { useStore } from '@nanostores/preact';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { listPracticeTeam } from '@/shared/lib/apiClient';
+import type { TeamSummary } from '@/shared/types/team';
+import {
+  markPracticeTeamCacheUserId,
+  practiceTeamCacheUserId,
+  practiceTeamInFlight,
+  practiceTeamLoaded,
+  practiceTeamStore,
+  resetPracticeTeamStore,
+  setPracticeTeamForKey,
+} from '@/shared/stores/practiceTeamStore';
+
+const DEFAULT_SUMMARY: TeamSummary = {
+  seatsIncluded: 1,
+  seatsUsed: 0,
+};
+
+type UsePracticeTeamOptions = {
+  enabled?: boolean;
+};
+
+export const usePracticeTeam = (
+  practiceId: string | null | undefined,
+  userId: string | null | undefined,
+  options: UsePracticeTeamOptions = {}
+) => {
+  const { enabled = true } = options;
+  const store = useStore(practiceTeamStore);
+  const loadedStore = useStore(practiceTeamLoaded);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+  const resolvedUserId = userId?.trim() || 'anonymous';
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
+
+  const cacheKey = useMemo(
+    () => `${resolvedUserId}:${practiceId ?? ''}`,
+    [practiceId, resolvedUserId]
+  );
+  const value = store[cacheKey];
+  const isLoaded = loadedStore.has(cacheKey);
+
+  const fetch = useCallback(async (fetchOptions: { force?: boolean; signal?: AbortSignal } = {}) => {
+    if (!enabled || !practiceId) return;
+    if (practiceTeamCacheUserId !== resolvedUserId) {
+      resetPracticeTeamStore();
+      markPracticeTeamCacheUserId(resolvedUserId);
+    }
+    if (!fetchOptions.force && practiceTeamLoaded.get().has(cacheKey)) return;
+
+    const inFlight = practiceTeamInFlight.get(cacheKey);
+    if (inFlight) {
+      await inFlight;
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    const promise = listPracticeTeam(practiceId, { signal: fetchOptions.signal });
+    practiceTeamInFlight.set(cacheKey, promise);
+
+    try {
+      const result = await promise;
+      if (!isMountedRef.current) return;
+      if (!practiceTeamInFlight.has(cacheKey)) return;
+
+      const nextLoaded = new Set(practiceTeamLoaded.get());
+      nextLoaded.add(cacheKey);
+      practiceTeamLoaded.set(nextLoaded);
+      setPracticeTeamForKey(cacheKey, result);
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      if (err instanceof Error && err.name === 'AbortError') return;
+
+      const nextLoaded = new Set(practiceTeamLoaded.get());
+      nextLoaded.delete(cacheKey);
+      practiceTeamLoaded.set(nextLoaded);
+
+      const message = err instanceof Error ? err.message : 'Failed to load team';
+      setError(message);
+      throw err;
+    } finally {
+      practiceTeamInFlight.delete(cacheKey);
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [cacheKey, enabled, practiceId]);
+
+  useEffect(() => {
+    if (!enabled || !practiceId || isLoaded) return;
+    const controller = new AbortController();
+    void fetch({ signal: controller.signal }).catch(() => undefined);
+    return () => controller.abort();
+  }, [enabled, fetch, isLoaded, practiceId]);
+
+  const refetch = useCallback(async (signal?: AbortSignal) => {
+    await fetch({ force: true, signal });
+  }, [fetch]);
+
+  return {
+    members: value?.members ?? [],
+    summary: value?.summary ?? DEFAULT_SUMMARY,
+    isLoaded,
+    isLoading,
+    error,
+    refetch,
+  };
+};

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -485,6 +485,74 @@ function toNullableString(value: unknown): string | null {
   return null;
 }
 
+function toNullableTimestamp(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+    const parsed = Date.parse(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+  return null;
+}
+
+function normalizeInvitationStatus(value: unknown): 'pending' | 'accepted' | 'declined' | null {
+  const normalized = toNullableString(value)?.toLowerCase();
+  if (normalized === 'pending' || normalized === 'accepted') {
+    return normalized;
+  }
+  if (normalized === 'declined' || normalized === 'rejected' || normalized === 'canceled' || normalized === 'cancelled') {
+    return 'declined';
+  }
+  return null;
+}
+
+function normalizePracticeInvitationPayload(payload: unknown): Record<string, unknown> | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const id = toNullableString(payload.id);
+  const practiceId = toNullableString(payload.practiceId ?? payload.practice_id ?? payload.organizationId ?? payload.organization_id);
+  const email = toNullableString(payload.email);
+  const role = toNullableString(payload.role);
+  const status = normalizeInvitationStatus(payload.status);
+  const invitedBy = toNullableString(payload.invitedBy ?? payload.invited_by ?? payload.inviterId ?? payload.inviter_id);
+  const expiresAt = toNullableTimestamp(payload.expiresAt ?? payload.expires_at);
+  const createdAt = toNullableTimestamp(payload.createdAt ?? payload.created_at);
+
+  if (!id || !practiceId || !email || !role || !status || !invitedBy || expiresAt === null || createdAt === null) {
+    return null;
+  }
+
+  return {
+    id,
+    practiceId,
+    practiceName: toNullableString(
+      payload.practiceName ??
+      payload.practice_name ??
+      payload.organizationName ??
+      payload.organization_name
+    ) ?? undefined,
+    email,
+    role,
+    status,
+    invitedBy,
+    expiresAt,
+    createdAt
+  };
+}
+
 function normalizePracticePayload(payload: unknown): Practice {
   if (!isRecord(payload)) {
     throw new Error('Invalid practice payload');
@@ -718,17 +786,22 @@ export async function listPracticeInvitations(
     throw new Error('practiceId is required');
   }
   const response = await apiClient.get(
-    `/api/practice/${encodeURIComponent(practiceId)}/invitations`,
-    { signal: config?.signal }
+    '/api/auth/organization/list-invitations',
+    {
+      params: { organizationId: practiceId },
+      signal: config?.signal
+    }
   );
   const payload = unwrapApiData(response.data);
-  if (Array.isArray(payload)) {
-    return payload;
-  }
-  if (isRecord(payload) && Array.isArray(payload.invitations)) {
-    return payload.invitations as unknown[];
-  }
-  return [];
+  const invitations = Array.isArray(payload)
+    ? payload
+    : isRecord(payload) && Array.isArray(payload.invitations)
+      ? payload.invitations
+      : [];
+
+  return invitations
+    .map((invitation) => normalizePracticeInvitationPayload(invitation))
+    .filter((invitation): invitation is Record<string, unknown> => Boolean(invitation));
 }
 
 export async function createPracticeInvitation(
@@ -738,9 +811,13 @@ export async function createPracticeInvitation(
   if (!practiceId) {
     throw new Error('practiceId is required');
   }
+  const requestBody = {
+    ...payload,
+    organizationId: practiceId
+  };
   const response = await apiClient.post(
-    `/api/practice/${encodeURIComponent(practiceId)}/invitations`,
-    payload
+    '/api/auth/organization/invite-member',
+    requestBody
   );
   const data = unwrapApiData(response.data);
   if (!isRecord(data)) {
@@ -771,9 +848,22 @@ export async function respondToPracticeInvitation(
   invitationId: string,
   action: 'accept' | 'decline'
 ): Promise<void> {
+  if (!invitationId) {
+    throw new Error('invitationId is required');
+  }
   await apiClient.post(
-    `/api/practice/invitations/${encodeURIComponent(invitationId)}/${action}`
+    action === 'accept'
+      ? '/api/auth/organization/accept-invitation'
+      : '/api/auth/organization/reject-invitation',
+    { invitationId }
   );
+}
+
+export async function cancelPracticeInvitation(invitationId: string): Promise<void> {
+  if (!invitationId) {
+    throw new Error('invitationId is required');
+  }
+  await apiClient.post('/api/auth/organization/cancel-invitation', { invitationId });
 }
 
 export async function listPracticeMembers(practiceId: string): Promise<unknown[]> {
@@ -843,7 +933,6 @@ export async function listPracticeTeam(
         member !== null
         && member !== undefined
         && member.userId.trim().length > 0
-        && member.email.trim().length > 0
       )),
     summary: {
       seatsIncluded: typeof rawSummary.seatsIncluded === 'number'

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -866,25 +866,6 @@ export async function cancelPracticeInvitation(invitationId: string): Promise<vo
   await apiClient.post('/api/auth/organization/cancel-invitation', { invitationId });
 }
 
-export async function listPracticeMembers(practiceId: string): Promise<unknown[]> {
-  if (!practiceId) {
-    throw new Error('practiceId is required');
-  }
-  const response = await apiClient.get(`/api/practice/${encodeURIComponent(practiceId)}`);
-  const payload = unwrapApiData(response.data);
-  const practiceRecord = isRecord(payload) && isRecord(payload.practice) ? payload.practice : payload;
-  if (isRecord(practiceRecord) && Array.isArray(practiceRecord.members)) {
-    return practiceRecord.members as unknown[];
-  }
-  if (Array.isArray(payload)) {
-    return payload;
-  }
-  if (isRecord(payload) && Array.isArray(payload.members)) {
-    return payload.members as unknown[];
-  }
-  return [];
-}
-
 export async function listPracticeTeam(
   practiceId: string,
   config?: Pick<AxiosRequestConfig, 'signal'>

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -7,6 +7,7 @@ import {
 } from '@/config/api';
 import type { Conversation } from '@/shared/types/conversation';
 import type { Address } from '@/shared/types/address';
+import type { PracticeTeamResponse } from '@/shared/types/team';
 import { getWorkerApiUrl, isWidgetTokenEligibleRequestUrl } from '@/config/urls';
 import {
   toMajorUnits,
@@ -15,6 +16,7 @@ import {
   assertMinorUnits,
   type MajorAmount
 } from '@/shared/utils/money';
+import { isTeamRole } from '@/shared/types/team';
 import { getWidgetAuthToken } from '@/shared/utils/widgetAuth';
 
 let cachedBaseUrl: string | null = null;
@@ -379,6 +381,7 @@ export type ConversationParticipant = {
   role?: string | null;
   name?: string | null;
   image?: string | null;
+  canMentionInternally?: boolean;
 };
 
 export async function getConversationParticipants(
@@ -414,6 +417,7 @@ export async function getConversationParticipants(
       role: typeof row.role === 'string' ? row.role : null,
       name: typeof row.name === 'string' ? row.name : null,
       image: typeof row.image === 'string' ? row.image : null,
+      canMentionInternally: row.canMentionInternally === true || row.can_mention_internally === true,
     }))
     .filter((row) => row.userId.trim().length > 0);
 }
@@ -789,6 +793,67 @@ export async function listPracticeMembers(practiceId: string): Promise<unknown[]
     return payload.members as unknown[];
   }
   return [];
+}
+
+export async function listPracticeTeam(
+  practiceId: string,
+  config?: Pick<AxiosRequestConfig, 'signal'>
+): Promise<PracticeTeamResponse> {
+  if (!practiceId) {
+    throw new Error('practiceId is required');
+  }
+
+  const response = await apiClient.get(
+    `/api/practice/${encodeURIComponent(practiceId)}/team`,
+    { signal: config?.signal }
+  );
+  const payload = unwrapApiData(response.data);
+  if (!isRecord(payload)) {
+    throw new Error('Invalid practice team response');
+  }
+
+  const members = Array.isArray(payload.members) ? payload.members : [];
+  const rawSummary = isRecord(payload.summary) ? payload.summary : {};
+
+  return {
+    members: members
+      .filter((member): member is Record<string, unknown> => isRecord(member))
+      .map<PracticeTeamResponse['members'][number] | null>((member) => {
+        const role = isTeamRole(member.role) ? member.role : null;
+        if (role === null) {
+          return null;
+        }
+
+        return {
+          userId: typeof member.userId === 'string'
+            ? member.userId
+            : (typeof member.user_id === 'string' ? member.user_id : ''),
+          email: typeof member.email === 'string' ? member.email : '',
+          name: typeof member.name === 'string' ? member.name : undefined,
+          image: typeof member.image === 'string' ? member.image : null,
+          role,
+          createdAt: typeof member.createdAt === 'number'
+            ? member.createdAt
+            : (typeof member.created_at === 'number' ? member.created_at : null),
+          canAssignToMatter: member.canAssignToMatter === true || member.can_assign_to_matter === true,
+          canMentionInternally: member.canMentionInternally === true || member.can_mention_internally === true,
+        };
+      })
+      .filter((member): member is PracticeTeamResponse['members'][number] => (
+        member !== null
+        && member !== undefined
+        && member.userId.trim().length > 0
+        && member.email.trim().length > 0
+      )),
+    summary: {
+      seatsIncluded: typeof rawSummary.seatsIncluded === 'number'
+        ? rawSummary.seatsIncluded
+        : (typeof rawSummary.seats_included === 'number' ? rawSummary.seats_included : 1),
+      seatsUsed: typeof rawSummary.seatsUsed === 'number'
+        ? rawSummary.seatsUsed
+        : (typeof rawSummary.seats_used === 'number' ? rawSummary.seats_used : 0),
+    }
+  };
 }
 
 export async function updatePracticeMemberRole(

--- a/src/shared/stores/practiceTeamStore.ts
+++ b/src/shared/stores/practiceTeamStore.ts
@@ -26,14 +26,13 @@ export const setPracticeTeamForKey = (key: string, value: PracticeTeamResponse) 
 
 export const invalidatePracticeTeamForPractice = (practiceId: string) => {
   if (!practiceId) return;
-  const searchPattern = `:${practiceId}`;
   const snapshot = practiceTeamStore.get();
   const loadedSnapshot = practiceTeamLoaded.get();
   const nextLoaded = new Set(loadedSnapshot);
   const next: StoreShape = {};
 
   for (const [key, value] of Object.entries(snapshot)) {
-    if (key.includes(searchPattern)) {
+    if (key.split(':').includes(practiceId)) {
       nextLoaded.delete(key);
       continue;
     }
@@ -41,7 +40,7 @@ export const invalidatePracticeTeamForPractice = (practiceId: string) => {
   }
 
   for (const key of practiceTeamInFlight.keys()) {
-    if (key.includes(searchPattern)) {
+    if (key.split(':').includes(practiceId)) {
       practiceTeamInFlight.delete(key);
     }
   }

--- a/src/shared/stores/practiceTeamStore.ts
+++ b/src/shared/stores/practiceTeamStore.ts
@@ -32,7 +32,7 @@ export const invalidatePracticeTeamForPractice = (practiceId: string) => {
   const next: StoreShape = {};
 
   for (const [key, value] of Object.entries(snapshot)) {
-    if (key.split(':').includes(practiceId)) {
+    if (key.split(':')[1] === practiceId) {
       nextLoaded.delete(key);
       continue;
     }
@@ -40,7 +40,7 @@ export const invalidatePracticeTeamForPractice = (practiceId: string) => {
   }
 
   for (const key of practiceTeamInFlight.keys()) {
-    if (key.split(':').includes(practiceId)) {
+    if (key.split(':')[1] === practiceId) {
       practiceTeamInFlight.delete(key);
     }
   }

--- a/src/shared/stores/practiceTeamStore.ts
+++ b/src/shared/stores/practiceTeamStore.ts
@@ -15,6 +15,15 @@ export const resetPracticeTeamStore = () => {
   practiceTeamCacheUserId = null;
 };
 
+export const ensurePracticeTeamCacheUserId = (userId: string | null) => {
+  if (practiceTeamCacheUserId !== userId) {
+    practiceTeamStore.set({});
+    practiceTeamLoaded.set(new Set());
+    practiceTeamInFlight.clear();
+    practiceTeamCacheUserId = userId;
+  }
+};
+
 export const markPracticeTeamCacheUserId = (userId: string | null) => {
   practiceTeamCacheUserId = userId;
 };

--- a/src/shared/stores/practiceTeamStore.ts
+++ b/src/shared/stores/practiceTeamStore.ts
@@ -1,0 +1,51 @@
+import { atom } from 'nanostores';
+import type { PracticeTeamResponse } from '@/shared/types/team';
+
+type StoreShape = Record<string, PracticeTeamResponse>;
+
+export const practiceTeamStore = atom<StoreShape>({});
+export const practiceTeamLoaded = atom<Set<string>>(new Set());
+export const practiceTeamInFlight = new Map<string, Promise<PracticeTeamResponse>>();
+export let practiceTeamCacheUserId: string | null = null;
+
+export const resetPracticeTeamStore = () => {
+  practiceTeamStore.set({});
+  practiceTeamLoaded.set(new Set());
+  practiceTeamInFlight.clear();
+  practiceTeamCacheUserId = null;
+};
+
+export const markPracticeTeamCacheUserId = (userId: string | null) => {
+  practiceTeamCacheUserId = userId;
+};
+
+export const setPracticeTeamForKey = (key: string, value: PracticeTeamResponse) => {
+  if (!key) return;
+  practiceTeamStore.set({ ...practiceTeamStore.get(), [key]: value });
+};
+
+export const invalidatePracticeTeamForPractice = (practiceId: string) => {
+  if (!practiceId) return;
+  const searchPattern = `:${practiceId}`;
+  const snapshot = practiceTeamStore.get();
+  const loadedSnapshot = practiceTeamLoaded.get();
+  const nextLoaded = new Set(loadedSnapshot);
+  const next: StoreShape = {};
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (key.includes(searchPattern)) {
+      nextLoaded.delete(key);
+      continue;
+    }
+    next[key] = value;
+  }
+
+  for (const key of practiceTeamInFlight.keys()) {
+    if (key.includes(searchPattern)) {
+      practiceTeamInFlight.delete(key);
+    }
+  }
+
+  practiceTeamLoaded.set(nextLoaded);
+  practiceTeamStore.set(next);
+};

--- a/src/shared/types/team.ts
+++ b/src/shared/types/team.ts
@@ -1,0 +1,36 @@
+export type TeamRole = 'owner' | 'admin' | 'attorney' | 'paralegal' | 'member';
+
+export const TEAM_ROLE_VALUES = ['owner', 'admin', 'attorney', 'paralegal', 'member'] as const satisfies TeamRole[];
+export const TEAM_ASSIGNABLE_ROLE_VALUES = ['owner', 'admin', 'attorney', 'paralegal'] as const satisfies TeamRole[];
+
+const TEAM_ROLE_SET = new Set<TeamRole>(TEAM_ROLE_VALUES);
+const TEAM_ASSIGNABLE_ROLE_SET = new Set<TeamRole>(TEAM_ASSIGNABLE_ROLE_VALUES);
+
+export interface TeamMember {
+  userId: string;
+  email: string;
+  name?: string;
+  image?: string | null;
+  role: TeamRole;
+  createdAt: number | null;
+  canAssignToMatter: boolean;
+  canMentionInternally: boolean;
+}
+
+export interface TeamSummary {
+  seatsIncluded: number;
+  seatsUsed: number;
+}
+
+export interface PracticeTeamResponse {
+  members: TeamMember[];
+  summary: TeamSummary;
+}
+
+export const isTeamRole = (value: unknown): value is TeamRole => (
+  typeof value === 'string' && TEAM_ROLE_SET.has(value as TeamRole)
+);
+
+export const canAssignTeamMemberToMatter = (role: TeamRole): boolean => (
+  TEAM_ASSIGNABLE_ROLE_SET.has(role)
+);

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -149,7 +149,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
         />
         
         {showValidationIcon && (
-          <div className="absolute inset-y-0 right-0 z-10 flex items-center pr-3">
+          <div className="absolute inset-y-0 right-0 z-10 flex items-center pr-3 pointer-events-none">
             {isEmailValid ? (
               <Icon icon={CheckIcon} className="w-4 h-4 text-green-600 dark:text-green-400"  />
             ) : (

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -68,7 +68,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
 
   const sizeClasses = {
     sm: 'px-2 py-1 text-sm',
-    md: 'px-3 py-2 text-sm',
+    md: 'px-3 py-2.5 text-sm',
     lg: 'px-4 py-3 text-base'
   };
 
@@ -128,7 +128,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
       )}
       
       <div className="relative">
-        <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+        <div className="absolute inset-y-0 left-0 z-10 flex items-center pl-3 pointer-events-none">
           <Icon icon={EnvelopeIcon} className="w-4 h-4 text-input-placeholder"  />
         </div>
         
@@ -149,7 +149,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
         />
         
         {showValidationIcon && (
-          <div className="absolute inset-y-0 right-0 flex items-center pr-3">
+          <div className="absolute inset-y-0 right-0 z-10 flex items-center pr-3">
             {isEmailValid ? (
               <Icon icon={CheckIcon} className="w-4 h-4 text-green-600 dark:text-green-400"  />
             ) : (

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
 export interface EmailInputProps {
+  id?: string;
   value?: string;
   onChange?: (value: string) => void;
   placeholder?: string;
@@ -26,6 +27,7 @@ export interface EmailInputProps {
 }
 
 export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
+  id,
   value = '',
   onChange,
   placeholder,
@@ -46,7 +48,8 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
   'data-testid': dataTestId
 }, ref) => {
   // Generate stable unique IDs for accessibility
-  const inputId = useUniqueId('email-input');
+  const generatedInputId = useUniqueId('email-input');
+  const inputId = id || generatedInputId;
   const descriptionId = useUniqueId('email-description');
   const validationErrorId = useUniqueId('email-validation-error');
   const externalErrorId = useUniqueId('email-external-error');
@@ -126,7 +129,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
       
       <div className="relative">
         <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-          <Icon icon={EnvelopeIcon} className="w-4 h-4 text-gray-400 dark:text-gray-500"  />
+          <Icon icon={EnvelopeIcon} className="w-4 h-4 text-input-placeholder"  />
         </div>
         
         <input

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -21,6 +21,7 @@ export interface NavRailProps {
   activeHref: string;
   variant: 'rail' | 'bottom';
   showLabels?: boolean;
+  hidden?: boolean;
   className?: string;
   onItemActivate?: () => void;
 }
@@ -52,12 +53,14 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
   activeHref,
   variant,
   showLabels = false,
+  hidden = false,
   className,
   onItemActivate,
 }) => {
   const location = useLocation();
   const { navigate } = useNavigation();
   const resolvedPath = normalizePath(activeHref || location.path);
+  if (hidden) return null;
   const activeItemId = items.reduce<{ id: string | null; score: number }>((best, item) => {
     if (item.isAction) return best;
     const score = getBestMatchScore(resolvedPath, item);

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseAuthSessionPayload, requirePracticeMember } from '../../../worker/middleware/auth';
+import type { Env } from '../../../worker/types';
+
+describe('auth middleware membership resolution', () => {
+  const env = {
+    BACKEND_API_URL: 'https://api.example.test',
+  } as Env;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses active membership role from Better Auth routing claims', () => {
+    const payload = parseAuthSessionPayload({
+      data: {
+        user: {
+          id: 'user-1',
+          email: 'owner@example.com',
+          name: 'Owner User',
+          emailVerified: true,
+        },
+        session: {
+          id: 'session-1',
+          expiresAt: new Date('2030-01-01T00:00:00.000Z').toISOString(),
+          activeOrganizationId: 'practice-1',
+        },
+        routing: {
+          active_membership_role: 'owner',
+        },
+      },
+    });
+
+    expect(payload.activeOrganizationId).toBe('practice-1');
+    expect(payload.activeMembershipRole).toBe('owner');
+  });
+
+  it('uses active org membership claims without fetching remote practice membership again', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === 'https://api.example.test/api/auth/get-session') {
+        return new Response(JSON.stringify({
+          data: {
+            user: {
+              id: 'user-1',
+              email: 'owner@example.com',
+              name: 'Owner User',
+              emailVerified: true,
+            },
+            session: {
+              id: 'session-1',
+              expiresAt: new Date('2030-01-01T00:00:00.000Z').toISOString(),
+              activeOrganizationId: 'practice-1',
+            },
+            routing: {
+              active_membership_role: 'owner',
+            },
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const request = new Request('https://worker.example.test/api/conversations/conv-1?practiceId=practice-1', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'better-auth.session_token=session-1',
+      },
+    });
+
+    const result = await requirePracticeMember(request, env, 'practice-1', 'paralegal');
+
+    expect(result.memberRole).toBe('owner');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.example.test/api/auth/get-session',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+  });
+});

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -26,7 +26,7 @@ describe('auth middleware membership resolution', () => {
           activeOrganizationId: 'practice-1',
         },
         routing: {
-          active_membership_role: 'owner',
+          active_membership_role: ' OwNeR ',
         },
       },
     });

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -106,7 +106,7 @@ describe('auth middleware membership resolution', () => {
     );
   });
 
-  it('matches remote practice membership when backend member payload uses nested user.id', async () => {
+  it('fetches active member role from Better Auth organization endpoint when session role is missing', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === 'https://api.example.test/api/auth/get-session') {
@@ -129,20 +129,9 @@ describe('auth middleware membership resolution', () => {
         });
       }
 
-      if (url === 'https://api.example.test/api/practice/practice-nested') {
+      if (url === 'https://api.example.test/api/auth/organization/get-active-member-role?organizationId=practice-nested') {
         return new Response(JSON.stringify({
-          practice: {
-            members: [
-              {
-                id: 'membership-1',
-                role: 'owner',
-                user: {
-                  id: 'user-nested',
-                  email: 'owner@example.com',
-                },
-              },
-            ],
-          },
+          role: 'owner',
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -165,7 +154,7 @@ describe('auth middleware membership resolution', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(fetchSpy).toHaveBeenNthCalledWith(
       2,
-      'https://api.example.test/api/practice/practice-nested',
+      'https://api.example.test/api/auth/organization/get-active-member-role?organizationId=practice-nested',
       expect.objectContaining({
         method: 'GET',
       })

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -35,6 +35,28 @@ describe('auth middleware membership resolution', () => {
     expect(payload.activeMembershipRole).toBe('owner');
   });
 
+  it('parses active organization id from root-level Better Auth payload fields', () => {
+    const payload = parseAuthSessionPayload({
+      data: {
+        user: {
+          id: 'user-1',
+          email: 'owner@example.com',
+          name: 'Owner User',
+          emailVerified: true,
+        },
+        session: {
+          id: 'session-1',
+          expiresAt: new Date('2030-01-01T00:00:00.000Z').toISOString(),
+        },
+      },
+      activeOrganizationId: 'practice-1',
+      active_membership_role: 'owner',
+    });
+
+    expect(payload.activeOrganizationId).toBe('practice-1');
+    expect(payload.activeMembershipRole).toBe('owner');
+  });
+
   it('uses active org membership claims without fetching remote practice membership again', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -78,6 +100,72 @@ describe('auth middleware membership resolution', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.example.test/api/auth/get-session',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+  });
+
+  it('matches remote practice membership when backend member payload uses nested user.id', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === 'https://api.example.test/api/auth/get-session') {
+        return new Response(JSON.stringify({
+          data: {
+            user: {
+              id: 'user-nested',
+              email: 'owner@example.com',
+              name: 'Owner User',
+              emailVerified: true,
+            },
+            session: {
+              id: 'session-nested',
+              expiresAt: new Date('2030-01-01T00:00:00.000Z').toISOString(),
+            },
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url === 'https://api.example.test/api/practice/practice-nested') {
+        return new Response(JSON.stringify({
+          practice: {
+            members: [
+              {
+                id: 'membership-1',
+                role: 'owner',
+                user: {
+                  id: 'user-nested',
+                  email: 'owner@example.com',
+                },
+              },
+            ],
+          },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const request = new Request('https://worker.example.test/api/conversations/conv-1?practiceId=practice-nested', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'better-auth.session_token=session-nested',
+      },
+    });
+
+    const result = await requirePracticeMember(request, env, 'practice-nested', 'paralegal');
+
+    expect(result.memberRole).toBe('owner');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.test/api/practice/practice-nested',
       expect.objectContaining({
         method: 'GET',
       })

--- a/tests/unit/routes/conversations.participants.test.ts
+++ b/tests/unit/routes/conversations.participants.test.ts
@@ -5,12 +5,18 @@ const mocks = vi.hoisted(() => ({
   optionalAuthMock: vi.fn(),
   withPracticeContextMock: vi.fn(async (request: Request) => request),
   getPracticeIdMock: vi.fn(() => 'practice-1'),
+  checkPracticeMembershipMock: vi.fn(),
   validateParticipantAccessMock: vi.fn(),
   addParticipantsMock: vi.fn(),
+  getConversationMock: vi.fn(),
+  getPracticeMembersMock: vi.fn(),
+  getPracticeTeamMock: vi.fn(),
 }));
 
 vi.mock('../../../worker/middleware/auth.js', () => ({
   optionalAuth: mocks.optionalAuthMock,
+  requirePracticeMember: vi.fn(),
+  checkPracticeMembership: mocks.checkPracticeMembershipMock,
 }));
 
 vi.mock('../../../worker/middleware/practiceContext.js', () => ({
@@ -22,11 +28,18 @@ vi.mock('../../../worker/services/ConversationService.js', () => ({
   ConversationService: vi.fn().mockImplementation(() => ({
     createConversation: vi.fn(),
     getConversations: vi.fn(),
-    getConversation: vi.fn(),
+    getConversation: mocks.getConversationMock,
     updateConversation: vi.fn(),
     validateParticipantAccess: mocks.validateParticipantAccessMock,
     addParticipants: mocks.addParticipantsMock,
   })),
+}));
+
+vi.mock('../../../worker/services/RemoteApiService.js', () => ({
+  RemoteApiService: {
+    getPracticeMembers: mocks.getPracticeMembersMock,
+    getPracticeTeam: mocks.getPracticeTeamMock,
+  },
 }));
 
 let handleConversations: (request: Request, env: Env) => Promise<Response>;
@@ -46,7 +59,28 @@ describe('handleConversations - participants endpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.optionalAuthMock.mockResolvedValue({ user: { id: 'user-1' } });
+    mocks.checkPracticeMembershipMock.mockResolvedValue({ isMember: true, memberRole: 'owner' });
     mocks.addParticipantsMock.mockResolvedValue({ id: 'conv-1' });
+    mocks.getConversationMock.mockResolvedValue({ participants: ['client-1'], user_id: 'client-1' });
+    mocks.getPracticeMembersMock.mockResolvedValue([
+      { user_id: 'client-1', role: 'client', name: 'Client Person', image: null },
+      { user_id: 'staff-1', role: 'member', name: 'Staff Person', image: null },
+    ]);
+    mocks.getPracticeTeamMock.mockResolvedValue({
+      members: [
+        {
+          userId: 'staff-1',
+          email: 'staff@example.com',
+          name: 'Staff Person',
+          image: null,
+          role: 'member',
+          createdAt: null,
+          canAssignToMatter: false,
+          canMentionInternally: true,
+        },
+      ],
+      summary: { seatsIncluded: 2, seatsUsed: 1 },
+    });
   });
 
   it('adds participants when caller is authorized', async () => {
@@ -61,7 +95,12 @@ describe('handleConversations - participants endpoint', () => {
 
     expect(response.status).toBe(200);
     expect(payload.success).toBe(true);
-    expect(mocks.validateParticipantAccessMock).toHaveBeenCalledWith('conv-1', 'practice-1', 'user-1');
+    expect(mocks.validateParticipantAccessMock).toHaveBeenCalledWith(
+      'conv-1',
+      'practice-1',
+      'user-1',
+      { previousAnonUserId: null }
+    );
     expect(mocks.addParticipantsMock).toHaveBeenCalledWith('conv-1', 'practice-1', ['user-2', 'user-3']);
   });
 
@@ -86,5 +125,33 @@ describe('handleConversations - participants endpoint', () => {
 
     await expect(handleConversations(request, env)).rejects.toHaveProperty('status', 400);
     expect(mocks.addParticipantsMock).not.toHaveBeenCalled();
+  });
+
+  it('expands mention candidates with the worker team view and flags internal mentions', async () => {
+    const request = new Request('https://example.com/api/conversations/conv-1/participants?practiceId=practice-1');
+
+    const response = await handleConversations(request, env);
+    const payload = await response.json() as {
+      success?: boolean;
+      data?: {
+        participants?: Array<{ userId: string; canMentionInternally?: boolean; role?: string | null }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(mocks.getPracticeTeamMock).toHaveBeenCalledWith(env, 'practice-1', request);
+    expect(payload.success).toBe(true);
+    expect(payload.data?.participants).toEqual([
+      expect.objectContaining({
+        userId: 'client-1',
+        role: 'client',
+        canMentionInternally: false,
+      }),
+      expect.objectContaining({
+        userId: 'staff-1',
+        role: 'member',
+        canMentionInternally: true,
+      }),
+    ]);
   });
 });

--- a/tests/unit/routes/practiceTeam.test.ts
+++ b/tests/unit/routes/practiceTeam.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../../../worker/types.js';
+import { handlePracticeTeam } from '../../../worker/routes/practiceTeam.js';
+
+const mocks = vi.hoisted(() => ({
+  getPracticeTeamMock: vi.fn(),
+}));
+
+vi.mock('../../../worker/services/RemoteApiService.js', () => ({
+  RemoteApiService: {
+    getPracticeTeam: mocks.getPracticeTeamMock,
+  },
+}));
+
+describe('handlePracticeTeam', () => {
+  const env = {
+    BACKEND_API_URL: 'https://example.com',
+  } as Env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPracticeTeamMock.mockResolvedValue({
+      members: [
+        {
+          userId: 'staff-1',
+          email: 'staff@example.com',
+          name: 'Staff Member',
+          image: null,
+          role: 'member',
+          createdAt: null,
+          canAssignToMatter: false,
+          canMentionInternally: true,
+        },
+      ],
+      summary: {
+        seatsIncluded: 3,
+        seatsUsed: 1,
+      },
+    });
+  });
+
+  it('returns the worker-owned team view for a practice', async () => {
+    const request = new Request('https://example.com/api/practice/practice-1/team');
+
+    const response = await handlePracticeTeam(request, env);
+    const payload = await response.json() as {
+      success: boolean;
+      data: {
+        members: Array<{ role: string; canMentionInternally: boolean }>;
+        summary: { seatsIncluded: number; seatsUsed: number };
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(mocks.getPracticeTeamMock).toHaveBeenCalledWith(env, 'practice-1', request);
+    expect(payload.success).toBe(true);
+    expect(payload.data.summary).toEqual({
+      seatsIncluded: 3,
+      seatsUsed: 1,
+    });
+    expect(payload.data.members).toEqual([
+      expect.objectContaining({
+        role: 'member',
+        canMentionInternally: true,
+      }),
+    ]);
+  });
+
+  it('rejects non-GET methods', async () => {
+    const request = new Request('https://example.com/api/practice/practice-1/team', {
+      method: 'POST',
+    });
+
+    await expect(handlePracticeTeam(request, env)).rejects.toHaveProperty('status', 405);
+    expect(mocks.getPracticeTeamMock).not.toHaveBeenCalled();
+  });
+});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -9,6 +9,7 @@ import {
   handleConfig,
   handleNotifications,
   handlePracticeDetails,
+  handlePracticeTeam,
   handleWidgetPracticeDetails,
   handlePractices,
   handleAuthProxy,
@@ -68,6 +69,8 @@ async function handleRequestInternal(request: Request, env: Env, _ctx: Execution
 
     if (path.startsWith('/api/auth')) {
       response = await handleAuthProxy(request, env);
+    } else if (/^\/api\/practice\/[^/]+\/team$/.test(path)) {
+      response = await handlePracticeTeam(request, env);
     } else if (
       path.startsWith('/api/onboarding') ||
       path.startsWith('/api/matters') ||

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -2,6 +2,7 @@ import { Env, HttpError } from "../types";
 import { HttpErrors } from "../errorHandler";
 import { Logger } from "../utils/logger";
 import { extractWidgetTokenFromRequest, validateWidgetAuthToken } from "../utils/widgetAuthToken.js";
+import { RemoteApiService } from "../services/RemoteApiService.js";
 
 export interface AuthenticatedUser {
   id: string;
@@ -495,66 +496,6 @@ export async function requireAuth(
   };
 }
 
-type RemoteMemberRecord = Record<string, unknown>;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
-
-function extractMembersPayload(payload: unknown): RemoteMemberRecord[] {
-  if (Array.isArray(payload)) {
-    return payload.filter(isRecord);
-  }
-  if (isRecord(payload)) {
-    if (isRecord(payload.practice) && Array.isArray(payload.practice.members)) {
-      return payload.practice.members.filter(isRecord);
-    }
-    if (Array.isArray(payload.members)) {
-      return payload.members.filter(isRecord);
-    }
-    if (isRecord(payload.data) && isRecord(payload.data.practice) && Array.isArray(payload.data.practice.members)) {
-      return payload.data.practice.members.filter(isRecord);
-    }
-    if (isRecord(payload.data) && Array.isArray(payload.data.members)) {
-      return payload.data.members.filter(isRecord);
-    }
-  }
-  return [];
-}
-
-function extractMemberIdentifiers(member: RemoteMemberRecord): {
-  userId?: string;
-  email?: string;
-  role?: string;
-} {
-  const nestedUser = isRecord(member.user) ? member.user : null;
-  const userId =
-    typeof member.user_id === 'string'
-      ? member.user_id
-      : typeof member.userId === 'string'
-        ? member.userId
-        : typeof member.id === 'string'
-          ? member.id
-          : typeof nestedUser?.id === 'string'
-            ? nestedUser.id
-        : undefined;
-  const email =
-    typeof member.email === 'string'
-      ? member.email.toLowerCase()
-      : typeof nestedUser?.email === 'string'
-        ? nestedUser.email.toLowerCase()
-      : undefined;
-  const role =
-    typeof member.role === 'string'
-      ? member.role
-      : typeof member.permission === 'string'
-        ? member.permission
-        : typeof member.memberRole === 'string'
-          ? member.memberRole
-        : undefined;
-
-  return { userId, email, role };
-}
-
 async function fetchMemberRoleFromRemote(
   cookie: string,
   env: Env,
@@ -577,81 +518,43 @@ async function fetchMemberRoleFromRemote(
   }
 
   const validationPromise = (async () => {
-    // ENV VAR: BACKEND_API_URL (worker/.dev.vars or wrangler.toml)
-    const baseUrl = resolveBackendApiUrl(env, 'practice membership verification');
-
     try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json'
-      };
       if (!cookie || !cookie.trim()) {
         throw HttpErrors.unauthorized('Authentication required');
       }
-      headers.Cookie = cookie;
-
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-      try {
-        const response = await fetch(
-          `${baseUrl}/api/practice/${encodeURIComponent(practiceId)}`,
-          {
-            method: 'GET',
-            headers,
-            signal: controller.signal
-          }
-        );
-        clearTimeout(timeoutId);
-
-        if (response.status === 404) {
-          throw HttpErrors.notFound('Practice not found');
+      const membershipRequest = new Request(`https://worker.invalid/api/practice/${encodeURIComponent(practiceId)}`, {
+        method: 'GET',
+        headers: {
+          Cookie: cookie,
+        },
+      });
+      const members = await RemoteApiService.getPracticeMembers(env, practiceId, membershipRequest);
+      const normalizedEmail = userEmail ? userEmail.toLowerCase() : undefined;
+      const match = members.find((member) => {
+        if (member.user_id === userId) {
+          return true;
         }
-
-        if (!response.ok) {
-          throw HttpErrors.badGateway(`Failed to verify membership (status ${response.status})`);
+        if (normalizedEmail && typeof member.email === 'string' && member.email.toLowerCase() === normalizedEmail) {
+          return true;
         }
+        return false;
+      });
 
-        const payload = await response.json().catch(() => ({}));
-        const members = extractMembersPayload(payload);
-        const normalizedEmail = userEmail ? userEmail.toLowerCase() : undefined;
-
-        const match = members.find((member) => {
-          const { userId: memberUserId, email } = extractMemberIdentifiers(member);
-          if (memberUserId && memberUserId === userId) {
-            return true;
-          }
-          if (email && normalizedEmail && email === normalizedEmail) {
-            return true;
-          }
-          return false;
-        });
-
-        if (!match) {
-          throw HttpErrors.forbidden('User is not a member of this practice');
-        }
-
-        const { role } = extractMemberIdentifiers(match);
-        if (!role) {
-          throw HttpErrors.forbidden('User membership is missing role information');
-        }
-
-        membershipCache.set(cacheKey, {
-          role,
-          expiresAt: Date.now() + MEMBERSHIP_CACHE_TTL_MS
-        });
-        pruneMembershipCache();
-
-        return role;
-      } catch (error) {
-        clearTimeout(timeoutId);
-        if (error instanceof Error && error.name === 'AbortError') {
-          throw HttpErrors.gatewayTimeout('Membership verification timed out');
-        }
-        if (error instanceof HttpError) {
-          throw error;
-        }
-        console.error('Error verifying practice membership via remote API:', error);
-        throw HttpErrors.badGateway('Failed to verify practice membership');
+      if (!match) {
+        throw HttpErrors.forbidden('User is not a member of this practice');
       }
+
+      if (!match.role) {
+        throw HttpErrors.forbidden('User membership is missing role information');
+      }
+
+      membershipCache.set(cacheKey, {
+        role: match.role,
+        expiresAt: Date.now() + MEMBERSHIP_CACHE_TTL_MS
+      });
+      pruneMembershipCache();
+
+      return match.role;
     } finally {
       membershipValidationInflight.delete(cacheKey);
     }

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -176,20 +176,39 @@ export function parseAuthSessionPayload(
     : (responseRecord.routing && typeof responseRecord.routing === 'object'
       ? responseRecord.routing as Record<string, unknown>
       : null);
+  const sessionRoutingRecord = sessionRecord?.routing && typeof sessionRecord.routing === 'object'
+    ? sessionRecord.routing as Record<string, unknown>
+    : null;
   const activeOrganizationId =
     typeof sessionRecord?.activeOrganizationId === 'string'
       ? sessionRecord.activeOrganizationId
       : typeof sessionRecord?.active_organization_id === 'string'
         ? sessionRecord.active_organization_id
+        : typeof dataPayload?.activeOrganizationId === 'string'
+          ? dataPayload.activeOrganizationId
+          : typeof dataPayload?.active_organization_id === 'string'
+            ? dataPayload.active_organization_id
+            : typeof responseRecord.activeOrganizationId === 'string'
+              ? responseRecord.activeOrganizationId
+              : typeof responseRecord.active_organization_id === 'string'
+                ? responseRecord.active_organization_id
         : null;
   const activeMembershipRole =
     typeof routingRecord?.active_membership_role === 'string'
       ? routingRecord.active_membership_role
-      : typeof sessionRecord?.activeMembershipRole === 'string'
-        ? sessionRecord.activeMembershipRole
-        : typeof sessionRecord?.active_membership_role === 'string'
-          ? sessionRecord.active_membership_role
-          : null;
+      : typeof sessionRoutingRecord?.active_membership_role === 'string'
+        ? sessionRoutingRecord.active_membership_role
+        : typeof dataPayload?.active_membership_role === 'string'
+          ? dataPayload.active_membership_role
+          : typeof responseRecord.active_membership_role === 'string'
+            ? responseRecord.active_membership_role
+            : typeof user.role === 'string'
+              ? user.role
+              : typeof sessionRecord?.activeMembershipRole === 'string'
+                ? sessionRecord.activeMembershipRole
+                : typeof sessionRecord?.active_membership_role === 'string'
+                  ? sessionRecord.active_membership_role
+                  : null;
   const previousAnonUserId =
     typeof sessionRecord?.previous_anon_user_id === 'string'
       ? sessionRecord.previous_anon_user_id
@@ -507,23 +526,30 @@ function extractMemberIdentifiers(member: RemoteMemberRecord): {
   email?: string;
   role?: string;
 } {
+  const nestedUser = isRecord(member.user) ? member.user : null;
   const userId =
     typeof member.user_id === 'string'
       ? member.user_id
       : typeof member.userId === 'string'
         ? member.userId
+        : typeof member.id === 'string'
+          ? member.id
+          : typeof nestedUser?.id === 'string'
+            ? nestedUser.id
         : undefined;
   const email =
     typeof member.email === 'string'
       ? member.email.toLowerCase()
-      : isRecord(member.user) && typeof member.user.email === 'string'
-        ? member.user.email.toLowerCase()
+      : typeof nestedUser?.email === 'string'
+        ? nestedUser.email.toLowerCase()
       : undefined;
   const role =
     typeof member.role === 'string'
       ? member.role
       : typeof member.permission === 'string'
         ? member.permission
+        : typeof member.memberRole === 'string'
+          ? member.memberRole
         : undefined;
 
   return { userId, email, role };

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -2,7 +2,6 @@ import { Env, HttpError } from "../types";
 import { HttpErrors } from "../errorHandler";
 import { Logger } from "../utils/logger";
 import { extractWidgetTokenFromRequest, validateWidgetAuthToken } from "../utils/widgetAuthToken.js";
-import { RemoteApiService } from "../services/RemoteApiService.js";
 
 export interface AuthenticatedUser {
   id: string;
@@ -553,49 +552,51 @@ async function fetchMemberRoleFromRemote(
       if (!cookie || !cookie.trim()) {
         throw HttpErrors.unauthorized('Authentication required');
       }
-      const membershipRequest = new Request(`https://worker.invalid/api/practice/${encodeURIComponent(practiceId)}`, {
-        method: 'GET',
-        headers: {
-          Cookie: cookie,
-        },
-      });
-      const members = await RemoteApiService.getPracticeMembers(env, practiceId, membershipRequest);
-      const normalizedEmail = userEmail ? userEmail.toLowerCase() : undefined;
-      const match = members.find((member) => {
-        if (member.user_id === userId) {
-          return true;
+      const baseUrl = resolveBackendApiUrl(env, 'active member role verification');
+      const params = new URLSearchParams({ organizationId: practiceId });
+      const response = await fetch(
+        `${baseUrl}/api/auth/organization/get-active-member-role?${params.toString()}`,
+        {
+          method: 'GET',
+          headers: {
+            Cookie: cookie,
+            'Content-Type': 'application/json',
+          },
         }
-        if (normalizedEmail && typeof member.email === 'string' && member.email.toLowerCase() === normalizedEmail) {
-          return true;
-        }
-        return false;
-      });
+      );
 
-      Logger.warn('[Auth] Remote practice membership lookup', {
+      const payload = await response.json().catch(() => null) as { role?: string | null; message?: string | null } | null;
+
+      Logger.warn('[Auth] Active member role lookup', {
         practiceId,
         userId,
-        normalizedEmailPresent: Boolean(normalizedEmail),
-        memberCount: members.length,
-        memberUserIdsSample: members.slice(0, 10).map((member) => member.user_id),
-        matchedUserId: match?.user_id ?? null,
-        matchedRole: match?.role ?? null,
+        userEmailPresent: Boolean(userEmail),
+        status: response.status,
+        role: typeof payload?.role === 'string' ? payload.role : null,
+        message: typeof payload?.message === 'string' ? payload.message : null,
       });
 
-      if (!match) {
+      if (response.status === 403) {
         throw HttpErrors.forbidden('User is not a member of this practice');
       }
+      if (response.status === 404) {
+        throw HttpErrors.notFound('Practice not found');
+      }
+      if (!response.ok) {
+        throw HttpErrors.badGateway(`Failed to verify membership role (status ${response.status})`);
+      }
 
-      if (!match.role) {
+      if (!payload?.role || typeof payload.role !== 'string') {
         throw HttpErrors.forbidden('User membership is missing role information');
       }
 
       membershipCache.set(cacheKey, {
-        role: match.role,
+        role: payload.role,
         expiresAt: Date.now() + MEMBERSHIP_CACHE_TTL_MS
       });
       pruneMembershipCache();
 
-      return match.role;
+      return payload.role;
     } finally {
       membershipValidationInflight.delete(cacheKey);
     }

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -202,9 +202,7 @@ export function parseAuthSessionPayload(
           ? dataPayload.active_membership_role
           : typeof responseRecord.active_membership_role === 'string'
             ? responseRecord.active_membership_role
-            : typeof user.role === 'string'
-              ? user.role
-              : typeof sessionRecord?.activeMembershipRole === 'string'
+            : typeof sessionRecord?.activeMembershipRole === 'string'
                 ? sessionRecord.activeMembershipRole
                 : typeof sessionRecord?.active_membership_role === 'string'
                   ? sessionRecord.active_membership_role
@@ -239,8 +237,6 @@ export function parseAuthSessionPayload(
           typeof dataPayload?.active_membership_role === 'string' ? dataPayload.active_membership_role : null,
         responseActiveMembershipRole:
           typeof responseRecord.active_membership_role === 'string' ? responseRecord.active_membership_role : null,
-        userRole:
-          typeof user.role === 'string' ? user.role : null,
         sessionActiveMembershipRole:
           typeof sessionRecord?.activeMembershipRole === 'string' ? sessionRecord.activeMembershipRole : null,
         sessionSnakeActiveMembershipRole:

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -219,6 +219,37 @@ export function parseAuthSessionPayload(
           ? (responseRecord as Record<string, unknown>).previous_anon_user_id as string
           : null;
 
+  if (
+    typeof activeOrganizationId === 'string'
+    && activeOrganizationId.trim().length > 0
+    && !(typeof activeMembershipRole === 'string' && activeMembershipRole.trim().length > 0)
+  ) {
+    Logger.warn('[Auth] Session payload missing active membership role', {
+      topLevelKeys: Object.keys(responseRecord),
+      dataKeys: dataPayload ? Object.keys(dataPayload) : [],
+      userKeys: user ? Object.keys(user as Record<string, unknown>) : [],
+      sessionKeys: sessionRecord ? Object.keys(sessionRecord) : [],
+      routingKeys: routingRecord ? Object.keys(routingRecord) : [],
+      sessionRoutingKeys: sessionRoutingRecord ? Object.keys(sessionRoutingRecord) : [],
+      candidateRoleValues: {
+        routingActiveMembershipRole:
+          typeof routingRecord?.active_membership_role === 'string' ? routingRecord.active_membership_role : null,
+        sessionRoutingActiveMembershipRole:
+          typeof sessionRoutingRecord?.active_membership_role === 'string' ? sessionRoutingRecord.active_membership_role : null,
+        dataActiveMembershipRole:
+          typeof dataPayload?.active_membership_role === 'string' ? dataPayload.active_membership_role : null,
+        responseActiveMembershipRole:
+          typeof responseRecord.active_membership_role === 'string' ? responseRecord.active_membership_role : null,
+        userRole:
+          typeof user.role === 'string' ? user.role : null,
+        sessionActiveMembershipRole:
+          typeof sessionRecord?.activeMembershipRole === 'string' ? sessionRecord.activeMembershipRole : null,
+        sessionSnakeActiveMembershipRole:
+          typeof sessionRecord?.active_membership_role === 'string' ? sessionRecord.active_membership_role : null,
+      },
+    });
+  }
+
   return {
     user: {
       id: sessionData.user.id,

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -540,6 +540,16 @@ async function fetchMemberRoleFromRemote(
         return false;
       });
 
+      Logger.warn('[Auth] Remote practice membership lookup', {
+        practiceId,
+        userId,
+        normalizedEmailPresent: Boolean(normalizedEmail),
+        memberCount: members.length,
+        memberUserIdsSample: members.slice(0, 10).map((member) => member.user_id),
+        matchedUserId: match?.user_id ?? null,
+        matchedRole: match?.role ?? null,
+      });
+
       if (!match) {
         throw HttpErrors.forbidden('User is not a member of this practice');
       }
@@ -603,6 +613,17 @@ async function requirePracticeMemberWithAuthContext(
   if (activeOrganizationId && activeOrganizationId === normalizedPracticeId && claimedRole) {
     userRole = claimedRole;
   }
+
+  Logger.warn('[Auth] requirePracticeMemberWithAuthContext start', {
+    practiceId: normalizedPracticeId,
+    userId: authContext.user.id,
+    isAnonymous: authContext.isAnonymous === true,
+    activeOrganizationId,
+    claimedRole,
+    usedClaimedRole: Boolean(userRole),
+    minimumRole: minimumRole ?? null,
+    hasCookie: authContext.cookie.trim().length > 0,
+  });
 
   // 3. Fall back to the remote membership lookup for non-active org contexts or
   // sessions that do not yet include routing membership claims.
@@ -674,9 +695,12 @@ export async function requirePracticeMemberRole(
   request: Request,
   env: Env,
   practiceId: string,
-  minimumRole?: "owner" | "admin" | "attorney" | "paralegal"
+  minimumRole?: "owner" | "admin" | "attorney" | "paralegal",
+  options?: { authContext?: AuthContext }
 ): Promise<AuthContext & { memberRole: string }> {
-  // Delegate to the primary implementation to prevent drift
+  if (options?.authContext) {
+    return requirePracticeMemberWithAuthContext(options.authContext, env, practiceId, minimumRole);
+  }
   return requirePracticeMember(request, env, practiceId, minimumRole);
 }
 

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -3,6 +3,8 @@ import { HttpErrors } from "../errorHandler";
 import { Logger } from "../utils/logger";
 import { extractWidgetTokenFromRequest, validateWidgetAuthToken } from "../utils/widgetAuthToken.js";
 
+const AUTH_TIMEOUT_MS = 3000;
+
 export interface AuthenticatedUser {
   id: string;
   email?: string;
@@ -305,7 +307,6 @@ export async function validateSessionWithRemoteServer(
   }
 
   const authServerUrl = resolveBackendApiUrl(env, 'Better Auth session validation');
-  const AUTH_TIMEOUT_MS = 3000;
   const validationPromise = (async () => {
     try {
       const getSessionUrl = `${authServerUrl}/api/auth/get-session`;
@@ -550,16 +551,29 @@ async function fetchMemberRoleFromRemote(
       }
       const baseUrl = resolveBackendApiUrl(env, 'active member role verification');
       const params = new URLSearchParams({ organizationId: practiceId });
-      const response = await fetch(
-        `${baseUrl}/api/auth/organization/get-active-member-role?${params.toString()}`,
-        {
-          method: 'GET',
-          headers: {
-            Cookie: cookie,
-            'Content-Type': 'application/json',
-          },
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), AUTH_TIMEOUT_MS);
+      let response: Response;
+      try {
+        response = await fetch(
+          `${baseUrl}/api/auth/organization/get-active-member-role?${params.toString()}`,
+          {
+            method: 'GET',
+            headers: {
+              Cookie: cookie,
+              'Content-Type': 'application/json',
+            },
+            signal: controller.signal,
+          }
+        );
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          throw HttpErrors.gatewayTimeout('Membership role verification timed out');
         }
-      );
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
 
       const payload = await response.json().catch(() => null) as { role?: string | null; message?: string | null } | null;
 
@@ -572,6 +586,9 @@ async function fetchMemberRoleFromRemote(
         message: typeof payload?.message === 'string' ? payload.message : null,
       });
 
+      if (response.status === 401) {
+        throw HttpErrors.unauthorized('Session expired or unauthorized');
+      }
       if (response.status === 403) {
         throw HttpErrors.forbidden('User is not a member of this practice');
       }

--- a/worker/middleware/auth.ts
+++ b/worker/middleware/auth.ts
@@ -21,6 +21,7 @@ export interface AuthContext {
   cookie: string;
   isAnonymous?: boolean; // Flag for anonymous users (Better Auth anonymous plugin)
   activeOrganizationId?: string | null;
+  activeMembershipRole?: string | null;
   previousAnonUserId?: string | null;
 }
 
@@ -29,6 +30,7 @@ type CachedSession = {
     user: AuthenticatedUser;
     session: { id: string; expiresAt: Date };
     activeOrganizationId?: string | null;
+    activeMembershipRole?: string | null;
     previousAnonUserId?: string | null;
   };
   expiresAt: number;
@@ -97,7 +99,13 @@ function resolveBackendApiUrl(env: Env, context = 'backend API'): string {
 
 export function parseAuthSessionPayload(
   rawResponse: unknown
-): { user: AuthenticatedUser; session: { id: string; expiresAt: Date }; activeOrganizationId?: string | null; previousAnonUserId?: string | null } {
+): {
+  user: AuthenticatedUser;
+  session: { id: string; expiresAt: Date };
+  activeOrganizationId?: string | null;
+  activeMembershipRole?: string | null;
+  previousAnonUserId?: string | null;
+} {
   if (!rawResponse || typeof rawResponse !== 'object') {
     console.error('[Auth] Invalid session payload from Better Auth API:', rawResponse);
     throw HttpErrors.unauthorized('Invalid session data - empty response');
@@ -163,12 +171,25 @@ export function parseAuthSessionPayload(
   const sessionRecord = session && typeof session === 'object'
     ? session as Record<string, unknown>
     : null;
+  const routingRecord = dataPayload?.routing && typeof dataPayload.routing === 'object'
+    ? dataPayload.routing as Record<string, unknown>
+    : (responseRecord.routing && typeof responseRecord.routing === 'object'
+      ? responseRecord.routing as Record<string, unknown>
+      : null);
   const activeOrganizationId =
     typeof sessionRecord?.activeOrganizationId === 'string'
       ? sessionRecord.activeOrganizationId
       : typeof sessionRecord?.active_organization_id === 'string'
         ? sessionRecord.active_organization_id
         : null;
+  const activeMembershipRole =
+    typeof routingRecord?.active_membership_role === 'string'
+      ? routingRecord.active_membership_role
+      : typeof sessionRecord?.activeMembershipRole === 'string'
+        ? sessionRecord.activeMembershipRole
+        : typeof sessionRecord?.active_membership_role === 'string'
+          ? sessionRecord.active_membership_role
+          : null;
   const previousAnonUserId =
     typeof sessionRecord?.previous_anon_user_id === 'string'
       ? sessionRecord.previous_anon_user_id
@@ -201,6 +222,9 @@ export function parseAuthSessionPayload(
     activeOrganizationId: typeof activeOrganizationId === 'string' && activeOrganizationId.trim().length > 0
       ? activeOrganizationId.trim()
       : null,
+    activeMembershipRole: typeof activeMembershipRole === 'string' && activeMembershipRole.trim().length > 0
+      ? activeMembershipRole.trim().toLowerCase()
+      : null,
     previousAnonUserId: typeof previousAnonUserId === 'string' && previousAnonUserId.trim().length > 0
       ? previousAnonUserId.trim()
       : null
@@ -217,6 +241,7 @@ export async function validateSessionWithRemoteServer(
   user: AuthenticatedUser;
   session: { id: string; expiresAt: Date };
   activeOrganizationId?: string | null;
+  activeMembershipRole?: string | null;
   previousAnonUserId?: string | null;
 }> {
   const cacheKey = getSessionCacheKey(cookie);
@@ -366,6 +391,7 @@ export async function requireAuth(
     user: AuthenticatedUser;
     session: { id: string; expiresAt: Date };
     activeOrganizationId?: string | null;
+    activeMembershipRole?: string | null;
     previousAnonUserId?: string | null;
   };
 
@@ -393,6 +419,7 @@ export async function requireAuth(
       cookie: '',
       isAnonymous: true,
       activeOrganizationId: null,
+      activeMembershipRole: null,
       previousAnonUserId: null
     };
   };
@@ -444,6 +471,7 @@ export async function requireAuth(
     ...authResult,
     cookie: normalizedCookie,
     isAnonymous,
+    activeMembershipRole: authResult.activeMembershipRole ?? null,
     previousAnonUserId
   };
 }
@@ -623,31 +651,45 @@ async function requirePracticeMemberWithAuthContext(
   practiceId: string,
   minimumRole?: "owner" | "admin" | "attorney" | "paralegal"
 ): Promise<AuthContext & { memberRole: string }> {
+  const roleHierarchy: Record<string, number> = {
+    'paralegal': 1,
+    'attorney': 2,
+    'admin': 3,
+    'owner': 4
+  };
 
   // 1. Validate practiceId
   if (!practiceId || typeof practiceId !== 'string' || practiceId.trim() === '') {
     throw HttpErrors.badRequest("Invalid or missing practiceId");
   }
 
-  // 2. Fetch user's membership from remote API
+  const normalizedPracticeId = practiceId.trim();
+  const activeOrganizationId = authContext.activeOrganizationId?.trim() ?? null;
+  const claimedRole = authContext.activeMembershipRole?.trim().toLowerCase() ?? null;
+
+  // 2. Prefer Better Auth routing/session claims for the active org when available.
+  // This avoids re-deriving same-org membership from the remote practice payload for
+  // every protected write and keeps auth aligned with the current session context.
+  let userRole: string | null = null;
+  if (activeOrganizationId && activeOrganizationId === normalizedPracticeId && claimedRole) {
+    userRole = claimedRole;
+  }
+
+  // 3. Fall back to the remote membership lookup for non-active org contexts or
+  // sessions that do not yet include routing membership claims.
   try {
-    const userRole = await fetchMemberRoleFromRemote(
-      authContext.cookie,
-      env,
-      practiceId,
-      authContext.user.id,
-      authContext.user.email
-    );
+    if (!userRole) {
+      userRole = await fetchMemberRoleFromRemote(
+        authContext.cookie,
+        env,
+        normalizedPracticeId,
+        authContext.user.id,
+        authContext.user.email
+      );
+    }
 
-    // 3. Enforce role requirements if minimumRole is specified
+    // 4. Enforce role requirements if minimumRole is specified
     if (minimumRole) {
-      const roleHierarchy: Record<string, number> = {
-        'paralegal': 1,
-        'attorney': 2,
-        'admin': 3,
-        'owner': 4
-      };
-
       // Validate that userRole exists in hierarchy
       const userRoleLevel = roleHierarchy[userRole];
       if (userRoleLevel === undefined) {
@@ -665,7 +707,7 @@ async function requirePracticeMemberWithAuthContext(
       }
     }
 
-    // 4. Return authContext with actual memberRole
+    // 5. Return authContext with actual memberRole
     return {
       ...authContext,
       memberRole: userRole,

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -976,18 +976,18 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       throw HttpErrors.forbidden('User is not authorized to view participants for this conversation');
     }
 
-    const [conversation, members] = await Promise.all([
+    const [conversation, members, team] = await Promise.all([
       conversationService.getConversation(conversationId, practiceId),
-      RemoteApiService.getPracticeMembers(env, practiceId, request)
+      RemoteApiService.getPracticeMembers(env, practiceId, request),
+      RemoteApiService.getPracticeTeam(env, practiceId, request)
     ]);
 
     const participantIds = Array.from(new Set([
       ...conversation.participants.filter((id) => typeof id === 'string' && id.trim().length > 0),
       ...(conversation.user_id ? [conversation.user_id] : [])
     ]));
-    const staffMemberIds = members
-      .filter((member) => member.role !== 'client')
-      .map((member) => member.user_id)
+    const staffMemberIds = team.members
+      .map((member) => member.userId)
       .filter((id) => typeof id === 'string' && id.trim().length > 0);
     const mentionableUserIds = callerIsStaff
       ? Array.from(new Set([
@@ -995,7 +995,12 @@ export async function handleConversations(request: Request, env: Env): Promise<R
         ...staffMemberIds
       ]))
       : participantIds;
-    const memberById = new Map(members.map((member) => [member.user_id, member]));
+    const memberById = new Map<string, {
+      role?: string | null;
+      name?: string | null;
+      image?: string | null;
+    }>(members.map((member) => [member.user_id, member]));
+    const teamMemberIds = new Set(team.members.map((member) => member.userId));
 
     const participants = mentionableUserIds.map((participantUserId) => {
       const member = memberById.get(participantUserId);
@@ -1004,6 +1009,7 @@ export async function handleConversations(request: Request, env: Env): Promise<R
         role: member?.role ?? null,
         name: member?.name ?? null,
         image: member?.image ?? null,
+        canMentionInternally: teamMemberIds.has(participantUserId),
       };
     });
 

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -4,7 +4,7 @@ import { HttpErrors } from '../errorHandler.js';
 import { HttpError, type Env } from '../types.js';
 import { ConversationService } from '../services/ConversationService.js';
 import { RemoteApiService } from '../services/RemoteApiService.js';
-import { optionalAuth, requirePracticeMember, checkPracticeMembership } from '../middleware/auth.js';
+import { optionalAuth, requirePracticeMember, requirePracticeMemberRole, checkPracticeMembership } from '../middleware/auth.js';
 import type { AuthContext } from '../middleware/auth.js';
 import { withPracticeContext, getPracticeId } from '../middleware/practiceContext.js';
 import { Logger } from '../utils/logger.js';
@@ -864,6 +864,16 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       || body.internalNotes !== undefined;
 
     if (isTriageUpdate) {
+      Logger.warn('[Conversations] Triage update auth check', {
+        conversationId,
+        practiceId,
+        authContextUserId: authContext.user.id,
+        authContextActiveOrganizationId: authContext.activeOrganizationId ?? null,
+        authContextActiveMembershipRole: authContext.activeMembershipRole ?? null,
+        assignedToPresent: body.assignedTo !== undefined,
+        priorityPresent: body.priority !== undefined,
+        internalNotesPresent: body.internalNotes !== undefined,
+      });
       if (body.assignedTo !== undefined && body.assignedTo !== null && typeof body.assignedTo !== 'string') {
         throw HttpErrors.badRequest('assignedTo must be a string or null');
       }
@@ -874,7 +884,7 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       if (authContext.isAnonymous) {
         throw HttpErrors.unauthorized('Authentication required');
       }
-      await requirePracticeMember(request, env, practiceId, 'paralegal');
+      await requirePracticeMemberRole(request, env, practiceId, 'paralegal', { authContext });
     } else {
       if (body.metadata && 'mentionedUserIds' in body.metadata) {
         delete body.metadata.mentionedUserIds;
@@ -986,13 +996,13 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       ...conversation.participants.filter((id) => typeof id === 'string' && id.trim().length > 0),
       ...(conversation.user_id ? [conversation.user_id] : [])
     ]));
-    const staffMemberIds = team.members
-      .map((member) => member.userId)
-      .filter((id) => typeof id === 'string' && id.trim().length > 0);
+    const mentionableStaffIds = team.members
+      .filter((m) => typeof m.userId === 'string' && m.userId.trim().length > 0 && m.canMentionInternally === true)
+      .map((m) => m.userId);
     const mentionableUserIds = callerIsStaff
       ? Array.from(new Set([
         ...participantIds,
-        ...staffMemberIds
+        ...mentionableStaffIds
       ]))
       : participantIds;
     const memberById = new Map<string, {
@@ -1000,16 +1010,17 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       name?: string | null;
       image?: string | null;
     }>(members.map((member) => [member.user_id, member]));
-    const teamMemberIds = new Set(team.members.map((member) => member.userId));
+    const teamMemberMap = new Map(team.members.map((member) => [member.userId, member]));
 
     const participants = mentionableUserIds.map((participantUserId) => {
       const member = memberById.get(participantUserId);
+      const teamMember = teamMemberMap.get(participantUserId);
       return {
         userId: participantUserId,
         role: member?.role ?? null,
         name: member?.name ?? null,
         image: member?.image ?? null,
-        canMentionInternally: teamMemberIds.has(participantUserId),
+        canMentionInternally: teamMember?.canMentionInternally ?? false,
       };
     });
 

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -10,6 +10,7 @@ import { withPracticeContext, getPracticeId } from '../middleware/practiceContex
 import { Logger } from '../utils/logger.js';
 import { SessionAuditService } from '../services/SessionAuditService.js';
 import { handleSubmitIntake } from './submitIntake.js';
+import { isTeamRole } from '../../src/shared/types/team.js';
 
 const SYSTEM_MESSAGE_ALLOWLIST = new Set([
   'system-intro',
@@ -986,19 +987,18 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       throw HttpErrors.forbidden('User is not authorized to view participants for this conversation');
     }
 
-    const [conversation, members, team] = await Promise.all([
+    const [conversation, members] = await Promise.all([
       conversationService.getConversation(conversationId, practiceId),
-      RemoteApiService.getPracticeMembers(env, practiceId, request),
-      RemoteApiService.getPracticeTeam(env, practiceId, request)
+      RemoteApiService.getPracticeMembers(env, practiceId, request)
     ]);
 
     const participantIds = Array.from(new Set([
       ...conversation.participants.filter((id) => typeof id === 'string' && id.trim().length > 0),
       ...(conversation.user_id ? [conversation.user_id] : [])
     ]));
-    const mentionableStaffIds = team.members
-      .filter((m) => typeof m.userId === 'string' && m.userId.trim().length > 0 && m.canMentionInternally === true)
-      .map((m) => m.userId);
+    const mentionableStaffIds = members
+      .filter((member) => isTeamRole(member.role) && typeof member.user_id === 'string' && member.user_id.trim().length > 0)
+      .map((member) => member.user_id);
     const mentionableUserIds = callerIsStaff
       ? Array.from(new Set([
         ...participantIds,
@@ -1010,17 +1010,14 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       name?: string | null;
       image?: string | null;
     }>(members.map((member) => [member.user_id, member]));
-    const teamMemberMap = new Map(team.members.map((member) => [member.userId, member]));
-
     const participants = mentionableUserIds.map((participantUserId) => {
       const member = memberById.get(participantUserId);
-      const teamMember = teamMemberMap.get(participantUserId);
       return {
         userId: participantUserId,
         role: member?.role ?? null,
         name: member?.name ?? null,
         image: member?.image ?? null,
-        canMentionInternally: teamMember?.canMentionInternally ?? false,
+        canMentionInternally: isTeamRole(member?.role),
       };
     });
 

--- a/worker/routes/index.ts
+++ b/worker/routes/index.ts
@@ -15,3 +15,4 @@ export { handleNotifications } from './notifications';
 export { handlePDF } from './pdf';
 export { handleDebug } from './debug';
 export { handleWidgetBootstrap } from './widget';
+export { handlePracticeTeam } from './practiceTeam';

--- a/worker/routes/practiceTeam.ts
+++ b/worker/routes/practiceTeam.ts
@@ -1,0 +1,29 @@
+import type { Env } from '../types.js';
+import { HttpErrors, createSuccessResponse } from '../errorHandler.js';
+import { RemoteApiService } from '../services/RemoteApiService.js';
+
+export async function handlePracticeTeam(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'GET') {
+    throw HttpErrors.methodNotAllowed('Method not allowed');
+  }
+
+  const url = new URL(request.url);
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length !== 4 || segments[0] !== 'api' || segments[1] !== 'practice' || segments[3] !== 'team') {
+    throw HttpErrors.notFound('Endpoint not found');
+  }
+
+  let practiceId = '';
+  try {
+    practiceId = decodeURIComponent(segments[2] ?? '');
+  } catch {
+    throw HttpErrors.badRequest('Invalid practice id encoding');
+  }
+
+  if (!practiceId) {
+    throw HttpErrors.badRequest('practice id is required');
+  }
+
+  const team = await RemoteApiService.getPracticeTeam(env, practiceId, request);
+  return createSuccessResponse(team);
+}

--- a/worker/services/ConversationService.ts
+++ b/worker/services/ConversationService.ts
@@ -867,22 +867,12 @@ export class ConversationService {
     if (updates.assignedTo !== undefined) {
       if (updates.assignedTo && updates.assignedTo.trim()) {
         const trimmedId = updates.assignedTo.trim();
-        const team = await RemoteApiService.getPracticeTeam(this.env, practiceId, options?.request);
-        Logger.warn('[ConversationService] Assignee team validation', {
+        const assignableMemberIds = await this.getAssignableTeamMemberIds(practiceId, options?.request);
+        Logger.debug('[ConversationService] Assignee team validation', {
           practiceId,
           requestedAssigneeUserId: trimmedId,
-          teamMembers: team.members.map((member) => ({
-            userId: member.userId,
-            role: member.role,
-            canAssignToMatter: member.canAssignToMatter,
-          })),
+          assignableMemberIds: Array.from(assignableMemberIds),
         });
-        const assignableMemberIds = new Set(
-          team.members
-            .filter((member) => member.canAssignToMatter)
-            .map((member) => member.userId)
-            .filter((userId) => typeof userId === 'string' && userId.trim().length > 0)
-        );
         if (!assignableMemberIds.has(trimmedId)) {
           throw HttpErrors.badRequest(`User ${trimmedId} is not an assignable team member of practice ${practiceId}`);
         }

--- a/worker/services/ConversationService.ts
+++ b/worker/services/ConversationService.ts
@@ -129,6 +129,32 @@ export class ConversationService {
     }
   }
 
+  private async getAssignableTeamMemberIds(
+    practiceId: string,
+    request?: Request
+  ): Promise<Set<string>> {
+    const team = await RemoteApiService.getPracticeTeam(this.env, practiceId, request);
+    return new Set(
+      team.members
+        .filter((member) => member.canAssignToMatter)
+        .map((member) => member.userId)
+        .filter((userId) => typeof userId === 'string' && userId.trim().length > 0)
+    );
+  }
+
+  private async getMentionableTeamMemberIds(
+    practiceId: string,
+    request?: Request
+  ): Promise<Set<string>> {
+    const team = await RemoteApiService.getPracticeTeam(this.env, practiceId, request);
+    return new Set(
+      team.members
+        .filter((member) => member.canMentionInternally)
+        .map((member) => member.userId)
+        .filter((userId) => typeof userId === 'string' && userId.trim().length > 0)
+    );
+  }
+
   private readTrimmedString(value: unknown): string | null {
     if (typeof value !== 'string') return null;
     const trimmed = value.trim();
@@ -841,11 +867,24 @@ export class ConversationService {
     if (updates.assignedTo !== undefined) {
       if (updates.assignedTo && updates.assignedTo.trim()) {
         const trimmedId = updates.assignedTo.trim();
-        // Verify user is a member of the practice
-        const members = await RemoteApiService.getPracticeMembers(this.env, practiceId, options?.request);
-        const isMember = members.some(m => m.user_id === trimmedId);
-        if (!isMember) {
-          throw HttpErrors.badRequest(`User ${trimmedId} is not a member of practice ${practiceId}`);
+        const team = await RemoteApiService.getPracticeTeam(this.env, practiceId, options?.request);
+        Logger.warn('[ConversationService] Assignee team validation', {
+          practiceId,
+          requestedAssigneeUserId: trimmedId,
+          teamMembers: team.members.map((member) => ({
+            userId: member.userId,
+            role: member.role,
+            canAssignToMatter: member.canAssignToMatter,
+          })),
+        });
+        const assignableMemberIds = new Set(
+          team.members
+            .filter((member) => member.canAssignToMatter)
+            .map((member) => member.userId)
+            .filter((userId) => typeof userId === 'string' && userId.trim().length > 0)
+        );
+        if (!assignableMemberIds.has(trimmedId)) {
+          throw HttpErrors.badRequest(`User ${trimmedId} is not an assignable team member of practice ${practiceId}`);
         }
         updatesList.push('assigned_to = ?');
         bindings.push(trimmedId);
@@ -942,12 +981,8 @@ export class ConversationService {
       )
     );
 
-    // Fetch practice members to validate mentions
-    const members = await RemoteApiService.getPracticeMembers(this.env, practiceId, options?.request);
-    const memberIds = new Set(members.map(m => m.user_id));
-    
-    // Filter to only include valid members
-    const normalizedMentionUserIds = rawMentionUserIds.filter(id => memberIds.has(id));
+    const mentionableMemberIds = await this.getMentionableTeamMemberIds(practiceId, options?.request);
+    const normalizedMentionUserIds = rawMentionUserIds.filter(id => mentionableMemberIds.has(id));
 
     const conversation = await this.getConversation(conversationId, practiceId);
     const metadata = { ...(conversation.user_info ?? {}) } as Record<string, unknown>;

--- a/worker/services/RemoteApiService.ts
+++ b/worker/services/RemoteApiService.ts
@@ -372,8 +372,7 @@ export class RemoteApiService {
     practiceId: string,
     request?: Request
   ): Promise<Array<{ user_id: string; email?: string | null; role?: string | null; name?: string | null; image?: string | null }>> {
-    const practice = await this.getPracticeMembershipData(env, practiceId, request);
-    return practice.members;
+    return this.getOrganizationMembers(env, practiceId, request);
   }
 
   static async getPracticeTeam(
@@ -443,6 +442,43 @@ export class RemoteApiService {
       };
       seats?: number | null;
     };
+    const [practiceResponse, members] = await Promise.all([
+      this.fetchFromRemoteApi(env, `/api/practice/${practiceId}`, request),
+      this.getOrganizationMembers(env, practiceId, request)
+    ]);
+
+    const practiceData = await practiceResponse.json() as PracticePayload;
+
+    const practiceRecord =
+      practiceData.practice ??
+      practiceData.data?.practice ??
+      practiceData.data ??
+      practiceData;
+
+    const seatsValue = typeof practiceRecord.seats === 'number'
+      ? practiceRecord.seats
+      : typeof practiceData.data?.seats === 'number'
+        ? practiceData.data.seats
+        : (typeof practiceData.seats === 'number' ? practiceData.seats : null);
+
+    return {
+      seats: seatsValue,
+      members,
+    };
+  }
+
+  private static async getOrganizationMembers(
+    env: Env,
+    practiceId: string,
+    request?: Request
+  ): Promise<Array<{
+    user_id: string;
+    email?: string | null;
+    role: string | null;
+    name?: string | null;
+    image?: string | null;
+    created_at: number | null;
+  }>> {
     type OrganizationMemberPayload = {
       id?: string;
       userId?: string;
@@ -458,58 +494,39 @@ export class RemoteApiService {
       };
     };
 
-    const [practiceResponse, membersResponse] = await Promise.all([
-      this.fetchFromRemoteApi(env, `/api/practice/${practiceId}`, request),
-      this.fetchFromRemoteApi(
-        env,
-        `/api/auth/organization/list-members?organizationId=${encodeURIComponent(practiceId)}`,
-        request
-      )
-    ]);
-
-    const practiceData = await practiceResponse.json() as PracticePayload;
+    const membersResponse = await this.fetchFromRemoteApi(
+      env,
+      `/api/auth/organization/list-members?organizationId=${encodeURIComponent(practiceId)}`,
+      request
+    );
     const membersData = await membersResponse.json() as {
       members?: OrganizationMemberPayload[];
     };
-
-    const practiceRecord =
-      practiceData.practice ??
-      practiceData.data?.practice ??
-      practiceData.data ??
-      practiceData;
-
-    const seatsValue = typeof practiceRecord.seats === 'number'
-      ? practiceRecord.seats
-      : (typeof practiceData.seats === 'number' ? practiceData.seats : null);
-
     const members = Array.isArray(membersData.members) ? membersData.members : [];
 
-    return {
-      seats: seatsValue,
-      members: members
-        .filter((member): member is OrganizationMemberPayload => (
+    return members
+      .filter((member): member is OrganizationMemberPayload => (
+        typeof member.userId === 'string'
+        || typeof member.user_id === 'string'
+        || typeof member.user?.id === 'string'
+      ))
+      .map((member) => ({
+        user_id: (
           typeof member.userId === 'string'
-          || typeof member.user_id === 'string'
-          || typeof member.user?.id === 'string'
-        ))
-        .map((member) => ({
-          user_id: (
-            typeof member.userId === 'string'
-              ? member.userId
-              : typeof member.user_id === 'string'
-                ? member.user_id
-                : member.user?.id
-          ) as string,
-          email: typeof member.user?.email === 'string' ? member.user.email : undefined,
-          role: typeof member.role === 'string' ? member.role : null,
-          name: typeof member.user?.name === 'string' ? member.user.name : undefined,
-          image: typeof member.user?.image === 'string' ? member.user.image : undefined,
-          created_at: this.normalizeMembershipTimestamp(
-            member.createdAt ??
-            member.created_at
-          ),
-        })),
-    };
+            ? member.userId
+            : typeof member.user_id === 'string'
+              ? member.user_id
+              : member.user?.id
+        ) as string,
+        email: typeof member.user?.email === 'string' ? member.user.email : undefined,
+        role: typeof member.role === 'string' ? member.role : null,
+        name: typeof member.user?.name === 'string' ? member.user.name : undefined,
+        image: typeof member.user?.image === 'string' ? member.user.image : undefined,
+        created_at: this.normalizeMembershipTimestamp(
+          member.createdAt ??
+          member.created_at
+        ),
+      }));
   }
 
   private static normalizeMembershipTimestamp(value: unknown): number | null {

--- a/worker/services/RemoteApiService.ts
+++ b/worker/services/RemoteApiService.ts
@@ -3,6 +3,7 @@ import { HttpError } from '../types.js';
 import { HttpErrors } from '../errorHandler.js';
 import { Logger } from '../utils/logger.js';
 import { warnIfNotMinorUnits } from '../utils/money.js';
+import { canAssignTeamMemberToMatter, isTeamRole, type PracticeTeamResponse } from '../../src/shared/types/team.js';
 
 /**
  * Service for fetching practice and subscription data from the remote API.
@@ -15,6 +16,7 @@ import { warnIfNotMinorUnits } from '../utils/money.js';
  */
 export class RemoteApiService {
   private static readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+  private static readonly DEFAULT_SEAT_COUNT = 1;
   /** Per-isolate cache for practice data - resets when isolate is evicted */
   private static practiceCache = new Map<string, { data: PracticeOrWorkspace; timestamp: number }>();
   /** Per-isolate cache for conversation config - resets when isolate is evicted */
@@ -370,6 +372,69 @@ export class RemoteApiService {
     practiceId: string,
     request?: Request
   ): Promise<Array<{ user_id: string; email?: string | null; role?: string | null; name?: string | null; image?: string | null }>> {
+    const practice = await this.getPracticeMembershipData(env, practiceId, request);
+    return practice.members;
+  }
+
+  static async getPracticeTeam(
+    env: Env,
+    practiceId: string,
+    request?: Request
+  ): Promise<PracticeTeamResponse> {
+    const practice = await this.getPracticeMembershipData(env, practiceId, request);
+    const members = practice.members
+      .filter((member): member is typeof practice.members[number] & {
+        role: import('../../src/shared/types/team.js').TeamRole;
+        email: string;
+      } => (
+        isTeamRole(member.role)
+        && typeof member.user_id === 'string'
+        && member.user_id.trim().length > 0
+        && typeof member.email === 'string'
+        && member.email.trim().length > 0
+      ))
+      .map((member) => ({
+        userId: member.user_id,
+        email: member.email,
+        name: member.name ?? undefined,
+        image: member.image ?? null,
+        role: member.role,
+        createdAt: member.created_at,
+        canAssignToMatter: canAssignTeamMemberToMatter(member.role),
+        canMentionInternally: true,
+      }));
+
+    return {
+      members,
+      summary: {
+        seatsIncluded: this.normalizeSeats(practice.seats),
+        seatsUsed: members.length,
+      },
+    };
+  }
+
+  private static normalizeSeats(seats?: number | null): number {
+    const seatsValue = seats ?? 0;
+    return Number.isFinite(seatsValue) && seatsValue > 0
+      ? seatsValue
+      : this.DEFAULT_SEAT_COUNT;
+  }
+
+  private static async getPracticeMembershipData(
+    env: Env,
+    practiceId: string,
+    request?: Request
+  ): Promise<{
+    seats: number | null;
+    members: Array<{
+      user_id: string;
+      email?: string | null;
+      role: string | null;
+      name?: string | null;
+      image?: string | null;
+      created_at: number | null;
+    }>;
+  }> {
     type PracticeMemberPayload = {
       user_id?: string;
       userId?: string;
@@ -382,28 +447,48 @@ export class RemoteApiService {
         image?: string | null;
         email?: string | null;
       };
+      created_at?: string | number | null;
+      createdAt?: string | number | null;
+      joined_at?: string | number | null;
+      joinedAt?: string | number | null;
     };
     const response = await this.fetchFromRemoteApi(env, `/api/practice/${practiceId}`, request);
     const data = await response.json() as {
-      practice?: { members?: PracticeMemberPayload[] };
+      practice?: { members?: PracticeMemberPayload[]; seats?: number | null };
       data?: {
         members?: PracticeMemberPayload[];
-        practice?: { members?: PracticeMemberPayload[] };
+        seats?: number | null;
+        practice?: { members?: PracticeMemberPayload[]; seats?: number | null };
       };
       members?: PracticeMemberPayload[];
+      seats?: number | null;
     };
 
+    const practiceRecord =
+      data.practice ??
+      data.data?.practice ??
+      data.data ??
+      data;
+
     const members =
-      data.practice?.members ??
-      data.data?.practice?.members ??
+      practiceRecord.members ??
       data.data?.members ??
       data.members;
 
+    const seatsValue = typeof practiceRecord.seats === 'number'
+      ? practiceRecord.seats
+      : (typeof data.seats === 'number' ? data.seats : null);
+
     if (!Array.isArray(members)) {
-      return [];
+      return {
+        seats: seatsValue,
+        members: [],
+      };
     }
 
-    return members
+    return {
+      seats: seatsValue,
+      members: members
       .filter((m): m is PracticeMemberPayload => typeof m.userId === 'string' || typeof m.user_id === 'string')
       .map((m) => ({
         user_id: (typeof m.userId === 'string' ? m.userId : m.user_id) as string,
@@ -417,7 +502,31 @@ export class RemoteApiService {
         image: typeof m.image === 'string'
           ? m.image
           : (typeof m.user?.image === 'string' ? m.user.image : undefined),
-      }));
+        created_at: this.normalizeMembershipTimestamp(
+          m.createdAt ??
+          m.created_at ??
+          m.joinedAt ??
+          m.joined_at
+        ),
+      })),
+    };
+  }
+
+  private static normalizeMembershipTimestamp(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim()) {
+      const numericValue = Number(value);
+      if (Number.isFinite(numericValue)) {
+        return numericValue;
+      }
+      const parsedDate = Date.parse(value);
+      if (Number.isFinite(parsedDate)) {
+        return parsedDate;
+      }
+    }
+    return null;
   }
 
   /**

--- a/worker/services/RemoteApiService.ts
+++ b/worker/services/RemoteApiService.ts
@@ -384,17 +384,14 @@ export class RemoteApiService {
     const members = practice.members
       .filter((member): member is typeof practice.members[number] & {
         role: import('../../src/shared/types/team.js').TeamRole;
-        email: string;
       } => (
         isTeamRole(member.role)
         && typeof member.user_id === 'string'
         && member.user_id.trim().length > 0
-        && typeof member.email === 'string'
-        && member.email.trim().length > 0
       ))
       .map((member) => ({
         userId: member.user_id,
-        email: member.email,
+        email: member.email ?? '',
         name: member.name ?? undefined,
         image: member.image ?? null,
         role: member.role,

--- a/worker/services/RemoteApiService.ts
+++ b/worker/services/RemoteApiService.ts
@@ -436,6 +436,7 @@ export class RemoteApiService {
     }>;
   }> {
     type PracticeMemberPayload = {
+      id?: string;
       user_id?: string;
       userId?: string;
       email?: string | null;
@@ -443,6 +444,7 @@ export class RemoteApiService {
       name?: string | null;
       image?: string | null;
       user?: {
+        id?: string;
         name?: string | null;
         image?: string | null;
         email?: string | null;
@@ -489,9 +491,22 @@ export class RemoteApiService {
     return {
       seats: seatsValue,
       members: members
-      .filter((m): m is PracticeMemberPayload => typeof m.userId === 'string' || typeof m.user_id === 'string')
+      .filter((m): m is PracticeMemberPayload =>
+        typeof m.userId === 'string'
+        || typeof m.user_id === 'string'
+        || typeof m.id === 'string'
+        || typeof m.user?.id === 'string'
+      )
       .map((m) => ({
-        user_id: (typeof m.userId === 'string' ? m.userId : m.user_id) as string,
+        user_id: (
+          typeof m.userId === 'string'
+            ? m.userId
+            : typeof m.user_id === 'string'
+              ? m.user_id
+              : typeof m.user?.id === 'string'
+                ? m.user.id
+                : m.id
+        ) as string,
         email: typeof m.email === 'string'
           ? m.email
           : (typeof m.user?.email === 'string' ? m.user.email : undefined),

--- a/worker/services/RemoteApiService.ts
+++ b/worker/services/RemoteApiService.ts
@@ -435,95 +435,80 @@ export class RemoteApiService {
       created_at: number | null;
     }>;
   }> {
-    type PracticeMemberPayload = {
+    type PracticePayload = {
+      practice?: { seats?: number | null };
+      data?: {
+        seats?: number | null;
+        practice?: { seats?: number | null };
+      };
+      seats?: number | null;
+    };
+    type OrganizationMemberPayload = {
       id?: string;
-      user_id?: string;
       userId?: string;
-      email?: string | null;
+      user_id?: string;
       role?: string | null;
-      name?: string | null;
-      image?: string | null;
+      createdAt?: string | number | null;
+      created_at?: string | number | null;
       user?: {
         id?: string;
+        email?: string | null;
         name?: string | null;
         image?: string | null;
-        email?: string | null;
       };
-      created_at?: string | number | null;
-      createdAt?: string | number | null;
-      joined_at?: string | number | null;
-      joinedAt?: string | number | null;
     };
-    const response = await this.fetchFromRemoteApi(env, `/api/practice/${practiceId}`, request);
-    const data = await response.json() as {
-      practice?: { members?: PracticeMemberPayload[]; seats?: number | null };
-      data?: {
-        members?: PracticeMemberPayload[];
-        seats?: number | null;
-        practice?: { members?: PracticeMemberPayload[]; seats?: number | null };
-      };
-      members?: PracticeMemberPayload[];
-      seats?: number | null;
+
+    const [practiceResponse, membersResponse] = await Promise.all([
+      this.fetchFromRemoteApi(env, `/api/practice/${practiceId}`, request),
+      this.fetchFromRemoteApi(
+        env,
+        `/api/auth/organization/list-members?organizationId=${encodeURIComponent(practiceId)}`,
+        request
+      )
+    ]);
+
+    const practiceData = await practiceResponse.json() as PracticePayload;
+    const membersData = await membersResponse.json() as {
+      members?: OrganizationMemberPayload[];
     };
 
     const practiceRecord =
-      data.practice ??
-      data.data?.practice ??
-      data.data ??
-      data;
-
-    const members =
-      practiceRecord.members ??
-      data.data?.members ??
-      data.members;
+      practiceData.practice ??
+      practiceData.data?.practice ??
+      practiceData.data ??
+      practiceData;
 
     const seatsValue = typeof practiceRecord.seats === 'number'
       ? practiceRecord.seats
-      : (typeof data.seats === 'number' ? data.seats : null);
+      : (typeof practiceData.seats === 'number' ? practiceData.seats : null);
 
-    if (!Array.isArray(members)) {
-      return {
-        seats: seatsValue,
-        members: [],
-      };
-    }
+    const members = Array.isArray(membersData.members) ? membersData.members : [];
 
     return {
       seats: seatsValue,
       members: members
-      .filter((m): m is PracticeMemberPayload =>
-        typeof m.userId === 'string'
-        || typeof m.user_id === 'string'
-        || typeof m.id === 'string'
-        || typeof m.user?.id === 'string'
-      )
-      .map((m) => ({
-        user_id: (
-          typeof m.userId === 'string'
-            ? m.userId
-            : typeof m.user_id === 'string'
-              ? m.user_id
-              : typeof m.user?.id === 'string'
-                ? m.user.id
-                : m.id
-        ) as string,
-        email: typeof m.email === 'string'
-          ? m.email
-          : (typeof m.user?.email === 'string' ? m.user.email : undefined),
-        role: m.role,
-        name: typeof m.name === 'string'
-          ? m.name
-          : (typeof m.user?.name === 'string' ? m.user.name : undefined),
-        image: typeof m.image === 'string'
-          ? m.image
-          : (typeof m.user?.image === 'string' ? m.user.image : undefined),
-        created_at: this.normalizeMembershipTimestamp(
-          m.createdAt ??
-          m.created_at ??
-          m.joinedAt ??
-          m.joined_at
-        ),
-      })),
+        .filter((member): member is OrganizationMemberPayload => (
+          typeof member.userId === 'string'
+          || typeof member.user_id === 'string'
+          || typeof member.user?.id === 'string'
+        ))
+        .map((member) => ({
+          user_id: (
+            typeof member.userId === 'string'
+              ? member.userId
+              : typeof member.user_id === 'string'
+                ? member.user_id
+                : member.user?.id
+          ) as string,
+          email: typeof member.user?.email === 'string' ? member.user.email : undefined,
+          role: typeof member.role === 'string' ? member.role : null,
+          name: typeof member.user?.name === 'string' ? member.user.name : undefined,
+          image: typeof member.user?.image === 'string' ? member.user.image : undefined,
+          created_at: this.normalizeMembershipTimestamp(
+            member.createdAt ??
+            member.created_at
+          ),
+        })),
     };
   }
 


### PR DESCRIPTION
## Summary
- add a worker-owned `/api/practice/:id/team` read model that excludes client memberships and computes seat summary
- add shared team types, API client, store, and `usePracticeTeam`, then migrate staff/team UI consumers off mixed membership filtering
- update conversation participant mentionability to use the unified team model and add focused worker/frontend tests

## Validation
- npm run lint
- npm run type-check
- npx vitest run tests/unit/routes/practiceTeam.test.ts tests/unit/routes/conversations.participants.test.ts src/shared/hooks/__tests__/usePracticeTeam.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New practice team API/view surfaces seat summaries and richer member details; practice-team endpoint added.
  * Widget Debug page for live widget configuration, embed snippet preview, and runtime inspection.

* **Improvements**
  * Mentioning and assignee lists now honor explicit member permissions (internal-mention / assign-to-matter).
  * Widget nav hides bottom rail in chat view.
  * Invitations: cancel action added; invitation UI and email input usability improved.

* **Tests**
  * Added unit tests covering practice team and participant flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->