### PR TITLE
[codex] fix mobile code block overflow

### DIFF
--- a/src/features/chat/components/ChatMarkdown.tsx
+++ b/src/features/chat/components/ChatMarkdown.tsx
@@ -75,6 +75,7 @@ const ChatMarkdown: FunctionComponent<ChatMarkdownProps> = memo(({
 
   const classes = [
     'chat-markdown',
+    'min-w-0 max-w-full',
     sizeClasses[size],
     variantClasses[variant],
     className,

--- a/src/features/chat/components/MessageBubble.tsx
+++ b/src/features/chat/components/MessageBubble.tsx
@@ -15,7 +15,7 @@ export const MessageBubble: FunctionComponent<MessageBubbleProps> = ({
 	className = '',
 	children
 }) => {
-	const baseClasses = 'flex flex-col max-w-full break-words relative';
+	const baseClasses = 'flex min-w-0 flex-col max-w-full break-words relative';
 	
 	const variantClasses = {
 		default: '',

--- a/src/features/chat/components/MessageContent.tsx
+++ b/src/features/chat/components/MessageContent.tsx
@@ -76,7 +76,7 @@ export const MessageContent: FunctionComponent<MessageContentProps> = ({
   }
 
   return (
-    <div className={`min-h-4 ${className}`}>
+    <div className={`min-h-4 min-w-0 max-w-full ${className}`}>
       <ChatMarkdown text={displayContent} isStreaming={isStreaming} variant={variant} size={size} />
     </div>
   );

--- a/src/shared/ui/markdown/markdownComponents.tsx
+++ b/src/shared/ui/markdown/markdownComponents.tsx
@@ -143,10 +143,10 @@ export const markdownComponents: Components = {
   pre({ children, ...props }) {
     const copyableText = getNodeText(children).replace(/\n$/, '');
     return (
-      <div className="group relative my-3">
+      <div className="group relative my-3 max-w-full min-w-0">
         {copyableText ? <CopyButton text={copyableText} /> : null}
         <pre
-          className="overflow-x-auto rounded-lg p-4 bg-black/40 backdrop-blur-sm text-gray-100 text-sm leading-relaxed"
+          className="max-w-full min-w-0 overflow-x-auto rounded-lg p-4 bg-black/40 backdrop-blur-sm text-gray-100 text-sm leading-relaxed"
           style={{ boxShadow: 'var(--glass-rim-subtle)' }}
           {...props}
         >


### PR DESCRIPTION
## What changed
- Added width constraints to the chat markdown wrapper and message bubble so long code blocks stay within the message column on mobile.
- Tightened the shared markdown `<pre>` wrapper so the block can scroll horizontally inside the bubble instead of widening the page.

## Why
- Some message code blocks were leaking past the viewport edge on small screens.
- The root cause was a missing `min-w-0`/width constraint in the flex layout around markdown content.

## Validation
- `npm run lint`
- `npm run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout constraints for chat messages and code blocks by adjusting width behavior, ensuring content properly respects container boundaries and handles overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->