### PR TITLE
Improve account settings billing and auth flows

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -246,6 +246,8 @@ export function MainApp({
   });
 
   const activeConversationId = normalizedRouteConversationId ?? setupConversationId;
+  const shouldEnableConversationTransport = workspaceView !== 'settings';
+  const liveConversationId = shouldEnableConversationTransport ? activeConversationId : null;
 
   useEffect(() => {
     if (sessionIsPending) return;
@@ -309,7 +311,7 @@ export function MainApp({
   const messageHandling = useMessageHandling({
     practiceId: effectivePracticeId,
     practiceSlug: resolvedPracticeSlug ?? undefined,
-    conversationId: activeConversationId ?? undefined,
+    conversationId: liveConversationId ?? undefined,
     ensureConversation: () => ensureConversation({ waitForSessionReadyMs: 3000 }),
     linkAnonymousConversationOnLoad: isPublicWorkspace,
     mode: conversationMode,
@@ -504,7 +506,7 @@ export function MainApp({
 
   const [mentionCandidates, setMentionCandidates] = useState<Array<{ userId: string; name: string }>>([]);
   useEffect(() => {
-    if (!isPracticeWorkspace || !practiceId || !activeConversationId) {
+    if (!isPracticeWorkspace || !practiceId || !liveConversationId) {
       setMentionCandidates([]);
       return;
     }
@@ -514,7 +516,7 @@ export function MainApp({
 
     (async () => {
       try {
-        const participants = await getConversationParticipants(activeConversationId, practiceId, { signal: controller.signal });
+        const participants = await getConversationParticipants(liveConversationId, practiceId, { signal: controller.signal });
         const nextMentionCandidates = participants
           .filter((participant) => participant.canMentionInternally === true)
           .map((participant) => ({
@@ -535,7 +537,7 @@ export function MainApp({
     })();
 
     return () => controller.abort();
-  }, [activeConversationId, isPracticeWorkspace, practiceId]);
+  }, [isPracticeWorkspace, liveConversationId, practiceId]);
 
   const handleUploadError = useCallback((error: unknown) => {
     console.error('File upload error:', error);
@@ -548,7 +550,7 @@ export function MainApp({
     handleCameraCapture, handleFileSelect, removePreviewFile,
     clearPreviewFiles, cancelUpload, isReadyToUpload,
   } = useFileUploadWithContext({
-    conversationId: activeConversationId ?? undefined,
+    conversationId: liveConversationId ?? undefined,
     ensureConversation: () => ensureConversation({ waitForSessionReadyMs: 3000 }),
     onError: handleUploadError,
   });
@@ -768,7 +770,7 @@ export function MainApp({
 
   // ── system messages ────────────────────────────────────────────────────────
   useConversationSystemMessages({
-    conversationId: activeConversationId,
+    conversationId: liveConversationId,
     practiceId: effectivePracticeId,
     ingestServerMessages,
   });

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -309,6 +309,7 @@ export function MainApp({
   );
 
   const messageHandling = useMessageHandling({
+    enabled: shouldEnableConversationTransport,
     practiceId: effectivePracticeId,
     practiceSlug: resolvedPracticeSlug ?? undefined,
     conversationId: liveConversationId ?? undefined,
@@ -506,6 +507,7 @@ export function MainApp({
 
   const [mentionCandidates, setMentionCandidates] = useState<Array<{ userId: string; name: string }>>([]);
   useEffect(() => {
+    console.log('[Participants] Loading for', { liveConversationId, practiceId });
     if (!isPracticeWorkspace || !practiceId || !liveConversationId) {
       setMentionCandidates([]);
       return;
@@ -516,6 +518,7 @@ export function MainApp({
 
     (async () => {
       try {
+        console.log('[Participants] Fetching participants...');
         const participants = await getConversationParticipants(liveConversationId, practiceId, { signal: controller.signal });
         const nextMentionCandidates = participants
           .filter((participant) => participant.canMentionInternally === true)
@@ -528,6 +531,7 @@ export function MainApp({
             && participant.name.length > 0
             && !looksLikeEmail(participant.name)
           ));
+        console.log('[Participants] Fetched', participants.length, 'participants');
         setMentionCandidates(nextMentionCandidates);
       } catch (error) {
         if ((error as DOMException)?.name === 'AbortError') return;
@@ -536,7 +540,10 @@ export function MainApp({
       }
     })();
 
-    return () => controller.abort();
+    return () => {
+      console.log('[Participants] Cleanup - aborting request');
+      controller.abort();
+    };
   }, [isPracticeWorkspace, liveConversationId, practiceId]);
 
   const handleUploadError = useCallback((error: unknown) => {

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -554,7 +554,6 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
                 conversations={conversations}
                 previews={previews}
                 practiceName={practiceConfig.name}
-                practiceLogo={practiceConfig.profileImage}
                 isLoading={isConversationsLoading}
                 onSelectConversation={(id) => {
                    setConversationId(id);

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -81,8 +81,11 @@ interface FeatureFlags {
      */
     enableMultiplePractices: boolean;
 
-
-
+    /**
+     * Enable account links settings UI
+     * When false, the account links section is hidden
+     */
+    enableAccountLinks: boolean;
     /**
      * Enable Plus subscription tier in UI
      * When false, the Plus plan is hidden from pricing/upgrade flows
@@ -115,6 +118,7 @@ const baseFeatureConfig: FeatureFlags = {
     enablePaymentIframe: false, // Disable payment iframe/drawer - only show "Open in Browser" button
     enableLeadQualification: true, // Enable lead qualification flow - AI asks questions before contact form
     enableMultiplePractices: true, // Enable multiple practices feature
+    enableAccountLinks: false, // Hide account links until the settings flow is ready
 
     enablePlusTier: false, // Hide Plus plan by default (not available at launch)
     enableActivity: false, // Disabled until activity is migrated off Worker/D1

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -188,7 +188,6 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
         name: 'Practice'
     };
     const clientProfile = {
-        src: null,
         name: conversationTitle?.trim() || 'Person'
     };
     const blawbyProfile = {

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -750,6 +750,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const fetchedPreviewIds = useRef<Set<string>>(new Set());
   const previewFailureCounts = useRef<Record<string, number>>({});
   const MAX_PREVIEW_ATTEMPTS = 2;
+  const shouldLoadConversationPreviews = view === 'home' || view === 'list';
 
   useEffect(() => {
     fetchedPreviewIds.current = new Set();
@@ -759,7 +760,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
 
   useEffect(() => {
     if (mockConversationPreviews || mockConversations) return;
-    if (view === 'conversation' || resolvedConversations.length === 0 || !practiceId) {
+    if (!shouldLoadConversationPreviews || resolvedConversations.length === 0 || !practiceId) {
       return;
     }
     if (workspace === 'practice' && (isSessionPending || !session?.user?.id)) {
@@ -800,7 +801,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [mockConversationPreviews, mockConversations, practiceId, resolvedConversations, isSessionPending, session?.user?.id, view, workspace]);
+  }, [mockConversationPreviews, mockConversations, practiceId, resolvedConversations, isSessionPending, session?.user?.id, shouldLoadConversationPreviews, workspace]);
 
   const handleSelectConversation = useCallback((conversationId: string) => {
     hasAutoNavigatedRef.current = true;
@@ -926,7 +927,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     error: practiceBillingError,
   } = usePracticeBillingData({
     practiceId: isPracticeWorkspace ? (currentPractice?.id ?? practiceId ?? null) : null,
-    enabled: isPracticeWorkspace,
+    enabled: isPracticeWorkspace && view === 'home',
     matterLimit: 25,
     windowSize: dashboardWindow,
     matters: mattersData.isLoaded ? mattersData.items : undefined,

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -94,8 +94,8 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
                   onClick={() => onSelectConversation(conversation.id)}
                 >
                   <Avatar
-                    src={practiceLogo}
-                    name={fallbackName}
+                    src={null}
+                    name={title}
                     size="md"
                     className="ring-2 ring-white/10"
                   />

--- a/src/features/chat/views/WidgetConversationListView.tsx
+++ b/src/features/chat/views/WidgetConversationListView.tsx
@@ -21,7 +21,6 @@ interface WidgetConversationListViewProps {
   conversations: Conversation[];
   previews: Record<string, ConversationPreview | undefined>;
   practiceName?: string | null;
-  practiceLogo?: string | null;
   isLoading?: boolean;
   error?: unknown;
   onSelectConversation: (conversationId: string) => void;
@@ -34,7 +33,6 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
   conversations,
   previews,
   practiceName,
-  practiceLogo,
   isLoading = false,
   error = null,
   onSelectConversation,

--- a/src/features/chat/views/WidgetConversationListView.tsx
+++ b/src/features/chat/views/WidgetConversationListView.tsx
@@ -101,8 +101,8 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
                   onClick={() => onSelectConversation(conversation.id)}
                 >
                   <Avatar
-                    src={practiceLogo}
-                    name={fallbackName}
+                    src={null}
+                    name={title}
                     size="md"
                     className="ring-2 ring-white/10"
                   />

--- a/src/features/settings/components/PasswordChangeForm.tsx
+++ b/src/features/settings/components/PasswordChangeForm.tsx
@@ -21,6 +21,8 @@ export interface PasswordChangeFormProps {
     newPassword?: string;
     confirmPassword?: string;
   };
+  showCurrentPassword?: boolean;
+  submitText?: string;
 }
 
 export const PasswordChangeForm = ({
@@ -36,7 +38,9 @@ export const PasswordChangeForm = ({
   className = '',
   isLoading = false,
   error,
-  fieldErrors
+  fieldErrors,
+  showCurrentPassword = true,
+  submitText
 }: PasswordChangeFormProps) => {
   const { t } = useTranslation(['settings']);
 
@@ -47,17 +51,19 @@ export const PasswordChangeForm = ({
       {error && (
         <div className="text-sm text-red-600 dark:text-red-400" role="alert">{error}</div>
       )}
-      <div>
-        <Input
-          type="password"
-          value={currentPassword}
-          onChange={(v) => !isLoading && onCurrentPasswordChange(v)}
-          label={t('settings:security.password.fields.current.label')}
-          placeholder={t('settings:security.password.fields.current.placeholder')}
-          id="current-password"
-          error={fieldErrors?.currentPassword}
-        />
-      </div>
+      {showCurrentPassword && (
+        <div>
+          <Input
+            type="password"
+            value={currentPassword}
+            onChange={(v) => !isLoading && onCurrentPasswordChange(v)}
+            label={t('settings:security.password.fields.current.label')}
+            placeholder={t('settings:security.password.fields.current.placeholder')}
+            id="current-password"
+            error={fieldErrors?.currentPassword}
+          />
+        </div>
+      )}
       
       <div>
         <Input
@@ -89,7 +95,7 @@ export const PasswordChangeForm = ({
         onCancel={() => { if (!isLoading) onCancel(); }}
         onSubmit={() => { if (!isLoading) onSubmit(); }}
         cancelText={t('settings:security.password.cancelButton')}
-        submitText={t('settings:security.password.submit')}
+        submitText={submitText ?? t('settings:security.password.submit')}
         submitType="button"
         isLoading={isLoading}
       />

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -986,7 +986,7 @@ export const AccountPage = ({
               onClick={handleDeleteAccount}
               data-testid="account-delete-action"
             >
-              Delete
+              {t('settings:account.delete.button')}
             </SettingsDangerButton>
           </SettingRow>
 
@@ -1112,10 +1112,10 @@ export const AccountPage = ({
           <div className="space-y-4">
             <div className="space-y-2">
               <p className="text-lg font-semibold text-input-text">
-                Add a password first
+                {t('settings:account.email.addPasswordFirst')}
               </p>
               <p className="text-sm text-input-placeholder">
-                Your account was created with Google, Microsoft, or Apple. To change your email, first add a password in Settings -&gt; Security -&gt; Password -&gt; Add.
+                {t('settings:account.email.oauthGatingExplanation')}
               </p>
             </div>
             <FormActions

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -59,6 +59,23 @@ const parsePeriodEndDate = (value: string | number | null | undefined): Date | n
   return isNaN(d.getTime()) ? null : d;
 };
 
+const normalizeErrorMessage = (value: unknown): string => {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
 export const AccountPage = ({
   isMobile: _isMobile = false,
   onClose: _onClose,
@@ -323,7 +340,17 @@ export const AccountPage = ({
     }));
   })();
   const emailAddress = emailSettings?.email ?? session?.user?.email ?? '';
-  const displayName = session?.user?.name ?? emailAddress;
+  const displayName = (() => {
+    const rawName = typeof session?.user?.name === 'string' ? session.user.name.trim() : '';
+    if (rawName) {
+      return rawName;
+    }
+    const rawEmail = typeof emailAddress === 'string' ? emailAddress.trim() : '';
+    if (rawEmail) {
+      return rawEmail;
+    }
+    return 'User';
+  })();
   const currentAvatarUrl = avatarPreviewUrl ?? session?.user?.image ?? null;
 
   const handleAvatarChange = useCallback(async (files: FileList | File[]) => {
@@ -776,7 +803,7 @@ export const AccountPage = ({
   }
 
   if (authAccountsError) {
-    throw new Error(authAccountsError);
+    throw new Error(normalizeErrorMessage(authAccountsError));
   }
 
   const currentPlanLabel = hasSubscription

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -10,16 +10,18 @@ import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useNavigation } from '@/shared/utils/navigation';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useWorkspace } from '@/shared/hooks/useWorkspace';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
+import { useAuthAccounts } from '@/shared/hooks/useAuthAccounts';
 import { signOut } from '@/shared/utils/auth';
 import { useTranslation } from '@/shared/i18n/hooks';
 import { usePaymentUpgrade } from '@/shared/hooks/usePaymentUpgrade';
 import { useLocation } from 'preact-iso';
 import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 import { formatDate } from '@/shared/utils/dateTime';
-import { deleteUser, getSession, updateUser } from '@/shared/lib/authClient';
+import { authClient, deleteUser, getSession, updateUser } from '@/shared/lib/authClient';
 import { getCurrentSubscription, type CurrentSubscription } from '@/shared/lib/apiClient';
 import { uploadWithProgress } from '@/shared/services/upload/UploadTransport';
-import { ChevronDownIcon, XMarkIcon, GlobeAltIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { ChevronDownIcon, ChevronRightIcon, XMarkIcon, GlobeAltIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { CheckIcon } from '@heroicons/react/20/solid';
 import { Icon } from '@/shared/ui/Icon';
 import type { UserLinks, EmailSettings } from '@/shared/types/user';
@@ -32,6 +34,7 @@ import { SettingsDangerButton } from '@/features/settings/components/SettingsDan
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { getPreferencesCategory, updatePreferencesCategory } from '@/shared/lib/preferencesApi';
 import type { AccountPreferences } from '@/shared/types/preferences';
+import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { FormActions, FormLabel } from '@/shared/ui/form';
 import { buildSettingsPath, resolveSettingsBasePath } from '@/shared/utils/workspace';
 
@@ -63,11 +66,18 @@ export const AccountPage = ({
   const { showSuccess, showError } = useToastContext();
   const location = useLocation();
   const { navigate, navigateToPricing } = useNavigation();
-  const { t } = useTranslation(['settings', 'common']);
+  const { t } = useTranslation(['settings', 'common', 'pricing']);
   const { openBillingPortal, submitting } = usePaymentUpgrade();
   const { currentPractice, loading: practiceLoading, refetch } = usePracticeManagement();
   const { session, isPending, activeMemberRole } = useSessionContext();
-  const { canAccessPractice: _canAccessPractice } = useWorkspace();
+  const { canAccessPractice: _canAccessPractice, workspaceFromPath } = useWorkspace();
+  const {
+    members
+  } = usePracticeTeam(
+    currentPractice?.id ?? null,
+    session?.user?.id ?? null,
+    { enabled: Boolean(currentPractice?.id && session?.user?.id) }
+  );
   const settingsBasePath = resolveSettingsBasePath(location.path);
   const toSettingsPath = (subPath?: string) => buildSettingsPath(settingsBasePath, subPath);
   const [links, setLinks] = useState<UserLinks | null>(null);
@@ -78,6 +88,10 @@ export const AccountPage = ({
   const [subscriptionLoading, setSubscriptionLoading] = useState(true);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showDomainModal, setShowDomainModal] = useState(false);
+  const [showEmailModal, setShowEmailModal] = useState(false);
+  const [newEmail, setNewEmail] = useState('');
+  const [emailChangeSubmitting, setEmailChangeSubmitting] = useState(false);
+  const [emailChangeError, setEmailChangeError] = useState<string | null>(null);
   const [domainInput, setDomainInput] = useState('');
   const [domainError, setDomainError] = useState<string | null>(null);
   const [deleteVerificationSent, setDeleteVerificationSent] = useState(false);
@@ -86,6 +100,11 @@ export const AccountPage = ({
   const [avatarUploadProgress, setAvatarUploadProgress] = useState<number | null>(null);
   const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string | null>(null);
   const avatarObjectUrlRef = useRef<string | null>(null);
+  const {
+    hasPasswordAccount,
+    isLoading: authAccountsLoading,
+    error: authAccountsError
+  } = useAuthAccounts(Boolean(session?.user));
   
 
   // Get renewal date from subscription current_period_end first, then practice webhook period end.
@@ -116,10 +135,14 @@ export const AccountPage = ({
       setError(null);
       const prefs = await getPreferencesCategory<AccountPreferences>('account');
       const user = session.user;
+      if (prefs?.custom_domains !== undefined && prefs?.custom_domains !== null && !Array.isArray(prefs.custom_domains)) {
+        throw new Error('Invalid account preferences: custom_domains must be an array when present.');
+      }
       const customDomains = Array.isArray(prefs?.custom_domains) ? prefs?.custom_domains : [];
+      const selectedDomain = typeof prefs?.selected_domain === 'string' ? prefs.selected_domain.trim() : '';
       
       const linksData: UserLinks = {
-        selectedDomain: prefs?.selected_domain || 'Select a domain',
+        selectedDomain,
         linkedinUrl: null,
         githubUrl: null,
         customDomains: customDomains.map((domain) => ({
@@ -153,21 +176,18 @@ export const AccountPage = ({
     }
   }, [loadAccountData, practiceLoading, currentPractice, session?.user]);
 
-  // Detect OAuth vs password users based on lastLoginMethod
-  const userWithExtendedProps = session?.user as typeof session.user & {
-    lastLoginMethod?: string;
-  };
-  const normalizedLoginMethod = userWithExtendedProps?.lastLoginMethod
-    ? String(userWithExtendedProps.lastLoginMethod).toLowerCase()
-    : null;
-  const loginMethodRequiresPassword = normalizedLoginMethod
-    ? ['email', 'credential', 'password'].includes(normalizedLoginMethod)
-    : false;
-  const requiresPassword = passwordRequiredOverride ?? loginMethodRequiresPassword;
+  const requiresPassword = passwordRequiredOverride ?? hasPasswordAccount;
   const isOAuthUser = !requiresPassword;
+  const shouldGateEmailManagement = isOAuthUser;
+  const currentUserEmail = typeof session?.user?.email === 'string' ? session.user.email.trim().toLowerCase() : '';
+  const currentMember = members.find((member) =>
+    (member.email && member.email.toLowerCase() === currentUserEmail) || member.userId === session?.user?.id
+  ) ?? null;
+  const resolvedRole = normalizePracticeRole(activeMemberRole) ?? normalizePracticeRole(currentMember?.role) ?? null;
 
-  const isOwner = activeMemberRole === 'owner';
+  const isOwner = resolvedRole === 'owner';
   const canManageBilling = isOwner;
+  const isClientWorkspace = workspaceFromPath === 'client';
 
   const subscriptionStatus = (currentSubscription?.status ?? 'none').toLowerCase();
   const subscriptionEnd = parsePeriodEndDate(currentSubscription?.currentPeriodEnd) || 
@@ -282,15 +302,35 @@ export const AccountPage = ({
   const currentPlanFeatures = (() => {
     const backendFeatures = currentSubscription?.plan?.features;
     if (!Array.isArray(backendFeatures)) {
-      return [] as PlanFeature[];
+      const freeFeatures = [
+        t('pricing:plans.free.features.basicChat.text'),
+        t('pricing:plans.free.features.documentAnalysis.text'),
+        t('pricing:plans.free.features.responseTime.text')
+      ];
+      return freeFeatures.map((feature): PlanFeature => ({
+        icon: CheckIcon,
+        text: feature
+      }));
     }
-    return backendFeatures.map((feature): PlanFeature => ({
+    const limitFeatures = [
+      typeof currentSubscription?.plan?.limits?.users === 'number'
+        ? `${currentSubscription.plan.limits.users < 0 ? 'Unlimited' : currentSubscription.plan.limits.users} users`
+        : null,
+      typeof currentSubscription?.plan?.limits?.storageGb === 'number'
+        ? `${currentSubscription.plan.limits.storageGb} GB storage`
+        : null,
+      typeof currentSubscription?.plan?.limits?.invoicesPerMonth === 'number'
+        ? `${currentSubscription.plan.limits.invoicesPerMonth < 0 ? 'Unlimited' : currentSubscription.plan.limits.invoicesPerMonth} invoices per month`
+        : null
+    ].filter((value): value is string => Boolean(value));
+
+    return [...backendFeatures, ...limitFeatures].map((feature): PlanFeature => ({
       icon: CheckIcon,
       text: feature
     }));
   })();
-  const emailAddress = emailSettings?.email || session?.user?.email || '';
-  const displayName = session?.user?.name || emailAddress || '—';
+  const emailAddress = emailSettings?.email ?? session?.user?.email ?? '';
+  const displayName = session?.user?.name ?? emailAddress;
   const currentAvatarUrl = avatarPreviewUrl ?? session?.user?.image ?? null;
 
   const handleAvatarChange = useCallback(async (files: FileList | File[]) => {
@@ -362,13 +402,13 @@ export const AccountPage = ({
       }
     };
   }, []);
-  const customDomainOptions = (links?.customDomains || []).map(domain => ({
+  const customDomainOptions = (links?.customDomains ?? []).map(domain => ({
     value: domain.domain,
     label: domain.domain
   }));
   const deleteListItems = t('settings:account.delete.listItems', { returnObjects: true }) as string[];
   const _confirmLabel = t('settings:account.delete.confirmLabel', { email: emailAddress });
-  const selectedDomain = links?.selectedDomain && links.selectedDomain !== 'Select a domain'
+  const selectedDomain = links?.selectedDomain
     ? links.selectedDomain
     : DOMAIN_SELECT_VALUE;
   const showLinksSection = true;
@@ -627,7 +667,7 @@ export const AccountPage = ({
       // Update user in database with current custom domains
         await updatePreferencesCategory('account', {
           selected_domain: domain,
-          custom_domains: (links?.customDomains || []).map((entry) => entry.domain)
+          custom_domains: (links?.customDomains ?? []).map((entry) => entry.domain)
         });
         
         setLinks(prev => prev ? { ...prev, selectedDomain: domain } : prev);
@@ -639,22 +679,22 @@ export const AccountPage = ({
         );
       }
     } else {
-      setLinks(prev => (prev ? { ...prev, selectedDomain: prev.selectedDomain ?? domain } : prev));
+      setLinks(prev => (prev ? { ...prev, selectedDomain: '' } : prev));
     }
   };
 
   const handleFeedbackEmailsChange = async (checked: boolean) => {
     try {
+      if (!emailSettings) {
+        throw new Error('Account email settings are not loaded.');
+      }
       await updatePreferencesCategory('account', { receive_feedback_emails: checked });
-      
-      setEmailSettings(prev => prev ? { 
-        ...prev, 
-        receiveFeedbackEmails: checked 
-      } : { 
-        email: '', 
-        receiveFeedbackEmails: checked, 
-        marketingEmails: false, 
-        securityAlerts: false 
+      setEmailSettings(prev => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          receiveFeedbackEmails: checked
+        };
       });
     } catch (error) {
       console.error('Failed to update email settings:', error);
@@ -665,13 +705,58 @@ export const AccountPage = ({
     }
   };
 
+  const handleEmailModalClose = () => {
+    setShowEmailModal(false);
+    setNewEmail('');
+    setEmailChangeError(null);
+  };
+
+  const handleEmailChangeSubmit = async () => {
+    const trimmedEmail = newEmail.trim().toLowerCase();
+
+    if (!trimmedEmail) {
+      setEmailChangeError('Enter a new email address.');
+      return;
+    }
+
+    if (trimmedEmail === emailAddress.trim().toLowerCase()) {
+      setEmailChangeError('Enter a different email address.');
+      return;
+    }
+
+    if (!origin) {
+      setEmailChangeError('Unable to start email change. Please try again.');
+      return;
+    }
+
+    try {
+      setEmailChangeSubmitting(true);
+      setEmailChangeError(null);
+      await authClient.changeEmail({
+        newEmail: trimmedEmail,
+        callbackURL: `${origin}${toSettingsPath('account')}`
+      });
+      handleEmailModalClose();
+      showSuccess(
+        'Check your email',
+        'We sent instructions to confirm your new email address.'
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setEmailChangeError(message);
+      showError('Unable to change email', message);
+    } finally {
+      setEmailChangeSubmitting(false);
+    }
+  };
+
   // Features are now loaded dynamically from the pricing service
 
   // Show loading state while session or practice is loading
   // Add timeout protection - if loading for more than 10 seconds, show error with retry
   const [loadingTimeout, setLoadingTimeout] = useState(false);
   useEffect(() => {
-    if (isPending || practiceLoading || subscriptionLoading) {
+    if (isPending || practiceLoading || subscriptionLoading || authAccountsLoading) {
       const timeout = setTimeout(() => {
         setLoadingTimeout(true);
       }, 10000); // 10 second timeout
@@ -679,9 +764,9 @@ export const AccountPage = ({
     } else {
       setLoadingTimeout(false);
     }
-  }, [isPending, practiceLoading, subscriptionLoading]);
+  }, [isPending, practiceLoading, subscriptionLoading, authAccountsLoading]);
 
-  if ((isPending || practiceLoading || subscriptionLoading) && !loadingTimeout) {
+  if ((isPending || practiceLoading || subscriptionLoading || authAccountsLoading) && !loadingTimeout) {
     return (
       <div className={`h-full flex items-center justify-center ${className}`}>
         <div className="w-8 h-8 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
@@ -697,30 +782,59 @@ export const AccountPage = ({
     );
   }
 
+  if (authAccountsError) {
+    throw new Error(authAccountsError);
+  }
+
   const currentPlanLabel = hasSubscription
-    ? (currentSubscription?.plan?.displayName || currentSubscription?.plan?.name || t('settings:account.plan.tiers.free'))
-    : t('settings:account.plan.tiers.free');
+    ? (currentSubscription?.plan?.displayName ?? currentSubscription?.plan?.name ?? '')
+    : (isClientWorkspace ? 'Blawby' : t('settings:account.plan.tiers.free'));
+  const planHeading = currentPlanLabel
+    ? `${currentPlanLabel} includes:`
+    : 'Current plan includes:';
+  const subscriptionDescription = hasSubscription && renewalDate
+    ? t('settings:account.plan.autoRenews', { date: formatDate(renewalDate) })
+    : undefined;
 
   return (
     <ContentPageLayout title={t('settings:account.title')} className={className}>
       <SettingRow label={t('settings:account.nameLabel')}>
-        <span className="text-sm text-input-text">
-          {displayName}
-        </span>
-      </SettingRow>
-      <SettingRow label="Profile photo" description="Upload a square image (max 5 MB).">
-        <div className="w-full">
-          <LogoUploadInput
-            imageUrl={currentAvatarUrl}
-            name={displayName}
-            accept="image/*"
-            multiple={false}
-            onChange={handleAvatarChange}
-            disabled={avatarUploading}
-            progress={avatarUploading ? avatarUploadProgress : null}
-          />
+        <div className="flex items-center gap-3">
+          <div className="w-10">
+            <LogoUploadInput
+              imageUrl={currentAvatarUrl}
+              name={displayName}
+              accept="image/*"
+              multiple={false}
+              buttonLabel="Change profile photo"
+              triggerMode="avatar"
+              size={36}
+              onChange={handleAvatarChange}
+              disabled={avatarUploading}
+              progress={avatarUploading ? avatarUploadProgress : null}
+            />
+          </div>
+          <span className="text-sm text-input-text">
+            {displayName}
+          </span>
         </div>
       </SettingRow>
+      <SectionDivider />
+      <button
+        type="button"
+        className="w-full text-left"
+        onClick={() => setShowEmailModal(true)}
+        aria-label="Manage email details"
+      >
+        <SettingRow label={t('settings:account.email.title')} className="cursor-pointer">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-input-text">
+              {emailAddress}
+            </span>
+            <Icon icon={ChevronRightIcon} className="w-5 h-5 text-input-placeholder" aria-hidden="true"  />
+          </div>
+        </SettingRow>
+      </button>
 
       <SectionDivider />
 
@@ -728,15 +842,11 @@ export const AccountPage = ({
           <SettingRow
             label={currentPlanLabel}
             labelClassName="text-input-text font-semibold"
-            description={
-              hasSubscription && renewalDate
-                ? t('settings:account.plan.autoRenews', { date: formatDate(renewalDate) })
-                : undefined
-            }
+            description={subscriptionDescription}
           >
             <div className="flex gap-2">
               {hasSubscription ? (
-                currentPractice && isOwner && canManageBilling ? (
+                currentPractice ? (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
@@ -753,6 +863,13 @@ export const AccountPage = ({
                       <DropdownMenuItem
                         onSelect={() => {
                           if (!currentPractice) return;
+                          if (!isOwner || !canManageBilling) {
+                            showError(
+                              t('common:error.title'),
+                              'Only the billing owner can cancel this subscription.'
+                            );
+                            return;
+                          }
                           if (!origin) {
                             showError(
                               t('common:error.title'),
@@ -775,13 +892,15 @@ export const AccountPage = ({
                   </DropdownMenu>
                 ) : null
               ) : (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => navigateToPricing()}
-                >
-                  {t('settings:account.plan.upgrade')}
-                </Button>
+                isClientWorkspace ? null : (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => navigateToPricing()}
+                  >
+                    {t('settings:account.plan.upgrade')}
+                  </Button>
+                )
               )}
             </div>
           </SettingRow>
@@ -798,7 +917,7 @@ export const AccountPage = ({
               <div className="space-y-3">
                 {hasSubscription && (
                   <p className="text-sm font-semibold text-input-text">
-                    {t('settings:account.plan.thanksForSubscribing')}
+                    {planHeading}
                   </p>
                 )}
                 <PlanFeaturesList features={currentPlanFeatures} />
@@ -976,18 +1095,6 @@ export const AccountPage = ({
         </>
       )}
 
-      {/* Email Section */}
-      <EmailSettingsSection
-        email={emailAddress}
-        receiveFeedbackEmails={emailSettings?.receiveFeedbackEmails || false}
-        onFeedbackChange={handleFeedbackEmailsChange}
-        title={t('settings:account.email.title')}
-        feedbackLabel={t('settings:account.email.receiveFeedback')}
-        showFeedbackToggle={showFeedbackToggle}
-      />
-
-      <SectionDivider />
-
       {/* Delete Account Confirmation Dialog */}
       <ConfirmationDialog
         isOpen={showDeleteConfirm}
@@ -1016,6 +1123,73 @@ export const AccountPage = ({
         passwordPlaceholder={passwordPlaceholder}
         passwordMissingMessage={passwordRequiredMessage}
       />
+
+      <Modal
+        isOpen={showEmailModal}
+        onClose={handleEmailModalClose}
+        title={t('settings:account.email.title')}
+        showCloseButton={true}
+        type="modal"
+      >
+        {shouldGateEmailManagement ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-lg font-semibold text-input-text">
+                Add a password first
+              </p>
+              <p className="text-sm text-input-placeholder">
+                Your account was created with Google, Microsoft, or Apple. To change your email, first add a password in Settings -&gt; Security -&gt; Password -&gt; Add.
+              </p>
+            </div>
+            <FormActions
+              className="justify-end"
+              size="sm"
+              onCancel={handleEmailModalClose}
+              onSubmit={() => {
+                handleEmailModalClose();
+                navigate(toSettingsPath('security'));
+              }}
+              cancelText="Not now"
+              submitText="Go to Security"
+              submitType="button"
+            />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <EmailSettingsSection
+              email={emailAddress}
+              receiveFeedbackEmails={emailSettings?.receiveFeedbackEmails ?? false}
+              onFeedbackChange={handleFeedbackEmailsChange}
+              title={t('settings:account.email.title')}
+              feedbackLabel={t('settings:account.email.receiveFeedback')}
+              showFeedbackToggle={showFeedbackToggle}
+            />
+            <Input
+              id="account-email-change"
+              type="email"
+              label="New email"
+              value={newEmail}
+              onChange={(value) => {
+                setNewEmail(value);
+                setEmailChangeError(null);
+              }}
+              placeholder="Enter your new email address"
+              error={emailChangeError ?? undefined}
+            />
+            <FormActions
+              className="justify-end"
+              size="sm"
+              onCancel={handleEmailModalClose}
+              onSubmit={() => void handleEmailChangeSubmit()}
+              cancelText="Cancel"
+              submitText={emailChangeSubmitting ? 'Sending...' : 'Change email'}
+              submitType="button"
+              submitDisabled={emailChangeSubmitting}
+              cancelDisabled={emailChangeSubmitting}
+            />
+          </div>
+        )}
+      </Modal>
 
       {/* Domain Input Modal */}
       <Modal

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -37,6 +37,7 @@ import type { AccountPreferences } from '@/shared/types/preferences';
 import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { FormActions, FormLabel } from '@/shared/ui/form';
 import { buildSettingsPath, resolveSettingsBasePath } from '@/shared/utils/workspace';
+import { features } from '@/config/features';
 
 
 export interface AccountPageProps {
@@ -399,7 +400,7 @@ export const AccountPage = ({
   const selectedDomain = links?.selectedDomain
     ? links.selectedDomain
     : DOMAIN_SELECT_VALUE;
-  const showLinksSection = true;
+  const showLinksSection = features.enableAccountLinks;
   const showFeedbackToggle = false;
 
 

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -195,7 +195,7 @@ export const AccountPage = ({
   }, [loadAccountData, practiceLoading, currentPractice, session?.user]);
 
   const requiresPassword = passwordRequiredOverride ?? hasPasswordAccount;
-  const isOAuthUser = !requiresPassword;
+  const isOAuthUser = !hasPasswordAccount;
   const shouldGateEmailManagement = isOAuthUser;
   const currentUserEmail = typeof session?.user?.email === 'string' ? session.user.email.trim().toLowerCase() : '';
   const currentMember = members.find((member) =>
@@ -321,15 +321,17 @@ export const AccountPage = ({
     const limitFeatures = [
       typeof currentSubscription?.plan?.limits?.users === 'number'
         ? currentSubscription.plan.limits.users < 0 
-          ? t('settings:account.plan.limits.unlimited')
+          ? t('settings:account.plan.limits.unlimitedUsers')
           : t('settings:account.plan.limits.users', { count: currentSubscription.plan.limits.users })
         : null,
       typeof currentSubscription?.plan?.limits?.storageGb === 'number'
-        ? t('settings:account.plan.limits.storageGb', { size: currentSubscription.plan.limits.storageGb })
+        ? currentSubscription.plan.limits.storageGb < 0
+          ? t('settings:account.plan.limits.unlimited')
+          : t('settings:account.plan.limits.storageGb', { size: currentSubscription.plan.limits.storageGb })
         : null,
       typeof currentSubscription?.plan?.limits?.invoicesPerMonth === 'number'
         ? currentSubscription.plan.limits.invoicesPerMonth < 0
-          ? t('settings:account.plan.limits.unlimited')
+          ? t('settings:account.plan.limits.unlimitedInvoices')
           : t('settings:account.plan.limits.invoicesPerMonth', { count: currentSubscription.plan.limits.invoicesPerMonth })
         : null
     ].filter((value): value is string => Boolean(value));
@@ -758,8 +760,8 @@ export const AccountPage = ({
       });
       handleEmailModalClose();
       showSuccess(
-        'Check your email',
-        'We sent instructions to confirm your new email address.'
+        t('settings:account.email.changeSuccess.title'),
+        t('settings:account.email.changeSuccess.body')
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -810,8 +812,8 @@ export const AccountPage = ({
     ? (currentSubscription?.plan?.displayName ?? currentSubscription?.plan?.name ?? '')
     : (isClientWorkspace ? 'Blawby' : t('settings:account.plan.tiers.free'));
   const planHeading = currentPlanLabel
-    ? `${currentPlanLabel} includes:`
-    : 'Current plan includes:';
+    ? t('settings:account.plan.includesWithLabel', { plan: currentPlanLabel })
+    : t('settings:account.plan.includesCurrent');
   const subscriptionDescription = hasSubscription && renewalDate
     ? t('settings:account.plan.autoRenews', { date: formatDate(renewalDate) })
     : undefined;
@@ -1124,8 +1126,8 @@ export const AccountPage = ({
                 handleEmailModalClose();
                 navigate(toSettingsPath('security'));
               }}
-              cancelText="Not now"
-              submitText="Go to Security"
+              cancelText={t('settings:account.email.modal.notNow')}
+              submitText={t('settings:account.email.modal.goToSecurity')}
               submitType="button"
             />
           </div>
@@ -1156,8 +1158,8 @@ export const AccountPage = ({
               size="sm"
               onCancel={handleEmailModalClose}
               onSubmit={() => void handleEmailChangeSubmit()}
-              cancelText="Cancel"
-              submitText={emailChangeSubmitting ? 'Sending...' : 'Change email'}
+              cancelText={t('settings:account.email.modal.cancel')}
+              submitText={emailChangeSubmitting ? t('settings:account.email.modal.sending') : t('settings:account.email.modal.changeEmail')}
               submitType="button"
               submitDisabled={emailChangeSubmitting}
               cancelDisabled={emailChangeSubmitting}

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -943,21 +943,6 @@ export const AccountPage = ({
 
       <SectionDivider />
 
-          <SettingRow
-            label={t('settings:account.payouts.sectionTitle')}
-            description={t('settings:account.payouts.description')}
-          >
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => navigate(toSettingsPath('account/payouts'))}
-            >
-              {t('settings:account.payouts.manage')}
-            </Button>
-          </SettingRow>
-
-      <SectionDivider />
-
           {/* Delete account Section */}
           <SettingRow
             label={t('settings:account.delete.sectionTitle')}

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -303,13 +303,17 @@ export const AccountPage = ({
     }
     const limitFeatures = [
       typeof currentSubscription?.plan?.limits?.users === 'number'
-        ? `${currentSubscription.plan.limits.users < 0 ? 'Unlimited' : currentSubscription.plan.limits.users} users`
+        ? currentSubscription.plan.limits.users < 0 
+          ? t('settings:account.plan.limits.unlimited')
+          : t('settings:account.plan.limits.users', { count: currentSubscription.plan.limits.users })
         : null,
       typeof currentSubscription?.plan?.limits?.storageGb === 'number'
-        ? `${currentSubscription.plan.limits.storageGb} GB storage`
+        ? t('settings:account.plan.limits.storageGb', { size: currentSubscription.plan.limits.storageGb })
         : null,
       typeof currentSubscription?.plan?.limits?.invoicesPerMonth === 'number'
-        ? `${currentSubscription.plan.limits.invoicesPerMonth < 0 ? 'Unlimited' : currentSubscription.plan.limits.invoicesPerMonth} invoices per month`
+        ? currentSubscription.plan.limits.invoicesPerMonth < 0
+          ? t('settings:account.plan.limits.unlimited')
+          : t('settings:account.plan.limits.invoicesPerMonth', { count: currentSubscription.plan.limits.invoicesPerMonth })
         : null
     ].filter((value): value is string => Boolean(value));
 
@@ -957,10 +961,9 @@ export const AccountPage = ({
             </SettingsDangerButton>
           </SettingRow>
 
-      <SectionDivider />
-
       {showLinksSection && (
         <>
+          <SectionDivider />
           {/* Links Section */}
           <SettingSection title={t('settings:account.links.title')}>
             {/* Domain Selector */}

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -754,10 +754,16 @@ export const AccountPage = ({
     try {
       setEmailChangeSubmitting(true);
       setEmailChangeError(null);
-      await authClient.changeEmail({
+      const { data: _data, error } = await authClient.changeEmail({
         newEmail: trimmedEmail,
         callbackURL: `${origin}${toSettingsPath('account')}`
       });
+      if (error) {
+        const message = error.message ?? String(error);
+        setEmailChangeError(message);
+        showError('Unable to change email', message);
+        return;
+      }
       handleEmailModalClose();
       showSuccess(
         t('settings:account.email.changeSuccess.title'),

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -198,18 +198,6 @@ export const AccountPage = ({
   const hasSubscription = Boolean(hasActiveSubscription || currentSubscription);
   const deletionBlockedBySubscription = isOwner && (hasActiveSubscription || hasActivePeriod);
   const isDeleteBlocked = deletionBlockedBySubscription;
-  const deletionBlockedMessage = (() => {
-    if (!deletionBlockedBySubscription) {
-      return '';
-    }
-    if (subscriptionStatus === 'canceled' && subscriptionEnd) {
-      return `Subscription will end on ${formatDate(subscriptionEnd)}. You can delete your account after it ends.`;
-    }
-    if (subscriptionEnd) {
-      return `Subscription is active until ${formatDate(subscriptionEnd)}. Cancel it before deleting your account.`;
-    }
-    return 'Subscription must be canceled before deleting your account.';
-  })();
 
   // SSR-safe origin for return URLs
   const origin = (typeof window !== 'undefined' && window.location)
@@ -929,7 +917,6 @@ export const AccountPage = ({
 
           <SettingRow
             label={t('settings:account.payments.sectionTitle')}
-            description={t('settings:account.payments.description')}
           >
             <Button
               variant="secondary"
@@ -974,42 +961,14 @@ export const AccountPage = ({
           {/* Delete account Section */}
           <SettingRow
             label={t('settings:account.delete.sectionTitle')}
-            description={isDeleteBlocked ? deletionBlockedMessage : undefined}
           >
-            {isDeleteBlocked ? (
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => {
-                    if (!currentPractice) return;
-                    if (!origin) {
-                      showError(
-                        t('common:error.title'),
-                        'Unable to open billing portal. Please try again.'
-                      );
-                      return;
-                    }
-                    void openBillingPortal({
-                      practiceId: currentPractice.id,
-                      returnUrl: `${origin}${toSettingsPath('account')}?sync=1`
-                    });
-                  }}
-                  disabled={!currentPractice || !isOwner || !canManageBilling}
-                  data-testid="account-delete-action"
-                >
-                  {t('settings:account.plan.manage')}
-                </Button>
-              </div>
-            ) : (
-              <SettingsDangerButton
-                size="sm"
-                onClick={handleDeleteAccount}
-                data-testid="account-delete-action"
-              >
-                {t('settings:account.delete.button')}
-              </SettingsDangerButton>
-            )}
+            <SettingsDangerButton
+              size="sm"
+              onClick={handleDeleteAccount}
+              data-testid="account-delete-action"
+            >
+              Delete
+            </SettingsDangerButton>
           </SettingRow>
 
       <SectionDivider />

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -314,7 +314,9 @@ export const SecurityPage = ({
           t('settings:security.password.success.title'),
           t('settings:security.password.success.body')
         );
-        await reloadAuthAccounts();
+        reloadAuthAccounts().catch((err) => {
+          console.error('Failed to reload auth accounts:', err);
+        });
         setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
         setIsChangingPassword(false);
       } else {
@@ -336,7 +338,9 @@ export const SecurityPage = ({
 
         setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
         setIsChangingPassword(false);
-        await reloadAuthAccounts();
+        reloadAuthAccounts().catch((err) => {
+          console.error('Failed to reload auth accounts:', err);
+        });
         showSuccess(
           t('settings:security.password.success.title'),
           t('settings:security.password.success.body')

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -6,6 +6,7 @@ import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useNavigation } from '@/shared/utils/navigation';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { authClient } from '@/shared/lib/authClient';
+import { useAuthAccounts } from '@/shared/hooks/useAuthAccounts';
 import Modal from '@/shared/components/Modal';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { Icon } from '@/shared/ui/Icon';
@@ -83,9 +84,17 @@ export const SecurityPage = ({
   const location = useLocation();
   const { t } = useTranslation(['settings', 'common']);
   const { session, isPending } = useSessionContext();
+  const {
+    hasPasswordAccount,
+    isLoading: authAccountsLoading,
+    error: authAccountsError,
+    reload: reloadAuthAccounts
+  } = useAuthAccounts(Boolean(session?.user));
   const [settings, setSettings] = useState<SecuritySettings | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
   const [showDisableMFAConfirm, setShowDisableMFAConfirm] = useState(false);
   const showMfa = false;
   const [passwordForm, setPasswordForm] = useState({
@@ -234,11 +243,12 @@ export const SecurityPage = ({
   };
 
   const handlePasswordChange = (field: string, value: string) => {
+    setPasswordError(null);
     setPasswordForm(prev => ({ ...prev, [field]: value }));
   };
 
   const handleChangePassword = async () => {
-    if (!passwordForm.currentPassword || !passwordForm.newPassword || !passwordForm.confirmPassword) {
+    if ((!hasPasswordAccount && !passwordForm.newPassword) || !passwordForm.confirmPassword || (hasPasswordAccount && !passwordForm.currentPassword)) {
       showError(
         t('settings:security.password.errors.missing.title'),
         t('settings:security.password.errors.missing.body')
@@ -263,29 +273,65 @@ export const SecurityPage = ({
     }
 
     try {
-      // Here you would call your API to change the password
-      // await authService.changePassword(passwordForm.currentPassword, passwordForm.newPassword);
-      
+      setPasswordSubmitting(true);
+      setPasswordError(null);
+      if (hasPasswordAccount) {
+        await authClient.changePassword({
+          currentPassword: passwordForm.currentPassword,
+          newPassword: passwordForm.newPassword
+        });
+      } else {
+        await authClient.setPassword({
+          newPassword: passwordForm.newPassword
+        });
+      }
+
       showSuccess(
-        t('settings:security.password.success.title'),
-        t('settings:security.password.success.body')
+        hasPasswordAccount
+          ? t('settings:security.password.success.title')
+          : 'Password added',
+        hasPasswordAccount
+          ? t('settings:security.password.success.body')
+          : 'You can now use your password to manage account details.'
       );
+      await reloadAuthAccounts();
       setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
       setIsChangingPassword(false);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t('settings:security.password.errors.failed.body');
+      setPasswordError(message);
+      showError(
+        t('settings:security.password.errors.failed.title'),
+        message
+      );
+    } finally {
+      setPasswordSubmitting(false);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (!session?.user?.email) {
+      showError(
+        t('settings:security.password.errors.failed.title'),
+        'Unable to reset password because your email is unavailable.'
+      );
+      return;
+    }
+
+    try {
+      await authClient.requestPasswordReset({
+        email: session.user.email
+      });
+      showSuccess(
+        t('settings:security.password.reset.title'),
+        t('settings:security.password.reset.body')
+      );
     } catch (error) {
       showError(
         t('settings:security.password.errors.failed.title'),
         error instanceof Error ? error.message : t('settings:security.password.errors.failed.body')
       );
     }
-  };
-
-  const handleResetPassword = () => {
-    // Here you would trigger a password reset email
-    showSuccess(
-      t('settings:security.password.reset.title'),
-      t('settings:security.password.reset.body')
-    );
   };
 
   const handleLogout = (type: 'current' | 'all') => {
@@ -303,7 +349,7 @@ export const SecurityPage = ({
   };
 
   // Show loading state while session or preferences are loading
-  if (isPending || isLoading) {
+  if (isPending || isLoading || authAccountsLoading) {
     return (
       <div className={`h-full flex items-center justify-center ${className}`}>
         <div className="w-8 h-8 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
@@ -311,6 +357,9 @@ export const SecurityPage = ({
     );
   }
 
+  if (authAccountsError) {
+    throw new Error(authAccountsError);
+  }
 
   if (!settings) {
     return (
@@ -325,7 +374,9 @@ export const SecurityPage = ({
       {/* Password Section */}
       <SettingSection
         title={t('settings:security.password.sectionTitle')}
-        description={t('settings:security.password.description')}
+        description={hasPasswordAccount
+          ? t('settings:security.password.description')
+          : 'Add a password to manage sensitive account changes after signing in with Google, Microsoft, or Apple.'}
       >
         <div className="flex items-center justify-end gap-2 mb-4">
           <Button
@@ -333,16 +384,20 @@ export const SecurityPage = ({
             size="sm"
             onClick={() => setIsChangingPassword(!isChangingPassword)}
           >
-            {isChangingPassword ? t('settings:security.password.cancelButton') : t('settings:security.password.changeButton')}
+            {isChangingPassword
+              ? t('settings:security.password.cancelButton')
+              : (hasPasswordAccount ? t('settings:security.password.changeButton') : 'Add password')}
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleResetPassword}
-            className="text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300"
-          >
-            {t('settings:security.password.resetButton')}
-          </Button>
+          {hasPasswordAccount && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleResetPassword()}
+              className="text-accent-600 dark:text-accent-400 hover:text-accent-700 dark:hover:text-accent-300"
+            >
+              {t('settings:security.password.resetButton')}
+            </Button>
+          )}
         </div>
 
         <PasswordChangeForm
@@ -355,9 +410,14 @@ export const SecurityPage = ({
           onSubmit={handleChangePassword}
           onCancel={() => {
             setIsChangingPassword(false);
+            setPasswordError(null);
             setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
           }}
           isOpen={isChangingPassword}
+          isLoading={passwordSubmitting}
+          error={passwordError}
+          showCurrentPassword={hasPasswordAccount}
+          submitText={hasPasswordAccount ? t('settings:security.password.submit') : 'Add password'}
         />
       </SettingSection>
 

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -68,6 +68,23 @@ const safeConvertLastPasswordChange = (value: unknown): Date | undefined => {
   return isNaN(date.getTime()) ? undefined : date;
 };
 
+type BetterAuthResult = {
+  data?: unknown;
+  error?: {
+    message?: string;
+  } | null;
+} | null | undefined;
+
+const getBetterAuthErrorMessage = (
+  result: BetterAuthResult,
+  fallbackMessage: string
+): string | null => {
+  if (!result?.error) {
+    return null;
+  }
+  return result.error.message || fallbackMessage;
+};
+
 export interface SecurityPageProps {
   isMobile?: boolean;
   onClose?: () => void;
@@ -276,27 +293,64 @@ export const SecurityPage = ({
       setPasswordSubmitting(true);
       setPasswordError(null);
       if (hasPasswordAccount) {
-        await authClient.changePassword({
+        const { data: _data, error } = await authClient.changePassword({
           currentPassword: passwordForm.currentPassword,
           newPassword: passwordForm.newPassword
         });
-      } else {
-        await authClient.setPassword({
-          newPassword: passwordForm.newPassword
-        });
-      }
+        const errorMessage = getBetterAuthErrorMessage(
+          { data: _data, error },
+          t('settings:security.password.errors.failed.body')
+        );
+        if (errorMessage) {
+          setPasswordError(errorMessage);
+          showError(
+            t('settings:security.password.errors.failed.title'),
+            errorMessage
+          );
+          return;
+        }
 
-      showSuccess(
-        hasPasswordAccount
-          ? t('settings:security.password.success.title')
-          : 'Password added',
-        hasPasswordAccount
-          ? t('settings:security.password.success.body')
-          : 'You can now use your password to manage account details.'
-      );
-      await reloadAuthAccounts();
-      setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
-      setIsChangingPassword(false);
+        showSuccess(
+          t('settings:security.password.success.title'),
+          t('settings:security.password.success.body')
+        );
+        await reloadAuthAccounts();
+        setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+        setIsChangingPassword(false);
+      } else {
+        if (!session?.user?.email) {
+          const message = 'Unable to add a password because your email is unavailable.';
+          setPasswordError(message);
+          showError(
+            t('settings:security.password.errors.failed.title'),
+            message
+          );
+          return;
+        }
+
+        const { data: _data, error } = await authClient.requestPasswordReset({
+          email: session.user.email
+        });
+        const errorMessage = getBetterAuthErrorMessage(
+          { data: _data, error },
+          t('settings:security.password.errors.failed.body')
+        );
+        if (errorMessage) {
+          setPasswordError(errorMessage);
+          showError(
+            t('settings:security.password.errors.failed.title'),
+            errorMessage
+          );
+          return;
+        }
+
+        setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+        setIsChangingPassword(false);
+        showSuccess(
+          t('settings:security.password.reset.title'),
+          t('settings:security.password.reset.body')
+        );
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : t('settings:security.password.errors.failed.body');
       setPasswordError(message);
@@ -319,9 +373,20 @@ export const SecurityPage = ({
     }
 
     try {
-      await authClient.requestPasswordReset({
+      const { data: _data, error } = await authClient.requestPasswordReset({
         email: session.user.email
       });
+      const errorMessage = getBetterAuthErrorMessage(
+        { data: _data, error },
+        t('settings:security.password.errors.failed.body')
+      );
+      if (errorMessage) {
+        showError(
+          t('settings:security.password.errors.failed.title'),
+          errorMessage
+        );
+        return;
+      }
       showSuccess(
         t('settings:security.password.reset.title'),
         t('settings:security.password.reset.body')

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -318,18 +318,8 @@ export const SecurityPage = ({
         setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
         setIsChangingPassword(false);
       } else {
-        if (!session?.user?.email) {
-          const message = t('settings:security.errorEmailUnavailable.add');
-          setPasswordError(message);
-          showError(
-            t('settings:security.password.errors.failed.title'),
-            t('settings:security.errorEmailUnavailable.add')
-          );
-          return;
-        }
-
-        const { data: _data, error } = await authClient.requestPasswordReset({
-          email: session.user.email
+        const { data: _data, error } = await authClient.setPassword({
+          newPassword: passwordForm.newPassword
         });
         const errorMessage = getBetterAuthErrorMessage(
           { data: _data, error },
@@ -346,9 +336,10 @@ export const SecurityPage = ({
 
         setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
         setIsChangingPassword(false);
+        await reloadAuthAccounts();
         showSuccess(
-          t('settings:security.password.reset.title'),
-          t('settings:security.password.reset.body')
+          t('settings:security.password.success.title'),
+          t('settings:security.password.success.body')
         );
       }
     } catch (error) {
@@ -451,7 +442,7 @@ export const SecurityPage = ({
           >
             {isChangingPassword
               ? t('settings:security.password.cancelButton')
-              : (hasPasswordAccount ? t('settings:security.password.changeButton') : 'Add password')}
+              : (hasPasswordAccount ? t('settings:security.password.changeButton') : t('settings:security.password.addButton'))}
           </Button>
           {hasPasswordAccount && (
             <Button

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -319,11 +319,11 @@ export const SecurityPage = ({
         setIsChangingPassword(false);
       } else {
         if (!session?.user?.email) {
-          const message = 'Unable to add a password because your email is unavailable.';
+          const message = t('settings:security.errorEmailUnavailable.add');
           setPasswordError(message);
           showError(
             t('settings:security.password.errors.failed.title'),
-            message
+            t('settings:security.errorEmailUnavailable.add')
           );
           return;
         }
@@ -367,7 +367,7 @@ export const SecurityPage = ({
     if (!session?.user?.email) {
       showError(
         t('settings:security.password.errors.failed.title'),
-        'Unable to reset password because your email is unavailable.'
+        t('settings:security.errorEmailUnavailable.reset')
       );
       return;
     }
@@ -441,7 +441,7 @@ export const SecurityPage = ({
         title={t('settings:security.password.sectionTitle')}
         description={hasPasswordAccount
           ? t('settings:security.password.description')
-          : 'Add a password to manage sensitive account changes after signing in with Google, Microsoft, or Apple.'}
+          : t('settings:security.password.addDescription')}
       >
         <div className="flex items-center justify-end gap-2 mb-4">
           <Button
@@ -482,7 +482,7 @@ export const SecurityPage = ({
           isLoading={passwordSubmitting}
           error={passwordError}
           showCurrentPassword={hasPasswordAccount}
-          submitText={hasPasswordAccount ? t('settings:security.password.submit') : 'Add password'}
+          submitText={hasPasswordAccount ? t('settings:security.password.submit') : t('settings:security.password.addPassword')}
         />
       </SettingSection>
 

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -358,7 +358,7 @@ export const SecurityPage = ({
     if (!session?.user?.email) {
       showError(
         t('settings:security.password.errors.failed.title'),
-        t('settings:security.errorEmailUnavailable.reset')
+        t('settings:security.password.errorEmailUnavailable.reset')
       );
       return;
     }
@@ -442,7 +442,7 @@ export const SecurityPage = ({
           >
             {isChangingPassword
               ? t('settings:security.password.cancelButton')
-              : (hasPasswordAccount ? t('settings:security.password.changeButton') : t('settings:security.password.addButton'))}
+              : (hasPasswordAccount ? t('settings:security.password.changeButton') : t('settings:security.password.addPassword'))}
           </Button>
           {hasPasswordAccount && (
             <Button

--- a/src/features/settings/pages/SettingsContent.tsx
+++ b/src/features/settings/pages/SettingsContent.tsx
@@ -21,8 +21,8 @@ export type SettingsView =
   | 'general'
   | 'notifications'
   | 'account'
-  | 'account-payouts'
   | 'practice'
+  | 'practice-payouts'
   | 'practice-services'
   | 'practice-team'
   | 'practice-pricing'
@@ -70,6 +70,7 @@ export const SettingsContent = ({
   };
 
   const isPracticeScopedView = view === 'practice'
+    || view === 'practice-payouts'
     || view === 'practice-services'
     || view === 'practice-team'
     || view === 'practice-pricing'
@@ -97,10 +98,10 @@ export const SettingsContent = ({
         return <NotificationsPage className="h-full" />;
       case 'account':
         return <AccountPage className="h-full" />;
-      case 'account-payouts':
-        return <PayoutsPage className="h-full" />;
       case 'practice':
         return <PracticePage className="h-full" />;
+      case 'practice-payouts':
+        return <PayoutsPage className="h-full" />;
       case 'practice-services':
         return <PracticeServicesPage className="h-full" />;
       case 'practice-team':

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -360,7 +360,7 @@ function PracticeAppRoute({
   invoiceId?: string;
   appId?: string;
   workspaceView?: 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceDetail' | 'reports' | 'settings';
-  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
+  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
   practiceSlug?: string;
 }) {
   const { session, isPending } = useSessionContext();
@@ -526,7 +526,7 @@ function ClientPracticeRoute({
   invoiceId?: string;
   appId?: string;
   workspaceView?: 'home' | 'list' | 'conversation' | 'matters' | 'invoices' | 'invoiceDetail' | 'settings';
-  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
+  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
 }) {
   const location = useLocation();
   const { session, isPending: sessionIsPending, activeMemberRole } = useSessionContext();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -234,7 +234,6 @@ function AppShell() {
           <Route path="/client/:practiceSlug/settings/general" component={ClientPracticeRoute} workspaceView="settings" settingsView="general" />
           <Route path="/client/:practiceSlug/settings/notifications" component={ClientPracticeRoute} workspaceView="settings" settingsView="notifications" />
           <Route path="/client/:practiceSlug/settings/account" component={ClientPracticeRoute} workspaceView="settings" settingsView="account" />
-          <Route path="/client/:practiceSlug/settings/account/payouts" component={ClientPracticeRoute} workspaceView="settings" settingsView="account-payouts" />
           <Route path="/client/:practiceSlug/settings/practice" component={ClientPracticeRoute} workspaceView="settings" settingsView="practice" />
           <Route path="/client/:practiceSlug/settings/practice/services" component={ClientPracticeRoute} workspaceView="settings" settingsView="practice-services" />
           <Route path="/client/:practiceSlug/settings/practice/team" component={ClientPracticeRoute} workspaceView="settings" settingsView="practice-team" />
@@ -263,8 +262,8 @@ function AppShell() {
           <Route path="/practice/:practiceSlug/settings/general" component={PracticeAppRoute} workspaceView="settings" settingsView="general" />
           <Route path="/practice/:practiceSlug/settings/notifications" component={PracticeAppRoute} workspaceView="settings" settingsView="notifications" />
           <Route path="/practice/:practiceSlug/settings/account" component={PracticeAppRoute} workspaceView="settings" settingsView="account" />
-          <Route path="/practice/:practiceSlug/settings/account/payouts" component={PracticeAppRoute} workspaceView="settings" settingsView="account-payouts" />
           <Route path="/practice/:practiceSlug/settings/practice" component={PracticeAppRoute} workspaceView="settings" settingsView="practice" />
+          <Route path="/practice/:practiceSlug/settings/practice/payouts" component={PracticeAppRoute} workspaceView="settings" settingsView="practice-payouts" />
           <Route path="/practice/:practiceSlug/settings/practice/services" component={PracticeAppRoute} workspaceView="settings" settingsView="practice-services" />
           <Route path="/practice/:practiceSlug/settings/practice/team" component={PracticeAppRoute} workspaceView="settings" settingsView="practice-team" />
           <Route path="/practice/:practiceSlug/settings/practice/pricing" component={PracticeAppRoute} workspaceView="settings" settingsView="practice-pricing" />
@@ -361,7 +360,7 @@ function PracticeAppRoute({
   invoiceId?: string;
   appId?: string;
   workspaceView?: 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceDetail' | 'reports' | 'settings';
-  settingsView?: 'general' | 'notifications' | 'account' | 'account-payouts' | 'practice' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
+  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
   practiceSlug?: string;
 }) {
   const { session, isPending } = useSessionContext();
@@ -527,7 +526,7 @@ function ClientPracticeRoute({
   invoiceId?: string;
   appId?: string;
   workspaceView?: 'home' | 'list' | 'conversation' | 'matters' | 'invoices' | 'invoiceDetail' | 'settings';
-  settingsView?: 'general' | 'notifications' | 'account' | 'account-payouts' | 'practice' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
+  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
 }) {
   const location = useLocation();
   const { session, isPending: sessionIsPending, activeMemberRole } = useSessionContext();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -360,7 +360,7 @@ function PracticeAppRoute({
   invoiceId?: string;
   appId?: string;
   workspaceView?: 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceDetail' | 'reports' | 'settings';
-  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
+  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
   practiceSlug?: string;
 }) {
   const { session, isPending } = useSessionContext();
@@ -526,7 +526,7 @@ function ClientPracticeRoute({
   invoiceId?: string;
   appId?: string;
   workspaceView?: 'home' | 'list' | 'conversation' | 'matters' | 'invoices' | 'invoiceDetail' | 'settings';
-  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
+  settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
 }) {
   const location = useLocation();
   const { session, isPending: sessionIsPending, activeMemberRole } = useSessionContext();

--- a/src/locales/ar/settings.json
+++ b/src/locales/ar/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "الخطة الحالية",
       "limits": {
         "unlimited": "غير محدود",
+        "unlimitedUsers": "مستخدمون غير محدودين",
+        "unlimitedInvoices": "فواتير غير محدودة شهرياً",
         "users": "{{count}} مستخدمين",
         "storageGb": "{{size}} GB تخزين",
         "invoicesPerMonth": "{{count}} فواتير شهرياً"

--- a/src/locales/ar/settings.json
+++ b/src/locales/ar/settings.json
@@ -85,8 +85,14 @@
         "business": "الخطة الحالية",
         "default": "الخطة الحالية"
       },
-      "upgradeButton": "الترقية إلى {{plan}}",
+      "upgradeButton": "ترقية إلى {{plan}}",
       "currentButton": "الخطة الحالية",
+      "limits": {
+        "unlimited": "غير محدود",
+        "users": "{{count}} مستخدمين",
+        "storageGb": "{{size}} GB تخزين",
+        "invoicesPerMonth": "{{count}} فواتير شهرياً"
+      },
       "toasts": {
         "upgrade": {
           "title": "ترقية",

--- a/src/locales/ar/settings.json
+++ b/src/locales/ar/settings.json
@@ -89,7 +89,7 @@
       "currentButton": "الخطة الحالية",
       "limits": {
         "unlimited": "غير محدود",
-        "unlimitedUsers": "مستخدمون غير محدودين",
+        "unlimitedUsers": "مستخدمون غير محدودون",
         "unlimitedInvoices": "فواتير غير محدودة شهرياً",
         "users": "{{count}} مستخدمين",
         "storageGb": "{{size}} GB تخزين",
@@ -273,6 +273,12 @@
         }
       },
       "submit": "تغيير كلمة المرور",
+      "addPassword": "إضافة كلمة مرور",
+      "addDescription": "أضف كلمة مرور لإدارة التغييرات الحساسة في الحساب بعد تسجيل الدخول باستخدام Google أو Microsoft أو Apple.",
+      "errorEmailUnavailable": {
+        "add": "لا يمكن إضافة كلمة المرور لأن بريدك الإلكتروني غير متاح.",
+        "reset": "لا يمكن إعادة تعيين كلمة المرور لأن بريدك الإلكتروني غير متاح."
+      },
       "errors": {
         "missing": {
           "title": "حقول مفقودة",

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "Upgrade auf {{plan}}",
       "currentButton": "Aktueller Plan",
+      "limits": {
+        "unlimited": "Unbegrenzt",
+        "users": "{{count}} Benutzer",
+        "storageGb": "{{size}} GB Speicher",
+        "invoicesPerMonth": "{{count}} Rechnungen pro Monat"
+      },
       "toasts": {
         "upgrade": {
           "title": "Upgrade",

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -89,9 +89,14 @@
       "currentButton": "Aktueller Plan",
       "limits": {
         "unlimited": "Unbegrenzt",
+        "unlimitedUsers": "Unbegrenzte Benutzer",
+        "unlimitedInvoices": "Unbegrenzte Rechnungen pro Monat",
         "users": "{{count}} Benutzer",
         "storageGb": "{{size}} GB Speicher",
-        "invoicesPerMonth": "{{count}} Rechnungen pro Monat"
+        "invoicesPerMonth": {
+          "one": "{{count}} Rechnung pro Monat",
+          "other": "{{count}} Rechnungen pro Monat"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -288,6 +288,12 @@
         }
       },
       "submit": "Passwort ändern",
+      "addPassword": "Passwort hinzufügen",
+      "addDescription": "Fügen Sie ein Passwort hinzu, um sensible Kontenänderungen nach der Anmeldung mit Google, Microsoft oder Apple zu verwalten.",
+      "errorEmailUnavailable": {
+        "add": "Passwort kann nicht hinzugefügt werden, da Ihre E-Mail nicht verfügbar ist.",
+        "reset": "Passwort kann nicht zurückgesetzt werden, da Ihre E-Mail nicht verfügbar ist."
+      },
       "errors": {
         "missing": {
           "title": "Fehlende Felder",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -273,6 +273,8 @@
     "email": {
       "title": "Email",
       "receiveFeedback": "Receive feedback emails",
+      "addPasswordFirst": "Add a password first",
+      "oauthGatingExplanation": "Your account was created with Google, Microsoft, or Apple. To change your email, first add a password in Settings -> Security -> Password -> Add.",
       "changeSuccess": {
         "title": "Check your email",
         "body": "We sent instructions to confirm your new email address."

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -180,6 +180,8 @@
       "currentButton": "Current plan",
       "limits": {
         "unlimited": "Unlimited",
+        "unlimitedUsers": "Unlimited users",
+        "unlimitedInvoices": "Unlimited invoices per month",
         "users": "{{count}} users",
         "storageGb": "{{size}} GB storage",
         "invoicesPerMonth": "{{count}} invoices per month"
@@ -418,6 +420,12 @@
         }
       },
       "submit": "Change Password",
+      "addDescription": "Add a password to manage sensitive account changes after signing in with Google, Microsoft, or Apple.",
+      "addPassword": "Add password",
+      "errorEmailUnavailable": {
+        "add": "Unable to add a password because your email is unavailable.",
+        "reset": "Unable to reset password because your email is unavailable."
+      },
       "errors": {
         "missing": {
           "title": "Missing fields",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -178,6 +178,12 @@
       },
       "upgradeButton": "Upgrade to {{plan}}",
       "currentButton": "Current plan",
+      "limits": {
+        "unlimited": "Unlimited",
+        "users": "{{count}} users",
+        "storageGb": "{{size}} GB storage",
+        "invoicesPerMonth": "{{count}} invoices per month"
+      },
       "cancel": {
         "modalTitle": "Are you sure you want to cancel?",
         "description": "Your subscription will be cancelled immediately and you'll lose access to premium features. This action cannot be undone.",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -165,6 +165,8 @@
         "plus": "Plus",
         "business": "Business"
       },
+      "includesWithLabel": "{{plan}} includes:",
+      "includesCurrent": "Current plan includes:",
       "descriptions": {
         "free": "Basic features with limited usage",
         "plus": "Enhanced features with higher limits",
@@ -180,11 +182,15 @@
       "currentButton": "Current plan",
       "limits": {
         "unlimited": "Unlimited",
-        "unlimitedUsers": "Unlimited users",
-        "unlimitedInvoices": "Unlimited invoices per month",
-        "users": "{{count}} users",
+        "users": {
+          "one": "{{count}} user",
+          "other": "{{count}} users"
+        },
         "storageGb": "{{size}} GB storage",
-        "invoicesPerMonth": "{{count}} invoices per month"
+        "invoicesPerMonth": {
+          "one": "{{count}} invoice per month",
+          "other": "{{count}} invoices per month"
+        }
       },
       "cancel": {
         "modalTitle": "Are you sure you want to cancel?",
@@ -266,7 +272,18 @@
     },
     "email": {
       "title": "Email",
-      "receiveFeedback": "Receive feedback emails"
+      "receiveFeedback": "Receive feedback emails",
+      "changeSuccess": {
+        "title": "Check your email",
+        "body": "We sent instructions to confirm your new email address."
+      },
+      "modal": {
+        "notNow": "Not now",
+        "goToSecurity": "Go to Security",
+        "cancel": "Cancel",
+        "sending": "Sending...",
+        "changeEmail": "Change email"
+      }
     },
     "delete": {
       "sectionTitle": "Delete account",

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -290,6 +290,12 @@
         }
       },
       "submit": "Cambiar contraseña",
+      "addPassword": "Añadir contraseña",
+      "addDescription": "Añade una contraseña para gestionar cambios sensibles en la cuenta después de iniciar sesión con Google, Microsoft o Apple.",
+      "errorEmailUnavailable": {
+        "add": "No se puede añadir una contraseña porque tu correo electrónico no está disponible.",
+        "reset": "No se puede restablecer la contraseña porque tu correo electrónico no está disponible."
+      },
       "errors": {
         "missing": {
           "title": "Campos incompletos",

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -86,6 +86,12 @@
       },
       "upgradeButton": "Mejorar a {{plan}}",
       "currentButton": "Plan actual",
+      "limits": {
+        "unlimited": "Ilimitado",
+        "users": "{{count}} usuarios",
+        "storageGb": "{{size}} GB de almacenamiento",
+        "invoicesPerMonth": "{{count}} facturas por mes"
+      },
       "toasts": {
         "upgrade": {
           "title": "Actualización",

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -88,9 +88,17 @@
       "currentButton": "Plan actual",
       "limits": {
         "unlimited": "Ilimitado",
-        "users": "{{count}} usuarios",
+        "unlimitedUsers": "Usuarios ilimitados",
+        "unlimitedInvoices": "Facturas ilimitadas por mes",
+        "users": {
+          "one": "{{count}} usuario",
+          "other": "{{count}} usuarios"
+        },
         "storageGb": "{{size}} GB de almacenamiento",
-        "invoicesPerMonth": "{{count}} facturas por mes"
+        "invoicesPerMonth": {
+          "one": "{{count}} factura",
+          "other": "{{count}} facturas"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -291,6 +291,12 @@
         }
       },
       "submit": "Changer le mot de passe",
+      "addPassword": "Ajouter un mot de passe",
+      "addDescription": "Ajoutez un mot de passe pour gérer les modifications sensibles du compte après vous être connecté avec Google, Microsoft ou Apple.",
+      "errorEmailUnavailable": {
+        "add": "Impossible d'ajouter un mot de passe car votre adresse e-mail n'est pas disponible.",
+        "reset": "Impossible de réinitialiser le mot de passe car votre adresse e-mail n'est pas disponible."
+      },
       "errors": {
         "missing": {
           "title": "Champs manquants",

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -89,9 +89,17 @@
       "currentButton": "Forfait actuel",
       "limits": {
         "unlimited": "Illimité",
-        "users": "{{count}} utilisateurs",
+        "unlimitedUsers": "Utilisateurs illimités",
+        "unlimitedInvoices": "Factures illimitées par mois",
+        "users": {
+          "one": "{{count}} utilisateur",
+          "other": "{{count}} utilisateurs"
+        },
         "storageGb": "{{size}} Go de stockage",
-        "invoicesPerMonth": "{{count}} factures par mois"
+        "invoicesPerMonth": {
+          "one": "{{count}} facture par mois",
+          "other": "{{count}} factures par mois"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "Passer à {{plan}}",
       "currentButton": "Forfait actuel",
+      "limits": {
+        "unlimited": "Illimité",
+        "users": "{{count}} utilisateurs",
+        "storageGb": "{{size}} Go de stockage",
+        "invoicesPerMonth": "{{count}} factures par mois"
+      },
       "toasts": {
         "upgrade": {
           "title": "Mise à niveau",

--- a/src/locales/hi/settings.json
+++ b/src/locales/hi/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "असीमित",
+        "unlimitedUsers": "असीमित उपयोगकर्ता",
+        "unlimitedInvoices": "प्रति माह असीमित इनवॉइस",
         "users": "{{count}} उपयोगकर्ता",
         "storageGb": "{{size}} GB स्टोरेज",
         "invoicesPerMonth": "{{count}} इनवॉइस प्रति महीना"

--- a/src/locales/hi/settings.json
+++ b/src/locales/hi/settings.json
@@ -93,7 +93,7 @@
         "unlimitedInvoices": "प्रति माह असीमित इनवॉइस",
         "users": "{{count}} उपयोगकर्ता",
         "storageGb": "{{size}} GB स्टोरेज",
-        "invoicesPerMonth": "{{count}} इनवॉइस प्रति महीना"
+        "invoicesPerMonth": "{{count}} इनवॉइस प्रति माह"
       },
       "toasts": {
         "upgrade": {
@@ -279,6 +279,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "पासवर्ड जोड़ें",
+      "addDescription": "Google, Microsoft, या Apple के साथ साइन इन करने के बाद संवेदनशील खाता परिवर्तनों को प्रबंधित करने के लिए एक पासवर्ड जोड़ें।",
+      "errorEmailUnavailable": {
+        "add": "आपका ईमेल उपलब्ध नहीं होने के कारण पासवर्ड जोड़ा नहीं जा सकता।",
+        "reset": "आपका ईमेल उपलब्ध नहीं होने के कारण पासवर्ड रीसेट नहीं किया जा सकता।"
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/hi/settings.json
+++ b/src/locales/hi/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "असीमित",
+        "users": "{{count}} उपयोगकर्ता",
+        "storageGb": "{{size}} GB स्टोरेज",
+        "invoicesPerMonth": "{{count}} इनवॉइस प्रति महीना"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/id/settings.json
+++ b/src/locales/id/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "Tidak terbatas",
+        "users": "{{count}} pengguna",
+        "storageGb": "{{size}} GB penyimpanan",
+        "invoicesPerMonth": "{{count}} faktur per bulan"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/id/settings.json
+++ b/src/locales/id/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "Tidak terbatas",
+        "unlimitedUsers": "Pengguna tidak terbatas",
+        "unlimitedInvoices": "Faktur tidak terbatas per bulan",
         "users": "{{count}} pengguna",
         "storageGb": "{{size}} GB penyimpanan",
         "invoicesPerMonth": "{{count}} faktur per bulan"

--- a/src/locales/id/settings.json
+++ b/src/locales/id/settings.json
@@ -273,6 +273,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Tambahkan kata sandi",
+      "addDescription": "Tambahkan kata sandi untuk mengelola perubahan akun yang sensitif setelah masuk dengan Google, Microsoft, atau Apple.",
+      "errorEmailUnavailable": {
+        "add": "Tidak dapat menambahkan kata sandi karena email Anda tidak tersedia.",
+        "reset": "Tidak dapat mengatur ulang kata sandi karena email Anda tidak tersedia."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/it/settings.json
+++ b/src/locales/it/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "Illimitato",
+        "users": "{{count}} utenti",
+        "storageGb": "{{size}} GB di archiviazione",
+        "invoicesPerMonth": "{{count}} fatture al mese"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/it/settings.json
+++ b/src/locales/it/settings.json
@@ -279,6 +279,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Aggiungi password",
+      "addDescription": "Aggiungi una password per gestire le modifiche sensibili dell'account dopo aver effettuato l'accesso con Google, Microsoft o Apple.",
+      "errorEmailUnavailable": {
+        "add": "Impossibile aggiungere una password perché la tua email non è disponibile.",
+        "reset": "Impossibile reimpostare la password perché la tua email non è disponibile."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/it/settings.json
+++ b/src/locales/it/settings.json
@@ -89,9 +89,17 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "Illimitato",
-        "users": "{{count}} utenti",
+        "unlimitedUsers": "Utenti illimitati",
+        "unlimitedInvoices": "Fatture illimitate al mese",
+        "users": {
+          "one": "{{count}} utente",
+          "other": "{{count}} utenti"
+        },
         "storageGb": "{{size}} GB di archiviazione",
-        "invoicesPerMonth": "{{count}} fatture al mese"
+        "invoicesPerMonth": {
+          "one": "{{count}} fattura al mese",
+          "other": "{{count}} fatture al mese"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "{{plan}} にアップグレード",
       "currentButton": "現在のプラン",
+      "limits": {
+        "unlimited": "無制限",
+        "users": "{{count}} ユーザー",
+        "storageGb": "{{size}} GB ストレージ",
+        "invoicesPerMonth": "{{count}} 請求書/月"
+      },
       "toasts": {
         "upgrade": {
           "title": "アップグレード",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -285,6 +285,12 @@
         }
       },
       "submit": "パスワードを変更",
+      "addPassword": "パスワードを追加",
+      "addDescription": "Google、Microsoft、またはAppleでサインインした後、機密性の高いアカウント変更を管理するためにパスワードを追加します。",
+      "errorEmailUnavailable": {
+        "add": "メールアドレスが利用できないため、パスワードを追加できません。",
+        "reset": "メールアドレスが利用できないため、パスワードをリセットできません。"
+      },
       "errors": {
         "missing": {
           "title": "項目が不足しています",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "現在のプラン",
       "limits": {
         "unlimited": "無制限",
+        "unlimitedUsers": "ユーザー数無制限",
+        "unlimitedInvoices": "請求書数無制限/月",
         "users": "{{count}} ユーザー",
         "storageGb": "{{size}} GB ストレージ",
         "invoicesPerMonth": "{{count}} 請求書/月"

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -273,6 +273,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "비밀번호 추가",
+      "addDescription": "Google, Microsoft 또는 Apple로 로그인한 후 민감한 계정 변경을 관리하기 위해 비밀번호를 추가하세요.",
+      "errorEmailUnavailable": {
+        "add": "이메일을 사용할 수 없어 비밀번호를 추가할 수 없습니다.",
+        "reset": "이메일을 사용할 수 없어 비밀번호를 재설정할 수 없습니다."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "무제한",
+        "users": "{{count}} 사용자",
+        "storageGb": "{{size}} GB 저장 공간",
+        "invoicesPerMonth": "{{count}} 청구서/월"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "무제한",
+        "unlimitedUsers": "무제한 사용자",
+        "unlimitedInvoices": "월 무제한 청구서",
         "users": "{{count}} 사용자",
         "storageGb": "{{size}} GB 저장 공간",
         "invoicesPerMonth": "{{count}} 청구서/월"

--- a/src/locales/nl/settings.json
+++ b/src/locales/nl/settings.json
@@ -89,9 +89,17 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "Onbeperkt",
-        "users": "{{count}} gebruikers",
+        "unlimitedUsers": "Onbeperkte gebruikers",
+        "unlimitedInvoices": "Onbeperkte facturen per maand",
+        "users": {
+          "one": "{{count}} gebruiker",
+          "other": "{{count}} gebruikers"
+        },
         "storageGb": "{{size}} GB opslag",
-        "invoicesPerMonth": "{{count}} facturen per maand"
+        "invoicesPerMonth": {
+          "one": "{{count}} factuur per maand",
+          "other": "{{count}} facturen per maand"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/nl/settings.json
+++ b/src/locales/nl/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "Onbeperkt",
+        "users": "{{count}} gebruikers",
+        "storageGb": "{{size}} GB opslag",
+        "invoicesPerMonth": "{{count}} facturen per maand"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/nl/settings.json
+++ b/src/locales/nl/settings.json
@@ -285,6 +285,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Wachtwoord toevoegen",
+      "addDescription": "Voeg een wachtwoord toe om gevoelige accountwijzigingen te beheren na het inloggen met Google, Microsoft of Apple.",
+      "errorEmailUnavailable": {
+        "add": "Kan geen wachtwoord toevoegen omdat uw e-mail niet beschikbaar is.",
+        "reset": "Kan wachtwoord niet opnieuw instellen omdat uw e-mail niet beschikbaar is."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/pl/settings.json
+++ b/src/locales/pl/settings.json
@@ -283,6 +283,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Dodaj hasło",
+      "addDescription": "Dodaj hasło, aby zarządzać wrażliwymi zmianami w koncie po zalogowaniu się za pomocą Google, Microsoft lub Apple.",
+      "errorEmailUnavailable": {
+        "add": "Nie można dodać hasła, ponieważ Twój e-mail jest niedostępny.",
+        "reset": "Nie można zresetować hasła, ponieważ Twój e-mail jest niedostępny."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/pl/settings.json
+++ b/src/locales/pl/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "Nieograniczony",
+        "users": "{{count}} użytkowników",
+        "storageGb": "{{size}} GB przechowywania",
+        "invoicesPerMonth": "{{count}} faktur miesięcznie"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/pl/settings.json
+++ b/src/locales/pl/settings.json
@@ -88,10 +88,22 @@
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
-        "unlimited": "Nieograniczony",
-        "users": "{{count}} użytkowników",
+        "unlimited": "Nieograniczone",
+        "unlimitedUsers": "Nieograniczona liczba użytkowników",
+        "unlimitedInvoices": "Nieograniczona liczba faktur miesięcznie",
+        "users": {
+          "one": "{{count}} użytkownik",
+          "few": "{{count}} użytkownika",
+          "many": "{{count}} użytkowników",
+          "other": "{{count}} użytkowników"
+        },
         "storageGb": "{{size}} GB przechowywania",
-        "invoicesPerMonth": "{{count}} faktur miesięcznie"
+        "invoicesPerMonth": {
+          "one": "{{count}} faktura miesięcznie",
+          "few": "{{count}} faktury miesięcznie",
+          "many": "{{count}} faktur miesięcznie",
+          "other": "{{count}} faktur miesięcznie"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/pt/settings.json
+++ b/src/locales/pt/settings.json
@@ -89,9 +89,17 @@
       "currentButton": "Plano atual",
       "limits": {
         "unlimited": "Ilimitado",
-        "users": "{{count}} usuários",
+        "unlimitedUsers": "Usuários ilimitados",
+        "unlimitedInvoices": "Faturas ilimitadas por mês",
+        "users": {
+          "one": "{{count}} usuário",
+          "other": "{{count}} usuários"
+        },
         "storageGb": "{{size}} GB de armazenamento",
-        "invoicesPerMonth": "{{count}} faturas por mês"
+        "invoicesPerMonth": {
+          "one": "{{count}} fatura por mês",
+          "other": "{{count}} faturas por mês"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/pt/settings.json
+++ b/src/locales/pt/settings.json
@@ -279,6 +279,12 @@
         }
       },
       "submit": "Alterar Senha",
+      "addPassword": "Adicionar senha",
+      "addDescription": "Adicione uma senha para gerenciar alterações sensíveis da conta após entrar com Google, Microsoft ou Apple.",
+      "errorEmailUnavailable": {
+        "add": "Não é possível adicionar uma senha porque seu e-mail não está disponível.",
+        "reset": "Não é possível redefinir a senha porque seu e-mail não está disponível."
+      },
       "errors": {
         "missing": {
           "title": "Campos faltando",

--- a/src/locales/pt/settings.json
+++ b/src/locales/pt/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "Fazer upgrade para {{plan}}",
       "currentButton": "Plano atual",
+      "limits": {
+        "unlimited": "Ilimitado",
+        "users": "{{count}} usuários",
+        "storageGb": "{{size}} GB de armazenamento",
+        "invoicesPerMonth": "{{count}} faturas por mês"
+      },
       "toasts": {
         "upgrade": {
           "title": "Upgrade",

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -283,6 +283,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Добавить пароль",
+      "addDescription": "Добавьте пароль для управления чувствительными изменениями в аккаунте после входа через Google, Microsoft или Apple.",
+      "errorEmailUnavailable": {
+        "add": "Не удается добавить пароль, так как ваш адрес электронной почты недоступен.",
+        "reset": "Не удается сбросить пароль, так как ваш адрес электронной почты недоступен."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -89,9 +89,21 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "Безлимитный",
-        "users": "{{count}} пользователей",
+        "unlimitedUsers": "Безлимитные пользователи",
+        "unlimitedInvoices": "Безлимитные счета в месяц",
+        "users": {
+          "one": "{{count}} пользователь",
+          "few": "{{count}} пользователя",
+          "many": "{{count}} пользователей",
+          "other": "{{count}} пользователей"
+        },
         "storageGb": "{{size}} GB хранилища",
-        "invoicesPerMonth": "{{count}} счетов в месяц"
+        "invoicesPerMonth": {
+          "one": "{{count}} счёт в месяц",
+          "few": "{{count}} счёта в месяц",
+          "many": "{{count}} счётов в месяц",
+          "other": "{{count}} счётов в месяц"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "Безлимитный",
+        "users": "{{count}} пользователей",
+        "storageGb": "{{size}} GB хранилища",
+        "invoicesPerMonth": "{{count}} счетов в месяц"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/th/settings.json
+++ b/src/locales/th/settings.json
@@ -271,6 +271,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "เพิ่มรหัสผ่าน",
+      "addDescription": "เพิ่มรหัสผ่านเพื่อจัดการการเปลี่ยนแปลงที่ละเอียดอ่อนของบัญชีหลังจากล็อกอินด้วย Google, Microsoft หรือ Apple",
+      "errorEmailUnavailable": {
+        "add": "ไม่สามารถเพิ่มรหัสผ่านได้เนื่องจากอีเมลของคุณไม่พร้อมใช้งาน",
+        "reset": "ไม่สามารถรีเซ็ตรหัสผ่านได้เนื่องจากอีเมลของคุณไม่พร้อมใช้งาน"
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/th/settings.json
+++ b/src/locales/th/settings.json
@@ -85,6 +85,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "ไม่จำกัด",
+        "users": "{{count}} ผู้ใช้",
+        "storageGb": "{{size}} GB พื้นที่จัดเก็บ",
+        "invoicesPerMonth": "{{count}} ใบแจ้งหนี้ต่อเดือน"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/th/settings.json
+++ b/src/locales/th/settings.json
@@ -87,6 +87,8 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "ไม่จำกัด",
+        "unlimitedUsers": "ผู้ใช้ไม่จำกัด",
+        "unlimitedInvoices": "ใบแจ้งหนี้ไม่จำกัดต่อเดือน",
         "users": "{{count}} ผู้ใช้",
         "storageGb": "{{size}} GB พื้นที่จัดเก็บ",
         "invoicesPerMonth": "{{count}} ใบแจ้งหนี้ต่อเดือน"

--- a/src/locales/tr/settings.json
+++ b/src/locales/tr/settings.json
@@ -272,7 +272,7 @@
           "placeholder": "Confirm new password"
         }
       },
-      "submit": "[NEEDS TRANSLATION] Change Password",
+      "submit": "Şifreyi Değiştir",
       "addPassword": "Şifre ekle",
       "addDescription": "Google, Microsoft veya Apple ile giriş yaptıktan sonra hassas hesap değişikliklerini yönetmek için bir şifre ekleyin.",
       "errorEmailUnavailable": {

--- a/src/locales/tr/settings.json
+++ b/src/locales/tr/settings.json
@@ -90,7 +90,7 @@
       "limits": {
         "unlimited": "Sınırsız",
         "unlimitedUsers": "Sınırsız kullanıcı",
-        "unlimitedInvoices": "Aylık sınırsız fatura",
+        "unlimitedInvoices": "Sınırsız fatura",
         "users": "{{count}} kullanıcı",
         "storageGb": "{{size}} GB depolama",
         "invoicesPerMonth": "{{count}} fatura/ay"
@@ -272,7 +272,13 @@
           "placeholder": "Confirm new password"
         }
       },
-      "submit": "Change Password",
+      "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Şifre ekle",
+      "addDescription": "Google, Microsoft veya Apple ile giriş yaptıktan sonra hassas hesap değişikliklerini yönetmek için bir şifre ekleyin.",
+      "errorEmailUnavailable": {
+        "add": "E-postanız kullanılamadığı için şifre eklenemiyor.",
+        "reset": "E-postanız kullanılamadığı için şifre sıfırlanamıyor."
+      },
       "errors": {
         "missing": {
           "title": "Missing fields",

--- a/src/locales/tr/settings.json
+++ b/src/locales/tr/settings.json
@@ -85,8 +85,14 @@
         "business": "Current Plan",
         "default": "Current Plan"
       },
-      "upgradeButton": "Upgrade to {{plan}}",
-      "currentButton": "Current plan",
+      "upgradeButton": "Yükseltme {{plan}}",
+      "currentButton": "Mevcut plan",
+      "limits": {
+        "unlimited": "Sınırsız",
+        "users": "{{count}} kullanıcı",
+        "storageGb": "{{size}} GB depolama",
+        "invoicesPerMonth": "{{count}} fatura/ay"
+      },
       "toasts": {
         "upgrade": {
           "title": "Upgrade",

--- a/src/locales/tr/settings.json
+++ b/src/locales/tr/settings.json
@@ -85,10 +85,12 @@
         "business": "Current Plan",
         "default": "Current Plan"
       },
-      "upgradeButton": "Yükseltme {{plan}}",
+      "upgradeButton": "{{plan}} planına geç",
       "currentButton": "Mevcut plan",
       "limits": {
         "unlimited": "Sınırsız",
+        "unlimitedUsers": "Sınırsız kullanıcı",
+        "unlimitedInvoices": "Aylık sınırsız fatura",
         "users": "{{count}} kullanıcı",
         "storageGb": "{{size}} GB depolama",
         "invoicesPerMonth": "{{count}} fatura/ay"

--- a/src/locales/uk/settings.json
+++ b/src/locales/uk/settings.json
@@ -89,9 +89,21 @@
       "currentButton": "[NEEDS TRANSLATION] Current plan",
       "limits": {
         "unlimited": "Безлімітний",
-        "users": "{{count}} користувачів",
+        "unlimitedUsers": "Безлімітні користувачі",
+        "unlimitedInvoices": "Безлімітні рахунки на місяць",
+        "users": {
+          "one": "{{count}} користувач",
+          "few": "{{count}} користувачі",
+          "many": "{{count}} користувачів",
+          "other": "{{count}} користувачів"
+        },
         "storageGb": "{{size}} GB сховища",
-        "invoicesPerMonth": "{{count}} рахунків на місяць"
+        "invoicesPerMonth": {
+          "one": "{{count}} рахунок на місяць",
+          "few": "{{count}} рахунки на місяць",
+          "many": "{{count}} рахунків на місяць",
+          "other": "{{count}} рахунків на місяць"
+        }
       },
       "toasts": {
         "upgrade": {

--- a/src/locales/uk/settings.json
+++ b/src/locales/uk/settings.json
@@ -283,6 +283,12 @@
         }
       },
       "submit": "[NEEDS TRANSLATION] Change Password",
+      "addPassword": "Додати пароль",
+      "addDescription": "Додайте пароль для керування чутливими змінами в акаунті після входу через Google, Microsoft або Apple.",
+      "errorEmailUnavailable": {
+        "add": "Не вдається додати пароль, оскільки ваша електронна пошта недоступна.",
+        "reset": "Не вдається скинути пароль, оскільки ваша електронна пошта недоступна."
+      },
       "errors": {
         "missing": {
           "title": "[NEEDS TRANSLATION] Missing fields",

--- a/src/locales/uk/settings.json
+++ b/src/locales/uk/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "[NEEDS TRANSLATION] Upgrade to {{plan}}",
       "currentButton": "[NEEDS TRANSLATION] Current plan",
+      "limits": {
+        "unlimited": "Безлімітний",
+        "users": "{{count}} користувачів",
+        "storageGb": "{{size}} GB сховища",
+        "invoicesPerMonth": "{{count}} рахунків на місяць"
+      },
       "toasts": {
         "upgrade": {
           "title": "[NEEDS TRANSLATION] Upgrade",

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "Nâng cấp lên {{plan}}",
       "currentButton": "Gói hiện tại",
+      "limits": {
+        "unlimited": "Không giới hạn",
+        "users": "{{count}} người dùng",
+        "storageGb": "{{size}} GB lưu trữ",
+        "invoicesPerMonth": "{{count}} hóa đơn mỗi tháng"
+      },
       "toasts": {
         "upgrade": {
           "title": "Nâng cấp",

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "Gói hiện tại",
       "limits": {
         "unlimited": "Không giới hạn",
+        "unlimitedUsers": "Người dùng không giới hạn",
+        "unlimitedInvoices": "Hóa đơn không giới hạn mỗi tháng",
         "users": "{{count}} người dùng",
         "storageGb": "{{size}} GB lưu trữ",
         "invoicesPerMonth": "{{count}} hóa đơn mỗi tháng"

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -284,7 +284,13 @@
           "placeholder": "Xác nhận mật khẩu mới"
         }
       },
-      "submit": "Thay đổi mật khẩu",
+      "submit": "Đổi mật khẩu",
+      "addPassword": "Thêm mật khẩu",
+      "addDescription": "Thêm mật khẩu để quản lý các thay đổi nhạy cảm của tài khoản sau khi đăng nhập bằng Google, Microsoft hoặc Apple.",
+      "errorEmailUnavailable": {
+        "add": "Không thể thêm mật khẩu vì email của bạn không khả dụng.",
+        "reset": "Không thể đặt lại mật khẩu vì email của bạn không khả dụng."
+      },
       "errors": {
         "missing": {
           "title": "Thiếu trường",

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -87,6 +87,12 @@
       },
       "upgradeButton": "升级至 {{plan}}",
       "currentButton": "当前套餐",
+      "limits": {
+        "unlimited": "无限",
+        "users": "{{count}} 用户",
+        "storageGb": "{{size}} GB 存储空间",
+        "invoicesPerMonth": "{{count}} 张发票/月"
+      },
       "toasts": {
         "upgrade": {
           "title": "升级",

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -285,6 +285,12 @@
         }
       },
       "submit": "更改密码",
+      "addPassword": "添加密码",
+      "addDescription": "在使用 Google、Microsoft 或 Apple 登录后，添加密码以管理敏感的账户更改。",
+      "errorEmailUnavailable": {
+        "add": "由于您的电子邮件不可用，无法添加密码。",
+        "reset": "由于您的电子邮件不可用，无法重置密码。"
+      },
       "errors": {
         "missing": {
           "title": "缺少字段",

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -89,6 +89,8 @@
       "currentButton": "当前套餐",
       "limits": {
         "unlimited": "无限",
+        "unlimitedUsers": "无限用户",
+        "unlimitedInvoices": "每月无限发票",
         "users": "{{count}} 用户",
         "storageGb": "{{size}} GB 存储空间",
         "invoicesPerMonth": "{{count}} 张发票/月"

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -3,10 +3,10 @@ import {
   ChartBarIcon,
   ChatBubbleOvalLeftEllipsisIcon,
   ClipboardDocumentListIcon,
-  Cog6ToothIcon,
   DocumentTextIcon,
   HomeIcon,
 } from '@heroicons/react/24/solid';
+import { SettingsNavIcon } from '@/shared/ui/nav/SettingsNavIcon';
 import { PEOPLE_DIRECTORY_LABEL } from '@/shared/domain/people';
 import type { PracticeRole } from '@/shared/utils/practiceRoles';
 
@@ -138,7 +138,7 @@ const buildPracticeRail = (basePath: string): NavRailItem[] => [
   {
     id: 'settings',
     label: 'Settings',
-    icon: Cog6ToothIcon,
+    icon: SettingsNavIcon,
     href: `${basePath}/settings/general`,
     matchHrefs: [`${basePath}/settings`],
   },
@@ -170,7 +170,7 @@ const buildClientRail = (basePath: string): NavRailItem[] => [
   {
     id: 'settings',
     label: 'Settings',
-    icon: Cog6ToothIcon,
+    icon: SettingsNavIcon,
     href: `${basePath}/settings/general`,
     matchHrefs: [`${basePath}/settings`],
   },

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -298,6 +298,7 @@ const buildSettingsSecondary = (basePath: string, canAccessPractice: boolean): N
       label: 'Practice',
       items: [
         { id: 'practice', label: 'Practice', href: `${basePath}/settings/practice` },
+        { id: 'practice-payouts', label: 'Payouts', href: `${basePath}/settings/practice/payouts` },
         { id: 'practice-services', label: 'Services', href: `${basePath}/settings/practice/services` },
         { id: 'practice-team', label: 'Team', href: `${basePath}/settings/practice/team` },
         { id: 'practice-pricing', label: 'Pricing', href: `${basePath}/settings/practice/pricing` },

--- a/src/shared/hooks/useAuthAccounts.ts
+++ b/src/shared/hooks/useAuthAccounts.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { authClient } from '@/shared/lib/authClient';
+
+export interface AuthAccountSummary {
+  providerId: string;
+}
+
+export const useAuthAccounts = (enabled = true) => {
+  const [accounts, setAccounts] = useState<AuthAccountSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
+  const parseAccountsResponse = (result: unknown): AuthAccountSummary[] => {
+    const responseRecord = (result && typeof result === 'object')
+      ? result as Record<string, unknown>
+      : null;
+    const nestedData = responseRecord?.data && typeof responseRecord.data === 'object'
+      ? responseRecord.data as Record<string, unknown>
+      : null;
+    const payload = Array.isArray(result)
+      ? result
+      : Array.isArray(responseRecord?.data)
+        ? responseRecord.data
+        : Array.isArray(nestedData?.data)
+          ? nestedData.data
+          : null;
+
+    if (!payload) {
+      throw new Error('Invalid Better Auth accounts response.');
+    }
+
+    return payload.map((account, index) => {
+      const record = account as Record<string, unknown>;
+      const providerId = typeof record.providerId === 'string'
+        ? record.providerId
+        : typeof record.provider_id === 'string'
+          ? record.provider_id
+          : '';
+
+      if (!providerId) {
+        throw new Error(`Invalid Better Auth account payload at index ${index}.`);
+      }
+
+      return { providerId };
+    });
+  };
+
+  const loadAccounts = useCallback(async (isMounted?: () => boolean) => {
+    if (!enabled) {
+      if (!isMounted || isMounted()) {
+        setAccounts([]);
+        setIsLoading(false);
+        setError(null);
+      }
+      return;
+    }
+
+    if (!isMounted || isMounted()) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const result = await authClient.listAccounts();
+      if (isMounted && !isMounted()) {
+        return;
+      }
+      const parsed = parseAccountsResponse(result);
+
+      if (!isMounted || isMounted()) {
+        setAccounts(parsed);
+      }
+    } catch (loadError) {
+      if (!isMounted || isMounted()) {
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+      }
+    } finally {
+      if (!isMounted || isMounted()) {
+        setIsLoading(false);
+      }
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    let isMounted = true;
+    void loadAccounts(() => isMounted);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [loadAccounts]);
+
+  const hasPasswordAccount = useMemo(
+    () => accounts.some((account) => account.providerId === 'credential'),
+    [accounts]
+  );
+
+  return {
+    accounts,
+    hasPasswordAccount,
+    isLoading,
+    error,
+    reload: loadAccounts
+  };
+};

--- a/src/shared/hooks/useChatComposer.ts
+++ b/src/shared/hooks/useChatComposer.ts
@@ -34,6 +34,7 @@ const SESSION_READY_TIMEOUT_MS = 8_000;
 
 
 export interface UseChatComposerOptions {
+  enabled?: boolean;
   practiceId?: string;
   practiceSlug?: string;
   conversationId?: string;
@@ -87,6 +88,7 @@ const createClientId = (prefix = 'client'): string => {
 // ─── hook ─────────────────────────────────────────────────────────────────────
 
 export const useChatComposer = ({
+  enabled = true,
   practiceId,
   practiceSlug,
   conversationId,
@@ -144,6 +146,7 @@ export const useChatComposer = ({
   // ── session readiness guard ───────────────────────────────────────────────
 
   const waitForSessionReady = useCallback(async () => {
+    if (!enabled) throw new Error('Chat is suspended.');
     if (sessionReadyRef.current) return;
     if (typeof window === 'undefined') throw new Error('Chat session is not available in this environment.');
     const start = Date.now();
@@ -152,9 +155,10 @@ export const useChatComposer = ({
       if (Date.now() - start > SESSION_READY_TIMEOUT_MS) throw new Error('Secure session is not ready yet. Please try again in a moment.');
       await new Promise(resolve => setTimeout(resolve, 200));
     }
-  }, []);
+  }, [enabled]);
 
   const ensureConversationId = useCallback(async () => {
+    if (!enabled) return '';
     const existingConversationId = conversationIdRef.current?.trim();
     if (existingConversationId) return existingConversationId;
 
@@ -190,7 +194,7 @@ export const useChatComposer = ({
 
     pendingEnsureConversationPromisesRef.current.set(contextKey, promise);
     return promise;
-  }, [conversationIdRef, ensureConversation, pendingEnsureConversationPromisesRef, currentUserId]);
+  }, [conversationIdRef, currentUserId, enabled, ensureConversation, pendingEnsureConversationPromisesRef]);
 
   // ── streaming bubble helpers ──────────────────────────────────────────────
 
@@ -228,6 +232,7 @@ export const useChatComposer = ({
     replyToMessageId?: string | null,
     conversationId?: string | null
   ) => {
+    if (!enabled) throw new Error('Chat is suspended.');
     if (!content.trim()) throw new Error('Message cannot be empty.');
     
     const effectivePracticeId = (practiceIdRef.current ?? '').trim();
@@ -316,7 +321,7 @@ export const useChatComposer = ({
       setMessages(prev => prev.filter(msg => msg.id !== tempId));
       throw error;
     });
-  }, [connectChatRoom, currentUserId, ensureConversationId, isSocketReadyRef, pendingAckRef, pendingClientMessageRef, sendFrame, setMessages, socketConversationIdRef, waitForSessionReady, waitForSocketReady]);
+  }, [connectChatRoom, currentUserId, enabled, ensureConversationId, isSocketReadyRef, pendingAckRef, pendingClientMessageRef, sendFrame, setMessages, socketConversationIdRef, waitForSessionReady, waitForSocketReady]);
 
   // ── SSE stream processor ──────────────────────────────────────────────────
 

--- a/src/shared/hooks/useChatComposer.ts
+++ b/src/shared/hooks/useChatComposer.ts
@@ -138,6 +138,7 @@ export const useChatComposer = ({
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const intentAbortRef = useRef<AbortController | null>(null);
+  const activeStreamingBubbleIdRef = useRef<string | null>(null);
   const hasLoggedIntentRef = useRef(false);
   const defaultModePersistedConversationRef = useRef<string | null>(null);
   const pendingIntakeInitRef = useRef<Promise<void> | null>(null);
@@ -218,6 +219,29 @@ export const useChatComposer = ({
   const removeStreamingBubble = useCallback((bubbleId: string) => {
     setMessages(prev => prev.filter(msg => msg.id !== bubbleId));
   }, [setMessages]);
+
+  const cleanupStreamingState = useCallback((bubbleId?: string | null) => {
+    const targetBubbleId = bubbleId ?? activeStreamingBubbleIdRef.current;
+    if (targetBubbleId) {
+      removeStreamingBubble(targetBubbleId);
+    }
+    if (activeStreamingBubbleIdRef.current === targetBubbleId) {
+      activeStreamingBubbleIdRef.current = null;
+    }
+    pendingStreamMessageIdRef.current = null;
+    if (orphanTimerRef.current !== null) {
+      clearTimeout(orphanTimerRef.current);
+      orphanTimerRef.current = null;
+    }
+  }, [orphanTimerRef, pendingStreamMessageIdRef, removeStreamingBubble]);
+
+  const abortActiveRequests = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    intentAbortRef.current?.abort();
+    intentAbortRef.current = null;
+    cleanupStreamingState();
+  }, [cleanupStreamingState]);
 
   // ── low-level WS send ─────────────────────────────────────────────────────
 
@@ -637,6 +661,10 @@ export const useChatComposer = ({
           if (intentError instanceof Error && intentError.name !== 'AbortError') {
             console.error('[useChatComposer] Intent classification failed:', intentError);
           }
+        } finally {
+          if (intentAbortRef.current === intentController) {
+            intentAbortRef.current = null;
+          }
         }
       }
 
@@ -656,6 +684,7 @@ export const useChatComposer = ({
       const streamRequestId = createClientId();
       const bubbleId = `${STREAMING_BUBBLE_PREFIX}${resolvedConversationId}-${streamRequestId}`;
       addStreamingBubble(bubbleId);
+      activeStreamingBubbleIdRef.current = bubbleId;
 
       abortControllerRef.current?.abort();
       const abortController = new AbortController();
@@ -677,7 +706,7 @@ export const useChatComposer = ({
         });
 
         if (!aiResponse.ok) {
-          removeStreamingBubble(bubbleId);
+          cleanupStreamingState(bubbleId);
           const errorData = await aiResponse.json().catch(() => ({})) as {
             error?: string;
             errorCode?: string;
@@ -725,7 +754,7 @@ export const useChatComposer = ({
 
         // JSON fallback (short-circuit replies — legal disclaimer, service list, etc.)
         if (contentType.includes('application/json')) {
-          removeStreamingBubble(bubbleId);
+          cleanupStreamingState(bubbleId);
           const aiData = await aiResponse.json() as {
             reply?: string;
             message?: ConversationMessage;
@@ -761,9 +790,19 @@ export const useChatComposer = ({
         await processSSEStream(aiResponse, bubbleId);
 
       } catch (streamError) {
-        if (streamError instanceof Error && streamError.name === 'AbortError') return;
-        removeStreamingBubble(bubbleId);
+        if (streamError instanceof Error && streamError.name === 'AbortError') {
+          cleanupStreamingState(bubbleId);
+          return;
+        }
+        cleanupStreamingState(bubbleId);
         throw streamError;
+      } finally {
+        if (abortControllerRef.current === abortController) {
+          abortControllerRef.current = null;
+        }
+        if (activeStreamingBubbleIdRef.current === bubbleId) {
+          activeStreamingBubbleIdRef.current = null;
+        }
       }
 
     } catch (error) {
@@ -780,6 +819,7 @@ export const useChatComposer = ({
     conversationId,
     conversationMetadataRef,
     conversationIdRef,
+    cleanupStreamingState,
     ensureConversationId,
     messagesRef,
     mode,
@@ -787,7 +827,6 @@ export const useChatComposer = ({
     practiceId,
     practiceSlug,
     processSSEStream,
-    removeStreamingBubble,
     sendMessageOverWs,
     setMessages,
     fetchConversationMetadata,
@@ -801,21 +840,24 @@ export const useChatComposer = ({
     intentAbortRef.current?.abort();
   }, []);
 
+  useEffect(() => {
+    if (enabled) return;
+    abortActiveRequests();
+  }, [abortActiveRequests, enabled]);
+
   // Cleanup on unmount
   useEffect(() => {
     isMountedRef.current = true;
     const currentPendingAck = pendingAckRef.current;
     return () => {
       isMountedRef.current = false;
-      abortControllerRef.current?.abort();
-      intentAbortRef.current?.abort();
-      if (orphanTimerRef.current) clearTimeout(orphanTimerRef.current);
+      abortActiveRequests();
       currentPendingAck.forEach(item => {
         clearTimeout(item.timer);
       });
       currentPendingAck.clear();
     };
-  }, [orphanTimerRef, pendingAckRef]);
+  }, [abortActiveRequests, pendingAckRef]);
 
   return {
     sendMessage,

--- a/src/shared/hooks/useChatComposer.ts
+++ b/src/shared/hooks/useChatComposer.ts
@@ -159,7 +159,7 @@ export const useChatComposer = ({
   }, [enabled]);
 
   const ensureConversationId = useCallback(async () => {
-    if (!enabled) return '';
+    if (!enabled) throw new Error('Chat is suspended.');
     const existingConversationId = conversationIdRef.current?.trim();
     if (existingConversationId) return existingConversationId;
 

--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -837,10 +837,13 @@ export const useConversation = ({
     socketConversationIdRef.current = targetConversationId;
     initSocketReadyPromise();
 
-    const ws = new WebSocket(appendWidgetTokenToUrl(getConversationWsEndpoint(targetConversationId)));
+    const wsUrl = appendWidgetTokenToUrl(getConversationWsEndpoint(targetConversationId));
+    console.log('[WebSocket] Creating connection to', wsUrl);
+    const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 
     ws.addEventListener('open', () => {
+      console.log('[WebSocket] Connection opened');
       reconnectAttemptRef.current = 0;
       clearReconnectTimer();
       ws.send(JSON.stringify({ type: 'auth', data: { protocol_version: CHAT_PROTOCOL_VERSION, client_info: { platform: 'web' } } }));
@@ -923,6 +926,7 @@ export const useConversation = ({
     });
 
     ws.addEventListener('close', () => {
+      console.log('[WebSocket] Connection closed');
       if (socketSessionRef.current !== sessionId) return;
       isSocketReadyRef.current = false;
       rejectSocketReady(new Error('Chat connection closed'));

--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -838,12 +838,16 @@ export const useConversation = ({
     initSocketReadyPromise();
 
     const wsUrl = appendWidgetTokenToUrl(getConversationWsEndpoint(targetConversationId));
-    console.log('[WebSocket] Creating connection to', wsUrl);
+    if (import.meta.env.DEV) {
+      console.log('[WebSocket] Creating connection to', wsUrl);
+    }
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 
     ws.addEventListener('open', () => {
-      console.log('[WebSocket] Connection opened');
+      if (import.meta.env.DEV) {
+        console.log('[WebSocket] Connection opened');
+      }
       reconnectAttemptRef.current = 0;
       clearReconnectTimer();
       ws.send(JSON.stringify({ type: 'auth', data: { protocol_version: CHAT_PROTOCOL_VERSION, client_info: { platform: 'web' } } }));
@@ -926,7 +930,9 @@ export const useConversation = ({
     });
 
     ws.addEventListener('close', () => {
-      console.log('[WebSocket] Connection closed');
+      if (import.meta.env.DEV) {
+        console.log('[WebSocket] Connection closed');
+      }
       if (socketSessionRef.current !== sessionId) return;
       isSocketReadyRef.current = false;
       rejectSocketReady(new Error('Chat connection closed'));

--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -132,6 +132,7 @@ const getMessageCacheKey = (practiceId: string, conversationId: string) =>
 // ─── types ────────────────────────────────────────────────────────────────────
 
 export interface UseConversationOptions {
+  enabled?: boolean;
   practiceId?: string;
   conversationId?: string;
   userId?: string | null;
@@ -143,6 +144,7 @@ export interface UseConversationOptions {
 // ─── hook ─────────────────────────────────────────────────────────────────────
 
 export const useConversation = ({
+  enabled = true,
   practiceId,
   conversationId,
   userId: externalUserId,
@@ -151,8 +153,8 @@ export const useConversation = ({
   onError,
 }: UseConversationOptions) => {
   const { session, isPending: sessionIsPending, isAnonymous } = useSessionContext();
-  const hasAnonymousWidgetContext = Boolean(linkAnonymousConversationOnLoad && conversationId && practiceId);
-  const sessionReady = !sessionIsPending && (Boolean(session?.user) || Boolean(externalUserId && hasAnonymousWidgetContext));
+  const hasAnonymousWidgetContext = Boolean(enabled && linkAnonymousConversationOnLoad && conversationId && practiceId);
+  const sessionReady = enabled && !sessionIsPending && (Boolean(session?.user) || Boolean(externalUserId && hasAnonymousWidgetContext));
   const currentUserId = externalUserId ?? session?.user?.id ?? null;
 
   // ── state ──────────────────────────────────────────────────────────────────
@@ -224,13 +226,18 @@ export const useConversation = ({
   messagesRef.current = messages;
 
   useEffect(() => {
+    if (!enabled) return;
     if (!conversationId || !currentUserId || !isAnonymous) return;
     rememberConversationAnonymousParticipant(conversationId, currentUserId);
-  }, [conversationId, currentUserId, isAnonymous]);
+  }, [conversationId, currentUserId, enabled, isAnonymous]);
 
   // ── anonymous conversation linking ────────────────────────────────────────
 
   useEffect(() => {
+    if (!enabled) {
+      setIsConversationLinkReady(true);
+      return;
+    }
     if (!conversationId || !practiceId) { setIsConversationLinkReady(true); return; }
     if (!linkAnonymousConversationOnLoad || !sessionReady || isAnonymous || !currentUserId) {
       setIsConversationLinkReady(true); return;
@@ -254,7 +261,7 @@ export const useConversation = ({
       }
     })();
     return () => { cancelled = true; };
-  }, [conversationId, currentUserId, isAnonymous, linkAnonymousConversationOnLoad, practiceId, sessionReady, onError]);
+  }, [conversationId, currentUserId, enabled, isAnonymous, linkAnonymousConversationOnLoad, practiceId, sessionReady, onError]);
 
   // ── metadata helpers ───────────────────────────────────────────────────────
 
@@ -302,6 +309,7 @@ export const useConversation = ({
   }, [applyConversationMetadata, conversationId, practiceId, sessionReady]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (!conversationId || !currentUserId || !isAnonymous) return;
     const existingMetadata = conversationMetadataRef.current;
     const storedParticipantId =
@@ -310,7 +318,7 @@ export const useConversation = ({
       null;
     if (storedParticipantId === currentUserId) return;
     void updateConversationMetadata({ anonParticipantId: currentUserId });
-  }, [conversationId, currentUserId, isAnonymous, updateConversationMetadata]);
+  }, [conversationId, currentUserId, enabled, isAnonymous, updateConversationMetadata]);
 
   const fetchConversationMetadata = useCallback(async (signal?: AbortSignal, targetConversationId?: string) => {
     if (!sessionReady) return null;
@@ -1129,6 +1137,7 @@ export const useConversation = ({
 
   // Message cache restore
   useEffect(() => {
+    if (!enabled) return;
     if (typeof window === 'undefined' || !conversationId || !practiceId) return;
     try {
       const raw = window.localStorage.getItem(getMessageCacheKey(practiceId, conversationId));
@@ -1142,26 +1151,33 @@ export const useConversation = ({
       setMessages(filtered);
       setMessagesReady(true);
     } catch (err) { if (import.meta.env.DEV) console.warn('[useConversation] Failed to load cached messages', err); }
-  }, [conversationId, practiceId]);
+  }, [conversationId, enabled, practiceId]);
 
   // Message cache write
   useEffect(() => {
+    if (!enabled) return;
     if (typeof window === 'undefined' || !conversationId || !practiceId || messages.length === 0) return;
     const trimmed = messages.filter(m => !m.id.startsWith(STREAMING_BUBBLE_PREFIX)).slice(-MESSAGE_CACHE_LIMIT);
     try { window.localStorage.setItem(getMessageCacheKey(practiceId, conversationId), JSON.stringify(trimmed)); }
     catch (err) { if (import.meta.env.DEV) console.warn('[useConversation] Failed to cache messages', err); }
-  }, [conversationId, messages, practiceId]);
+  }, [conversationId, enabled, messages, practiceId]);
 
   // Conversation change — full reset
   useEffect(() => {
+    if (!enabled) return;
     if (lastConversationIdRef.current && conversationId && lastConversationIdRef.current !== conversationId) {
       clearMessages(); applyConversationMetadata(null);
     }
     lastConversationIdRef.current = conversationId;
-  }, [conversationId, applyConversationMetadata, clearMessages]);
+  }, [conversationId, enabled, applyConversationMetadata, clearMessages]);
 
   // Main lifecycle — fetch + connect
   useEffect(() => {
+    if (!enabled) {
+      conversationIdRef.current = undefined;
+      closeChatSocket();
+      return;
+    }
     if (!sessionReady) { closeChatSocket(); return; }
     if (!isConversationLinkReady) { closeChatSocket(); return; }
     if (!conversationId || !practiceId) { conversationIdRef.current = undefined; closeChatSocket(); return; }
@@ -1184,7 +1200,7 @@ export const useConversation = ({
     fetchConversationMetadata(controller.signal).catch(err => { console.warn('[useConversation] Failed to fetch metadata', err); });
     connectChatRoom(conversationId);
     return () => { controller.abort(); closeChatSocket(); };
-  }, [closeChatSocket, connectChatRoom, conversationId, fetchConversationMetadata, fetchMessages, isConversationLinkReady, practiceId, resetRealtimeState, sessionReady]);
+  }, [closeChatSocket, connectChatRoom, conversationId, enabled, fetchConversationMetadata, fetchMessages, isConversationLinkReady, practiceId, resetRealtimeState, sessionReady]);
 
   // Disposal
   useEffect(() => {

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -133,6 +133,7 @@ const emitWidgetLeadSubmitted = (payload: {
 };
 
 interface UseIntakeFlowOptions {
+  enabled?: boolean;
   conversationId: string | undefined;
   practiceId: string | undefined;
   practiceSlug?: string | null;
@@ -200,6 +201,7 @@ interface UseIntakeFlowResult {
 }
 
 export function useIntakeFlow({
+  enabled = true,
   conversationId,
   practiceId,
   practiceSlug,
@@ -249,6 +251,7 @@ export function useIntakeFlow({
   // ---------------------------------------------------------------------------
 
   const applyIntakeFields = useCallback(async (payload: IntakeFieldsPayload, options?: IntakeFieldChangeOptions) => {
+    if (!enabled) return;
     const currentConsultation = resolveConsultationState(conversationMetadataRef.current);
     const current = currentConsultation?.case ?? intakeConversationState;
     const next: IntakeConversationState = { ...current };
@@ -289,7 +292,7 @@ export function useIntakeFlow({
         console.warn('[Intake] Failed to post manual update ack', err);
       }
     }
-  }, [conversationId, practiceId, conversationMetadataRef, updateConversationMetadata, intakeConversationState]);
+  }, [conversationId, enabled, practiceId, conversationMetadataRef, updateConversationMetadata, intakeConversationState]);
 
   const resetIntakeCta = useCallback(async () => {
     const current = consultation?.case ?? intakeConversationState;
@@ -824,6 +827,7 @@ export function useIntakeFlow({
   }, [handleConfirmSubmit]);
 
   const handleContactFormSubmit = useCallback(async (draft: ContactData) => {
+    if (!enabled) return;
     try {
       const sanitizedContactDetails = {
         name: (draft.name ?? '').trim(),
@@ -840,7 +844,7 @@ export function useIntakeFlow({
       console.error('[Intake] Contact form submit failed', error);
       onError?.('Failed to submit contact information.');
     }
-  }, [handleSlimFormContinue, onError, sendMessageOverWs]);
+  }, [enabled, handleSlimFormContinue, onError, sendMessageOverWs]);
 
   return {
     intakeStatus,

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -602,6 +602,9 @@ export function useIntakeFlow({
             clearTimeout(paymentPollingTimerRef.current);
             paymentPollingTimerRef.current = null;
           }
+          if (!enabled) {
+            return;
+          }
           paymentPollingCancelledRef.current = false;
           const POLL_INTERVAL_MS = 5_000;
           const POLL_TIMEOUT_MS = 10 * 60 * 1_000;

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -308,6 +308,7 @@ export function useIntakeFlow({
   }, [conversationId, enabled, practiceId, conversationMetadataRef, updateConversationMetadata, intakeConversationState]);
 
   const resetIntakeCta = useCallback(async () => {
+    if (!enabled) return;
     const current = consultation?.case ?? intakeConversationState;
     await updateConversationMetadata(
       applyConsultationPatchToMetadata(
@@ -318,9 +319,10 @@ export function useIntakeFlow({
         { mirrorLegacyFields: true }
       )
     );
-  }, [consultation, conversationMetadataRef, intakeConversationState, updateConversationMetadata]);
+  }, [consultation, conversationMetadataRef, enabled, intakeConversationState, updateConversationMetadata]);
 
   const handleSlimFormContinue = useCallback(async (draft: ContactData) => {
+    if (!enabled) return;
     const nextDraft: SlimContactDraft = {
       name: (draft.name ?? '').trim(),
       email: (draft.email ?? '').trim(),
@@ -389,12 +391,14 @@ export function useIntakeFlow({
     applyServerMessages,
     conversationId,
     conversationMetadataRef,
+    enabled,
     practiceId,
     updateConversationMetadata,
     normalizedPracticeSlug,
   ]);
 
   const handleBuildBrief = useCallback(async () => {
+    if (!enabled) return;
     const currentConsultation = resolveConsultationState(conversationMetadataRef.current);
     const current = currentConsultation?.case ?? intakeConversationState;
     const patch: ConversationMetadata = applyConsultationPatchToMetadata(
@@ -419,9 +423,10 @@ export function useIntakeFlow({
     } catch (error) {
       console.error('[Intake] Failed to start brief-building conversation', error);
     }
-  }, [conversationMetadataRef, intakeConversationState, sendMessage, updateConversationMetadata]);
+  }, [conversationMetadataRef, enabled, intakeConversationState, sendMessage, updateConversationMetadata]);
 
   const handleIntakeCtaResponse = useCallback(async (response: 'ready' | 'not_yet') => {
+    if (!enabled) return;
     const currentConsultation = resolveConsultationState(conversationMetadataRef.current);
     const current = currentConsultation?.case ?? intakeConversationState;
     if (response === 'ready') {
@@ -452,13 +457,14 @@ export function useIntakeFlow({
     } catch (error) {
       if (import.meta.env.DEV) console.warn('[Intake] Failed to send "Not yet" response', error);
     }
-  }, [conversationMetadataRef, intakeConversationState, sendMessage, updateConversationMetadata]);
+  }, [conversationMetadataRef, enabled, intakeConversationState, sendMessage, updateConversationMetadata]);
 
   /**
    * Phase 1 — validate contact, link user identity, persist practice slug.
    * Delegates straight to handleFinalizeSubmit.
    */
   const handleConfirmSubmit = useCallback(async () => {
+    if (!enabled) return;
     if (!conversationId || !practiceId) return;
     if (!resolvedSlimContactDraft) {
       if (import.meta.env.DEV) {
@@ -710,6 +716,7 @@ export function useIntakeFlow({
     conversationId,
     conversationMetadataRef,
     currentUserId,
+    enabled,
     isAnonymous,
     onError,
     practiceId,
@@ -725,6 +732,7 @@ export function useIntakeFlow({
    *   - by the payment UI's onSuccess callback after payment completes.
    */
   const handleFinalizeSubmit = useCallback(async (options?: { generatePaymentLinkOnly?: boolean }): Promise<{ paymentLinkUrl: string | null }> => {
+    if (!enabled) return { paymentLinkUrl: null };
     if (!conversationId || !practiceId) return { paymentLinkUrl: null };
 
     const existingSubmission = conversationMetadataRef.current?.submission as { intakeUuid?: string } | undefined;
@@ -830,6 +838,7 @@ export function useIntakeFlow({
     applyServerMessages,
     conversationId,
     conversationMetadataRef,
+    enabled,
     onError,
     practiceId,
     updateConversationMetadata,

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -221,6 +221,7 @@ export function useIntakeFlow({
   const phase1InFlightRef = useRef(false);
   const finalizeRef = useRef<(options?: { generatePaymentLinkOnly?: boolean }) => Promise<{ paymentLinkUrl: string | null }>>(async () => ({ paymentLinkUrl: null }));
   const paymentPollingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const paymentPollingCancelledRef = useRef(false);
 
   // ---------------------------------------------------------------------------
   // Derived State
@@ -245,6 +246,18 @@ export function useIntakeFlow({
   const intakeStatus = useMemo((): DerivedIntakeStatus => (
     deriveIntakeStatusFromConsultation(conversationMetadata)
   ), [conversationMetadata]);
+
+  useEffect(() => {
+    if (enabled) {
+      paymentPollingCancelledRef.current = false;
+      return;
+    }
+    paymentPollingCancelledRef.current = true;
+    if (paymentPollingTimerRef.current !== null) {
+      clearTimeout(paymentPollingTimerRef.current);
+      paymentPollingTimerRef.current = null;
+    }
+  }, [enabled]);
 
   // ---------------------------------------------------------------------------
   // Actions
@@ -583,6 +596,7 @@ export function useIntakeFlow({
             clearTimeout(paymentPollingTimerRef.current);
             paymentPollingTimerRef.current = null;
           }
+          paymentPollingCancelledRef.current = false;
           const POLL_INTERVAL_MS = 5_000;
           const POLL_TIMEOUT_MS = 10 * 60 * 1_000;
           const pollStart = Date.now();
@@ -594,6 +608,7 @@ export function useIntakeFlow({
           const capturedConversationId = conversationId;
           const capturedPracticeId = practiceId;
           const postPaymentConfirmedMessage = async () => {
+            if (paymentPollingCancelledRef.current) return;
             const name =
               (conversationMetadataRef.current as Record<string, unknown> | null)?.practiceName as string | undefined
               ?? 'the practice';
@@ -611,33 +626,45 @@ export function useIntakeFlow({
           };
 
           const pollOnce = () => {
+            if (paymentPollingCancelledRef.current) {
+              if (paymentPollingTimerRef.current !== null) {
+                clearTimeout(paymentPollingTimerRef.current);
+                paymentPollingTimerRef.current = null;
+              }
+              return;
+            }
             if (Date.now() - pollStart > POLL_TIMEOUT_MS) {
               if (paymentPollingTimerRef.current !== null) {
                 clearTimeout(paymentPollingTimerRef.current);
                 paymentPollingTimerRef.current = null;
               }
+              if (paymentPollingCancelledRef.current) return;
               onError?.('Payment not confirmed after 10 minutes. Please refresh the page to check your status.');
               return;
             }
             if (inFlight) {
               // Previous fetch still running — skip this tick and reschedule.
+              if (paymentPollingCancelledRef.current) return;
               paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
               return;
             }
             inFlight = true;
             fetchIntakePaymentStatus(intakeUuid)
               .then(async (status) => {
+                if (paymentPollingCancelledRef.current) return;
                 if (isPaidIntakeStatus(status)) {
                   if (paymentPollingTimerRef.current !== null) {
                     clearTimeout(paymentPollingTimerRef.current);
                     paymentPollingTimerRef.current = null;
                   }
+                  if (paymentPollingCancelledRef.current) return;
                   await postPaymentConfirmedMessage();
                 } else if (isTerminalUnpaidStatus(status)) {
                   if (paymentPollingTimerRef.current !== null) {
                     clearTimeout(paymentPollingTimerRef.current);
                     paymentPollingTimerRef.current = null;
                   }
+                  if (paymentPollingCancelledRef.current) return;
                   const name =
                     (conversationMetadataRef.current as Record<string, unknown> | null)?.practiceName as string | undefined
                     ?? 'the practice';
@@ -652,11 +679,13 @@ export function useIntakeFlow({
                     console.warn('[handleConfirmSubmit] Failed to post payment failed message', msgError);
                   }
                 } else {
+                  if (paymentPollingCancelledRef.current) return;
                   paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
                 }
               })
               .catch((pollErr) => {
                 console.warn('[handleConfirmSubmit] Payment status poll failed', pollErr);
+                if (paymentPollingCancelledRef.current) return;
                 paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
               })
               .finally(() => { inFlight = false; });
@@ -813,6 +842,7 @@ export function useIntakeFlow({
   // Cancel any in-flight payment polling when the hook unmounts.
   useEffect(() => {
     return () => {
+      paymentPollingCancelledRef.current = true;
       if (paymentPollingTimerRef.current !== null) {
         clearTimeout(paymentPollingTimerRef.current);
         paymentPollingTimerRef.current = null;

--- a/src/shared/hooks/useMessageHandling.ts
+++ b/src/shared/hooks/useMessageHandling.ts
@@ -10,6 +10,7 @@ import { resolveConsultationState } from '@/shared/utils/consultationState';
 import type { IntakePaymentRequest } from '@/shared/utils/intakePayments';
 
 export interface UseMessageHandlingOptions {
+  enabled?: boolean;
   practiceId?: string;
   practiceSlug?: string;
   conversationId?: string;
@@ -30,6 +31,7 @@ export const useMessageHandlingWithContext = (options: Omit<UseMessageHandlingOp
 
 export const useMessageHandling = (options: UseMessageHandlingOptions) => {
   const {
+    enabled = true,
     practiceId,
     practiceSlug,
     conversationId,
@@ -44,6 +46,7 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
 
   // 1. Core Transport & State
   const conversation = useConversation({
+    enabled,
     practiceId,
     conversationId,
     userId,
@@ -60,6 +63,7 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
 
   // 2. Intake Flow logic
   const intake = useIntakeFlow({
+    enabled,
     conversationId,
     practiceId,
     practiceSlug,
@@ -77,6 +81,7 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
 
   // 3. User Actions & AI (Streaming, Intent, etc)
   const composer = useChatComposer({
+    enabled,
     practiceId,
     practiceSlug,
     conversationId,
@@ -118,6 +123,7 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
   const [verifiedPaidIntakeUuids, setVerifiedPaidIntakeUuids] = useState<Set<string>>(new Set());
   
   const payments = usePaymentStatus({
+    enabled,
     conversationId,
     practiceId,
     latestIntakeSubmission: {
@@ -137,53 +143,90 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
 
   // Derived state for UI orchestration
   const isConsultFlowActive = useMemo(() => {
+    if (!enabled) return false;
     if (mode === 'REQUEST_CONSULTATION') return true;
     if (mode === 'ASK_QUESTION' || mode === 'PRACTICE_ONBOARDING' || mode === null) return false;
     return false;
-  }, [mode]);
+  }, [enabled, mode]);
+
+  const suspendedState = useMemo(() => ({
+    messages: [],
+    conversationMetadata: null,
+    messagesReady: false,
+    hasMoreMessages: false,
+    isLoadingMoreMessages: false,
+    isSocketReady: false,
+    loadMoreMessages: async () => {},
+    startConsultFlow: () => {},
+    clearMessages: () => {},
+    addMessage: () => {},
+    updateMessage: () => {},
+    ingestServerMessages: () => {},
+    updateConversationMetadata: async () => null,
+    requestMessageReactions: async (_messageId: string) => {},
+    toggleMessageReaction: async (_messageId: string, _emoji: string) => {},
+    sendMessage: async () => {},
+    paymentRetryNotice: null,
+    verifiedPaidIntakeUuids: new Set<string>(),
+    intakeStatus: null,
+    intakeConversationState: null,
+    slimContactDraft: null,
+    handleSlimFormContinue: async () => {},
+    handleBuildBrief: async () => {},
+    handleIntakeCtaResponse: async () => {},
+    resetIntakeCta: async () => {},
+    handleConfirmSubmit: async () => {},
+    handleFinalizeSubmit: async () => ({ paymentLinkUrl: null }),
+    handleSubmitNow: async () => {},
+    handleContactFormSubmit: async () => {},
+    applyIntakeFields: async () => {},
+    isConsultFlowActive: false,
+  }), []);
 
   return useMemo(() => ({
+    ...(enabled ? {} : suspendedState),
     // Transport & State (from useConversation)
-    messages: conversation.messages,
-    conversationMetadata: conversation.conversationMetadata,
-    messagesReady: conversation.messagesReady,
-    hasMoreMessages: conversation.hasMoreMessages,
-    isLoadingMoreMessages: conversation.isLoadingMoreMessages,
-    isSocketReady: conversation.isSocketReady,
-    loadMoreMessages: conversation.loadMoreMessages,
-    startConsultFlow: conversation.startConsultFlow,
-    clearMessages: conversation.clearMessages,
-    addMessage: conversation.addMessage,
-    updateMessage: conversation.updateMessage,
-    ingestServerMessages: conversation.ingestServerMessages,
-    updateConversationMetadata: conversation.updateConversationMetadata,
-    requestMessageReactions: conversation.requestMessageReactions,
-    toggleMessageReaction: conversation.toggleMessageReaction,
+    messages: enabled ? conversation.messages : suspendedState.messages,
+    conversationMetadata: enabled ? conversation.conversationMetadata : suspendedState.conversationMetadata,
+    messagesReady: enabled ? conversation.messagesReady : suspendedState.messagesReady,
+    hasMoreMessages: enabled ? conversation.hasMoreMessages : suspendedState.hasMoreMessages,
+    isLoadingMoreMessages: enabled ? conversation.isLoadingMoreMessages : suspendedState.isLoadingMoreMessages,
+    isSocketReady: enabled ? conversation.isSocketReady : suspendedState.isSocketReady,
+    loadMoreMessages: enabled ? conversation.loadMoreMessages : suspendedState.loadMoreMessages,
+    startConsultFlow: enabled ? conversation.startConsultFlow : suspendedState.startConsultFlow,
+    clearMessages: enabled ? conversation.clearMessages : suspendedState.clearMessages,
+    addMessage: enabled ? conversation.addMessage : suspendedState.addMessage,
+    updateMessage: enabled ? conversation.updateMessage : suspendedState.updateMessage,
+    ingestServerMessages: enabled ? conversation.ingestServerMessages : suspendedState.ingestServerMessages,
+    updateConversationMetadata: enabled ? conversation.updateConversationMetadata : suspendedState.updateConversationMetadata,
+    requestMessageReactions: enabled ? conversation.requestMessageReactions : suspendedState.requestMessageReactions,
+    toggleMessageReaction: enabled ? conversation.toggleMessageReaction : suspendedState.toggleMessageReaction,
 
     // Actions & Sending (from useChatComposer)
-    sendMessage: composer.sendMessage,
+    sendMessage: enabled ? composer.sendMessage : suspendedState.sendMessage,
 
     // Payments (from usePaymentStatus)
-    paymentRetryNotice: payments.paymentRetryNotice,
-    verifiedPaidIntakeUuids,
+    paymentRetryNotice: enabled ? payments.paymentRetryNotice : suspendedState.paymentRetryNotice,
+    verifiedPaidIntakeUuids: enabled ? verifiedPaidIntakeUuids : suspendedState.verifiedPaidIntakeUuids,
 
     // Intake Logic (from useIntakeFlow)
-    intakeStatus: intake.intakeStatus,
-    intakeConversationState: intake.intakeConversationState,
-    slimContactDraft: intake.slimContactDraft,
-    handleSlimFormContinue: intake.handleSlimFormContinue,
-    handleBuildBrief: intake.handleBuildBrief,
-    handleIntakeCtaResponse: intake.handleIntakeCtaResponse,
-    resetIntakeCta: intake.resetIntakeCta,
-    handleConfirmSubmit: intake.handleConfirmSubmit,
-    handleFinalizeSubmit: intake.handleFinalizeSubmit,
-    handleSubmitNow: intake.handleSubmitNow,
-    handleContactFormSubmit: intake.handleContactFormSubmit,
-    applyIntakeFields: intake.applyIntakeFields,
+    intakeStatus: enabled ? intake.intakeStatus : suspendedState.intakeStatus,
+    intakeConversationState: enabled ? intake.intakeConversationState : suspendedState.intakeConversationState,
+    slimContactDraft: enabled ? intake.slimContactDraft : suspendedState.slimContactDraft,
+    handleSlimFormContinue: enabled ? intake.handleSlimFormContinue : suspendedState.handleSlimFormContinue,
+    handleBuildBrief: enabled ? intake.handleBuildBrief : suspendedState.handleBuildBrief,
+    handleIntakeCtaResponse: enabled ? intake.handleIntakeCtaResponse : suspendedState.handleIntakeCtaResponse,
+    resetIntakeCta: enabled ? intake.resetIntakeCta : suspendedState.resetIntakeCta,
+    handleConfirmSubmit: enabled ? intake.handleConfirmSubmit : suspendedState.handleConfirmSubmit,
+    handleFinalizeSubmit: enabled ? intake.handleFinalizeSubmit : suspendedState.handleFinalizeSubmit,
+    handleSubmitNow: enabled ? intake.handleSubmitNow : suspendedState.handleSubmitNow,
+    handleContactFormSubmit: enabled ? intake.handleContactFormSubmit : suspendedState.handleContactFormSubmit,
+    applyIntakeFields: enabled ? intake.applyIntakeFields : suspendedState.applyIntakeFields,
 
     // App state
-    isConsultFlowActive,
+    isConsultFlowActive: enabled ? isConsultFlowActive : suspendedState.isConsultFlowActive,
   }), [
+    enabled,
     conversation.messages,
     conversation.conversationMetadata,
     conversation.messagesReady,
@@ -215,5 +258,6 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
     intake.handleContactFormSubmit,
     intake.applyIntakeFields,
     isConsultFlowActive,
+    suspendedState,
   ]);
 };

--- a/src/shared/hooks/usePaymentStatus.ts
+++ b/src/shared/hooks/usePaymentStatus.ts
@@ -173,9 +173,7 @@ export const usePaymentStatus = ({
       cancelled = true;
       controller.abort();
     };
-  // Run once on mount (and on conversation/practice change in case of navigation)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [conversationId, practiceId]);
+  }, [conversationId, practiceId, postPaymentConfirmation]);
 
   // ── backend payment reconciliation ────────────────────────────────────────
   // Runs whenever the latest intake submission changes — handles the case

--- a/src/shared/hooks/usePaymentStatus.ts
+++ b/src/shared/hooks/usePaymentStatus.ts
@@ -31,6 +31,7 @@ export interface LatestIntakeSubmission {
 }
 
 export interface UsePaymentStatusOptions {
+  enabled?: boolean;
   conversationId: string | null | undefined;
   practiceId: string | null | undefined;
   latestIntakeSubmission: LatestIntakeSubmission;
@@ -69,6 +70,7 @@ const parseStoredFlag = (raw: string | null): { practiceName?: string; practiceI
 // ─── hook ─────────────────────────────────────────────────────────────────────
 
 export const usePaymentStatus = ({
+  enabled = true,
   conversationId,
   practiceId,
   latestIntakeSubmission,
@@ -90,6 +92,7 @@ export const usePaymentStatus = ({
     practiceName: string,
     signal?: AbortSignal,
   ) => {
+    if (!enabled) return;
     if (!conversationId || !practiceId) return;
 
     const messageId = `system-payment-confirm-${uuid}`;
@@ -123,7 +126,7 @@ export const usePaymentStatus = ({
       onError?.(error);
       throw error;
     }
-  }, [applyServerMessages, conversationId, onError, onPaymentConfirmed, practiceId]);
+  }, [applyServerMessages, conversationId, enabled, onError, onPaymentConfirmed, practiceId]);
 
   // ── sessionStorage reconciliation (Stripe return) ─────────────────────────
 

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -282,6 +282,11 @@ export interface CurrentSubscriptionPlan {
   yearlyPrice?: string | null;
   currency?: string | null;
   features?: string[] | null;
+  limits?: {
+    users?: number | null;
+    storageGb?: number | null;
+    invoicesPerMonth?: number | null;
+  } | null;
   isActive?: boolean | null;
 }
 
@@ -1887,24 +1892,43 @@ export async function getCurrentSubscription(
     throw new Error('Invalid /api/subscriptions/current payload: subscription must be an object or null.');
   }
 
-  const plan = isRecord(container.plan)
-    ? {
-      id: toNullableString(container.plan.id),
-      name: toNullableString(container.plan.name),
-      displayName: toNullableString(container.plan.display_name),
-      description: toNullableString(container.plan.description),
-      stripeProductId: toNullableString(container.plan.stripe_product_id),
-      stripeMonthlyPriceId: toNullableString(container.plan.stripe_monthly_price_id),
-      stripeYearlyPriceId: toNullableString(container.plan.stripe_yearly_price_id),
-      monthlyPrice: toNullableString(container.plan.monthly_price),
-      yearlyPrice: toNullableString(container.plan.yearly_price),
-      currency: toNullableString(container.plan.currency),
-      features: Array.isArray(container.plan.features)
-        ? container.plan.features.filter((feature): feature is string => typeof feature === 'string')
-        : null,
-      isActive: typeof container.plan.is_active === 'boolean' ? container.plan.is_active : null
-    }
-    : null;
+  if (!isRecord(container.plan)) {
+    throw new Error('Invalid /api/subscriptions/current payload: subscription is missing plan metadata.');
+  }
+
+  const planName = toNullableString(container.plan.name);
+  const planDisplayName = toNullableString(container.plan.display_name);
+  if (!planName && !planDisplayName) {
+    throw new Error('Invalid /api/subscriptions/current payload: subscription plan is missing name metadata.');
+  }
+
+  if (!Array.isArray(container.plan.features)) {
+    throw new Error('Invalid /api/subscriptions/current payload: subscription plan is missing features metadata.');
+  }
+
+  const plan = {
+    id: toNullableString(container.plan.id),
+    name: planName,
+    displayName: planDisplayName,
+    description: toNullableString(container.plan.description),
+    stripeProductId: toNullableString(container.plan.stripe_product_id),
+    stripeMonthlyPriceId: toNullableString(container.plan.stripe_monthly_price_id),
+    stripeYearlyPriceId: toNullableString(container.plan.stripe_yearly_price_id),
+    monthlyPrice: toNullableString(container.plan.monthly_price),
+    yearlyPrice: toNullableString(container.plan.yearly_price),
+    currency: toNullableString(container.plan.currency),
+    features: container.plan.features.filter((feature): feature is string => typeof feature === 'string'),
+    limits: isRecord(container.plan.limits)
+      ? {
+        users: typeof container.plan.limits.users === 'number' ? container.plan.limits.users : null,
+        storageGb: typeof container.plan.limits.storage_gb === 'number' ? container.plan.limits.storage_gb : null,
+        invoicesPerMonth: typeof container.plan.limits.invoices_per_month === 'number'
+          ? container.plan.limits.invoices_per_month
+          : null
+      }
+      : null,
+    isActive: typeof container.plan.is_active === 'boolean' ? container.plan.is_active : null
+  };
 
   return {
     id: toNullableString(container.id),

--- a/src/shared/lib/authClient.ts
+++ b/src/shared/lib/authClient.ts
@@ -96,78 +96,22 @@ export function getClient(): AuthClientType {
   return getAuthClient();
 }
 
-// Export the auth client getter
+// Export the auth client getter.
+//
+// Better Auth already returns a dynamic proxy. Wrapping that proxy again
+// makes harmless property reads look like route traversals, which can turn
+// accidental lookups into requests such as /api/auth/fetch-options/... .
+// We keep the export as a thin pass-through and explicitly block the
+// non-public fetchOptions property so it fails locally instead of being
+// interpreted as an auth route.
 export const authClient = new Proxy({} as AuthClientType, {
   get(_target, prop) {
+    if (prop === 'fetchOptions') {
+      return undefined;
+    }
+
     const client = getAuthClient();
-    const value = (client as Record<PropertyKey, unknown>)[prop];
-
-    // If it's a function, it might also have properties (like subscription.upgrade, subscription.list)
-    // Create a proxy that handles both calling the function AND accessing its properties
-    if (typeof value === 'function') {
-      const boundFn = value.bind(client);
-      // Create a function that has the properties from the original value
-      // We'll use Object.assign to copy properties, but the main approach is to proxy property access
-      const proxiedFn = Object.assign(boundFn, value);
-
-      // Return a proxy that handles both function calls and property access
-      return new Proxy(proxiedFn, {
-        apply(_target, _thisArg, args) {
-          // When called as a function, call the bound function
-          return boundFn(...args);
-        },
-        get(_target, subProp) {
-          // When accessing properties (like subscription.upgrade), get them from the original value
-          // Properties are on the original function, not the bound one
-          const subValue = (value as unknown as Record<PropertyKey, unknown>)[subProp];
-
-          if (typeof subValue === 'function') {
-            // Bind nested functions to the original value to preserve 'this'
-            return subValue.bind(value);
-          }
-          // Handle further nesting (e.g., subscription.upgrade might return an object)
-          if (subValue && typeof subValue === 'object') {
-            return new Proxy(subValue, {
-              get(_target, subSubProp) {
-                const subSubValue = subValue[subSubProp];
-                if (typeof subSubValue === 'function') {
-                  return subSubValue.bind(subValue);
-                }
-                return subSubValue;
-              }
-            });
-          }
-          return subValue;
-        }
-      });
-    }
-
-    // If it's an object (like signUp, signIn, organization which have nested methods), return a proxy for it
-    if (value && typeof value === 'object') {
-      return new Proxy(value, {
-        get(_target, subProp) {
-          const subValue = value[subProp];
-          if (typeof subValue === 'function') {
-            // Bind the function to preserve 'this' context
-            return subValue.bind(value);
-          }
-          // Handle further nesting (e.g., signUp.email)
-          if (subValue && typeof subValue === 'object') {
-            return new Proxy(subValue, {
-              get(_target, subSubProp) {
-                const subSubValue = subValue[subSubProp];
-                if (typeof subSubValue === 'function') {
-                  return subSubValue.bind(subValue);
-                }
-                return subSubValue;
-              }
-            });
-          }
-          return subValue;
-        }
-      });
-    }
-    return value;
+    return (client as Record<PropertyKey, unknown>)[prop];
   }
 }) as AuthClientType;
 

--- a/src/shared/ui/input/LogoUploadInput.tsx
+++ b/src/shared/ui/input/LogoUploadInput.tsx
@@ -103,6 +103,7 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
           role={triggerMode === 'avatar' ? 'button' : undefined}
           tabIndex={triggerMode === 'avatar' && !disabled ? 0 : undefined}
           aria-label={triggerMode === 'avatar' ? buttonLabel : undefined}
+          aria-disabled={triggerMode === 'avatar' && disabled ? 'true' : undefined}
         >
         {normalizedProgress !== null && (
           <svg

--- a/src/shared/ui/input/LogoUploadInput.tsx
+++ b/src/shared/ui/input/LogoUploadInput.tsx
@@ -1,8 +1,10 @@
 import { forwardRef } from 'preact/compat';
 import { useRef } from 'preact/hooks';
+import { UserIcon } from '@heroicons/react/24/outline';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 import { cn } from '@/shared/utils/cn';
 import { Button } from '@/shared/ui/Button';
+import { Icon } from '@/shared/ui/Icon';
 
 export interface LogoUploadInputProps {
   imageUrl?: string | null;
@@ -17,6 +19,7 @@ export interface LogoUploadInputProps {
   className?: string;
   size?: number;
   progress?: number | null;
+  triggerMode?: 'button' | 'avatar';
   onChange?: (files: FileList | File[]) => void;
 }
 
@@ -33,23 +36,12 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
   className,
   size = 48,
   progress = null,
+  triggerMode = 'button',
   onChange
 }, ref) => {
   const internalRef = useRef<HTMLInputElement | null>(null);
   const inputId = useUniqueId('logo-upload');
   const hasImage = typeof imageUrl === 'string' && imageUrl.trim().length > 0;
-
-  const initials = (() => {
-    if (!name || typeof name !== 'string') return '';
-    const trimmed = name.trim();
-    if (!trimmed) return '';
-    return trimmed
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((part) => part.charAt(0).toUpperCase())
-      .join('')
-      .slice(0, 2);
-  })();
 
   const handleFileChange = (event: Event) => {
     const target = event.target as HTMLInputElement;
@@ -99,8 +91,18 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
       )}
       <div className="mt-2 flex items-center gap-x-3">
         <div
-          className="relative shrink-0"
+          className={cn('relative shrink-0', triggerMode === 'avatar' && !disabled && 'cursor-pointer')}
           style={{ width: ringSize, height: ringSize }}
+          onClick={triggerMode === 'avatar' ? handleButtonClick : undefined}
+          onKeyDown={triggerMode === 'avatar' ? (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              handleButtonClick();
+            }
+          } : undefined}
+          role={triggerMode === 'avatar' ? 'button' : undefined}
+          tabIndex={triggerMode === 'avatar' && !disabled ? 0 : undefined}
+          aria-label={triggerMode === 'avatar' ? buttonLabel : undefined}
         >
         {normalizedProgress !== null && (
           <svg
@@ -134,23 +136,23 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-white/5">
-            <span className="text-xs font-semibold text-input-placeholder">
-              {initials || 'Logo'}
-            </span>
+            <Icon icon={UserIcon} className="h-1/2 w-1/2 text-input-placeholder"  />
           </div>
         )}
         </div>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={handleButtonClick}
-            disabled={disabled}
-          >
-            {buttonLabel}
-          </Button>
+          {triggerMode === 'button' && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleButtonClick}
+              disabled={disabled}
+            >
+              {buttonLabel}
+            </Button>
+          )}
           <input
             ref={setInputRef}
             id={inputId}

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -26,6 +26,7 @@ import { PERSON_RELATIONSHIP_STATUS_LABELS } from '@/shared/domain/people';
 import type { Address } from '@/shared/types/address';
 import type { IntakeConversationState, DerivedIntakeStatus } from '@/shared/types/intake';
 import { resolveStrengthTier, resolveStrengthLabel, resolveStrengthStyle, resolveStrengthDescription } from '@/shared/utils/intakeStrength';
+import { renderUserAvatar } from '@/shared/ui/profile';
 
 type InspectorConfig =
   | { type: 'conversation' }

--- a/src/shared/ui/nav/SettingsNavIcon.tsx
+++ b/src/shared/ui/nav/SettingsNavIcon.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'preact';
 import { Cog6ToothIcon } from '@heroicons/react/24/solid';
+import { cn } from '@/shared/utils/cn';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { Avatar } from '@/shared/ui/profile';
 
@@ -19,7 +20,7 @@ export const SettingsNavIcon: FunctionComponent<SettingsNavIconProps> = ({ class
         src={userImage} 
         name={userName} 
         size="sm"
-        className="h-5 w-5 flex-shrink-0"
+        className={cn("h-5 w-5 flex-shrink-0", className)}
       />
     );
   }

--- a/src/shared/ui/nav/SettingsNavIcon.tsx
+++ b/src/shared/ui/nav/SettingsNavIcon.tsx
@@ -1,0 +1,29 @@
+import { FunctionComponent } from 'preact';
+import { Cog6ToothIcon } from '@heroicons/react/24/solid';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
+import { Avatar } from '@/shared/ui/profile';
+
+interface SettingsNavIconProps {
+  className?: string;
+}
+
+export const SettingsNavIcon: FunctionComponent<SettingsNavIconProps> = ({ className = '' }) => {
+  const { session } = useSessionContext();
+  const userImage = session?.user?.image;
+  const userName = session?.user?.name || session?.user?.email || 'User';
+
+  // If user has avatar image, show it; otherwise fallback to cog icon
+  if (userImage) {
+    return (
+      <Avatar 
+        src={userImage} 
+        name={userName} 
+        size="sm"
+        className="h-5 w-5 flex-shrink-0"
+      />
+    );
+  }
+
+  // Fallback to cog icon when no user image
+  return <Cog6ToothIcon className={className} />;
+};

--- a/src/shared/ui/nav/SettingsNavIcon.tsx
+++ b/src/shared/ui/nav/SettingsNavIcon.tsx
@@ -1,30 +1,32 @@
-import { FunctionComponent } from 'preact';
+import type { ComponentProps, FunctionComponent, JSX } from 'preact';
 import { Cog6ToothIcon } from '@heroicons/react/24/solid';
 import { cn } from '@/shared/utils/cn';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { Avatar } from '@/shared/ui/profile';
 
-interface SettingsNavIconProps {
-  className?: string;
-}
+export type SettingsNavIconProps = ComponentProps<typeof Cog6ToothIcon>;
 
-export const SettingsNavIcon: FunctionComponent<SettingsNavIconProps> = ({ className = '' }) => {
+export const SettingsNavIcon: FunctionComponent<SettingsNavIconProps> = ({ className = '', ...props }) => {
   const { session } = useSessionContext();
   const userImage = session?.user?.image;
   const userName = session?.user?.name || session?.user?.email || 'User';
+  const wrapperProps = props as unknown as JSX.HTMLAttributes<HTMLSpanElement>;
+  const resolvedClassName = typeof className === 'string' ? className : '';
 
   // If user has avatar image, show it; otherwise fallback to cog icon
   if (userImage) {
     return (
-      <Avatar 
-        src={userImage} 
-        name={userName} 
-        size="sm"
-        className={cn("h-5 w-5 flex-shrink-0", className)}
-      />
+      <span {...wrapperProps} className={cn('inline-flex items-center justify-center', resolvedClassName)}>
+        <Avatar 
+          src={userImage} 
+          name={userName} 
+          size="sm"
+          className="h-5 w-5 flex-shrink-0"
+        />
+      </span>
     );
   }
 
   // Fallback to cog icon when no user image
-  return <Cog6ToothIcon className={className} />;
+  return <Cog6ToothIcon {...props} className={resolvedClassName} />;
 };

--- a/src/shared/ui/profile/atoms/Avatar.tsx
+++ b/src/shared/ui/profile/atoms/Avatar.tsx
@@ -4,6 +4,8 @@
  */
 
 import { useState, useEffect } from 'preact/hooks';
+import { UserIcon } from '@heroicons/react/24/outline';
+import { Icon } from '@/shared/ui/Icon';
 import { sanitizeUserImageUrl } from '@/shared/utils/urlValidation';
 
 interface AvatarProps {
@@ -66,6 +68,7 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
   };
 
   const sanitizedImageUrl = sanitizeUserImageUrl(src);
+  const initials = getInitials(name);
 
   const statusClasses = {
     active: 'bg-emerald-500',
@@ -91,7 +94,11 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
             onError={() => setHasImgError(true)}
           />
         ) : (
-          <span className={`font-medium text-input-text ${textSizeClasses[size]}`}>{getInitials(name)}</span>
+          initials ? (
+            <span className={`font-medium text-input-text ${textSizeClasses[size]}`}>{initials}</span>
+          ) : (
+            <Icon icon={UserIcon} className="h-1/2 w-1/2 text-input-placeholder" />
+          )
         )}
       </div>
       {status && (


### PR DESCRIPTION
## Summary
- improve the account settings subscription row and plan details for paid and client workspaces
- add Better Auth-backed password/email account handling in account and security settings
- stop workspace shell preview and billing fetches from loading while viewing settings

## Validation
- npm run lint
- npm run type-check

## Notes
- left unrelated settings nav icon work unstaged in the local workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email management moved to a modal with gated flows for password vs. OAuth accounts.
  * Practice-level payouts view/route added; settings navigation updated.

* **UI Improvements**
  * Subscription plan limits shown with translations across locales.
  * Logo upload supports button or avatar trigger modes.
  * Avatar fallback shows user icon when initials absent; conversation lists no longer load practice logos.
  * Settings nav may show the user avatar instead of a cog icon.

* **Other**
  * Password add/reset flows refined; current-password input and submit text are now configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->