### PR TITLE
[codex] polish invoice shells

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -1088,7 +1088,7 @@ export function MainApp({
             : undefined
       }
       invoicesListContent={
-        (isPracticeWorkspace || isClientWorkspace) && layoutMode === 'desktop'
+        (isPracticeWorkspace || isClientWorkspace) && layoutMode === 'desktop' && resolvedWorkspaceView !== 'invoiceDetail'
           ? (statusFilter) => (
             <Suspense fallback={<WorkspaceSubviewFallback />}>
               {isPracticeWorkspace ? (
@@ -1134,7 +1134,7 @@ export function MainApp({
                 onClick: () => window.dispatchEvent(new CustomEvent(INVOICE_CREATE_SEND_EVENT)),
                 icon: PaperAirplaneIcon,
               }
-          : (resolvedWorkspaceView === 'invoices' || resolvedWorkspaceView === 'invoiceDetail') && isPracticeWorkspace && practiceInvoicesPath
+          : resolvedWorkspaceView === 'invoices' && isPracticeWorkspace && practiceInvoicesPath
             ? {
                 label: 'New Invoice',
                 onClick: () => navigate(`${practiceInvoicesPath}/new`),

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1441,7 +1441,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       recentClients={recentClients}
       onDashboardWindowChange={setDashboardWindow}
       onCreateInvoice={handleDashboardCreateInvoice}
-      onOpenInvoice={(invoiceId) => navigate(`${normalizedBase}/matters?invoice=${encodeURIComponent(invoiceId)}`)}
+      onOpenInvoice={(invoiceId) => navigate(`${normalizedBase}/invoices/${encodeURIComponent(invoiceId)}`)}
       onViewAllClients={() => navigate(`${normalizedBase}/people`)}
       onViewClient={(clientId) => navigate(`${normalizedBase}/people/${encodeURIComponent(clientId)}`)}
     />

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -33,7 +33,7 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
   conversations,
   previews,
   practiceName,
-  practiceLogo,
+  practiceLogo: _practiceLogo,
   isLoading = false,
   error = null,
   onSelectConversation,

--- a/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
@@ -5,11 +5,12 @@ import { Page } from '@/shared/ui/layout/Page';
 import { Panel } from '@/shared/ui/layout/Panel';
 import { useNavigation } from '@/shared/utils/navigation';
 import { useToastContext } from '@/shared/contexts/ToastContext';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
 import {
   getOnboardingStatus,
-  listUserDetails,
   type UserDetailRecord,
 } from '@/shared/lib/apiClient';
+import { useClientsData } from '@/shared/hooks/useClientsData';
 import { listMatters, type BackendMatter, updateMatterMilestone } from '@/features/matters/services/mattersApi';
 import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
 import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
@@ -33,23 +34,6 @@ const mergeRecordsById = <T extends { id: string }>(currentRecords: T[], incomin
     mergedRecords.push(record);
   }
   return mergedRecords;
-};
-
-const loadFirstClientPage = async (practiceId: string, signal: AbortSignal) => {
-  return listUserDetails(practiceId, { limit: PAGE_SIZE, offset: 0, signal });
-};
-
-const loadRemainingClientPages = async (
-  practiceId: string,
-  signal: AbortSignal,
-  onPage: (records: UserDetailRecord[]) => void
-) => {
-  for (let offset = PAGE_SIZE; ; offset += PAGE_SIZE) {
-    const response = await listUserDetails(practiceId, { limit: PAGE_SIZE, offset, signal });
-    if (response.data.length === 0) break;
-    onPage(response.data);
-    if (response.data.length < PAGE_SIZE) break;
-  }
 };
 
 const loadFirstMatterPage = async (practiceId: string, signal: AbortSignal) => {
@@ -85,12 +69,18 @@ export function PracticeInvoiceCreatePage({
   const location = useLocation();
   const { navigate } = useNavigation();
   const { showError } = useToastContext();
-  const [clients, setClients] = useState<UserDetailRecord[]>([]);
   const [matters, setMatters] = useState<BackendMatter[]>([]);
   const [connectedAccountId, setConnectedAccountId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const builderRef = useRef<InvoiceFormHandle | null>(null);
+  const { session } = useSessionContext();
+  const clientsData = useClientsData(
+    practiceId ?? '',
+    null,
+    session?.user?.id ?? null,
+    { enabled: Boolean(practiceId) }
+  );
 
   // Read cached practice identity — no extra requests; usePracticeManagement uses shared snapshot cache
   const { currentPractice } = usePracticeManagement({
@@ -118,7 +108,7 @@ export function PracticeInvoiceCreatePage({
   const missingDraftError = draftId && !draftContext
     ? 'Invoice draft context was not found. Start invoice creation from the matter or invoices page again.'
     : null;
-  const displayError = loadError ?? missingDraftError;
+  const displayError = loadError ?? clientsData.error ?? missingDraftError;
 
   useEffect(() => {
     if (!practiceId) return;
@@ -128,33 +118,22 @@ export function PracticeInvoiceCreatePage({
 
     void (async () => {
       try {
-        const [clientPage, matterPage, onboardingStatus] = await Promise.all([
-          loadFirstClientPage(practiceId, controller.signal),
+        const [matterPage, onboardingStatus] = await Promise.all([
           loadFirstMatterPage(practiceId, controller.signal),
           getOnboardingStatus(practiceId, { signal: controller.signal }),
         ]);
 
         if (controller.signal.aborted) return;
 
-        setClients(clientPage.data);
         setMatters(matterPage);
         setConnectedAccountId(onboardingStatus.connectedAccountId ?? null);
 
-        void Promise.allSettled([
-          loadRemainingClientPages(practiceId, controller.signal, (records) => {
-            if (controller.signal.aborted) return;
-            setClients((current) => mergeRecordsById(current, records));
-          }),
-          loadRemainingMatterPages(practiceId, controller.signal, (records) => {
+        void loadRemainingMatterPages(practiceId, controller.signal, (records) => {
             if (controller.signal.aborted) return;
             setMatters((current) => mergeRecordsById(current, records));
-          }),
-        ]).then((results) => {
+        }).catch((error) => {
           if (controller.signal.aborted) return;
-          const rejection = results.find((result) => result.status === 'rejected');
-          if (rejection && rejection.status === 'rejected') {
-            setLoadError(rejection.reason instanceof Error ? rejection.reason.message : 'Failed to load invoice builder');
-          }
+          setLoadError(error instanceof Error ? error.message : 'Failed to load invoice builder');
         });
       } catch (error) {
         if ((error as DOMException)?.name === 'AbortError' || controller.signal.aborted) return;
@@ -178,12 +157,12 @@ export function PracticeInvoiceCreatePage({
   }, []);
 
   const clientOptions = useMemo(() => {
-    return clients.map((client) => ({
+    return (clientsData.items as UserDetailRecord[]).map((client) => ({
       value: client.id,
       label: getClientLabel(client),
       meta: client.user?.email ?? undefined,
     }));
-  }, [clients]);
+  }, [clientsData.items]);
 
   const matterOptions = useMemo(() => {
     return matters.map((matter) => ({
@@ -245,7 +224,7 @@ export function PracticeInvoiceCreatePage({
             {displayError}
           </div>
         ) : null}
-        {loading ? (
+        {loading || (!clientsData.isLoaded && clientsData.isLoading) ? (
           <Panel className="p-6">
             <div className="text-sm text-input-placeholder">Loading invoice builder...</div>
           </Panel>

--- a/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
@@ -1,11 +1,14 @@
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import Modal from '@/shared/components/Modal';
 import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
+import { WorkspaceListHeader } from '@/shared/ui/layout/WorkspaceListHeader';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { useToastContext } from '@/shared/contexts/ToastContext';
+import { getUserDetail } from '@/shared/lib/apiClient';
 import { useNavigation } from '@/shared/utils/navigation';
 import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
 import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
@@ -51,6 +54,7 @@ export function PracticeInvoiceDetailPage({
   const [detail, setDetail] = useState<InvoiceDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [resolvedClientLabel, setResolvedClientLabel] = useState<string | null>(null);
 
   const [refundModalOpen, setRefundModalOpen] = useState(false);
   const [refundReason, setRefundReason] = useState('');
@@ -86,6 +90,38 @@ export function PracticeInvoiceDetailPage({
     return () => controller.abort();
   }, [loadDetail]);
 
+  useEffect(() => {
+    if (!practiceId || !detail?.sourceInvoice.client_id) {
+      setResolvedClientLabel(null);
+      return;
+    }
+
+    const embeddedLabel = detail.clientName?.trim();
+    if (embeddedLabel) {
+      setResolvedClientLabel(embeddedLabel);
+      return;
+    }
+
+    const controller = new AbortController();
+    setResolvedClientLabel(null);
+
+    void getUserDetail(practiceId, detail.sourceInvoice.client_id, { signal: controller.signal })
+      .then((clientDetail) => {
+        if (controller.signal.aborted) return;
+        const hydratedLabel =
+          clientDetail?.user?.name?.trim() ||
+          clientDetail?.user?.email?.trim() ||
+          null;
+        setResolvedClientLabel(hydratedLabel);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted || err.name === 'AbortError') return;
+        console.error('[PracticeInvoiceDetailPage] Failed to hydrate invoice client label', err);
+      });
+
+    return () => controller.abort();
+  }, [detail?.clientName, detail?.sourceInvoice.client_id, practiceId]);
+
   const status = useMemo(() => (detail?.status ?? 'draft').toLowerCase(), [detail?.status]);
   const mode = useMemo(() => resolveInvoicePageMode(status), [status]);
   const isDraft = mode === 'edit';
@@ -94,9 +130,9 @@ export function PracticeInvoiceDetailPage({
 
   const builderClientOptions = useMemo(() => {
     if (!detail) return [];
-    const label = detail.clientName?.trim() || 'Person';
+    const label = resolvedClientLabel?.trim() || detail.clientName?.trim() || 'Person';
     return [{ value: detail.sourceInvoice.client_id, label }];
-  }, [detail]);
+  }, [detail, resolvedClientLabel]);
 
   const builderMatterOptions = useMemo(() => {
     if (!detail?.sourceInvoice.matter_id) return [];
@@ -199,39 +235,58 @@ export function PracticeInvoiceDetailPage({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
-      <DetailHeader
-        title={detail.invoiceNumber}
-        subtitle={`Issued ${renderEventDate(detail.issueDate)} • Due ${renderEventDate(detail.dueDate)} • Paid ${renderEventDate(detail.paidAt)}`}
-        showBack={showBack}
-        onBack={handleBackToList}
-        leadingAction={leadingAction}
-        onInspector={onInspector}
-        inspectorOpen={inspectorOpen}
-        actions={(
-          <div className="flex flex-wrap items-center gap-2">
-            {isDraft ? (
-              <>
-                <Button onClick={() => formRef.current?.requestSend()}>
-                  Send invoice
-                </Button>
-              </>
-            ) : null}
-            {isActionableOpenStatus(status) ? (
-              <>
+      {isDraft ? (
+        <WorkspaceListHeader
+          leftControls={(
+            <div className="flex items-center gap-3">
+              <Button
+                type="button"
+                variant="icon"
+                size="icon-sm"
+                aria-label="Close invoice composer"
+                onClick={handleBackToList}
+                icon={XMarkIcon}
+                iconClassName="h-5 w-5"
+              />
+              <div className="h-5 w-px bg-line-glass/30" aria-hidden="true" />
+            </div>
+          )}
+          title={<h1 className="workspace-header__title">Edit Invoice</h1>}
+          controls={(
+            <Button type="button" size="sm" onClick={() => formRef.current?.requestSend()}>
+              Send Invoice
+            </Button>
+          )}
+          className="px-0 py-0"
+        />
+      ) : (
+        <DetailHeader
+          title={detail.invoiceNumber}
+          subtitle={`Issued ${renderEventDate(detail.issueDate)} • Due ${renderEventDate(detail.dueDate)} • Paid ${renderEventDate(detail.paidAt)}`}
+          showBack={showBack}
+          onBack={handleBackToList}
+          leadingAction={leadingAction}
+          onInspector={onInspector}
+          inspectorOpen={inspectorOpen}
+          actions={(
+            <div className="flex flex-wrap items-center gap-2">
+              {isActionableOpenStatus(status) ? (
+                <>
+                  <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
+                  <Button variant="secondary" onClick={() => void handleSync()}>Sync</Button>
+                  <Button variant="danger-ghost" onClick={() => void handleVoid()}>Void</Button>
+                </>
+              ) : null}
+              {status === 'paid' ? (
                 <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
-                <Button variant="secondary" onClick={() => void handleSync()}>Sync</Button>
-                <Button variant="danger-ghost" onClick={() => void handleVoid()}>Void</Button>
-              </>
-            ) : null}
-            {status === 'paid' ? (
-              <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
-            ) : null}
-            {canMockRefund ? (
-              <Button variant="secondary" onClick={() => setRefundModalOpen(true)}>Issue refund (Mock)</Button>
-            ) : null}
-          </div>
-        )}
-      />
+              ) : null}
+              {canMockRefund ? (
+                <Button variant="secondary" onClick={() => setRefundModalOpen(true)}>Issue refund (Mock)</Button>
+              ) : null}
+            </div>
+          )}
+        />
+      )}
 
       <InvoiceForm
         ref={formRef}

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -33,9 +33,9 @@ const statusClass = (status: ActivityEntry['status']) => {
   const normalized = status.toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  if (normalized === 'draft') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
-  if (normalized === 'sent' || normalized === 'pending') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
-  return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  if (normalized === 'draft') return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  if (normalized === 'sent' || normalized === 'pending') return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
 };
 
 export const RecentActivityTable = ({ days, loading = false, error = null, onOpenInvoice }: RecentActivityTableProps) => (

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -31,10 +31,11 @@ const statusIcon = (status: ActivityEntry['status']) => {
 
 const statusClass = (status: ActivityEntry['status']) => {
   const normalized = status.toLowerCase();
-  if (normalized === 'paid') return 'text-emerald-300 bg-emerald-500/10 ring-emerald-500/20';
-  if (normalized === 'overdue') return 'text-rose-300 bg-rose-500/10 ring-rose-500/20';
-  if (normalized === 'sent' || normalized === 'pending') return 'text-input-placeholder bg-surface-glass ring-line-glass/50';
-  return 'bg-surface-glass text-input-placeholder ring-line-glass/50';
+  if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
+  if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
+  if (normalized === 'draft') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
+  if (normalized === 'sent' || normalized === 'pending') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
+  return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
 };
 
 export const RecentActivityTable = ({ days, loading = false, error = null, onOpenInvoice }: RecentActivityTableProps) => (
@@ -84,8 +85,8 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                       <tr className="text-sm text-input-text">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
-                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-glass/30 bg-surface-glass" />
-                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-glass/30 bg-surface-glass" />
+                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-glass/30 bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-glass/30 bg-surface-overlay/70" />
                         </th>
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (
@@ -138,7 +139,7 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                                 onClick={() => onOpenInvoice?.(entry)}
                                 className="text-sm font-medium text-accent-400 hover:text-accent-300"
                               >
-                                View transaction
+                                View invoice
                               </button>
                             </div>
                             <div className="mt-1 text-xs text-input-placeholder">

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -33,9 +33,9 @@ const statusClass = (status: ActivityEntry['status']) => {
   const normalized = status.toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  if (normalized === 'draft') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
-  if (normalized === 'sent' || normalized === 'pending') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
-  return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
+  if (normalized === 'draft') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  if (normalized === 'sent' || normalized === 'pending') return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  return 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
 };
 
 export const RecentActivityTable = ({ days, loading = false, error = null, onOpenInvoice }: RecentActivityTableProps) => (

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -7,10 +7,11 @@ import { formatDate } from '@/shared/utils/dateTime';
 import type { RecentClient } from '@/features/practice-dashboard/hooks/usePracticeBillingData';
 
 const statusTone: Record<string, string> = {
-  paid: 'text-emerald-300 bg-emerald-500/10 ring-emerald-500/20',
-  overdue: 'text-rose-300 bg-rose-500/10 ring-rose-500/20',
-  sent: 'text-input-placeholder bg-surface-glass ring-line-glass/50',
-  pending: 'text-input-placeholder bg-surface-glass ring-line-glass/50'
+  paid: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
+  overdue: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
+  draft: 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder',
+  sent: 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder',
+  pending: 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder'
 };
 
 type RecentClientsGridProps = {
@@ -51,8 +52,11 @@ export const RecentClientsGrid = ({
       ) : (
         <ul className="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
           {clients.map((client) => (
-            <li key={client.id} className="overflow-hidden rounded-xl outline outline-1 outline-line-glass/40">
-              <div className="flex items-center gap-x-4 border-b border-line-glass/20 bg-surface-glass p-6">
+            <li
+              key={client.id}
+              className="overflow-hidden rounded-xl bg-surface-overlay/80 outline outline-1 outline-line-glass/40 backdrop-blur-xl"
+            >
+              <div className="flex items-center gap-x-4 border-b border-line-glass/20 bg-surface-overlay/70 p-6">
                 <Avatar 
                   src={client.avatarUrl} 
                   name={client.name} 
@@ -81,7 +85,7 @@ export const RecentClientsGrid = ({
                 </DropdownMenu>
               </div>
               {client.lastInvoice ? (
-                <dl className="-my-3 divide-y divide-line-glass/20 px-6 py-4 text-sm">
+                <dl className="-my-3 divide-y divide-line-glass/20 bg-surface-overlay/60 px-6 py-4 text-sm">
                   <div className="flex justify-between gap-x-4 py-3">
                     <dt className="text-input-placeholder">Last invoice</dt>
                     <dd className="text-input-text">
@@ -105,7 +109,7 @@ export const RecentClientsGrid = ({
                     <dt className="text-input-placeholder">Amount</dt>
                     <dd className="flex items-start gap-x-2">
                       <div className="font-medium text-input-text">{formatCurrency(client.lastInvoice.amount)}</div>
-                      <div className={`rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${statusTone[client.lastInvoice.status?.toLowerCase() || ''] ?? 'text-input-placeholder bg-surface-glass ring-line-glass/50'}`}>
+                      <div className={`rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${statusTone[client.lastInvoice.status?.toLowerCase() || ''] ?? 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder'}`}>
                         {client.lastInvoice.status ?? '-'}
                       </div>
                     </dd>

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -6,12 +6,13 @@ import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatDate } from '@/shared/utils/dateTime';
 import type { RecentClient } from '@/features/practice-dashboard/hooks/usePracticeBillingData';
 
+const neutralTone = 'ring-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
 const statusTone: Record<string, string> = {
   paid: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   overdue: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
-  draft: 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder',
-  sent: 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder',
-  pending: 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder'
+  draft: neutralTone,
+  sent: neutralTone,
+  pending: neutralTone
 };
 
 type RecentClientsGridProps = {

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -110,7 +110,7 @@ export const RecentClientsGrid = ({
                     <dt className="text-input-placeholder">Amount</dt>
                     <dd className="flex items-start gap-x-2">
                       <div className="font-medium text-input-text">{formatCurrency(client.lastInvoice.amount)}</div>
-                      <div className={`rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${statusTone[client.lastInvoice.status?.toLowerCase() || ''] ?? 'border border-line-glass/20 bg-surface-overlay/80 text-input-placeholder'}`}>
+                      <div className={`rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${statusTone[client.lastInvoice.status?.toLowerCase() || ''] ?? neutralTone}`}>
                         {client.lastInvoice.status ?? '-'}
                       </div>
                     </dd>

--- a/src/features/settings/pages/PracticeServicesPage.tsx
+++ b/src/features/settings/pages/PracticeServicesPage.tsx
@@ -6,7 +6,6 @@ import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 import { ServicesEditor } from '@/features/services/components/ServicesEditor';
 import { SERVICE_CATALOG } from '@/features/services/data/serviceCatalog';
 import type { Service } from '@/features/services/types';
-import type { PracticeDetails } from '@/shared/lib/apiClient';
 import { getServiceDetailsForSave } from '@/features/services/utils';
 import { resolveServiceDetails } from '@/features/services/utils/serviceNormalization';
 import { useToastContext } from '@/shared/contexts/ToastContext';
@@ -28,7 +27,6 @@ export const PracticeServicesPage = ({ onNavigate, className }: PracticeServices
   const { navigate: baseNavigate } = useNavigation();
   const { t } = useTranslation(['settings', 'common']);
   const navigate = onNavigate ?? baseNavigate;
-  const defaultDetails: PracticeDetails = { services: [] };
   const location = useLocation();
   const [servicesError, setServicesError] = useState<string | null>(null);
   const settingsBasePath = resolveSettingsBasePath(location.path);
@@ -87,7 +85,7 @@ export const PracticeServicesPage = ({ onNavigate, className }: PracticeServices
       };
     };
     const optimisticDetails = {
-      ...(details ?? defaultDetails),
+      ...(details ?? { services: [] }),
       services: apiServices
     };
     pendingSaveSnapshotsRef.current.set(saveId, { optimisticDetails });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import AcceptInvitationPage from '@/pages/AcceptInvitationPage';
 import OnboardingPage from '@/pages/OnboardingPage';
 import PricingPage from '@/pages/PricingPage';
 import DebugStylesPage from '@/pages/DebugStylesPage';
+import DebugModalsPage from '@/pages/DebugModalsPage';
 import DebugChatPage from '@/pages/DebugChatPage';
 import DebugConversationsPage from '@/pages/DebugConversationsPage';
 import DebugMatterPage from '@/pages/DebugMatterPage';
@@ -46,6 +47,16 @@ const DevDebugStylesRoute = () => {
 const DevDebugChatRoute = () => {
   if (!import.meta.env.DEV) return <App404 />;
   return <DebugChatPage />;
+};
+
+const DevDebugModalsRoute = () => {
+  if (!import.meta.env.DEV) return <App404 />;
+  return <DebugModalsPage />;
+};
+
+const DevDebugModalPreviewRoute = ({ previewId }: { previewId?: string }) => {
+  if (!import.meta.env.DEV) return <App404 />;
+  return <DebugModalsPage previewId={previewId} />;
 };
 
 const DevDebugConversationsRoute = () => {
@@ -214,6 +225,8 @@ function AppShell() {
           <Route path="/pricing" component={PricingPage} />
           <Route path="/onboarding" component={OnboardingPage} />
           <Route path="/debug/styles" component={DevDebugStylesRoute} />
+          <Route path="/debug/modals" component={DevDebugModalsRoute} />
+          <Route path="/debug/modals/:previewId" component={DevDebugModalPreviewRoute} />
           <Route path="/debug/chat" component={DevDebugChatRoute} />
           <Route path="/debug/conversations" component={DevDebugConversationsRoute} />
           <Route path="/debug/matters" component={DevDebugMatterRoute} />

--- a/src/pages/DebugModalsPage.tsx
+++ b/src/pages/DebugModalsPage.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from 'preact';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import type { FileAttachment } from '../../worker/types';
 import Modal from '@/shared/components/Modal';
 import ConfirmationDialog from '@/shared/components/ConfirmationDialog';
@@ -455,12 +455,24 @@ function GalleryCard({ item }: { item: ModalInventoryItem }) {
 export default function DebugModalsPage({ previewId }: DebugModalsPageProps) {
   const { navigate } = useNavigation();
 
-  const previewItem = useMemo(
-    () => inventory.find((item) => item.previewId === previewId),
-    [previewId]
-  );
+  const previewItem = inventory.find((item) => item.previewId === previewId);
 
-  if (previewId && previewItem?.previewId) {
+  if (previewId && !previewItem) {
+    return (
+      <PreviewSurface>
+        <div className="mx-auto flex min-h-screen max-w-2xl items-center justify-center p-8">
+          <div className="w-full rounded-2xl border border-line-glass/30 bg-surface-overlay/80 p-8 text-center shadow-2xl backdrop-blur-xl">
+            <p className="text-lg font-semibold text-input-text">Preview not found</p>
+            <p className="mt-2 text-sm text-input-placeholder">
+              The requested modal preview does not exist.
+            </p>
+          </div>
+        </div>
+      </PreviewSurface>
+    );
+  }
+
+  if (previewItem?.previewId) {
     return (
       <PreviewSurface>
         <PreviewRenderer previewId={previewItem.previewId} />

--- a/src/pages/DebugModalsPage.tsx
+++ b/src/pages/DebugModalsPage.tsx
@@ -1,0 +1,549 @@
+import type { ComponentChildren } from 'preact';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import type { FileAttachment } from '../../worker/types';
+import Modal from '@/shared/components/Modal';
+import ConfirmationDialog from '@/shared/components/ConfirmationDialog';
+import WelcomeModal from '@/features/modals/components/WelcomeModal';
+import CameraModal from '@/features/modals/components/CameraModal';
+import { AppConnectionModal } from '@/features/settings/components/AppConnectionModal';
+import { mockApps } from '@/features/settings/pages/appsData';
+import AuthForm from '@/shared/components/AuthForm';
+import { ContactForm, type ContactData } from '@/features/intake/components/ContactForm';
+import { ChatDockedAction } from '@/features/chat/components/ChatDockedAction';
+import { MessageAttachments } from '@/features/chat/components/MessageAttachments';
+import MediaSidebar from '@/features/media/components/MediaSidebar';
+import { Button } from '@/shared/ui/Button';
+import { useNavigation } from '@/shared/utils/navigation';
+
+type PreviewId =
+  | 'shared-modal'
+  | 'shared-drawer'
+  | 'shared-drawer-right'
+  | 'shared-fullscreen'
+  | 'confirmation'
+  | 'welcome'
+  | 'camera'
+  | 'app-connection'
+  | 'message-attachments'
+  | 'media-sidebar'
+  | 'docked-auth'
+  | 'docked-contact';
+
+type ModalInventoryItem = {
+  name: string;
+  file: string;
+  role: string;
+  usedFor: string;
+  simplify: string;
+  previewId?: PreviewId;
+  frameHeight?: number;
+};
+
+type DebugModalsPageProps = {
+  previewId?: string;
+};
+
+const mockImageUrl =
+  `data:image/svg+xml;utf8,${encodeURIComponent(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="900" viewBox="0 0 1200 900">
+      <defs>
+        <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+          <stop stop-color="#3b82f6" offset="0%"/>
+          <stop stop-color="#14b8a6" offset="100%"/>
+        </linearGradient>
+      </defs>
+      <rect width="1200" height="900" fill="url(#g)"/>
+      <circle cx="240" cy="220" r="120" fill="rgba(255,255,255,0.22)"/>
+      <circle cx="940" cy="280" r="180" fill="rgba(255,255,255,0.14)"/>
+      <rect x="120" y="600" width="960" height="120" rx="28" fill="rgba(255,255,255,0.14)"/>
+      <text x="120" y="160" fill="white" font-size="56" font-family="Arial, sans-serif">Mock attachment preview</text>
+    </svg>
+  `)}`;
+
+const mockPdfUrl =
+  `data:text/plain;charset=utf-8,${encodeURIComponent('Mock document download')}`;
+
+const mockFiles: FileAttachment[] = [
+  {
+    id: 'file-1',
+    name: 'intake-summary.png',
+    size: 182_400,
+    type: 'image/png',
+    url: mockImageUrl
+  },
+  {
+    id: 'file-2',
+    name: 'signed-engagement-letter.pdf',
+    size: 248_000,
+    type: 'application/pdf',
+    url: mockPdfUrl
+  }
+];
+
+const inventory: ModalInventoryItem[] = [
+  {
+    name: 'Modal',
+    file: 'src/shared/components/Modal.tsx',
+    role: 'Shared shell',
+    usedFor: 'Base centered dialog container.',
+    simplify: 'Split shell variants into smaller primitives instead of one component handling every mode.',
+    previewId: 'shared-modal',
+    frameHeight: 420
+  },
+  {
+    name: 'Modal drawer',
+    file: 'src/shared/components/Modal.tsx',
+    role: 'Shared shell',
+    usedFor: 'Bottom sheet container.',
+    simplify: 'Keep bottom-sheet behavior separate from centered dialog behavior.',
+    previewId: 'shared-drawer',
+    frameHeight: 520
+  },
+  {
+    name: 'Modal right drawer',
+    file: 'src/shared/components/Modal.tsx',
+    role: 'Shared shell',
+    usedFor: 'Right-side drawer for inspector/detail flows.',
+    simplify: 'This could be its own drawer primitive instead of a branch inside the base modal.',
+    previewId: 'shared-drawer-right',
+    frameHeight: 520
+  },
+  {
+    name: 'Modal fullscreen',
+    file: 'src/shared/components/Modal.tsx',
+    role: 'Shared shell',
+    usedFor: 'Fullscreen takeover used by media and capture flows.',
+    simplify: 'Treat fullscreen as its own primitive with a dedicated layout contract.',
+    previewId: 'shared-fullscreen',
+    frameHeight: 420
+  },
+  {
+    name: 'ConfirmationDialog',
+    file: 'src/shared/components/ConfirmationDialog.tsx',
+    role: 'Feature modal',
+    usedFor: 'Destructive confirmation with typed confirmation and submit flow.',
+    simplify: 'Good candidate for a single shared destructive-dialog pattern.',
+    previewId: 'confirmation',
+    frameHeight: 520
+  },
+  {
+    name: 'WelcomeModal',
+    file: 'src/features/modals/components/WelcomeModal.tsx',
+    role: 'Feature modal',
+    usedFor: 'Welcome and onboarding modal.',
+    simplify: 'Feature content is already reasonably separate from the modal shell.',
+    previewId: 'welcome',
+    frameHeight: 560
+  },
+  {
+    name: 'AppConnectionModal',
+    file: 'src/features/settings/components/AppConnectionModal.tsx',
+    role: 'Feature modal',
+    usedFor: 'App/integration connection modal from settings.',
+    simplify: 'Focus management and shell responsibilities could be shared instead of reimplemented here.',
+    previewId: 'app-connection',
+    frameHeight: 620
+  },
+  {
+    name: 'CameraModal',
+    file: 'src/features/modals/components/CameraModal.tsx',
+    role: 'Feature modal',
+    usedFor: 'Camera capture modal.',
+    simplify: 'Capture logic should stay separate, but the fullscreen host can be standardized.',
+    previewId: 'camera',
+    frameHeight: 520
+  },
+  {
+    name: 'MessageAttachments',
+    file: 'src/features/chat/components/MessageAttachments.tsx',
+    role: 'Inline launcher',
+    usedFor: 'Inline attachments list that opens the fullscreen media viewer.',
+    simplify: 'Separate launchers from the shared fullscreen media viewer they open.',
+    previewId: 'message-attachments',
+    frameHeight: 460
+  },
+  {
+    name: 'MediaSidebar',
+    file: 'src/features/media/components/MediaSidebar.tsx',
+    role: 'Inline launcher',
+    usedFor: 'Sidebar media list that opens the fullscreen media viewer.',
+    simplify: 'Another launcher into the same viewer pattern, so it is a strong consolidation target.',
+    previewId: 'media-sidebar',
+    frameHeight: 520
+  },
+  {
+    name: 'ChatDockedAction + AuthForm',
+    file: 'src/features/chat/components/ChatDockedAction.tsx + src/shared/components/AuthForm.tsx',
+    role: 'Docked surface',
+    usedFor: 'Chat auth prompt shown as a docked panel, not a portal modal.',
+    simplify: 'Useful for consolidating shared spacing, headers, and action-surface patterns across non-modal transient UI.',
+    previewId: 'docked-auth',
+    frameHeight: 640
+  },
+  {
+    name: 'ChatDockedAction + ContactForm',
+    file: 'src/features/chat/components/ChatDockedAction.tsx + src/features/intake/components/ContactForm.tsx',
+    role: 'Docked surface',
+    usedFor: 'Slim contact form shown as a docked panel in chat, not a portal modal.',
+    simplify: 'This should align visually with modal forms where appropriate, but remain a distinct container pattern.',
+    previewId: 'docked-contact',
+    frameHeight: 620
+  },
+  {
+    name: 'MatterCreateModal / MatterCreateForm',
+    file: 'src/features/matters/components/MatterCreateModal.tsx',
+    role: 'Form content',
+    usedFor: 'Create-matter form content. In actual implementation this is page-hosted, not a modal shell.',
+    simplify: 'Keep this content separate and standardize the host pattern around it.'
+  },
+  {
+    name: 'LinkMatterModal',
+    file: 'src/features/chat/components/LinkMatterModal.tsx',
+    role: 'Feature modal',
+    usedFor: 'Attach or change a matter linked to a conversation.',
+    simplify: 'Needs service/data separation before it becomes easy to preview and reuse cleanly.'
+  },
+  {
+    name: 'InspectorPanel',
+    file: 'src/shared/ui/inspector/InspectorPanel.tsx',
+    role: 'Page-owned drawer',
+    usedFor: 'Right-side inspector flow.',
+    simplify: 'Likely wants a dedicated drawer primitive and a slimmer page-owned content layer.'
+  },
+  {
+    name: 'PracticeMattersPage',
+    file: 'src/features/matters/pages/PracticeMattersPage.tsx',
+    role: 'Page-owned launchers',
+    usedFor: 'Page-level flows that launch several dialog/content patterns.',
+    simplify: 'The page should launch smaller standardized primitives instead of owning many modal flavors.'
+  }
+];
+
+function AutoOpenMessageAttachments() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const button = hostRef.current?.querySelector<HTMLElement>('.message-media-container img, .message-media-container video');
+    button?.click();
+  }, []);
+
+  return (
+    <div ref={hostRef} className="p-4">
+      <MessageAttachments files={mockFiles} />
+    </div>
+  );
+}
+
+function AutoOpenMediaSidebar() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const trigger = hostRef.current?.querySelector<HTMLElement>('[data-slot="accordion-trigger"], button');
+    trigger?.click();
+    requestAnimationFrame(() => {
+      const mediaRow = hostRef.current?.querySelector<HTMLElement>('[role="button"][tabindex="0"]');
+      mediaRow?.click();
+    });
+  }, []);
+
+  return (
+    <div ref={hostRef} className="p-4">
+      <MediaSidebar messages={[{ files: mockFiles }]} />
+    </div>
+  );
+}
+
+function DockedAuthPreview() {
+  const [mode, setMode] = useState<'signin' | 'signup'>('signup');
+
+  return (
+    <div className="p-4">
+      <ChatDockedAction
+        isOpen
+        title={mode === 'signup' ? 'Sign up' : 'Sign in'}
+        description={mode === 'signup' ? 'Create an account to get started' : 'Welcome back — please sign in'}
+        onClose={() => {}}
+      >
+        <AuthForm
+          mode={mode}
+          defaultMode="signup"
+          onModeChange={setMode}
+          initialEmail="demo@blawby.test"
+          initialName="Demo User"
+          showHeader={false}
+          variant="plain"
+        />
+      </ChatDockedAction>
+    </div>
+  );
+}
+
+function DockedContactPreview() {
+  const initialValues: ContactData = {
+    name: 'Jordan Miles',
+    email: 'jordan@example.com',
+    phone: '(555) 123-9876'
+  };
+
+  return (
+    <div className="p-4">
+      <ChatDockedAction
+        isOpen
+        title="Request Consultation"
+        description="Provide your contact details"
+        onClose={() => {}}
+      >
+        <ContactForm
+          onSubmit={() => {}}
+          fields={['name', 'email', 'phone']}
+          required={['name', 'email', 'phone']}
+          initialValues={initialValues}
+          variant="plain"
+          showSubmitButton
+          submitFullWidth
+          submitLabel="Continue"
+        />
+      </ChatDockedAction>
+    </div>
+  );
+}
+
+function PreviewSurface({ children }: { children: ComponentChildren }) {
+  return (
+    <main className="min-h-screen bg-app px-4 py-4">
+      {children}
+    </main>
+  );
+}
+
+function PreviewRenderer({ previewId }: { previewId: PreviewId }) {
+  const [confirmationResolved, setConfirmationResolved] = useState(false);
+
+  if (previewId === 'confirmation') {
+    return (
+      <ConfirmationDialog
+        isOpen
+        onClose={() => {}}
+        onConfirm={async () => {
+          setConfirmationResolved(true);
+        }}
+        title="Archive intake configuration"
+        description="Preview of the destructive confirmation flow."
+        confirmText={confirmationResolved ? 'Archived' : 'Archive'}
+        confirmationValue="ARCHIVE"
+        confirmationLabel="Type this text to continue:"
+        warningItems={[
+          'Automation rules connected to this intake',
+          'Saved draft responses attached to the intake flow',
+          'The current public intake entry point'
+        ]}
+        showSuccessMessage={confirmationResolved}
+        successMessage={{
+          title: 'Preview completed',
+          body: 'Confirmation dialog success state.'
+        }}
+      />
+    );
+  }
+
+  if (previewId === 'welcome') {
+    return <WelcomeModal isOpen onClose={() => {}} onComplete={() => {}} workspace="practice" />;
+  }
+
+  if (previewId === 'camera') {
+    return <CameraModal isOpen onClose={() => {}} onCapture={() => {}} />;
+  }
+
+  if (previewId === 'app-connection') {
+    return (
+      <AppConnectionModal
+        isOpen
+        onClose={() => {}}
+        app={mockApps[1]}
+        onConnect={() => {}}
+      />
+    );
+  }
+
+  if (previewId === 'message-attachments') {
+    return <AutoOpenMessageAttachments />;
+  }
+
+  if (previewId === 'media-sidebar') {
+    return <AutoOpenMediaSidebar />;
+  }
+
+  if (previewId === 'docked-auth') {
+    return <DockedAuthPreview />;
+  }
+
+  if (previewId === 'docked-contact') {
+    return <DockedContactPreview />;
+  }
+
+  const type =
+    previewId === 'shared-modal'
+      ? 'modal'
+      : previewId === 'shared-drawer'
+        ? 'drawer'
+        : previewId === 'shared-drawer-right'
+          ? 'drawer-right'
+          : 'fullscreen';
+
+  return (
+    <Modal
+      isOpen
+      onClose={() => {}}
+      title={type === 'fullscreen' ? undefined : 'Shared shell'}
+      type={type}
+      bodyClassName={type === 'fullscreen' ? 'p-0' : undefined}
+      contentClassName={type === 'modal' ? 'max-w-2xl' : type === 'drawer-right' ? 'max-w-2xl' : undefined}
+      disableBackdropClick
+    >
+      {type === 'fullscreen' ? (
+        <div className="flex min-h-screen items-center justify-center p-8">
+          <div className="max-w-xl text-center">
+            <p className="text-lg font-medium text-input-text">Shared fullscreen shell</p>
+            <p className="mt-2 text-sm text-input-placeholder">Used by media and camera flows.</p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-input-text">Shared shell preview.</p>
+          <p className="text-sm text-input-placeholder">No additional feature UI injected.</p>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function GalleryCard({ item }: { item: ModalInventoryItem }) {
+  const frameSrc = item.previewId ? `/debug/modals/${item.previewId}` : null;
+
+  return (
+    <article className="space-y-3 rounded-2xl border border-line-glass/30 bg-white/[0.02] p-4">
+      <div className="space-y-2">
+        <h2 className="text-base font-semibold text-input-text">{item.name}</h2>
+        <p className="break-all text-xs text-input-placeholder">{item.file}</p>
+      </div>
+      <dl className="grid gap-3 text-sm md:grid-cols-[140px_1fr]">
+        <dt className="font-medium text-input-text">Role</dt>
+        <dd className="text-input-placeholder">{item.role}</dd>
+        <dt className="font-medium text-input-text">Used for</dt>
+        <dd className="text-input-placeholder">{item.usedFor}</dd>
+        <dt className="font-medium text-input-text">Simplify</dt>
+        <dd className="text-input-placeholder">{item.simplify}</dd>
+      </dl>
+      {frameSrc ? (
+        <div className="overflow-hidden rounded-xl border border-line-glass/20 bg-app">
+          <iframe
+            title={`${item.name} preview`}
+            src={frameSrc}
+            className="block w-full border-0 bg-app"
+            style={{ height: `${item.frameHeight ?? 480}px` }}
+          />
+        </div>
+      ) : (
+        <div className="rounded-xl border border-dashed border-line-glass/20 px-4 py-6 text-sm text-input-placeholder">
+          No side-by-side preview yet.
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function DebugModalsPage({ previewId }: DebugModalsPageProps) {
+  const { navigate } = useNavigation();
+
+  const previewItem = useMemo(
+    () => inventory.find((item) => item.previewId === previewId),
+    [previewId]
+  );
+
+  if (previewId && previewItem?.previewId) {
+    return (
+      <PreviewSurface>
+        <PreviewRenderer previewId={previewItem.previewId} />
+      </PreviewSurface>
+    );
+  }
+
+  const sharedShells = inventory.filter((item) => item.role === 'Shared shell');
+  const featureModals = inventory.filter((item) => item.role === 'Feature modal');
+  const launcherPatterns = inventory.filter((item) => item.role === 'Inline launcher');
+  const dockedSurfaces = inventory.filter((item) => item.role === 'Docked surface');
+  const relatedPatterns = inventory.filter((item) => item.role === 'Form content' || item.role === 'Page-owned drawer' || item.role === 'Page-owned launchers');
+
+  return (
+    <main className="mx-auto max-w-[1600px] space-y-8 p-6">
+      <header className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold text-input-text">Debug Modals</h1>
+            <p className="text-sm text-input-placeholder">
+              Side-by-side review of actual modal implementations and launcher patterns.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="secondary" size="sm" onClick={() => navigate('/debug/styles')}>
+              Styles
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => navigate('/debug/matters')}>
+              Matters
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium text-input-text">Shared Shells</h2>
+          <p className="text-sm text-input-placeholder">Core container patterns. Review these first if the goal is consolidation.</p>
+        </div>
+        <div className="space-y-4">
+          {sharedShells.map((item) => <GalleryCard key={item.name} item={item} />)}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium text-input-text">Feature Modals</h2>
+          <p className="text-sm text-input-placeholder">Real feature implementations layered on top of the shared shell.</p>
+        </div>
+        <div className="space-y-4">
+          {featureModals.map((item) => <GalleryCard key={item.name} item={item} />)}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium text-input-text">Launcher Patterns</h2>
+          <p className="text-sm text-input-placeholder">Inline components that launch modal experiences rather than being modal shells themselves.</p>
+        </div>
+        <div className="space-y-4">
+          {launcherPatterns.map((item) => <GalleryCard key={item.name} item={item} />)}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium text-input-text">Docked Surfaces</h2>
+          <p className="text-sm text-input-placeholder">Transient UI that is not a portal modal but should still align with the shared design system.</p>
+        </div>
+        <div className="space-y-4">
+          {dockedSurfaces.map((item) => <GalleryCard key={item.name} item={item} />)}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium text-input-text">Related Patterns</h2>
+          <p className="text-sm text-input-placeholder">Important adjacent pieces that affect a modal refactor but are not straightforward modal previews.</p>
+        </div>
+        <div className="space-y-4">
+          {relatedPatterns.map((item) => <GalleryCard key={item.name} item={item} />)}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -22,6 +22,7 @@ interface AuthFormProps {
   showHeader?: boolean;
   showGoogleSignIn?: boolean;
   showModeToggle?: boolean;
+  disableActions?: boolean;
   className?: string;
   variant?: 'card' | 'plain';
 }
@@ -39,6 +40,7 @@ const AuthForm = ({
   showHeader = true,
   showGoogleSignIn = true,
   showModeToggle = true,
+  disableActions = false,
   className = '',
   variant = 'card'
 }: AuthFormProps) => {
@@ -78,6 +80,11 @@ const AuthForm = ({
   }, [onSuccess, resolvedMode]);
 
   const handleSubmit = async (_data?: Record<string, unknown>) => {
+    if (disableActions) {
+      setError('');
+      setMessage('Preview mode: auth actions are disabled.');
+      return;
+    }
     setLoading(true);
     setError('');
     setMessage('');
@@ -163,6 +170,11 @@ const AuthForm = ({
   };
 
   const handleGoogleSignIn = async () => {
+    if (disableActions) {
+      setError('');
+      setMessage('Preview mode: auth actions are disabled.');
+      return;
+    }
     setLoading(true);
     setError('');
     setMessage('');
@@ -264,7 +276,7 @@ const AuthForm = ({
               variant="secondary"
               size="md"
               onClick={handleGoogleSignIn}
-              disabled={loading}
+              disabled={loading || disableActions}
               className="w-full justify-center"
               icon={
                 <svg className="w-5 h-5" viewBox="0 0 24 24">
@@ -305,15 +317,16 @@ const AuthForm = ({
                         type="text"
                         required={resolvedMode === 'signup'}
                         value={formData.name}
-                        onChange={(value) => {
-                          onChange(value);
-                          setFormData(prev => ({ ...prev, name: String(value) }));
-                        }}
-                        placeholder={t('signup.fullNamePlaceholder')}
-                        icon={UserCircleIcon} iconClassName="h-5 w-5 text-input-placeholder"
-                        error={fieldError?.message}
-                        data-testid="signup-name-input"
-                      />
+                      onChange={(value) => {
+                        onChange(value);
+                        setFormData(prev => ({ ...prev, name: String(value) }));
+                      }}
+                      placeholder={t('signup.fullNamePlaceholder')}
+                      icon={UserCircleIcon} iconClassName="h-5 w-5 text-input-placeholder"
+                      error={fieldError?.message}
+                      disabled={disableActions}
+                      data-testid="signup-name-input"
+                    />
                     </FormControl>
                     {fieldError && <FormMessage>{fieldError.message}</FormMessage>}
                   </FormItem>
@@ -335,6 +348,7 @@ const AuthForm = ({
                       }}
                       placeholder={t(resolvedMode === 'signup' ? 'signup.emailPlaceholder' : 'signin.emailPlaceholder')}
                       error={fieldError?.message}
+                      disabled={disableActions}
                       data-testid={resolvedMode === 'signup' ? 'signup-email-input' : 'signin-email-input'}
                     />
                   </FormControl>
@@ -358,6 +372,7 @@ const AuthForm = ({
                       }}
                       placeholder={t(resolvedMode === 'signup' ? 'signup.passwordPlaceholder' : 'signin.passwordPlaceholder')}
                       error={fieldError?.message}
+                      disabled={disableActions}
                       data-testid={resolvedMode === 'signup' ? 'signup-password-input' : 'signin-password-input'}
                     />
                   </FormControl>
@@ -382,6 +397,7 @@ const AuthForm = ({
                         }}
                         placeholder={t('signup.confirmPasswordPlaceholder')}
                         error={fieldError?.message}
+                        disabled={disableActions}
                         data-testid="signup-confirm-password-input"
                       />
                     </FormControl>
@@ -409,7 +425,7 @@ const AuthForm = ({
               type="submit"
               variant="primary"
               size="md"
-              disabled={loading}
+              disabled={loading || disableActions}
               data-testid={resolvedMode === 'signup' ? 'signup-submit-button' : 'signin-submit-button'}
               className="w-full justify-center"
               aria-busy={loading}
@@ -432,7 +448,7 @@ const AuthForm = ({
                 size="sm"
                 type="button"
                 onClick={handleToggleMode}
-                disabled={loading}
+                disabled={loading || disableActions}
                 className="text-accent-500 hover:text-accent-400"
               >
                 {resolvedMode === 'signup' 

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -26,7 +26,6 @@ import { PERSON_RELATIONSHIP_STATUS_LABELS } from '@/shared/domain/people';
 import type { Address } from '@/shared/types/address';
 import type { IntakeConversationState, DerivedIntakeStatus } from '@/shared/types/intake';
 import { resolveStrengthTier, resolveStrengthLabel, resolveStrengthStyle, resolveStrengthDescription } from '@/shared/utils/intakeStrength';
-import { renderUserAvatar } from '@/shared/ui/profile';
 
 type InspectorConfig =
   | { type: 'conversation' }


### PR DESCRIPTION
## What changed
- Moved invoice create/edit onto the shared client data path so invoice forms use the clients endpoint instead of custom fallback-heavy loading.
- Hydrated invoice detail client labels from /api/clients when invoice payloads do not include a usable person name.
- Kept dashboard invoice rows using invoice data, but fixed the invoice detail/edit shell so draft editing uses the composer-style header and hides the list pane.
- Cleaned up the dashboard card/status color tokens and the debug modals preview lint issue.

## Validation
- npm run type-check
- npm run lint (warnings remain in unrelated files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice detail now hides the invoices list on desktop for a focused view.
  * Invoice links now navigate to a dedicated invoice URL path.
  * Draft invoice header updated with improved navigation and send controls.

* **Bug Fixes**
  * Client loading and error reporting improved for invoice creation.
  * Client name display fixed when source client details are missing.

* **Style**
  * Refreshed invoice/status visuals and updated “View invoice” action label.

* **Other**
  * Auth form supports a preview mode that disables auth actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->