### PR TITLE
fix: use direct backend API for auth to resolve state_mismatch error

### DIFF
--- a/src/shared/lib/authClient.ts
+++ b/src/shared/lib/authClient.ts
@@ -4,7 +4,7 @@ import { anonymousClient } from 'better-auth/client/plugins';
 import { stripeClient } from '@better-auth/stripe/client';
 import { useMemo } from 'preact/hooks';
 import { transformSessionUser, type BetterAuthSessionUser } from '@/shared/types/user';
-import { getWorkerApiUrl } from '@/config/urls';
+import { getBackendApiUrl } from '@/config/urls';
 
 // Type for the auth client (inferred from createAuthClient return type)
 type AuthClientType = ReturnType<typeof createAuthClient>;
@@ -25,13 +25,13 @@ type TypedSessionData = NonNullable<AuthSessionData> extends { user: unknown; se
   ) | Extract<AuthSessionData, null | undefined>
   : AuthSessionData;
 
-// Auth requests are proxied through the Worker to keep session cookies same-origin.
+// Auth requests go directly to backend API to fix OAuth state_mismatch issues.
 function getAuthBaseUrl(): string | undefined {
   if (typeof window === 'undefined') {
     return 'https://placeholder-auth-server.com';
   }
 
-  return getWorkerApiUrl();
+  return getBackendApiUrl();
 }
 
 // Cached auth client instance (only one is ever created and cached - the browser client)


### PR DESCRIPTION
- Change auth client to use getBackendApiUrl() instead of getWorkerApiUrl()
- This fixes OAuth flow where state cookies were being lost through proxy
- Removes unnecessary proxy hop that was causing cross-origin issues
- Updates comment to reflect direct backend connection approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication client routing to directly connect to the backend API instead of proxying requests through an intermediary service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->