### PR TITLE
[codex] fix widget intake flow

### DIFF
--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -35,6 +35,7 @@ interface WidgetAppProps {
   practiceId: string;
   practiceConfig: UIPracticeConfig;
   routeConversationId?: string;
+  bootstrapConversationId?: string | null;
   bootstrapSession?: {
     user?: {
       id: string;
@@ -48,10 +49,11 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
   practiceId,
   practiceConfig,
   routeConversationId,
+  bootstrapConversationId,
   bootstrapSession
 }) => {
   const [view, setView] = useState<'home' | 'list' | 'chat'>(routeConversationId ? 'chat' : 'home');
-  const [setupConversationId, setConversationId] = useState<string | null>(null);
+  const [setupConversationId, setConversationId] = useState<string | null>(bootstrapConversationId ?? null);
   const [conversationMode, setConversationMode] = useState<ConversationMode | null>(null);
   const [isInspectorOpen, setIsInspectorOpen] = useState(false);
   const [hasPersistError, setHasPersistError] = useState(false);
@@ -96,6 +98,12 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
     if (!options?.forceNew && existingConversationId) return existingConversationId;
     return createConversation(options);
   }, [createConversation, routeConversationId, setupConversationId]);
+
+  useEffect(() => {
+    if (routeConversationId) return;
+    if (!bootstrapConversationId) return;
+    setConversationId((current) => current ?? bootstrapConversationId);
+  }, [bootstrapConversationId, routeConversationId]);
 
   const applyConversationMode = useCallback(async (mode: ConversationMode, targetId: string, source: string, startIntake: boolean): Promise<boolean> => {
     try {

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -53,7 +53,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
   bootstrapSession
 }) => {
   const [view, setView] = useState<'home' | 'list' | 'chat'>(routeConversationId ? 'chat' : 'home');
-  const [setupConversationId, setConversationId] = useState<string | null>(bootstrapConversationId ?? null);
+  const [setupConversationId, setConversationId] = useState<string | null>(null);
   const [conversationMode, setConversationMode] = useState<ConversationMode | null>(null);
   const [isInspectorOpen, setIsInspectorOpen] = useState(false);
   const [hasPersistError, setHasPersistError] = useState(false);
@@ -71,6 +71,8 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
   const isAnonymous = bootstrapSession?.user?.isAnonymous ?? bootstrapSession?.user?.is_anonymous ?? true;
 
   const isEmbedded = typeof window !== 'undefined' && window.parent !== window;
+
+  const effectiveConversationId = routeConversationId ?? setupConversationId ?? bootstrapConversationId ?? null;
 
   const createConversation = useCallback(async (options?: { forceNew?: boolean }): Promise<string> => {
     if (inFlightCreateRef.current) return inFlightCreateRef.current;
@@ -94,16 +96,10 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
   }, [practiceId, currentUserId, setConversationId]);
 
   const ensureConversation = useCallback(async (options?: { forceNew?: boolean }): Promise<string | null> => {
-    const existingConversationId = setupConversationId ?? routeConversationId ?? null;
+    const existingConversationId = effectiveConversationId;
     if (!options?.forceNew && existingConversationId) return existingConversationId;
     return createConversation(options);
-  }, [createConversation, routeConversationId, setupConversationId]);
-
-  useEffect(() => {
-    if (routeConversationId) return;
-    if (!bootstrapConversationId) return;
-    setConversationId((current) => current ?? bootstrapConversationId);
-  }, [bootstrapConversationId, routeConversationId]);
+  }, [createConversation, effectiveConversationId]);
 
   const applyConversationMode = useCallback(async (mode: ConversationMode, targetId: string, source: string, startIntake: boolean): Promise<boolean> => {
     try {
@@ -256,7 +252,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
   const messageHandling = useMessageHandling({
     practiceId,
     practiceSlug: practiceConfig.slug ?? undefined,
-    conversationId: setupConversationId ?? routeConversationId ?? undefined,
+    conversationId: effectiveConversationId ?? undefined,
     ensureConversation: () => ensureConversation(),
     userId: currentUserId,
     linkAnonymousConversationOnLoad: true,
@@ -278,7 +274,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
 
   useEffect(() => { clearMessages(); }, [practiceId, clearMessages]);
 
-  const activeConversationId = setupConversationId ?? routeConversationId;
+  const activeConversationId = effectiveConversationId;
 
   // Intake Auth (simplistic for widget, just redirecting or showing prompt if needed)
   const intakeUuid = intakeStatus?.intakeUuid ?? null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -919,6 +919,7 @@ function WidgetRoute({
         practiceId={resolvedPracticeId}
         practiceConfig={practiceConfig}
         routeConversationId={conversationId}
+        bootstrapConversationId={data.conversationId}
         bootstrapSession={data.session}
       />
     </>

--- a/tests/e2e/widget-intake-flow.spec.ts
+++ b/tests/e2e/widget-intake-flow.spec.ts
@@ -33,18 +33,23 @@ test.describe('Public widget intake flow', () => {
   test.describe.configure({ timeout: 120000 });
 
   test.beforeEach(async ({ anonPage }) => {
-    await anonPage.addInitScript(() => {
+    const storageResetToken = `widget-intake-flow-${randomUUID()}`;
+    await anonPage.addInitScript((token: string) => {
       try {
+        if (window.name === token) {
+          return;
+        }
         const keysToRemove = Object.keys(sessionStorage).filter((key) =>
           key.startsWith('blawby_widget_bootstrap_')
           || key === 'blawby:postAuthConversation'
           || key === 'blawby:widget:attribution'
         );
         keysToRemove.forEach((key) => sessionStorage.removeItem(key));
+        window.name = token;
       } catch {
         // Ignore storage access failures in the test harness.
       }
-    });
+    }, storageResetToken);
   });
 
   const isActiveConversationFetch = (response: { request: () => { method: () => string }; url: () => string }): boolean => (
@@ -194,7 +199,7 @@ test.describe('Public widget intake flow', () => {
     const submitNowButton = anonPage.getByRole('button', { name: /submit request/i });
     const paymentContinueButton = anonPage
       .locator('button:visible')
-      .filter({ hasText: /continue(\s+to\s+payment)?|pay\s*(?:&|and)\s*submit/i })
+      .filter({ hasText: /^(continue|continue\s+to\s+payment|pay\s*(?:&|and)\s*submit)$/i })
       .first();
     const buildBriefButton = anonPage.getByRole('button', { name: /build stronger brief/i });
     const aiTranscript: Array<{ prompt?: string; user: string; contentType: string; replyText: string }> = [];
@@ -381,12 +386,12 @@ test.describe('Public widget intake flow', () => {
       const buildVisibleBefore = await buildBriefButton.isVisible().catch(() => false);
       const paymentPromptVisibleBefore = await anonPage
         .locator('button')
-        .filter({ hasText: /continue(\s+to\s+payment)?|pay\s*(?:&|and)\s*submit/i })
+        .filter({ hasText: /^(continue|continue\s+to\s+payment|pay\s*(?:&|and)\s*submit)$/i })
         .isVisible()
         .catch(() => false);
       const bodyTextBefore = await bodyLocator.innerText().catch(() => '');
       const readyPromptBefore = /ready to submit your case|are you ready to submit|submit your case to the firm/i.test(bodyTextBefore);
-      if (submitVisibleBefore || paymentPromptVisibleBefore || (buildVisibleBefore && readyPromptBefore)) {
+      if (submitVisibleBefore || paymentPromptVisibleBefore || readyPromptBefore) {
         reachedSubmitReady = true;
         if (paymentPromptVisibleBefore) reachedPaymentTerminal = true;
         break;
@@ -409,12 +414,12 @@ test.describe('Public widget intake flow', () => {
       const buildVisible = await buildBriefButton.isVisible().catch(() => false);
       const paymentPromptVisible = await anonPage
         .locator('button')
-        .filter({ hasText: /continue(\s+to\s+payment)?|pay\s*(?:&|and)\s*submit/i })
+        .filter({ hasText: /^(continue|continue\s+to\s+payment|pay\s*(?:&|and)\s*submit)$/i })
         .isVisible()
         .catch(() => false);
       const bodyText = await bodyLocator.innerText().catch(() => '');
       const readyPrompt = /ready to submit your case|are you ready to submit|submit your case to the firm/i.test(bodyText);
-      if (submitVisible || paymentPromptVisible || (buildVisible && readyPrompt)) {
+      if (submitVisible || paymentPromptVisible || readyPrompt) {
         reachedSubmitReady = true;
         if (paymentPromptVisible) reachedPaymentTerminal = true;
         break;
@@ -428,7 +433,8 @@ test.describe('Public widget intake flow', () => {
       );
     }
 
-    if (reachedPaymentTerminal) {
+    const paymentVisibleAtAction = await paymentContinueButton.isVisible().catch(() => false);
+    if (reachedPaymentTerminal || paymentVisibleAtAction) {
       await expect(paymentContinueButton).toBeVisible({ timeout: 10000 });
       await paymentContinueButton.click();
     } else {
@@ -746,8 +752,8 @@ test.describe('Public widget intake flow', () => {
         contentType: 'application/json',
       });
 
-      // Manually seed the sessionStorage handoff so the context-carry assertion
-      // can still be exercised even without an in-app CTA.
+      // Seed sessionStorage before navigation so the auth page keeps the same
+      // handoff data in its own document context.
       if (capturedConversationId) {
         await anonPage.evaluate(({ convId, fallbackPracticeId }) => {
           try {
@@ -941,6 +947,7 @@ test.describe('Public widget intake flow', () => {
     const reloadedBootstrapBody = await reloadedBootstrapResponse.json().catch(() => null) as {
       session?: { user?: { id?: string } | null } | null;
       widgetAuthToken?: string | null;
+      widgetQueryAuthToken?: string | null;
     } | null;
 
     expect(
@@ -1088,6 +1095,27 @@ test.describe('Public widget intake flow', () => {
     const getButtons = async () =>
       anonPage.locator('button:visible').allInnerTexts().catch(() => [] as string[]);
 
+    await expect.poll(
+      async () => {
+        const count = await aiLocator.count();
+        if (count === 0) return '';
+        return (await aiLocator.nth(count - 1).innerText().catch(() => '')).trim();
+      },
+      {
+        timeout: LEAD_TURN_TIMEOUT_MS,
+        message: 'Expected planner to prompt for the legal situation after contact capture.',
+      }
+    ).toMatch(/legal situation|what'?s going on|describe what'?s going on|tell me a bit/i);
+    await expect
+      .poll(
+        async () => streamingLocator.count(),
+        {
+          timeout: LEAD_TURN_TIMEOUT_MS,
+          message: 'Expected initial planner prompt to finish streaming before turn 1.',
+        }
+      )
+      .toBe(0);
+
     // ── Turn 1: Description ──────────────────────────────────────────────────
     const { reply: reply1, donePayload: done1 } = await sendAndAwait(
       'My landlord is refusing to return my security deposit after I moved out.'
@@ -1135,7 +1163,7 @@ test.describe('Public widget intake flow', () => {
 
     const hasSubmitButton = buttonsAfterTurn3.some((b) => /submit request/i.test(b));
     const hasPaymentButton = buttonsAfterTurn3.some((b) =>
-      /continue(\s+to\s+payment)?|pay\s*(?:&|and)\s*submit/i.test(b)
+      /^(continue|continue\s+to\s+payment|pay\s*(?:&|and)\s*submit)$/i.test(b)
     );
     const hasUrgencyChips = buttonsAfterTurn3.some((b) =>
       /routine|time.sensitive|emergency/i.test(b)
@@ -1171,7 +1199,7 @@ test.describe('Public widget intake flow', () => {
 
     // ── Assert: submit button eventually appears within remaining turns ────────
     const submitButton = anonPage.getByRole('button', { name: /submit request/i });
-    const paymentButton = anonPage.locator('button:visible').filter({ hasText: /continue(\s+to\s+payment)?|pay.*submit/i }).first();
+    const paymentButton = anonPage.locator('button:visible').filter({ hasText: /^(continue|continue\s+to\s+payment|pay.*submit)$/i }).first();
     const MAX_REMAINING_TURNS = 6;
     let submitReached = false;
     for (let i = 0; i < MAX_REMAINING_TURNS; i++) {

--- a/tests/e2e/widget-intake-flow.spec.ts
+++ b/tests/e2e/widget-intake-flow.spec.ts
@@ -1199,7 +1199,7 @@ test.describe('Public widget intake flow', () => {
 
     // ── Assert: submit button eventually appears within remaining turns ────────
     const submitButton = anonPage.getByRole('button', { name: /submit request/i });
-    const paymentButton = anonPage.locator('button:visible').filter({ hasText: /^(continue|continue\s+to\s+payment|pay.*submit)$/i }).first();
+    const paymentButton = anonPage.locator('button:visible').filter({ hasText: /^(continue|continue\s+to\s+payment|pay\s*(?:&|and)\s*submit)$/i }).first();
     const MAX_REMAINING_TURNS = 6;
     let submitReached = false;
     for (let i = 0; i < MAX_REMAINING_TURNS; i++) {

--- a/worker/routes/aiChatIntake.ts
+++ b/worker/routes/aiChatIntake.ts
@@ -93,7 +93,7 @@ const buildIntakeConversationCtaInstruction = (
   if (isSubmissionReady && isPlannerFinished && messageCount < INTAKE_CLOSING_MESSAGE_THRESHOLD) {
     return `\nYou have all the required details. Ask: "Are you ready to submit your case to the firm?" in one short sentence. Do not summarize again. Do not ask if they want to add anything else.`;
   }
-  if (!isIntakeSubmittable(mergedState, submissionGate) && paymentRequiredBeforeSubmit && !paymentCompleted) {
+  if (isCaseInfoComplete(mergedState) && paymentRequiredBeforeSubmit && !paymentCompleted) {
     return '\nYou already have the required case details. Do NOT ask for more case details. Briefly explain that payment is required before submission and ask the user to tap Continue to payment. Do NOT include raw URLs or placeholders like [Insert Payment Link].';
   }
   return `\nAsk exactly ONE focused question about the single most important missing piece of information. Priority: situation description → city and state → opposing party → urgency → desired outcome → documents. Do not ask for submission readiness until all required details are collected.`;
@@ -116,6 +116,8 @@ Conversation rules:
 - Be warm and human — like a knowledgeable friend, not a form
 - Never give legal advice
 - Never ask for contact info (name, email, phone) — already collected
+- If the prompt says "IMPORTANT: The next missing piece is ...", you must ask only about that exact missing piece next
+- Never revisit or ask for more detail about fields already listed under "KNOWN SO FAR"
 - Never output JSON, tool names, or structured data
 - If your question has 2-3 predictable short answers, end your response with a line formatted exactly as: QUICK_REPLIES: Option 1 | Option 2 | Option 3. Otherwise omit this line entirely. Never use QUICK_REPLIES for open-ended questions like description or desired outcome.`;
 };
@@ -167,7 +169,7 @@ const buildIntakeConversationStatePrompt = (
   };
 
   const nextFieldHint = plannerStep && plannerStep.nextField && plannerStep.chips.length === 0 && !isSubmissionReady
-    ? `\nIMPORTANT: The next missing piece is: ${fieldLabels[plannerStep.nextField] ?? plannerStep.nextField}. Ask about this specifically.`
+    ? `\nIMPORTANT: The next missing piece is: ${fieldLabels[plannerStep.nextField] ?? plannerStep.nextField}. Ask exactly one short question about this and nothing else. Do not revisit any other field.`
     : '';
 
   return `${knownSection}${nextFieldHint}${buildIntakeConversationCtaInstruction(mergedState, messageCount, submissionGate, isPlannerFinished)}`.trim();

--- a/worker/routes/aiChatIntake.ts
+++ b/worker/routes/aiChatIntake.ts
@@ -3,6 +3,10 @@ import {
   readAnyString,
   LEGAL_INTENT_REGEX,
 } from './aiChatShared.js';
+import {
+  isIntakeReadyForSubmission as isSharedIntakeReadyForSubmission,
+  isIntakeSubmittable as isSharedIntakeSubmittable,
+} from '../../src/shared/utils/consultationState';
 
 // messageCount includes both user and assistant turns; 10 total turns is roughly
 // 5 user turns before we pivot to closing language. This is a UX default and may
@@ -93,7 +97,7 @@ const buildIntakeConversationCtaInstruction = (
   if (isSubmissionReady && isPlannerFinished && messageCount < INTAKE_CLOSING_MESSAGE_THRESHOLD) {
     return `\nYou have all the required details. Ask: "Are you ready to submit your case to the firm?" in one short sentence. Do not summarize again. Do not ask if they want to add anything else.`;
   }
-  if (isCaseInfoComplete(mergedState) && paymentRequiredBeforeSubmit && !paymentCompleted) {
+  if (isIntakeReadyForSubmission(mergedState) && paymentRequiredBeforeSubmit && !paymentCompleted) {
     return '\nYou already have the required case details. Do NOT ask for more case details. Briefly explain that payment is required before submission and ask the user to tap Continue to payment. Do NOT include raw URLs or placeholders like [Insert Payment Link].';
   }
   return `\nAsk exactly ONE focused question about the single most important missing piece of information. Priority: situation description → city and state → opposing party → urgency → desired outcome → documents. Do not ask for submission readiness until all required details are collected.`;
@@ -194,36 +198,23 @@ const mergeIntakeState = (
   return { ...(base ?? {}), ...(patch ?? {}) };
 };
 
-const isMinimumViableBriefComplete = (state: Record<string, unknown> | null): boolean => {
-  if (!state) return false;
-  const hasDescription = hasNonEmptyStringField(state, 'description');
-  const hasLocation = hasNonEmptyStringField(state, 'city') && hasNonEmptyStringField(state, 'state');
-  const hasOpposingParty = hasNonEmptyStringField(state, 'opposingParty');
-  return hasDescription && hasLocation && hasOpposingParty;
-};
-
-const isCaseInfoComplete = (state: Record<string, unknown> | null): boolean => {
-  if (!isMinimumViableBriefComplete(state)) return false;
-  if (!state) return false;
-  const hasUrgency = hasNonEmptyStringField(state, 'urgency');
-  const hasDesiredOutcome = hasNonEmptyStringField(state, 'desiredOutcome');
-  const hasDocumentAnswer = typeof state.hasDocuments === 'boolean';
-  return hasUrgency && hasDesiredOutcome && hasDocumentAnswer;
-};
-
 export interface IntakeSubmissionGate {
   paymentRequiredBeforeSubmit: boolean;
   paymentCompleted: boolean;
 }
 
+const isIntakeReadyForSubmission = (state: Record<string, unknown> | null): boolean => (
+  isSharedIntakeReadyForSubmission(state as Parameters<typeof isSharedIntakeReadyForSubmission>[0])
+);
+
 const isIntakeSubmittable = (
   state: Record<string, unknown> | null,
   submissionGate?: IntakeSubmissionGate | null,
 ): boolean => {
-  if (!isMinimumViableBriefComplete(state)) return false;
-  const paymentRequiredBeforeSubmit = submissionGate?.paymentRequiredBeforeSubmit === true;
-  const paymentCompleted = submissionGate?.paymentCompleted === true;
-  return !paymentRequiredBeforeSubmit || paymentCompleted;
+  return isSharedIntakeSubmittable(state as Parameters<typeof isSharedIntakeSubmittable>[0], {
+    paymentRequired: submissionGate?.paymentRequiredBeforeSubmit === true,
+    paymentReceived: submissionGate?.paymentCompleted === true,
+  });
 };
 
 /**
@@ -683,7 +674,7 @@ export {
   buildIntakeConversationStablePrompt,
   buildIntakeConversationStatePrompt,
   mergeIntakeState,
-  isCaseInfoComplete,
+  isIntakeReadyForSubmission,
   isIntakeSubmittable,
   normalizeServicesForPrompt,
   extractServiceNames,

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -154,11 +154,14 @@ const readStringField = (record: Record<string, unknown> | null | undefined, key
 };
 
 const isCaseInfoComplete = (state: IntakeConversationState | null | undefined, draft?: SlimContactDraft | null): boolean => {
+  const readTrimmedString = (value: unknown): string | null => (
+    typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+  );
   const readinessState = {
-    description: state?.description?.trim() || draft?.description?.trim() || null,
-    city: state?.city?.trim() || draft?.city?.trim() || null,
-    state: state?.state?.trim() || draft?.state?.trim() || null,
-    opposingParty: state?.opposingParty?.trim() || draft?.opposingParty?.trim() || null,
+    description: readTrimmedString(state?.description) || readTrimmedString(draft?.description),
+    city: readTrimmedString(state?.city) || readTrimmedString(draft?.city),
+    state: readTrimmedString(state?.state) || readTrimmedString(draft?.state),
+    opposingParty: readTrimmedString(state?.opposingParty) || readTrimmedString(draft?.opposingParty),
   };
   return isIntakeReadyForSubmission(readinessState);
 };

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -17,7 +17,7 @@ import type { AuthContext } from '../middleware/auth.js';
 import { withPracticeContext, getPracticeId } from '../middleware/practiceContext.js';
 import { Logger } from '../utils/logger.js';
 import type { Env } from '../types.js';
-import { resolveConsultationState } from '../../src/shared/utils/consultationState';
+import { isIntakeReadyForSubmission, resolveConsultationState } from '../../src/shared/utils/consultationState';
 
 // ------------------------------------------------------------------
 // Types
@@ -154,13 +154,13 @@ const readStringField = (record: Record<string, unknown> | null | undefined, key
 };
 
 const isCaseInfoComplete = (state: IntakeConversationState | null | undefined, draft?: SlimContactDraft | null): boolean => {
-  if (!state) return false;
-  const draftRecord = draft as unknown as Record<string, string | undefined> | null | undefined;
-  const hasDescription = Boolean(state.description?.trim() || draftRecord?.description?.trim());
-  const hasLocation = Boolean(state.city?.trim() || draftRecord?.city?.trim())
-    && Boolean(state.state?.trim() || draftRecord?.state?.trim());
-  const hasOpposingParty = Boolean(state.opposingParty?.trim() || draftRecord?.opposingParty?.trim());
-  return hasDescription && hasLocation && hasOpposingParty;
+  const readinessState = {
+    description: state?.description?.trim() || draft?.description?.trim() || null,
+    city: state?.city?.trim() || draft?.city?.trim() || null,
+    state: state?.state?.trim() || draft?.state?.trim() || null,
+    opposingParty: state?.opposingParty?.trim() || draft?.opposingParty?.trim() || null,
+  };
+  return isIntakeReadyForSubmission(readinessState);
 };
 
 const buildIntakePayload = (


### PR DESCRIPTION
## What changed

- Threaded the bootstrap conversation ID into `WidgetApp` so the widget uses the worker-provided conversation after reload.
- Fixed the widget sign-in handoff test so `sessionStorage` survives the auth-page navigation.
- Tightened the intake planner prompt so payment is only introduced after case details are complete.

## Validation

- `npm run lint`
- `npm run type-check`
- Targeted Playwright passes for the cookie-clear widget flow and sign-in handoff flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations can be initialized from the bootstrap payload and follow a defined priority when selecting the active conversation.

* **Bug Fixes**
  * Payment/submission prompts now align with intake readiness rules.
  * Planner assistant no longer revisits other fields and asks only the single specified missing field.

* **Tests**
  * More stable e2e intake tests: deterministic sessionStorage handling, stricter button matching, and stronger planner readiness assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->