### PR TITLE
Adjust workspace shell nav and inspector surfaces

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
     --surface-base: 255 255 255;
     --surface-overlay: 255 255 255;
     --surface-nav-rail: 244 246 251;
-    --surface-nav-secondary: 240 242 249;
+    --surface-nav-secondary: 238 241 248;
     --surface-list-panel: 236 239 247;
     --surface-glass: 255 255 255;
     --line-glass: 255 255 255;
@@ -39,7 +39,7 @@
     --surface-base: 3 7 18;
     --surface-overlay: 10 15 26;
     --surface-nav-rail: 18 22 34;
-    --surface-nav-secondary: 14 18 30;
+    --surface-nav-secondary: 16 20 34;
     --surface-list-panel: 11 15 25;
     --surface-glass: 255 255 255;
     --line-glass: 255 255 255;

--- a/src/shared/ui/layout/AppShell.tsx
+++ b/src/shared/ui/layout/AppShell.tsx
@@ -152,7 +152,7 @@ export const AppShell = ({
       {hasSidebar && (
         <aside
           className={cn(
-            'relative z-10 row-start-2 min-h-0 overflow-y-auto border-r border-line-glass/15 bg-transparent hidden lg:block',
+            'relative z-10 row-start-2 min-h-0 overflow-y-auto bg-transparent hidden lg:block',
             sidebarClassName
           )}
         >
@@ -164,7 +164,6 @@ export const AppShell = ({
         <aside
           className={cn(
             'relative z-10 row-start-2 min-h-0 overflow-y-auto bg-surface-nav-secondary hidden lg:block',
-            !hasListPanel ? 'border-r border-line-glass/15' : undefined,
             secondarySidebarColStartClass,
             secondarySidebarClassName
           )}
@@ -198,7 +197,7 @@ export const AppShell = ({
       {hasInspector && (
         <aside
           className={cn(
-            'relative z-10 row-start-2 min-h-0 overflow-y-auto border-l border-line-glass/15 hidden lg:block',
+            'relative z-10 row-start-2 min-h-0 overflow-y-auto bg-surface-nav-secondary hidden lg:block',
             inspectorColStartClass,
             inspectorClassName
           )}
@@ -219,7 +218,7 @@ export const AppShell = ({
           ) : (
             <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" />
           )}
-          <aside className="absolute right-0 top-0 h-dvh w-full max-w-2xl overflow-y-auto border-l border-line-glass/15 bg-surface-base">
+          <aside className="absolute right-0 top-0 h-dvh w-full max-w-2xl overflow-y-auto bg-surface-nav-secondary">
             {inspector}
           </aside>
         </div>
@@ -237,7 +236,7 @@ export const AppShell = ({
           ) : (
             <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" />
           )}
-          <aside className="absolute left-0 top-0 h-dvh w-full max-w-xs overflow-y-auto border-r border-line-glass/15 bg-surface-base">
+          <aside className="absolute left-0 top-0 h-dvh w-full max-w-xs overflow-y-auto bg-surface-nav-secondary">
             {secondarySidebar}
           </aside>
         </div>

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -77,7 +77,7 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
     : 'min-w-0 flex-1 flex-col gap-1 rounded-2xl px-2 py-2 text-xs';
 
   const containerClass = variant === 'rail'
-    ? 'flex h-full flex-col items-center gap-2 border-r border-line-glass/30 bg-[rgb(var(--nav-surface))] px-3 py-4'
+    ? 'flex h-full flex-col items-center gap-2 bg-[rgb(var(--nav-surface))] px-3 py-4'
     : 'flex w-full items-center justify-around border-t border-line-glass/30 bg-[rgb(var(--nav-surface))] px-4 py-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] nav-rail--bottom';
 
   return (

--- a/tests/component/app-shell.test.tsx
+++ b/tests/component/app-shell.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/preact';
+import type { ComponentType } from 'preact';
+import { describe, expect, it, vi } from 'vitest';
+import { AppShell } from '@/shared/ui/layout/AppShell';
+import { NavRail, type NavRailItem } from '@/shared/ui/nav/NavRail';
+
+vi.mock('preact-iso', () => ({
+  useLocation: () => ({
+    path: '/practice/test/messages',
+    query: {}
+  })
+}));
+
+vi.mock('@/shared/utils/navigation', () => ({
+  useNavigation: () => ({
+    navigate: vi.fn()
+  })
+}));
+
+vi.mock('@/shared/ui/Icon', () => ({
+  Icon: ({
+    icon: IconComponent,
+    className
+  }: {
+    icon: ComponentType<{ className?: string }>;
+    className?: string;
+  }) => <IconComponent className={className} />
+}));
+
+const DummyIcon = ({ className }: { className?: string }) => (
+  <svg aria-hidden="true" className={className} />
+);
+
+const railItems: NavRailItem[] = [
+  {
+    id: 'messages',
+    label: 'Messages',
+    icon: DummyIcon,
+    href: '/practice/test/messages'
+  }
+];
+
+describe('AppShell surfaces', () => {
+  it('removes desktop divider borders and uses the shared secondary surface for the inspector', () => {
+    render(
+      <AppShell
+        sidebar={<div data-testid="sidebar-content">Sidebar</div>}
+        secondarySidebar={<div data-testid="secondary-content">Secondary</div>}
+        inspector={<div data-testid="inspector-content">Inspector</div>}
+        main={<div>Main</div>}
+      />
+    );
+
+    const sidebarWrapper = screen.getByTestId('sidebar-content').parentElement;
+    const secondaryWrapper = screen.getByTestId('secondary-content').parentElement;
+    const inspectorWrapper = screen.getByTestId('inspector-content').parentElement;
+
+    expect(sidebarWrapper).not.toHaveClass('border-r');
+    expect(secondaryWrapper).not.toHaveClass('border-r');
+    expect(secondaryWrapper).toHaveClass('bg-surface-nav-secondary');
+    expect(inspectorWrapper).not.toHaveClass('border-l');
+    expect(inspectorWrapper).toHaveClass('bg-surface-nav-secondary');
+  });
+
+  it('uses the shared secondary surface for the mobile sheets without divider borders', () => {
+    render(
+      <AppShell
+        secondarySidebar={<div data-testid="mobile-secondary-content">Secondary</div>}
+        inspector={<div data-testid="mobile-inspector-content">Inspector</div>}
+        mobileSecondaryNavOpen
+        inspectorMobileOpen
+        main={<div>Main</div>}
+      />
+    );
+
+    const mobileSecondaryWrapper = screen
+      .getAllByTestId('mobile-secondary-content')
+      .map((node) => node.parentElement)
+      .find((node) => node?.className.includes('max-w-xs'));
+    const mobileInspectorWrapper = screen
+      .getAllByTestId('mobile-inspector-content')
+      .map((node) => node.parentElement)
+      .find((node) => node?.className.includes('max-w-2xl'));
+
+    expect(mobileSecondaryWrapper).toBeDefined();
+    expect(mobileSecondaryWrapper).toHaveClass('bg-surface-nav-secondary');
+    expect(mobileSecondaryWrapper).not.toHaveClass('border-r');
+
+    expect(mobileInspectorWrapper).toBeDefined();
+    expect(mobileInspectorWrapper).toHaveClass('bg-surface-nav-secondary');
+    expect(mobileInspectorWrapper).not.toHaveClass('border-l');
+  });
+
+  it('keeps the desktop rail surface without a built-in divider border', () => {
+    render(
+      <NavRail
+        items={railItems}
+        activeHref="/practice/test/messages"
+        variant="rail"
+      />
+    );
+
+    const railContainer = screen.getByRole('button', { name: 'Messages' }).parentElement;
+
+    expect(railContainer?.className).toContain('bg-[rgb(var(--nav-surface))]');
+    expect(railContainer).not.toHaveClass('border-r');
+  });
+});


### PR DESCRIPTION
## Summary
- remove shared workspace shell divider borders from the desktop rail, secondary nav, and inspector wrappers
- use the same secondary surface for the shared desktop/mobile inspector and mobile secondary-nav sheets
- add focused component coverage for the shared shell surface classes

## Testing
- npm run lint
- npm run type-check
- npm run test:component -- tests/component/app-shell.test.tsx

Closes #402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated secondary navigation surface colors in light and dark theme modes for improved visual consistency.
  * Refined navigation and layout styling by adjusting borders and background colors across sidebar, inspector, and rail components.

* **Tests**
  * Added comprehensive test coverage validating navigation and layout component styling behavior across desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->