### PR TITLE
[codex] Add participant mention repository and policy

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -37,7 +37,8 @@ const ClientInvoiceDetailPage = lazy(() => import('@/features/invoices/pages/Cli
 const PracticeReportsPage = lazy(() => import('@/features/reports/pages/PracticeReportsPage').then(m => ({ default: m.PracticeReportsPage })));
 import { useConversationSystemMessages } from '@/shared/hooks/useConversationSystemMessages';
 import { initializeAccentColor } from '@/shared/utils/accentColors';
-import { getConversationParticipants, linkConversationToUser } from '@/shared/lib/apiClient';
+import { linkConversationToUser } from '@/shared/lib/apiClient';
+import { useMentionCandidates } from '@/shared/hooks/useMentionCandidates';
 import { isIntakeReadyForSubmission, resolveConsultationState } from '@/shared/utils/consultationState';
 import {
   peekAnonymousSessionId,
@@ -505,46 +506,7 @@ export function MainApp({
     });
   }, [sendMessage, isPracticeWorkspace]);
 
-  const [mentionCandidates, setMentionCandidates] = useState<Array<{ userId: string; name: string }>>([]);
-  useEffect(() => {
-    console.log('[Participants] Loading for', { liveConversationId, practiceId });
-    if (!isPracticeWorkspace || !practiceId || !liveConversationId) {
-      setMentionCandidates([]);
-      return;
-    }
-
-    const looksLikeEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-    const controller = new AbortController();
-
-    (async () => {
-      try {
-        console.log('[Participants] Fetching participants...');
-        const participants = await getConversationParticipants(liveConversationId, practiceId, { signal: controller.signal });
-        const nextMentionCandidates = participants
-          .filter((participant) => participant.canMentionInternally === true)
-          .map((participant) => ({
-            userId: participant.userId,
-            name: (participant.name ?? '').trim(),
-          }))
-          .filter((participant) => (
-            participant.userId.trim().length > 0
-            && participant.name.length > 0
-            && !looksLikeEmail(participant.name)
-          ));
-        console.log('[Participants] Fetched', participants.length, 'participants');
-        setMentionCandidates(nextMentionCandidates);
-      } catch (error) {
-        if ((error as DOMException)?.name === 'AbortError') return;
-        console.warn('[MainApp] Failed to load conversation participants for mentions', error);
-        setMentionCandidates([]);
-      }
-    })();
-
-    return () => {
-      console.log('[Participants] Cleanup - aborting request');
-      controller.abort();
-    };
-  }, [isPracticeWorkspace, liveConversationId, practiceId]);
+  const { mentionCandidates } = useMentionCandidates(practiceId, liveConversationId);
 
   const handleUploadError = useCallback((error: unknown) => {
     console.error('File upload error:', error);

--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -29,6 +29,7 @@
 
 import { useState, useMemo, useCallback, useRef, useEffect } from 'preact/hooks';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
+import { invalidateParticipants } from '@/shared/lib/conversationRepository';
 import type { ChatMessageUI, MessageReaction } from '../../../worker/types';
 import { getConversationMessagesEndpoint, getConversationWsEndpoint } from '@/config/api';
 import { getWorkerApiUrl } from '@/config/urls';
@@ -885,6 +886,11 @@ export const useConversation = ({
         case 'message.new': handleMessageNew(frame.data); return;
         case 'message.ack': handleMessageAck(frame.data); return;
         case 'reaction.update': handleReactionUpdate(frame.data); return;
+        case 'membership.changed':
+          if (practiceId) {
+            invalidateParticipants(practiceId, targetConversationId);
+          }
+          return;
         case 'error': {
           const code = typeof frame.data.code === 'string' ? frame.data.code : null;
           const msg = typeof frame.data.message === 'string' ? frame.data.message : 'Chat error';
@@ -942,7 +948,7 @@ export const useConversation = ({
     });
 
     ws.addEventListener('error', (err) => { if (import.meta.env.DEV) console.warn('[useConversation] WebSocket error', err); });
-  }, [clearReconnectTimer, fetchGapMessages, flushPendingAcks, handleMessageAck, handleMessageNew, handleReactionUpdate, initSocketReadyPromise, onError, rejectSocketReady, resolveSocketReady, scheduleReconnect, sendFrame, sendReadUpdate, sessionReady]);
+  }, [clearReconnectTimer, fetchGapMessages, flushPendingAcks, handleMessageAck, handleMessageNew, handleReactionUpdate, initSocketReadyPromise, onError, practiceId, rejectSocketReady, resolveSocketReady, scheduleReconnect, sendFrame, sendReadUpdate, sessionReady]);
 
   connectChatRoomRef.current = connectChatRoom;
 

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -763,7 +763,12 @@ export function useIntakeFlow({
       const generatePaymentLinkParam = options?.generatePaymentLinkOnly ? '&generatePaymentLinkOnly=true' : '';
       const response = await fetch(
         `/api/conversations/${encodeURIComponent(conversationId)}/submit-intake?practiceId=${encodeURIComponent(practiceId)}${generatePaymentLinkParam}`,
-        { method: 'POST', headers: withWidgetAuthHeaders({ 'Content-Type': 'application/json' }), credentials: 'include' },
+        {
+          method: 'POST',
+          headers: withWidgetAuthHeaders({ 'Content-Type': 'application/json' }),
+          credentials: 'include',
+          body: JSON.stringify({ mergedIntakeState: intakeConversationState }),
+        },
       );
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({})) as { error?: string };

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -761,13 +761,14 @@ export function useIntakeFlow({
     submitInFlightRef.current = true;
     try {
       const generatePaymentLinkParam = options?.generatePaymentLinkOnly ? '&generatePaymentLinkOnly=true' : '';
+      const latestMergedIntakeState = conversationMetadataRef.current?.mergedIntakeState ?? intakeConversationState;
       const response = await fetch(
         `/api/conversations/${encodeURIComponent(conversationId)}/submit-intake?practiceId=${encodeURIComponent(practiceId)}${generatePaymentLinkParam}`,
         {
           method: 'POST',
           headers: withWidgetAuthHeaders({ 'Content-Type': 'application/json' }),
           credentials: 'include',
-          body: JSON.stringify({ mergedIntakeState: intakeConversationState }),
+          body: JSON.stringify({ mergedIntakeState: latestMergedIntakeState }),
         },
       );
       if (!response.ok) {

--- a/src/shared/hooks/useMentionCandidates.ts
+++ b/src/shared/hooks/useMentionCandidates.ts
@@ -22,7 +22,7 @@ const toMentionCandidates = (
         : participant.canBeMentionedByClient === true
     ))
     .map((participant) => ({
-      userId: participant.userId.trim(),
+      userId: (participant.userId ?? '').trim(),
       name: (participant.name ?? '').trim(),
       image: participant.image ?? null,
     }))

--- a/src/shared/hooks/useMentionCandidates.ts
+++ b/src/shared/hooks/useMentionCandidates.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { getParticipants, clearParticipants, type ParticipantRecord } from '@/shared/lib/conversationRepository';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
+import { isTeamRole } from '@/shared/types/team';
+
+export type MentionCandidate = {
+  userId: string;
+  name: string;
+  image: string | null;
+};
+
+const toMentionCandidates = (
+  participants: ParticipantRecord[],
+  senderType: 'team_member' | 'client'
+): MentionCandidate[] => {
+  const seen = new Set<string>();
+
+  return participants
+    .filter((participant) => (
+      senderType === 'team_member'
+        ? participant.canBeMentionedByTeamMember === true
+        : participant.canBeMentionedByClient === true
+    ))
+    .map((participant) => ({
+      userId: participant.userId.trim(),
+      name: (participant.name ?? '').trim(),
+      image: participant.image ?? null,
+    }))
+    .filter((participant) => {
+      if (participant.userId.length === 0 || participant.name.length === 0) {
+        return false;
+      }
+      if (seen.has(participant.userId)) {
+        return false;
+      }
+      seen.add(participant.userId);
+      return true;
+    });
+};
+
+export function useMentionCandidates(practiceId: string | null, conversationId: string | null) {
+  const { isAnonymous, activeMemberRole } = useSessionContext();
+  const [mentionCandidates, setMentionCandidates] = useState<MentionCandidate[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const previousPracticeIdRef = useRef<string | null>(practiceId);
+
+  useEffect(() => {
+    const previousPracticeId = previousPracticeIdRef.current;
+    if (previousPracticeId && previousPracticeId !== practiceId) {
+      clearParticipants();
+    }
+    previousPracticeIdRef.current = practiceId;
+  }, [practiceId]);
+
+  useEffect(() => {
+    if (!practiceId || !conversationId || isAnonymous) {
+      setMentionCandidates([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    const senderType = isTeamRole(activeMemberRole) ? 'team_member' : 'client';
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+
+    void getParticipants(practiceId, conversationId)
+      .then((participants) => {
+        if (cancelled) return;
+        setMentionCandidates(toMentionCandidates(participants, senderType));
+        setIsLoading(false);
+      })
+      .catch((nextError: unknown) => {
+        if (cancelled) return;
+        setMentionCandidates([]);
+        setIsLoading(false);
+        setError(nextError instanceof Error ? nextError.message : 'Failed to load mention candidates');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeMemberRole, conversationId, isAnonymous, practiceId]);
+
+  return {
+    mentionCandidates,
+    isLoading,
+    error,
+  };
+}

--- a/src/shared/hooks/useMentionCandidates.ts
+++ b/src/shared/hooks/useMentionCandidates.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
-import { getParticipants, clearParticipants, type ParticipantRecord } from '@/shared/lib/conversationRepository';
+import { getParticipants, invalidateParticipants, type ParticipantRecord } from '@/shared/lib/conversationRepository';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { isTeamRole } from '@/shared/types/team';
 
@@ -48,7 +48,7 @@ export function useMentionCandidates(practiceId: string | null, conversationId: 
   useEffect(() => {
     const previousPracticeId = previousPracticeIdRef.current;
     if (previousPracticeId && previousPracticeId !== practiceId) {
-      clearParticipants();
+      invalidateParticipants(previousPracticeId);
     }
     previousPracticeIdRef.current = practiceId;
   }, [practiceId]);

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -383,9 +383,12 @@ export async function updateConversationMatter(
 
 export type ConversationParticipant = {
   userId: string;
-  role?: string | null;
-  name?: string | null;
-  image?: string | null;
+  role: string | null;
+  name: string | null;
+  image: string | null;
+  isTeamMember: boolean;
+  canBeMentionedByTeamMember: boolean;
+  canBeMentionedByClient: boolean;
   canMentionInternally?: boolean;
 };
 
@@ -422,6 +425,9 @@ export async function getConversationParticipants(
       role: typeof row.role === 'string' ? row.role : null,
       name: typeof row.name === 'string' ? row.name : null,
       image: typeof row.image === 'string' ? row.image : null,
+      isTeamMember: row.isTeamMember === true || row.is_team_member === true,
+      canBeMentionedByTeamMember: row.canBeMentionedByTeamMember === true || row.can_be_mentioned_by_team_member === true,
+      canBeMentionedByClient: row.canBeMentionedByClient === true || row.can_be_mentioned_by_client === true,
       canMentionInternally: row.canMentionInternally === true || row.can_mention_internally === true,
     }))
     .filter((row) => row.userId.trim().length > 0);

--- a/src/shared/lib/conversationRepository.ts
+++ b/src/shared/lib/conversationRepository.ts
@@ -14,15 +14,23 @@ type CacheEntry = {
 const participantCache = new Map<string, CacheEntry>();
 const participantInflight = new Map<string, Promise<ParticipantRecord[]>>();
 const participantGenerations = new Map<string, number>();
+let participantGenerationCounter = 0;
 
 let authClearListenerRegistered = false;
 
 const getCacheKey = (practiceId: string, conversationId: string) => `${practiceId}::${conversationId}`;
+const getGeneration = (key: string) => participantGenerations.get(key) ?? participantGenerationCounter;
 
 const pruneExpiredEntries = (now: number) => {
   for (const [key, entry] of participantCache.entries()) {
     if (entry.expiresAt <= now) {
       participantCache.delete(key);
+    }
+  }
+
+  for (const key of participantGenerations.keys()) {
+    if (!participantCache.has(key) && !participantInflight.has(key)) {
+      participantGenerations.delete(key);
     }
   }
 };
@@ -63,7 +71,7 @@ export async function getParticipants(practiceId: string, conversationId: string
   ensureGlobalListeners();
 
   const key = getCacheKey(normalizedPracticeId, normalizedConversationId);
-  const generation = participantGenerations.get(key) ?? 0;
+  const generation = getGeneration(key);
   const now = Date.now();
   pruneExpiredEntries(now);
 
@@ -81,7 +89,7 @@ export async function getParticipants(practiceId: string, conversationId: string
   const request = getConversationParticipants(normalizedConversationId, normalizedPracticeId)
     .then((participants) => {
       const nextNow = Date.now();
-      if ((participantGenerations.get(key) ?? 0) === generation) {
+      if (getGeneration(key) === generation) {
         participantCache.set(key, {
           value: participants,
           expiresAt: nextNow + CACHE_TTL_MS,
@@ -93,7 +101,12 @@ export async function getParticipants(practiceId: string, conversationId: string
       return participants;
     })
     .finally(() => {
-      participantInflight.delete(key);
+      if (participantInflight.get(key) === request) {
+        participantInflight.delete(key);
+      }
+      if (!participantCache.has(key) && !participantInflight.has(key)) {
+        participantGenerations.delete(key);
+      }
     });
 
   participantInflight.set(key, request);
@@ -108,28 +121,31 @@ export function invalidateParticipants(practiceId: string, conversationId?: stri
     const normalizedConversationId = conversationId.trim();
     if (!normalizedConversationId) return;
     const key = getCacheKey(normalizedPracticeId, normalizedConversationId);
-    participantGenerations.set(key, (participantGenerations.get(key) ?? 0) + 1);
+    const nextGeneration = getGeneration(key) + 1;
     participantCache.delete(key);
+    participantGenerations.delete(key);
     participantInflight.delete(key);
+    participantGenerations.set(key, nextGeneration);
     return;
   }
 
   const prefix = `${normalizedPracticeId}::`;
-  for (const key of [...participantCache.keys()]) {
-    if (key.startsWith(prefix)) {
-      participantGenerations.set(key, (participantGenerations.get(key) ?? 0) + 1);
-      participantCache.delete(key);
-    }
-  }
-  for (const key of [...participantInflight.keys()]) {
-    if (key.startsWith(prefix)) {
-      participantGenerations.set(key, (participantGenerations.get(key) ?? 0) + 1);
-      participantInflight.delete(key);
-    }
+  const matchingKeys = new Set([
+    ...[...participantCache.keys()].filter((key) => key.startsWith(prefix)),
+    ...[...participantInflight.keys()].filter((key) => key.startsWith(prefix)),
+  ]);
+
+  for (const key of matchingKeys) {
+    const nextGeneration = getGeneration(key) + 1;
+    participantCache.delete(key);
+    participantGenerations.delete(key);
+    participantInflight.delete(key);
+    participantGenerations.set(key, nextGeneration);
   }
 }
 
 export function clearParticipants(): void {
+  participantGenerationCounter += 1;
   participantCache.clear();
   participantInflight.clear();
   participantGenerations.clear();

--- a/src/shared/lib/conversationRepository.ts
+++ b/src/shared/lib/conversationRepository.ts
@@ -1,0 +1,136 @@
+import { getConversationParticipants, type ConversationParticipant } from '@/shared/lib/apiClient';
+
+export type ParticipantRecord = ConversationParticipant;
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 50;
+
+type CacheEntry = {
+  value: ParticipantRecord[];
+  expiresAt: number;
+  lastAccessedAt: number;
+};
+
+const participantCache = new Map<string, CacheEntry>();
+const participantInflight = new Map<string, Promise<ParticipantRecord[]>>();
+const participantGenerations = new Map<string, number>();
+
+let authClearListenerRegistered = false;
+
+const getCacheKey = (practiceId: string, conversationId: string) => `${practiceId}::${conversationId}`;
+
+const pruneExpiredEntries = (now: number) => {
+  for (const [key, entry] of participantCache.entries()) {
+    if (entry.expiresAt <= now) {
+      participantCache.delete(key);
+    }
+  }
+};
+
+const pruneOverflowEntries = () => {
+  if (participantCache.size <= MAX_CACHE_ENTRIES) return;
+
+  const entriesByAge = [...participantCache.entries()].sort(
+    (left, right) => left[1].lastAccessedAt - right[1].lastAccessedAt
+  );
+
+  while (entriesByAge.length > 0 && participantCache.size > MAX_CACHE_ENTRIES) {
+    const oldest = entriesByAge.shift();
+    if (!oldest) break;
+    participantCache.delete(oldest[0]);
+  }
+};
+
+const ensureGlobalListeners = () => {
+  if (authClearListenerRegistered || typeof window === 'undefined') return;
+
+  const clearCache = () => clearParticipants();
+  window.addEventListener('auth:session-cleared', clearCache);
+  authClearListenerRegistered = true;
+};
+
+export async function getParticipants(practiceId: string, conversationId: string): Promise<ParticipantRecord[]> {
+  const normalizedPracticeId = practiceId.trim();
+  const normalizedConversationId = conversationId.trim();
+
+  if (!normalizedPracticeId) {
+    throw new Error('practiceId is required');
+  }
+  if (!normalizedConversationId) {
+    throw new Error('conversationId is required');
+  }
+
+  ensureGlobalListeners();
+
+  const key = getCacheKey(normalizedPracticeId, normalizedConversationId);
+  const generation = participantGenerations.get(key) ?? 0;
+  const now = Date.now();
+  pruneExpiredEntries(now);
+
+  const cached = participantCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    cached.lastAccessedAt = now;
+    return cached.value;
+  }
+
+  const inflight = participantInflight.get(key);
+  if (inflight) {
+    return inflight;
+  }
+
+  const request = getConversationParticipants(normalizedConversationId, normalizedPracticeId)
+    .then((participants) => {
+      const nextNow = Date.now();
+      if ((participantGenerations.get(key) ?? 0) === generation) {
+        participantCache.set(key, {
+          value: participants,
+          expiresAt: nextNow + CACHE_TTL_MS,
+          lastAccessedAt: nextNow,
+        });
+      }
+      pruneExpiredEntries(nextNow);
+      pruneOverflowEntries();
+      return participants;
+    })
+    .finally(() => {
+      participantInflight.delete(key);
+    });
+
+  participantInflight.set(key, request);
+  return request;
+}
+
+export function invalidateParticipants(practiceId: string, conversationId?: string): void {
+  const normalizedPracticeId = practiceId.trim();
+  if (!normalizedPracticeId) return;
+
+  if (conversationId) {
+    const normalizedConversationId = conversationId.trim();
+    if (!normalizedConversationId) return;
+    const key = getCacheKey(normalizedPracticeId, normalizedConversationId);
+    participantGenerations.set(key, (participantGenerations.get(key) ?? 0) + 1);
+    participantCache.delete(key);
+    participantInflight.delete(key);
+    return;
+  }
+
+  const prefix = `${normalizedPracticeId}::`;
+  for (const key of [...participantCache.keys()]) {
+    if (key.startsWith(prefix)) {
+      participantGenerations.set(key, (participantGenerations.get(key) ?? 0) + 1);
+      participantCache.delete(key);
+    }
+  }
+  for (const key of [...participantInflight.keys()]) {
+    if (key.startsWith(prefix)) {
+      participantGenerations.set(key, (participantGenerations.get(key) ?? 0) + 1);
+      participantInflight.delete(key);
+    }
+  }
+}
+
+export function clearParticipants(): void {
+  participantCache.clear();
+  participantInflight.clear();
+  participantGenerations.clear();
+}

--- a/tests/component/conversationRepository.test.ts
+++ b/tests/component/conversationRepository.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getConversationParticipantsMock: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({
+  getConversationParticipants: mocks.getConversationParticipantsMock,
+}));
+
+describe('conversationRepository', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-02T00:00:00.000Z'));
+    mocks.getConversationParticipantsMock.mockReset();
+
+    const repository = await import('@/shared/lib/conversationRepository');
+    repository.clearParticipants();
+  });
+
+  it('dedupes concurrent callers for the same key', async () => {
+    mocks.getConversationParticipantsMock.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 10))
+    );
+
+    const repository = await import('@/shared/lib/conversationRepository');
+    const first = repository.getParticipants('practice-1', 'conversation-1');
+    const second = repository.getParticipants('practice-1', 'conversation-1');
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(first).resolves.toEqual([]);
+    await expect(second).resolves.toEqual([]);
+    expect(mocks.getConversationParticipantsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches empty successful responses', async () => {
+    mocks.getConversationParticipantsMock.mockResolvedValue([]);
+
+    const repository = await import('@/shared/lib/conversationRepository');
+
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([]);
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([]);
+
+    expect(mocks.getConversationParticipantsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache failed requests', async () => {
+    mocks.getConversationParticipantsMock
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([]);
+
+    const repository = await import('@/shared/lib/conversationRepository');
+
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).rejects.toThrow('boom');
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([]);
+
+    expect(mocks.getConversationParticipantsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches after ttl expiry', async () => {
+    mocks.getConversationParticipantsMock
+      .mockResolvedValueOnce([{ userId: 'u1', name: 'First', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: true }])
+      .mockResolvedValueOnce([{ userId: 'u1', name: 'Second', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: true }]);
+
+    const repository = await import('@/shared/lib/conversationRepository');
+
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([
+      expect.objectContaining({ name: 'First' }),
+    ]);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([
+      expect.objectContaining({ name: 'Second' }),
+    ]);
+
+    expect(mocks.getConversationParticipantsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches after manual invalidation', async () => {
+    mocks.getConversationParticipantsMock
+      .mockResolvedValueOnce([{ userId: 'u1', name: 'First', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: true }])
+      .mockResolvedValueOnce([{ userId: 'u1', name: 'Second', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: true }]);
+
+    const repository = await import('@/shared/lib/conversationRepository');
+
+    await repository.getParticipants('practice-1', 'conversation-1');
+    repository.invalidateParticipants('practice-1', 'conversation-1');
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([
+      expect.objectContaining({ name: 'Second' }),
+    ]);
+
+    expect(mocks.getConversationParticipantsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears cached entries on logout event', async () => {
+    mocks.getConversationParticipantsMock
+      .mockResolvedValueOnce([{ userId: 'u1', name: 'First', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: true }])
+      .mockResolvedValueOnce([{ userId: 'u1', name: 'Second', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: true }]);
+
+    const repository = await import('@/shared/lib/conversationRepository');
+
+    await repository.getParticipants('practice-1', 'conversation-1');
+    window.dispatchEvent(new CustomEvent('auth:session-cleared'));
+    await expect(repository.getParticipants('practice-1', 'conversation-1')).resolves.toEqual([
+      expect.objectContaining({ name: 'Second' }),
+    ]);
+
+    expect(mocks.getConversationParticipantsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/component/useMentionCandidates.test.tsx
+++ b/tests/component/useMentionCandidates.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor } from '@testing-library/preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMentionCandidates } from '@/shared/hooks/useMentionCandidates';
+import { SessionContext, type SessionContextValue } from '@/shared/contexts/SessionContext';
+
+const mocks = vi.hoisted(() => ({
+  getParticipantsMock: vi.fn(),
+  clearParticipantsMock: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/conversationRepository', () => ({
+  getParticipants: mocks.getParticipantsMock,
+  clearParticipants: mocks.clearParticipantsMock,
+}));
+
+function Harness({ practiceId, conversationId }: { practiceId: string | null; conversationId: string | null }) {
+  const { mentionCandidates } = useMentionCandidates(practiceId, conversationId);
+  return <pre data-testid="output">{JSON.stringify(mentionCandidates)}</pre>;
+}
+
+const createSessionContext = (overrides: Partial<SessionContextValue> = {}): SessionContextValue => ({
+  session: {
+    user: { id: 'user-1', isAnonymous: false } as never,
+    session: { id: 'session-1' } as never,
+  } as never,
+  isPending: false,
+  error: null,
+  isAnonymous: false,
+  stripeCustomerId: null,
+  activePracticeId: 'practice-1',
+  activeMemberRole: null,
+  activeMemberRoleLoading: false,
+  routingClaims: null,
+  ...overrides,
+});
+
+const renderHarness = (contextValue: SessionContextValue, props: { practiceId: string | null; conversationId: string | null }) => (
+  render(
+    <SessionContext.Provider value={contextValue}>
+      <Harness {...props} />
+    </SessionContext.Provider>
+  )
+);
+
+describe('useMentionCandidates', () => {
+  beforeEach(() => {
+    mocks.getParticipantsMock.mockReset();
+    mocks.clearParticipantsMock.mockReset();
+  });
+
+  it('shows only team-member-allowed targets for a team sender', async () => {
+    mocks.getParticipantsMock.mockResolvedValue([
+      { userId: 'team-1', name: 'Team Member', image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+      { userId: 'blocked-1', name: 'Blocked Client', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: false, canBeMentionedByClient: true },
+    ]);
+
+    renderHarness(createSessionContext({ activeMemberRole: 'attorney' }), {
+      practiceId: 'practice-1',
+      conversationId: 'conversation-1',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('output').textContent).toBe(JSON.stringify([
+        { userId: 'team-1', name: 'Team Member', image: null },
+      ]));
+    });
+  });
+
+  it('shows only client-allowed targets for a client sender', async () => {
+    mocks.getParticipantsMock.mockResolvedValue([
+      { userId: 'team-1', name: 'Team Member', image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+      { userId: 'blocked-1', name: 'Blocked Client', image: null, role: null, isTeamMember: false, canBeMentionedByTeamMember: true, canBeMentionedByClient: false },
+    ]);
+
+    renderHarness(createSessionContext({ activeMemberRole: null }), {
+      practiceId: 'practice-1',
+      conversationId: 'conversation-1',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('output').textContent).toBe(JSON.stringify([
+        { userId: 'team-1', name: 'Team Member', image: null },
+      ]));
+    });
+  });
+
+  it('filters blank names out of suggestions', async () => {
+    mocks.getParticipantsMock.mockResolvedValue([
+      { userId: 'team-1', name: ' ', image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+      { userId: 'team-2', name: null, image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+      { userId: 'team-3', name: 'Valid Name', image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+    ]);
+
+    renderHarness(createSessionContext({ activeMemberRole: 'attorney' }), {
+      practiceId: 'practice-1',
+      conversationId: 'conversation-1',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('output').textContent).toBe(JSON.stringify([
+        { userId: 'team-3', name: 'Valid Name', image: null },
+      ]));
+    });
+  });
+
+  it('does not mutate raw participant records', async () => {
+    const participants = [
+      { userId: 'team-1', name: 'Team Member', image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+    ];
+    mocks.getParticipantsMock.mockResolvedValue(participants);
+
+    renderHarness(createSessionContext({ activeMemberRole: 'attorney' }), {
+      practiceId: 'practice-1',
+      conversationId: 'conversation-1',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('output').textContent).toContain('Team Member');
+    });
+
+    expect(participants).toEqual([
+      { userId: 'team-1', name: 'Team Member', image: null, role: 'attorney', isTeamMember: true, canBeMentionedByTeamMember: true, canBeMentionedByClient: true },
+    ]);
+  });
+
+  it('clears participant cache when the practice changes', async () => {
+    mocks.getParticipantsMock.mockResolvedValue([]);
+
+    const contextValue = createSessionContext({ activeMemberRole: 'attorney' });
+    const view = renderHarness(contextValue, {
+      practiceId: 'practice-1',
+      conversationId: 'conversation-1',
+    });
+
+    await waitFor(() => {
+      expect(mocks.getParticipantsMock).toHaveBeenCalledWith('practice-1', 'conversation-1');
+    });
+
+    view.rerender(
+      <SessionContext.Provider value={contextValue}>
+        <Harness practiceId="practice-2" conversationId="conversation-1" />
+      </SessionContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mocks.clearParticipantsMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/e2e/lead-flow.spec.ts
+++ b/tests/e2e/lead-flow.spec.ts
@@ -942,4 +942,239 @@ test.describe('Lead intake workflow', () => {
       )
       .not.toBeNull();
   });
+  test('intake planner follows deterministic field order and structured data is extracted', async ({
+    anonPage,
+  }, testInfo) => {
+    const practiceSlug = normalizePracticeSlug(DEFAULT_PRACTICE_SLUG);
+    const uniqueId = randomUUID().slice(0, 8);
+    const authName = `Planner E2E ${uniqueId}`;
+    const authEmail = `planner-e2e+${uniqueId}@example.com`;
+
+    // Capture done events from /api/ai/chat SSE stream
+    const donePayloads: Array<{
+      intakeFields?: Record<string, unknown> | null;
+      quickReplies?: string[] | null;
+    }> = [];
+
+    anonPage.on('response', async (response) => {
+      if (
+        response.request().method() !== 'POST' ||
+        !response.url().includes('/api/ai/chat')
+      ) return;
+      try {
+        const text = await response.text().catch(() => '');
+        const lines = text.split('\n').filter((l) => l.trim().startsWith('data: '));
+        for (const line of lines) {
+          try {
+            const payload = JSON.parse(line.replace(/^data:\s*/, ''));
+            if (payload?.done === true) donePayloads.push(payload);
+          } catch { /* skip malformed lines */ }
+        }
+      } catch { /* ignore */ }
+    });
+
+    await anonPage.goto(`/public/${encodeURIComponent(practiceSlug)}?v=widget`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // ── Slim form ────────────────────────────────────────────────────────────
+    const consultationCta = anonPage.locator('button:visible').filter({ hasText: /request consultation/i }).first();
+    const messageInput = anonPage.locator('[data-testid="message-input"]:visible').first();
+
+    await expect.poll(
+      async () => ({
+        ctaVisible: await consultationCta.isVisible().catch(() => false),
+        composerVisible: await messageInput.isVisible().catch(() => false),
+      }),
+      { timeout: 20_000, message: 'Expected widget home CTA or composer to render' }
+    ).not.toEqual({ ctaVisible: false, composerVisible: false });
+
+    if (await consultationCta.isVisible().catch(() => false)) {
+      await consultationCta.click();
+    }
+
+    const slimFormName = anonPage.locator('input[placeholder*="full name" i]:visible').first();
+    const slimFormEmail = anonPage.locator('input[type="email"]:visible').first();
+    const slimFormPhone = anonPage.locator('input[type="tel"]:visible').first();
+    const slimFormContinue = anonPage.locator('button:visible').filter({ hasText: /^continue$/i }).first();
+
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      if (await messageInput.isEnabled({ timeout: 250 }).catch(() => false)) break;
+      if (await slimFormContinue.isVisible({ timeout: 250 }).catch(() => false)) {
+        if (await slimFormName.isVisible({ timeout: 250 }).catch(() => false)) {
+          await slimFormName.fill(authName).catch(() => undefined);
+        }
+        if (await slimFormEmail.isVisible({ timeout: 250 }).catch(() => false)) {
+          await slimFormEmail.fill(authEmail).catch(() => undefined);
+        }
+        if (await slimFormPhone.isVisible({ timeout: 250 }).catch(() => false)) {
+          await slimFormPhone.fill('5555550123').catch(() => undefined);
+        }
+        await slimFormContinue.click().catch(() => undefined);
+      }
+      await anonPage.waitForTimeout(400);
+    }
+
+    await expect(messageInput).toBeEnabled({ timeout: 20_000 });
+
+    // ── Turn helper ──────────────────────────────────────────────────────────
+    const aiLocator = anonPage.locator('[data-testid="ai-message"], [data-testid="system-message"]');
+    const streamingLocator = anonPage.locator('[id^="message-streaming-"]');
+
+    const sendAndAwait = async (text: string) => {
+      const signatureBefore = JSON.stringify(
+        await aiLocator.evaluateAll((els) => els.map((el) => (el.textContent ?? '').trim()))
+      );
+      const responsePromise = anonPage.waitForResponse(
+        (r) => r.request().method() === 'POST' && r.url().includes('/api/ai/chat') && r.status() === 200,
+        { timeout: LEAD_TURN_TIMEOUT_MS }
+      );
+      await messageInput.fill(text);
+      await anonPage.getByRole('button', { name: /send message/i }).click();
+      await responsePromise;
+      // Wait for UI to settle
+      await expect.poll(
+        async () => {
+          const [sig, streamCount] = await Promise.all([
+            aiLocator.evaluateAll((els) => JSON.stringify(els.map((el) => (el.textContent ?? '').trim()))),
+            streamingLocator.count(),
+          ]);
+          return sig !== signatureBefore || streamCount === 0;
+        },
+        { timeout: LEAD_TURN_TIMEOUT_MS, message: `UI did not settle after sending: "${text}"` }
+      ).toBe(true);
+      await expect.poll(
+        async () => {
+          const count = await aiLocator.count();
+          if (count === 0) return false;
+          const last = (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+          return last.length > 0 && !/loading markdown/i.test(last);
+        },
+        { timeout: LEAD_TURN_TIMEOUT_MS, message: 'AI reply did not render after send' }
+      ).toBe(true);
+      const count = await aiLocator.count();
+      return (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+    };
+
+    const getButtons = async () =>
+      anonPage.locator('button:visible').allInnerTexts().catch(() => [] as string[]);
+
+    // ── Turn 1: Description ──────────────────────────────────────────────────
+    const reply1 = await sendAndAwait(
+      'My landlord is refusing to return my security deposit after I moved out.'
+    );
+    await testInfo.attach('planner-turn1-reply.txt', { body: reply1, contentType: 'text/plain' });
+
+    // After description, planner should ask about location next
+    expect(
+      /city|state|location|where/i.test(reply1),
+      `After description, AI should ask about location. Got: "${reply1.slice(0, 300)}"`
+    ).toBe(true);
+
+    // done payload should have description extracted
+    const done1 = donePayloads[donePayloads.length - 1];
+    expect(
+      done1?.intakeFields?.description,
+      'description should be extracted after turn 1'
+    ).toBeTruthy();
+
+    // ── Turn 2: Location ─────────────────────────────────────────────────────
+    const reply2 = await sendAndAwait('Raleigh, NC');
+    await testInfo.attach('planner-turn2-reply.txt', { body: reply2, contentType: 'text/plain' });
+
+    // After location, planner should ask about opposing party
+    expect(
+      /landlord|other party|opposing|who|party/i.test(reply2),
+      `After location, AI should ask about opposing party. Got: "${reply2.slice(0, 300)}"`
+    ).toBe(true);
+
+    const done2 = donePayloads[donePayloads.length - 1];
+    expect(done2?.intakeFields?.city, 'city should be extracted after turn 2').toBeTruthy();
+    expect(done2?.intakeFields?.state, 'state should be extracted after turn 2').toBeTruthy();
+
+    // ── Turn 3: Opposing party → minimum viable brief complete ───────────────
+    const reply3 = await sendAndAwait('My landlord, Johnson Properties LLC');
+    await testInfo.attach('planner-turn3-reply.txt', { body: reply3, contentType: 'text/plain' });
+
+    const done3 = donePayloads[donePayloads.length - 1];
+    expect(done3?.intakeFields?.opposingParty, 'opposingParty should be extracted after turn 3').toBeTruthy();
+
+    // After minimum viable brief (description + location + opposingParty),
+    // the submit button OR urgency chips should appear
+    const buttonsAfterTurn3 = await getButtons();
+    await testInfo.attach('planner-turn3-buttons.json', {
+      body: JSON.stringify(buttonsAfterTurn3, null, 2),
+      contentType: 'application/json',
+    });
+
+    const hasSubmitButton = buttonsAfterTurn3.some((b) => /submit request/i.test(b));
+    const hasUrgencyChips = buttonsAfterTurn3.some((b) =>
+      /routine|time.sensitive|emergency/i.test(b)
+    );
+    const hasYesNoChips = buttonsAfterTurn3.some((b) => /^yes$|^no$/i.test(b));
+
+    expect(
+      hasSubmitButton || hasUrgencyChips || hasYesNoChips,
+      `After minimum viable brief, expected submit button or planner chips. Buttons: ${JSON.stringify(buttonsAfterTurn3)}`
+    ).toBe(true);
+
+    // ── Turn 4: Urgency (if chips appeared, click one; otherwise type) ────────
+    if (hasUrgencyChips) {
+      const timeSensitiveChip = anonPage.locator('button:visible').filter({ hasText: /time.sensitive/i }).first();
+      if (await timeSensitiveChip.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        // Clicking a chip sends it as a message — wait for AI response
+        const responsePromise = anonPage.waitForResponse(
+          (r) => r.request().method() === 'POST' && r.url().includes('/api/ai/chat') && r.status() === 200,
+          { timeout: LEAD_TURN_TIMEOUT_MS }
+        );
+        await timeSensitiveChip.click();
+        await responsePromise;
+        await anonPage.waitForTimeout(2_000);
+      }
+    } else if (!hasSubmitButton) {
+      await sendAndAwait('Time-sensitive');
+    }
+
+    // ── Assert: submit button eventually appears within remaining turns ────────
+    const submitButton = anonPage.getByRole('button', { name: /submit request/i });
+    const paymentButton = anonPage.locator('button:visible').filter({ hasText: /continue(\s+to\s+payment)?|pay.*submit/i }).first();
+
+    await expect.poll(
+      async () => {
+        const submitVisible = await submitButton.isVisible().catch(() => false);
+        const paymentVisible = await paymentButton.isVisible().catch(() => false);
+        if (submitVisible || paymentVisible) return true;
+        // If AI is still asking questions, send generic answers
+        const count = await aiLocator.count();
+        if (count === 0) return false;
+        const last = (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+        if (/desired outcome|hoping for/i.test(last)) {
+          await sendAndAwait('Get my full deposit back');
+        } else if (/documents|paperwork/i.test(last)) {
+          await sendAndAwait('Yes, I have documents');
+        } else if (/ready to submit|are you ready/i.test(last)) {
+          return true;
+        }
+        return false;
+      },
+      {
+        timeout: 90_000,
+        message: 'Submit button never appeared after completing intake planner sequence',
+      }
+    ).toBe(true);
+
+    // ── Verify final intakeFields structure ───────────────────────────────────
+    const finalDone = donePayloads[donePayloads.length - 1];
+    await testInfo.attach('planner-final-done-payload.json', {
+      body: JSON.stringify(finalDone, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(finalDone?.intakeFields?.description, 'final state: description must be present').toBeTruthy();
+    expect(finalDone?.intakeFields?.city, 'final state: city must be present').toBeTruthy();
+    expect(finalDone?.intakeFields?.state, 'final state: state must be present').toBeTruthy();
+    expect(finalDone?.intakeFields?.opposingParty, 'final state: opposingParty must be present').toBeTruthy();
+    expect(finalDone?.intakeFields?.intakeReady, 'final state: intakeReady must be true').toBe(true);
+  });
 });

--- a/tests/e2e/lead-flow.spec.ts
+++ b/tests/e2e/lead-flow.spec.ts
@@ -950,28 +950,26 @@ test.describe('Lead intake workflow', () => {
     const authName = `Planner E2E ${uniqueId}`;
     const authEmail = `planner-e2e+${uniqueId}@example.com`;
 
-    // Capture done events from /api/ai/chat SSE stream
-    const donePayloads: Array<{
+    type DonePayload = {
       intakeFields?: Record<string, unknown> | null;
       quickReplies?: string[] | null;
-    }> = [];
+    };
 
-    anonPage.on('response', async (response) => {
-      if (
-        response.request().method() !== 'POST' ||
-        !response.url().includes('/api/ai/chat')
-      ) return;
-      try {
-        const text = await response.text().catch(() => '');
-        const lines = text.split('\n').filter((l) => l.trim().startsWith('data: '));
-        for (const line of lines) {
-          try {
-            const payload = JSON.parse(line.replace(/^data:\s*/, ''));
-            if (payload?.done === true) donePayloads.push(payload);
-          } catch { /* skip malformed lines */ }
+    const parseDonePayloads = (text: string) => {
+      const payloads: DonePayload[] = [];
+      const lines = text.split('\n').filter((line) => line.trim().startsWith('data: '));
+      for (const line of lines) {
+        try {
+          const payload = JSON.parse(line.replace(/^data:\s*/, ''));
+          if (payload?.done === true) {
+            payloads.push(payload);
+          }
+        } catch {
+          // Skip malformed SSE payload lines.
         }
-      } catch { /* ignore */ }
-    });
+      }
+      return payloads;
+    };
 
     await anonPage.goto(`/public/${encodeURIComponent(practiceSlug)}?v=widget`, {
       waitUntil: 'domcontentloaded',
@@ -1021,8 +1019,9 @@ test.describe('Lead intake workflow', () => {
     // ── Turn helper ──────────────────────────────────────────────────────────
     const aiLocator = anonPage.locator('[data-testid="ai-message"], [data-testid="system-message"]');
     const streamingLocator = anonPage.locator('[id^="message-streaming-"]');
+    let latestDonePayload: DonePayload | null = null;
 
-    const sendAndAwait = async (text: string) => {
+    const sendAndAwait = async (text: string): Promise<{ reply: string; donePayload: DonePayload | null }> => {
       const signatureBefore = JSON.stringify(
         await aiLocator.evaluateAll((els) => els.map((el) => (el.textContent ?? '').trim()))
       );
@@ -1032,7 +1031,12 @@ test.describe('Lead intake workflow', () => {
       );
       await messageInput.fill(text);
       await anonPage.getByRole('button', { name: /send message/i }).click();
-      await responsePromise;
+      const response = await responsePromise;
+      const responseText = await response.text().catch(() => '');
+      const donePayload = parseDonePayloads(responseText).at(-1) ?? null;
+      if (donePayload) {
+        latestDonePayload = donePayload;
+      }
       // Wait for UI to settle
       await expect.poll(
         async () => {
@@ -1040,7 +1044,7 @@ test.describe('Lead intake workflow', () => {
             aiLocator.evaluateAll((els) => JSON.stringify(els.map((el) => (el.textContent ?? '').trim()))),
             streamingLocator.count(),
           ]);
-          return sig !== signatureBefore || streamCount === 0;
+          return sig !== signatureBefore && streamCount === 0;
         },
         { timeout: LEAD_TURN_TIMEOUT_MS, message: `UI did not settle after sending: "${text}"` }
       ).toBe(true);
@@ -1054,14 +1058,17 @@ test.describe('Lead intake workflow', () => {
         { timeout: LEAD_TURN_TIMEOUT_MS, message: 'AI reply did not render after send' }
       ).toBe(true);
       const count = await aiLocator.count();
-      return (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+      return {
+        reply: (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim(),
+        donePayload,
+      };
     };
 
     const getButtons = async () =>
       anonPage.locator('button:visible').allInnerTexts().catch(() => [] as string[]);
 
     // ── Turn 1: Description ──────────────────────────────────────────────────
-    const reply1 = await sendAndAwait(
+    const { reply: reply1, donePayload: done1 } = await sendAndAwait(
       'My landlord is refusing to return my security deposit after I moved out.'
     );
     await testInfo.attach('planner-turn1-reply.txt', { body: reply1, contentType: 'text/plain' });
@@ -1073,14 +1080,13 @@ test.describe('Lead intake workflow', () => {
     ).toBe(true);
 
     // done payload should have description extracted
-    const done1 = donePayloads[donePayloads.length - 1];
     expect(
       done1?.intakeFields?.description,
       'description should be extracted after turn 1'
     ).toBeTruthy();
 
     // ── Turn 2: Location ─────────────────────────────────────────────────────
-    const reply2 = await sendAndAwait('Raleigh, NC');
+    const { reply: reply2, donePayload: done2 } = await sendAndAwait('Raleigh, NC');
     await testInfo.attach('planner-turn2-reply.txt', { body: reply2, contentType: 'text/plain' });
 
     // After location, planner should ask about opposing party
@@ -1089,15 +1095,13 @@ test.describe('Lead intake workflow', () => {
       `After location, AI should ask about opposing party. Got: "${reply2.slice(0, 300)}"`
     ).toBe(true);
 
-    const done2 = donePayloads[donePayloads.length - 1];
     expect(done2?.intakeFields?.city, 'city should be extracted after turn 2').toBeTruthy();
     expect(done2?.intakeFields?.state, 'state should be extracted after turn 2').toBeTruthy();
 
     // ── Turn 3: Opposing party → minimum viable brief complete ───────────────
-    const reply3 = await sendAndAwait('My landlord, Johnson Properties LLC');
+    const { reply: reply3, donePayload: done3 } = await sendAndAwait('My landlord, Johnson Properties LLC');
     await testInfo.attach('planner-turn3-reply.txt', { body: reply3, contentType: 'text/plain' });
 
-    const done3 = donePayloads[donePayloads.length - 1];
     expect(done3?.intakeFields?.opposingParty, 'opposingParty should be extracted after turn 3').toBeTruthy();
 
     // After minimum viable brief (description + location + opposingParty),
@@ -1129,7 +1133,12 @@ test.describe('Lead intake workflow', () => {
           { timeout: LEAD_TURN_TIMEOUT_MS }
         );
         await timeSensitiveChip.click();
-        await responsePromise;
+        const response = await responsePromise;
+        const responseText = await response.text().catch(() => '');
+        const donePayload = parseDonePayloads(responseText).at(-1) ?? null;
+        if (donePayload) {
+          latestDonePayload = donePayload;
+        }
         await anonPage.waitForTimeout(2_000);
       }
     } else if (!hasSubmitButton) {
@@ -1139,33 +1148,52 @@ test.describe('Lead intake workflow', () => {
     // ── Assert: submit button eventually appears within remaining turns ────────
     const submitButton = anonPage.getByRole('button', { name: /submit request/i });
     const paymentButton = anonPage.locator('button:visible').filter({ hasText: /continue(\s+to\s+payment)?|pay.*submit/i }).first();
+    const plannerDeadline = Date.now() + LEAD_TURN_TIMEOUT_MS;
+    while (Date.now() < plannerDeadline) {
+      const [submitVisible, paymentVisible] = await Promise.all([
+        submitButton.isVisible().catch(() => false),
+        paymentButton.isVisible().catch(() => false),
+      ]);
+      if (submitVisible || paymentVisible) {
+        break;
+      }
+
+      const count = await aiLocator.count();
+      if (count === 0) {
+        await anonPage.waitForTimeout(500);
+        continue;
+      }
+
+      const last = (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+      if (/ready to submit|are you ready/i.test(last)) {
+        break;
+      }
+      if (/desired outcome|hoping for/i.test(last)) {
+        await sendAndAwait('Get my full deposit back');
+        continue;
+      }
+      if (/documents|paperwork/i.test(last)) {
+        await sendAndAwait('Yes, I have documents');
+        continue;
+      }
+
+      await anonPage.waitForTimeout(500);
+    }
 
     await expect.poll(
       async () => {
         const submitVisible = await submitButton.isVisible().catch(() => false);
         const paymentVisible = await paymentButton.isVisible().catch(() => false);
-        if (submitVisible || paymentVisible) return true;
-        // If AI is still asking questions, send generic answers
-        const count = await aiLocator.count();
-        if (count === 0) return false;
-        const last = (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
-        if (/desired outcome|hoping for/i.test(last)) {
-          await sendAndAwait('Get my full deposit back');
-        } else if (/documents|paperwork/i.test(last)) {
-          await sendAndAwait('Yes, I have documents');
-        } else if (/ready to submit|are you ready/i.test(last)) {
-          return true;
-        }
-        return false;
+        return submitVisible || paymentVisible;
       },
       {
-        timeout: 90_000,
+        timeout: 5_000,
         message: 'Submit button never appeared after completing intake planner sequence',
       }
     ).toBe(true);
 
     // ── Verify final intakeFields structure ───────────────────────────────────
-    const finalDone = donePayloads[donePayloads.length - 1];
+    const finalDone = latestDonePayload;
     await testInfo.attach('planner-final-done-payload.json', {
       body: JSON.stringify(finalDone, null, 2),
       contentType: 'application/json',

--- a/tests/e2e/widget-embed.spec.ts
+++ b/tests/e2e/widget-embed.spec.ts
@@ -495,6 +495,12 @@ test.describe('Widget embed (cross-origin iframe flow)', () => {
           return false; // re-poll to confirm composer appears
         }
 
+        const consultBtn = iframe.getByRole('button', { name: /request.*consultation/i }).first();
+        if (await consultBtn.isVisible({ timeout: 300 }).catch(() => false)) {
+          await consultBtn.click().catch(() => null);
+          return false;
+        }
+
         // Home screen with send message button
         const sendBtn = iframe.getByRole('button', { name: /send.*(message|us)/i }).first();
         if (await sendBtn.isVisible({ timeout: 300 }).catch(() => false)) {

--- a/tests/e2e/widget-embed.spec.ts
+++ b/tests/e2e/widget-embed.spec.ts
@@ -480,24 +480,42 @@ test.describe('Widget embed (cross-origin iframe flow)', () => {
 
     const iframe = page.frameLocator('iframe[src*="/public/"]').first();
     const messageInput = iframe.locator('[data-testid="message-input"]');
-    const composerReady = await messageInput.isEnabled().catch(() => false);
-    if (!composerReady) {
-      let state = 'waiting' as 'composer' | 'cta' | 'waiting';
-      await expect.poll(
-        async () => {
-          const inputEnabled = await iframe.locator('[data-testid="message-input"]').isEnabled().catch(() => false);
-          const sendButtonVisible = await iframe.locator('button').filter({ hasText: /send us a message/i }).first().isVisible().catch(() => false);
-          state = inputEnabled ? 'composer' : sendButtonVisible ? 'cta' : 'waiting';
-          return state;
-        },
-        { timeout: INTERACTIVE_TIMEOUT_MS, message: 'Expected widget home CTA or composer to appear in iframe' }
-      ).toMatch(/composer|cta/);
-      if (state === 'cta') {
-        await iframe.locator('button').filter({ hasText: /send us a message/i }).first().click();
+    // Navigate from widget home screen to composer
+    // The home screen may show: Ask a question CTA, Request consultation CTA,
+    // or go directly to the composer if a previous conversation exists.
+    await expect.poll(
+      async () => {
+        // Already at composer
+        if (await messageInput.isEnabled({ timeout: 300 }).catch(() => false)) return true;
+
+        // Ask a question button present → click it
+        const askBtn = iframe.getByRole('button', { name: /ask a question/i }).first();
+        if (await askBtn.isVisible({ timeout: 300 }).catch(() => false)) {
+          await askBtn.click().catch(() => null);
+          return false; // re-poll to confirm composer appears
+        }
+
+        // Home screen with send message button
+        const sendBtn = iframe.getByRole('button', { name: /send.*(message|us)/i }).first();
+        if (await sendBtn.isVisible({ timeout: 300 }).catch(() => false)) {
+          await sendBtn.click().catch(() => null);
+          return false;
+        }
+
+        // Recent conversation present — clicking it goes to composer
+        const recentMsg = iframe.locator('[data-testid="recent-message"], .recent-conversation').first();
+        if (await recentMsg.isVisible({ timeout: 300 }).catch(() => false)) {
+          await recentMsg.click().catch(() => null);
+          return false;
+        }
+
+        return false;
+      },
+      {
+        timeout: INTERACTIVE_TIMEOUT_MS,
+        message: 'Widget never reached composer after navigating home screen',
       }
-    }
-    // Wait for composer to be interactive.
-    await expect(messageInput).toBeEnabled({ timeout: INTERACTIVE_TIMEOUT_MS });
+    ).toBe(true);
 
     // Wait for AI chat response.
     const aiResponsePromise = page.waitForResponse(

--- a/tests/unit/routes/conversations.participants.test.ts
+++ b/tests/unit/routes/conversations.participants.test.ts
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => ({
   addParticipantsMock: vi.fn(),
   getConversationMock: vi.fn(),
   getPracticeMembersMock: vi.fn(),
-  getPracticeTeamMock: vi.fn(),
 }));
 
 vi.mock('../../../worker/middleware/auth.js', () => ({
@@ -38,7 +37,6 @@ vi.mock('../../../worker/services/ConversationService.js', () => ({
 vi.mock('../../../worker/services/RemoteApiService.js', () => ({
   RemoteApiService: {
     getPracticeMembers: mocks.getPracticeMembersMock,
-    getPracticeTeam: mocks.getPracticeTeamMock,
   },
 }));
 
@@ -61,26 +59,10 @@ describe('handleConversations - participants endpoint', () => {
     mocks.optionalAuthMock.mockResolvedValue({ user: { id: 'user-1' } });
     mocks.checkPracticeMembershipMock.mockResolvedValue({ isMember: true, memberRole: 'owner' });
     mocks.addParticipantsMock.mockResolvedValue({ id: 'conv-1' });
-    mocks.getConversationMock.mockResolvedValue({ participants: ['client-1'], user_id: 'client-1' });
+    mocks.getConversationMock.mockResolvedValue({ participants: ['client-1'], user_id: 'client-1', is_anonymous: false, user_info: { name: 'Client Person' } });
     mocks.getPracticeMembersMock.mockResolvedValue([
-      { user_id: 'client-1', role: 'client', name: 'Client Person', image: null },
-      { user_id: 'staff-1', role: 'member', name: 'Staff Person', image: null },
+      { user_id: 'staff-1', role: 'attorney', name: 'Staff Person', image: null },
     ]);
-    mocks.getPracticeTeamMock.mockResolvedValue({
-      members: [
-        {
-          userId: 'staff-1',
-          email: 'staff@example.com',
-          name: 'Staff Person',
-          image: null,
-          role: 'member',
-          createdAt: null,
-          canAssignToMatter: false,
-          canMentionInternally: true,
-        },
-      ],
-      summary: { seatsIncluded: 2, seatsUsed: 1 },
-    });
   });
 
   it('adds participants when caller is authorized', async () => {
@@ -127,30 +109,40 @@ describe('handleConversations - participants endpoint', () => {
     expect(mocks.addParticipantsMock).not.toHaveBeenCalled();
   });
 
-  it('expands mention candidates with the worker team view and flags internal mentions', async () => {
+  it('returns explicit mention permissions for team members and clients', async () => {
     const request = new Request('https://example.com/api/conversations/conv-1/participants?practiceId=practice-1');
 
     const response = await handleConversations(request, env);
     const payload = await response.json() as {
       success?: boolean;
       data?: {
-        participants?: Array<{ userId: string; canMentionInternally?: boolean; role?: string | null }>;
+        participants?: Array<{
+          userId: string;
+          role?: string | null;
+          isTeamMember?: boolean;
+          canBeMentionedByTeamMember?: boolean;
+          canBeMentionedByClient?: boolean;
+        }>;
       };
     };
 
     expect(response.status).toBe(200);
-    expect(mocks.getPracticeTeamMock).toHaveBeenCalledWith(env, 'practice-1', request);
+    expect(mocks.getPracticeMembersMock).toHaveBeenCalledWith(env, 'practice-1', request);
     expect(payload.success).toBe(true);
     expect(payload.data?.participants).toEqual([
       expect.objectContaining({
         userId: 'client-1',
-        role: 'client',
-        canMentionInternally: false,
+        role: null,
+        isTeamMember: false,
+        canBeMentionedByTeamMember: true,
+        canBeMentionedByClient: true,
       }),
       expect.objectContaining({
         userId: 'staff-1',
-        role: 'member',
-        canMentionInternally: true,
+        role: 'attorney',
+        isTeamMember: true,
+        canBeMentionedByTeamMember: true,
+        canBeMentionedByClient: true,
       }),
     ]);
   });

--- a/tests/unit/services/conversationParticipantService.test.ts
+++ b/tests/unit/services/conversationParticipantService.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getPracticeMembersMock: vi.fn(),
+}));
+
+vi.mock('../../../worker/services/RemoteApiService.js', () => ({
+  RemoteApiService: {
+    getPracticeMembers: mocks.getPracticeMembersMock,
+  },
+}));
+
+describe('ConversationParticipantService', () => {
+  beforeEach(() => {
+    mocks.getPracticeMembersMock.mockReset();
+  });
+
+  it('allows a team member to mention another team member', async () => {
+    mocks.getPracticeMembersMock.mockResolvedValue([
+      { user_id: 'team-1', role: 'attorney', name: 'Attorney One', image: null },
+      { user_id: 'team-2', role: 'paralegal', name: 'Paralegal Two', image: null },
+    ]);
+
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+    const participants = await service.listConversationParticipantRecords({
+      env: {} as never,
+      practiceId: 'practice-1',
+      conversation: { user_id: 'client-1', is_anonymous: false, participants: ['client-1'], user_info: { name: 'Client One' } },
+    });
+
+    expect(service.validateMentionTargets({
+      participants,
+      senderType: 'team_member',
+      mentionedUserIds: ['team-2'],
+    })).toEqual(['team-2']);
+  });
+
+  it('allows a team member to mention a client in the conversation', async () => {
+    mocks.getPracticeMembersMock.mockResolvedValue([
+      { user_id: 'team-1', role: 'attorney', name: 'Attorney One', image: null },
+    ]);
+
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+    const participants = await service.listConversationParticipantRecords({
+      env: {} as never,
+      practiceId: 'practice-1',
+      conversation: { user_id: 'client-1', is_anonymous: false, participants: ['client-1'], user_info: { name: 'Client One' } },
+    });
+
+    expect(service.validateMentionTargets({
+      participants,
+      senderType: 'team_member',
+      mentionedUserIds: ['client-1'],
+    })).toEqual(['client-1']);
+  });
+
+  it('allows a client to mention a team member', async () => {
+    mocks.getPracticeMembersMock.mockResolvedValue([
+      { user_id: 'team-1', role: 'attorney', name: 'Attorney One', image: null },
+    ]);
+
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+    const participants = await service.listConversationParticipantRecords({
+      env: {} as never,
+      practiceId: 'practice-1',
+      conversation: { user_id: 'client-1', is_anonymous: false, participants: ['client-1'], user_info: { name: 'Client One' } },
+    });
+
+    expect(service.validateMentionTargets({
+      participants,
+      senderType: 'client',
+      mentionedUserIds: ['team-1'],
+    })).toEqual(['team-1']);
+  });
+
+  it('allows a client to mention another client in the same conversation', async () => {
+    mocks.getPracticeMembersMock.mockResolvedValue([]);
+
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+    const participants = await service.listConversationParticipantRecords({
+      env: {} as never,
+      practiceId: 'practice-1',
+      conversation: { user_id: 'client-1', is_anonymous: false, participants: ['client-1', 'client-2'], user_info: { name: 'Client One' } },
+    });
+
+    expect(service.validateMentionTargets({
+      participants,
+      senderType: 'client',
+      mentionedUserIds: ['client-2'],
+    })).toEqual(['client-2']);
+  });
+
+  it('rejects anonymous senders', async () => {
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+
+    expect(() => service.validateMentionTargets({
+      participants: [],
+      senderType: 'anonymous',
+      mentionedUserIds: ['team-1'],
+    })).toThrow('Anonymous users cannot mention anyone');
+  });
+
+  it('rejects unknown targets', async () => {
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+
+    expect(() => service.validateMentionTargets({
+      participants: [],
+      senderType: 'client',
+      mentionedUserIds: ['unknown-1'],
+    })).toThrow('Unknown mention target: unknown-1');
+  });
+
+  it('rejects anonymous targets unless explicitly supported', async () => {
+    const service = await import('../../../worker/services/ConversationParticipantService.js');
+
+    expect(() => service.validateMentionTargets({
+      participants: [
+        {
+          userId: 'anon-1',
+          name: null,
+          image: null,
+          role: null,
+          isTeamMember: false,
+          canBeMentionedByTeamMember: false,
+          canBeMentionedByClient: false,
+        },
+      ],
+      senderType: 'team_member',
+      mentionedUserIds: ['anon-1'],
+    })).toThrow('Mention target is not allowed: anon-1');
+  });
+});

--- a/worker/durable-objects/ChatRoom.ts
+++ b/worker/durable-objects/ChatRoom.ts
@@ -5,6 +5,14 @@ import { HttpError } from '../types.js';
 import { checkPracticeMembership, requireAuth } from '../middleware/auth.js';
 import { parseEnvBool } from '../utils/safeStringUtils.js';
 import { createAiClient } from '../utils/aiClient.js';
+import { ConversationService } from '../services/ConversationService.js';
+import {
+  extractMentionUserIds,
+  listConversationParticipantRecords,
+  validateMentionTargets,
+  withValidatedMentionMetadata,
+  type MentionSenderType,
+} from '../services/ConversationParticipantService.js';
 
 const DEFAULT_AI_MODEL = '@cf/zai-org/glm-4.7-flash';
 
@@ -24,6 +32,7 @@ const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 interface ConnectionAttachment {
   conversationId: string;
   userId: string;
+  isAnonymous: boolean;
   negotiated: boolean;
   negotiationDeadline: number | null;
   lastActivityAt: number;
@@ -84,6 +93,7 @@ interface PersistOptions {
   replyToMessageId?: string | null;
   userId: string | null;
   role: 'user' | 'system';
+  senderType?: MentionSenderType;
 }
 
 type PersistResult =
@@ -181,6 +191,7 @@ export class ChatRoom {
     const attachment: ConnectionAttachment = {
       conversationId,
       userId: auth.user.id,
+      isAnonymous: auth.isAnonymous === true,
       negotiated: false,
       negotiationDeadline: null,
       lastActivityAt: Date.now(),
@@ -385,7 +396,10 @@ export class ChatRoom {
       metadata: payloadMetadata,
       replyToMessageId,
       userId: attachment.userId,
-      role: 'user'
+      role: 'user',
+      senderType: attachment.isAnonymous
+        ? 'anonymous'
+        : (attachment.isPracticeMember ? 'team_member' : 'client')
     });
 
     if (result.kind === 'error') {
@@ -608,7 +622,8 @@ export class ChatRoom {
       metadata: payloadMetadata,
       replyToMessageId,
       userId,
-      role: roleValue
+      role: roleValue,
+      senderType: roleValue === 'user' ? 'client' : undefined
     });
 
     if (result.kind === 'error') {
@@ -641,7 +656,8 @@ export class ChatRoom {
       metadata,
       replyToMessageId,
       userId,
-      role
+      role,
+      senderType
     } = options;
 
     await this.sweepPending(conversationId);
@@ -712,7 +728,37 @@ export class ChatRoom {
 
     const serverTs = new Date().toISOString();
     const messageId = crypto.randomUUID();
-    const metadataJson = metadata ? JSON.stringify(metadata) : null;
+    let sanitizedMetadata = metadata;
+
+    if (role === 'user' && senderType) {
+      try {
+        const conversationService = new ConversationService(this.env);
+        const conversation = await conversationService.getConversation(conversationId, practiceId);
+        const participants = await listConversationParticipantRecords({
+          env: this.env,
+          practiceId,
+          conversation,
+        });
+        const validatedMentionUserIds = validateMentionTargets({
+          participants,
+          senderType,
+          mentionedUserIds: extractMentionUserIds(metadata),
+        });
+        sanitizedMetadata = withValidatedMentionMetadata(metadata, validatedMentionUserIds);
+      } catch (error) {
+        if (error instanceof HttpError) {
+          return {
+            kind: 'error',
+            code: 'invalid_payload',
+            message: error.message,
+            closeCode: 4400
+          };
+        }
+        throw error;
+      }
+    }
+
+    const metadataJson = sanitizedMetadata ? JSON.stringify(sanitizedMetadata) : null;
 
     const shouldUpdateContent = role !== 'system' && content.trim().length > 0;
     const persistBatch = async (includeLastMessageContent: boolean) => {
@@ -834,7 +880,7 @@ export class ChatRoom {
       content,
       ...(replyToMessageId ? { reply_to_message_id: replyToMessageId } : {}),
       ...(attachments.length > 0 ? { attachments } : {}),
-      ...(metadata ? { metadata } : {})
+      ...(sanitizedMetadata ? { metadata: sanitizedMetadata } : {})
     };
 
     return {

--- a/worker/durable-objects/ChatRoom.ts
+++ b/worker/durable-objects/ChatRoom.ts
@@ -729,8 +729,9 @@ export class ChatRoom {
     const serverTs = new Date().toISOString();
     const messageId = crypto.randomUUID();
     let sanitizedMetadata = metadata;
+    const mentionUserIds = extractMentionUserIds(metadata);
 
-    if (role === 'user' && senderType) {
+    if (role === 'user' && senderType && mentionUserIds.length > 0) {
       try {
         const conversationService = new ConversationService(this.env);
         const conversation = await conversationService.getConversation(conversationId, practiceId);
@@ -742,7 +743,7 @@ export class ChatRoom {
         const validatedMentionUserIds = validateMentionTargets({
           participants,
           senderType,
-          mentionedUserIds: extractMentionUserIds(metadata),
+          mentionedUserIds: mentionUserIds,
         });
         sanitizedMetadata = withValidatedMentionMetadata(metadata, validatedMentionUserIds);
       } catch (error) {

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -9,8 +9,8 @@ import type { AuthContext } from '../middleware/auth.js';
 import { withPracticeContext, getPracticeId } from '../middleware/practiceContext.js';
 import { Logger } from '../utils/logger.js';
 import { SessionAuditService } from '../services/SessionAuditService.js';
+import { listConversationParticipantRecords, validateMentionTargets, type MentionSenderType } from '../services/ConversationParticipantService.js';
 import { handleSubmitIntake } from './submitIntake.js';
-import { isTeamRole } from '../../src/shared/types/team.js';
 
 const SYSTEM_MESSAGE_ALLOWLIST = new Set([
   'system-intro',
@@ -50,6 +50,11 @@ const STAFF_MEMBER_ROLES = new Set(['owner', 'admin', 'attorney', 'paralegal']);
 const isStaffMemberRole = (role: string | undefined): boolean => {
   if (!role) return false;
   return STAFF_MEMBER_ROLES.has(role);
+};
+
+const resolveMentionSenderType = (authContext: AuthContext, memberRole?: string): MentionSenderType => {
+  if (authContext.isAnonymous) return 'anonymous';
+  return isStaffMemberRole(memberRole) ? 'team_member' : 'client';
 };
 
 const resolvePracticeContext = async (options: {
@@ -613,10 +618,16 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     const practiceId = getPracticeId(requestWithContext);
     const body = await parseJsonBody(request) as { mentionedUserIds?: string[] };
 
-    if (authContext.isAnonymous) {
-      throw HttpErrors.unauthorized('Authentication required');
+    const membership = authContext.isAnonymous
+      ? { memberRole: undefined }
+      : await checkPracticeMembership(request, env, practiceId, { authContext });
+    const senderType = resolveMentionSenderType(authContext, membership.memberRole);
+
+    if (senderType === 'team_member') {
+      await requirePracticeMember(request, env, practiceId, 'paralegal');
+    } else {
+      await conversationService.validateParticipantAccess(conversationId, practiceId, userId, { previousAnonUserId: prevAnonId });
     }
-    await requirePracticeMember(request, env, practiceId, 'paralegal');
 
     if (!Array.isArray(body.mentionedUserIds)) {
       throw HttpErrors.badRequest('mentionedUserIds must be an array');
@@ -632,14 +643,26 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       sanitizedMentionedUserIds.push(el.trim());
     }
 
-    const conversation = await conversationService.setConversationMentions(
+    const conversation = await conversationService.getConversation(conversationId, practiceId);
+    const participants = await listConversationParticipantRecords({
+      env,
+      practiceId,
+      conversation,
+      request,
+    });
+    const allowedMentionedUserIds = validateMentionTargets({
+      participants,
+      senderType,
+      mentionedUserIds: sanitizedMentionedUserIds,
+    });
+
+    const updatedConversation = await conversationService.setConversationMentions(
       conversationId,
       practiceId,
-      sanitizedMentionedUserIds,
-      { request }
+      allowedMentionedUserIds
     );
 
-    return createJsonResponse(conversation);
+    return createJsonResponse(updatedConversation);
   }
 
   // PATCH /api/conversations/:id/link - Link anonymous conversation to authenticated user
@@ -987,38 +1010,12 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       throw HttpErrors.forbidden('User is not authorized to view participants for this conversation');
     }
 
-    const [conversation, members] = await Promise.all([
-      conversationService.getConversation(conversationId, practiceId),
-      RemoteApiService.getPracticeMembers(env, practiceId, request)
-    ]);
-
-    const participantIds = Array.from(new Set([
-      ...conversation.participants.filter((id) => typeof id === 'string' && id.trim().length > 0),
-      ...(conversation.user_id ? [conversation.user_id] : [])
-    ]));
-    const mentionableStaffIds = members
-      .filter((member) => isTeamRole(member.role) && typeof member.user_id === 'string' && member.user_id.trim().length > 0)
-      .map((member) => member.user_id);
-    const mentionableUserIds = callerIsStaff
-      ? Array.from(new Set([
-        ...participantIds,
-        ...mentionableStaffIds
-      ]))
-      : participantIds;
-    const memberById = new Map<string, {
-      role?: string | null;
-      name?: string | null;
-      image?: string | null;
-    }>(members.map((member) => [member.user_id, member]));
-    const participants = mentionableUserIds.map((participantUserId) => {
-      const member = memberById.get(participantUserId);
-      return {
-        userId: participantUserId,
-        role: member?.role ?? null,
-        name: member?.name ?? null,
-        image: member?.image ?? null,
-        canMentionInternally: isTeamRole(member?.role),
-      };
+    const conversation = await conversationService.getConversation(conversationId, practiceId);
+    const participants = await listConversationParticipantRecords({
+      env,
+      practiceId,
+      conversation,
+      request,
     });
 
     return createJsonResponse({

--- a/worker/services/ConversationParticipantService.ts
+++ b/worker/services/ConversationParticipantService.ts
@@ -1,0 +1,208 @@
+import { HttpErrors } from '../errorHandler.js';
+import type { Env } from '../types.js';
+import { RemoteApiService } from './RemoteApiService.js';
+import { isTeamRole } from '../../src/shared/types/team.js';
+
+export type ParticipantRecord = {
+  userId: string;
+  name: string | null;
+  image: string | null;
+  role: string | null;
+  isTeamMember: boolean;
+  canBeMentionedByTeamMember: boolean;
+  canBeMentionedByClient: boolean;
+};
+
+type ConversationRecord = {
+  user_id: string | null;
+  is_anonymous?: boolean;
+  participants: string[];
+  user_info: Record<string, unknown> | null;
+};
+
+export type MentionSenderType = 'team_member' | 'client' | 'anonymous';
+
+const normalizeParticipantIds = (conversation: ConversationRecord): string[] => {
+  const ids = new Set<string>();
+  if (typeof conversation.user_id === 'string' && conversation.user_id.trim().length > 0) {
+    ids.add(conversation.user_id.trim());
+  }
+  for (const userId of conversation.participants) {
+    if (typeof userId === 'string' && userId.trim().length > 0) {
+      ids.add(userId.trim());
+    }
+  }
+  return [...ids];
+};
+
+const extractConversationClientName = (userInfo: Record<string, unknown> | null): string | null => {
+  if (!userInfo) return null;
+
+  const directName = typeof userInfo.name === 'string' ? userInfo.name.trim() : '';
+  if (directName) return directName;
+
+  const directEmail = typeof userInfo.email === 'string' ? userInfo.email.trim() : '';
+  if (directEmail) return directEmail;
+
+  const intakeSlimContactDraft = userInfo.intakeSlimContactDraft;
+  if (intakeSlimContactDraft && typeof intakeSlimContactDraft === 'object') {
+    const draft = intakeSlimContactDraft as Record<string, unknown>;
+    const name = typeof draft.name === 'string' ? draft.name.trim() : '';
+    if (name) return name;
+    const email = typeof draft.email === 'string' ? draft.email.trim() : '';
+    if (email) return email;
+  }
+
+  const consultation = userInfo.consultation;
+  if (consultation && typeof consultation === 'object') {
+    const consultationRecord = consultation as Record<string, unknown>;
+    const contact = consultationRecord.contact;
+    if (contact && typeof contact === 'object') {
+      const contactRecord = contact as Record<string, unknown>;
+      const name = typeof contactRecord.name === 'string' ? contactRecord.name.trim() : '';
+      if (name) return name;
+      const email = typeof contactRecord.email === 'string' ? contactRecord.email.trim() : '';
+      if (email) return email;
+    }
+  }
+
+  return null;
+};
+
+export async function listConversationParticipantRecords(options: {
+  env: Env;
+  practiceId: string;
+  conversation: ConversationRecord;
+  request?: Request;
+}): Promise<ParticipantRecord[]> {
+  const { env, practiceId, conversation, request } = options;
+  const practiceMembers = await RemoteApiService.getPracticeMembers(env, practiceId, request);
+  const participantIds = normalizeParticipantIds(conversation);
+  const teamMembersById = new Map(
+    practiceMembers
+      .filter((member) => typeof member.user_id === 'string' && member.user_id.trim().length > 0)
+      .map((member) => [member.user_id.trim(), member] as const)
+  );
+
+  const orderedIds = Array.from(new Set([
+    ...participantIds,
+    ...practiceMembers
+      .filter((member) => isTeamRole(member.role))
+      .map((member) => member.user_id.trim()),
+  ]));
+
+  const conversationClientName = extractConversationClientName(conversation.user_info);
+
+  return orderedIds.map((userId) => {
+    const member = teamMembersById.get(userId);
+    const isTeamMember = isTeamRole(member?.role);
+    const isAnonymousConversationOwner = conversation.is_anonymous === true && conversation.user_id === userId;
+    const isClientParticipant = participantIds.includes(userId) && !isTeamMember && !isAnonymousConversationOwner;
+
+    const name = member?.name?.trim()
+      ? member.name.trim()
+      : (userId === conversation.user_id ? conversationClientName : null);
+
+    return {
+      userId,
+      name: name && name.length > 0 ? name : null,
+      image: typeof member?.image === 'string' ? member.image : null,
+      role: typeof member?.role === 'string' ? member.role : null,
+      isTeamMember,
+      canBeMentionedByTeamMember: isTeamMember || isClientParticipant,
+      canBeMentionedByClient: isTeamMember || isClientParticipant,
+    };
+  });
+}
+
+export function validateMentionTargets(options: {
+  participants: ParticipantRecord[];
+  senderType: MentionSenderType;
+  mentionedUserIds: string[];
+}): string[] {
+  const rawMentionUserIds = Array.from(new Set(
+    options.mentionedUserIds
+      .map((userId) => userId.trim())
+      .filter((userId) => userId.length > 0)
+  ));
+
+  if (rawMentionUserIds.length === 0) {
+    return [];
+  }
+
+  if (options.senderType === 'anonymous') {
+    throw HttpErrors.badRequest('Anonymous users cannot mention anyone');
+  }
+
+  const participantById = new Map(options.participants.map((participant) => [participant.userId, participant] as const));
+
+  for (const userId of rawMentionUserIds) {
+    const participant = participantById.get(userId);
+    if (!participant) {
+      throw HttpErrors.badRequest(`Unknown mention target: ${userId}`);
+    }
+
+    const isAllowed = options.senderType === 'team_member'
+      ? participant.canBeMentionedByTeamMember === true
+      : participant.canBeMentionedByClient === true;
+
+    if (!isAllowed) {
+      throw HttpErrors.badRequest(`Mention target is not allowed: ${userId}`);
+    }
+  }
+
+  return rawMentionUserIds;
+}
+
+export function extractMentionUserIds(metadata: Record<string, unknown> | null | undefined): string[] {
+  if (!metadata) return [];
+
+  const rawValues = [
+    metadata.mentionedUserIds,
+    metadata.mentionUserIds,
+    metadata.mentions,
+    metadata.mentioned_user_ids,
+  ];
+
+  const mentionUserIds: string[] = [];
+  for (const rawValue of rawValues) {
+    if (!Array.isArray(rawValue)) continue;
+    for (const value of rawValue) {
+      if (typeof value === 'string') {
+        mentionUserIds.push(value);
+      }
+    }
+  }
+
+  return mentionUserIds;
+}
+
+export function withValidatedMentionMetadata(
+  metadata: Record<string, unknown> | null,
+  mentionedUserIds: string[],
+): Record<string, unknown> | null {
+  if (!metadata) {
+    return mentionedUserIds.length > 0
+      ? {
+        mentionedUserIds,
+        mentionUserIds: mentionedUserIds,
+        mentions: mentionedUserIds,
+      }
+      : null;
+  }
+
+  const nextMetadata = { ...metadata };
+  if (mentionedUserIds.length === 0) {
+    delete nextMetadata.mentionedUserIds;
+    delete nextMetadata.mentionUserIds;
+    delete nextMetadata.mentions;
+    delete nextMetadata.mentioned_user_ids;
+    return nextMetadata;
+  }
+
+  nextMetadata.mentionedUserIds = mentionedUserIds;
+  nextMetadata.mentionUserIds = mentionedUserIds;
+  nextMetadata.mentions = mentionedUserIds;
+  delete nextMetadata.mentioned_user_ids;
+  return nextMetadata;
+}

--- a/worker/services/ConversationParticipantService.ts
+++ b/worker/services/ConversationParticipantService.ts
@@ -88,7 +88,8 @@ export async function listConversationParticipantRecords(options: {
     ...participantIds,
     ...practiceMembers
       .filter((member) => isTeamRole(member.role))
-      .map((member) => member.user_id.trim()),
+      .map((member) => (typeof member.user_id === 'string' ? member.user_id.trim() : ''))
+      .filter((userId) => userId.length > 0),
   ]));
 
   const conversationClientName = extractConversationClientName(conversation.user_info);
@@ -110,7 +111,7 @@ export async function listConversationParticipantRecords(options: {
       role: typeof member?.role === 'string' ? member.role : null,
       isTeamMember,
       canBeMentionedByTeamMember: isTeamMember || isClientParticipant,
-      canBeMentionedByClient: isTeamMember || isClientParticipant,
+      canBeMentionedByClient: isTeamMember || (isClientParticipant && userId !== conversation.user_id),
     };
   });
 }

--- a/worker/services/ConversationService.ts
+++ b/worker/services/ConversationService.ts
@@ -142,19 +142,6 @@ export class ConversationService {
     );
   }
 
-  private async getMentionableTeamMemberIds(
-    practiceId: string,
-    request?: Request
-  ): Promise<Set<string>> {
-    const team = await RemoteApiService.getPracticeTeam(this.env, practiceId, request);
-    return new Set(
-      team.members
-        .filter((member) => member.canMentionInternally)
-        .map((member) => member.userId)
-        .filter((userId) => typeof userId === 'string' && userId.trim().length > 0)
-    );
-  }
-
   private readTrimmedString(value: unknown): string | null {
     if (typeof value !== 'string') return null;
     const trimmed = value.trim();
@@ -960,19 +947,15 @@ export class ConversationService {
   async setConversationMentions(
     conversationId: string,
     practiceId: string,
-    mentionUserIds: string[],
-    options?: { request?: Request }
+    mentionUserIds: string[]
   ): Promise<Conversation> {
-    const rawMentionUserIds = Array.from(
+    const normalizedMentionUserIds = Array.from(
       new Set(
         mentionUserIds
           .map((userId) => userId.trim())
           .filter((userId) => userId.length > 0)
       )
     );
-
-    const mentionableMemberIds = await this.getMentionableTeamMemberIds(practiceId, options?.request);
-    const normalizedMentionUserIds = rawMentionUserIds.filter(id => mentionableMemberIds.has(id));
 
     const conversation = await this.getConversation(conversationId, practiceId);
     const metadata = { ...(conversation.user_info ?? {}) } as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- add a shared conversation participant repository with ttl caching, in-flight dedupe, and invalidation hooks
- move mention candidate selection into a UI hook that filters on backend-provided mention permissions
- update worker participant responses and websocket/send validation to use explicit cross-party mention rules for team members, clients, and anonymous senders

## Why
- participant loading was happening directly in UI code with no shared cache boundary
- mention eligibility was still effectively team-only and could drift between suggestion filtering and backend validation
- this keeps the work scoped to participant loading plus mention policy, separate from the earlier inspector/avatar PR

## Validation
- `npm run lint`
- `npm run type-check`
- `npx vitest run -c config/vitest/vitest.config.component.ts tests/component/conversationRepository.test.ts tests/component/useMentionCandidates.test.tsx`
- `npx vitest run -c config/vitest/vitest.config.unit.ts tests/unit/routes/conversations.participants.test.ts tests/unit/services/conversationParticipantService.test.ts`

## Notes
- unrelated local changes in `tests/e2e/lead-flow.spec.ts`, `tests/e2e/widget-embed.spec.ts`, and untracked `playwright/` files were intentionally left out of this PR scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter mention suggestions that respect sender type (team member / client) and explicit mention permissions.
  * Participant caching with automatic invalidation to reduce duplicate fetches and improve responsiveness.

* **Bug Fixes**
  * Participant lists update correctly on membership changes and session clears.
  * Intake submission now includes merged intake state for more reliable processing.
  * Improved widget navigation to reliably reach the composer.

* **Tests**
  * Added unit, component, and E2E tests covering mentions, caching, and intake flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->