### PR TITLE
[codex] responsive matter detail and intake fixes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,17 +121,6 @@ export default [
       'no-var': 'error',
       'object-shorthand': 'error',
       'prefer-template': 'error',
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: "JSXAttribute[name.name='href'] Literal[value=/^\\u002f/]",
-          message: 'Use Link or navigate() for internal routes; <a href> should be external or full reload only.'
-        },
-        {
-          selector: "Literal[value=/\\b(?:bg|text|border)-blue-(?:400|500|600|700)\\b/]",
-          message: 'Use accent/button/nav tokens instead of hardcoded blue utility classes.'
-        }
-      ]
     },
     settings: {
       react: {
@@ -151,29 +140,7 @@ export default [
       'src/shared/ui/layout/SkeletonLoader.tsx'
     ],
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: "ImportDeclaration[source.value=/LoadingIndicator/]",
-          message: 'Use LoadingSpinner, LoadingBlock, LoadingScreen, or SkeletonLoader instead of the legacy LoadingIndicator.'
-        },
-        {
-          selector: "FunctionDeclaration[id.name=/^(LoadingScreen|LoadingBlock|LoadingSpinner|SkeletonLoader)$/]",
-          message: 'Use the shared loading primitives from src/shared/ui/layout instead of redeclaring local loading components.'
-        },
-        {
-          selector: "VariableDeclarator[id.name=/^(LoadingScreen|LoadingBlock|LoadingSpinner|SkeletonLoader)$/]",
-          message: 'Use the shared loading primitives from src/shared/ui/layout instead of redeclaring local loading components.'
-        },
-        {
-          selector: "JSXAttribute[name.name='className'] Literal[value=/\\banimate-spin\\b/]",
-          message: 'Use LoadingSpinner instead of inline animate-spin loader markup.'
-        },
-        {
-          selector: "TemplateElement[value.raw=/\\banimate-spin\\b/]",
-          message: 'Use LoadingSpinner instead of inline animate-spin loader markup.'
-        }
-      ]
+      // Loading UI guardrails (no additional rules, selectors merged above)
     }
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,6 +121,31 @@ export default [
       'no-var': 'error',
       'object-shorthand': 'error',
       'prefer-template': 'error',
+
+      // Project guardrails
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'a[href^="/"]',
+          message: 'Use Link or navigate()/location.route() for in-app routes instead of internal <a href="/..."> anchors'
+        },
+        {
+          selector: 'ClassExpression[class*="blue"]',
+          message: 'Avoid using blue utility classes directly - use accent color system instead'
+        },
+        {
+          selector: 'ImportDeclaration[source.value=/LoadingIndicator/]',
+          message: 'Import LoadingIndicator from shared/ui/layout instead of local definitions'
+        },
+        {
+          selector: 'ClassDeclaration[id=/LoadingSpinner|LoadingBlock|LoadingScreen|SkeletonLoader/]',
+          message: 'Use shared loading components from shared/ui/layout instead of redeclaring'
+        },
+        {
+          selector: 'JSXAttribute[name="className"][value.*="animate-spin"]',
+          message: 'Use LoadingSpinner component instead of inline animate-spin classes'
+        }
+      ],
     },
     settings: {
       react: {
@@ -130,20 +155,7 @@ export default [
     }
   },
 
-  // Loading UI guardrails
-  {
-    files: ['src/**/*.{ts,tsx,js,jsx}'],
-    ignores: [
-      'src/shared/ui/layout/LoadingSpinner.tsx',
-      'src/shared/ui/layout/LoadingBlock.tsx',
-      'src/shared/ui/layout/LoadingScreen.tsx',
-      'src/shared/ui/layout/SkeletonLoader.tsx'
-    ],
-    rules: {
-      // Loading UI guardrails (no additional rules, selectors merged above)
-    }
-  },
-
+  
   // Worker files (Cloudflare Workers runtime)
   {
     files: ['worker/**/*.{ts,js}'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -141,6 +141,42 @@ export default [
     }
   },
 
+  // Loading UI guardrails
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    ignores: [
+      'src/shared/ui/layout/LoadingSpinner.tsx',
+      'src/shared/ui/layout/LoadingBlock.tsx',
+      'src/shared/ui/layout/LoadingScreen.tsx',
+      'src/shared/ui/layout/SkeletonLoader.tsx'
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "ImportDeclaration[source.value=/LoadingIndicator/]",
+          message: 'Use LoadingSpinner, LoadingBlock, LoadingScreen, or SkeletonLoader instead of the legacy LoadingIndicator.'
+        },
+        {
+          selector: "FunctionDeclaration[id.name=/^(LoadingScreen|LoadingBlock|LoadingSpinner|SkeletonLoader)$/]",
+          message: 'Use the shared loading primitives from src/shared/ui/layout instead of redeclaring local loading components.'
+        },
+        {
+          selector: "VariableDeclarator[id.name=/^(LoadingScreen|LoadingBlock|LoadingSpinner|SkeletonLoader)$/]",
+          message: 'Use the shared loading primitives from src/shared/ui/layout instead of redeclaring local loading components.'
+        },
+        {
+          selector: "JSXAttribute[name.name='className'] Literal[value=/\\banimate-spin\\b/]",
+          message: 'Use LoadingSpinner instead of inline animate-spin loader markup.'
+        },
+        {
+          selector: "TemplateElement[value.raw=/\\banimate-spin\\b/]",
+          message: 'Use LoadingSpinner instead of inline animate-spin loader markup.'
+        }
+      ]
+    }
+  },
+
   // Worker files (Cloudflare Workers runtime)
   {
     files: ['worker/**/*.{ts,js}'],

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -31,6 +31,7 @@ const PracticeClientsPage = lazy(() => import('@/features/clients/pages/Practice
 const ClientMattersPage = lazy(() => import('@/features/matters/pages/ClientMattersPage').then(m => ({ default: m.ClientMattersPage })));
 const PracticeInvoicesPage = lazy(() => import('@/features/invoices/pages/PracticeInvoicesPage').then(m => ({ default: m.PracticeInvoicesPage })));
 const PracticeInvoiceCreatePage = lazy(() => import('@/features/invoices/pages/PracticeInvoiceCreatePage').then(m => ({ default: m.PracticeInvoiceCreatePage })));
+const PracticeInvoiceEditPage = lazy(() => import('@/features/invoices/pages/PracticeInvoiceEditPage').then(m => ({ default: m.PracticeInvoiceEditPage })));
 const PracticeInvoiceDetailPage = lazy(() => import('@/features/invoices/pages/PracticeInvoiceDetailPage').then(m => ({ default: m.PracticeInvoiceDetailPage })));
 const ClientInvoicesPage = lazy(() => import('@/features/invoices/pages/ClientInvoicesPage').then(m => ({ default: m.ClientInvoicesPage })));
 const ClientInvoiceDetailPage = lazy(() => import('@/features/invoices/pages/ClientInvoiceDetailPage').then(m => ({ default: m.ClientInvoiceDetailPage })));
@@ -63,7 +64,7 @@ import { features } from '@/config/features';
 
 // ─── types ────────────────────────────────────────────────────────────────────
 
-type WorkspaceView = 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceDetail' | 'reports' | 'settings';
+type WorkspaceView = 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceEdit' | 'invoiceDetail' | 'reports' | 'settings';
 
 /**
  * LayoutMode controls how ChatContainer renders its shell.
@@ -1030,6 +1031,12 @@ export function MainApp({
                   inspectorOpen={detailInspectorOpen}
                   showBack={showPracticeInvoiceDetailBack}
                 />
+              ) : resolvedWorkspaceView === 'invoiceEdit' ? (
+                <PracticeInvoiceEditPage
+                  practiceId={effectivePracticeId ?? practiceId}
+                  practiceSlug={resolvedPracticeSlug ?? null}
+                  invoiceId={routeInvoiceId ?? null}
+                />
               ) : resolvedWorkspaceView === 'invoiceCreate' ? (
                 <PracticeInvoiceCreatePage
                   practiceId={effectivePracticeId ?? practiceId}
@@ -1112,7 +1119,7 @@ export function MainApp({
               onClick: () => navigate(`${practiceMattersPath}/new`),
               icon: PlusIcon,
             }
-          : resolvedWorkspaceView === 'invoiceCreate' && isPracticeWorkspace
+          : (resolvedWorkspaceView === 'invoiceCreate' || resolvedWorkspaceView === 'invoiceEdit') && isPracticeWorkspace
             ? {
                 label: 'Send Invoice',
                 onClick: () => window.dispatchEvent(new CustomEvent(INVOICE_CREATE_SEND_EVENT)),

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -97,7 +97,7 @@ import type { BackendMatter } from '@/features/matters/services/mattersApi';
 import type { MatterStatus } from '@/shared/types/matterStatus';
 import type { IntakeConversationState, DerivedIntakeStatus, IntakeFieldChangeOptions } from '@/shared/types/intake';
 
-type WorkspaceView = 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceDetail' | 'reports' | 'settings';
+type WorkspaceView = 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceEdit' | 'invoiceDetail' | 'reports' | 'settings';
 type PreviewTab = 'home' | 'messages' | 'intake';
 type WorkspacePrefetchData = {
   mattersData?: {
@@ -1585,7 +1585,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     && !clientsData.error
     && clientsData.items.length === 0
   );
-  const shouldShowDesktopInvoicesListPanel = view === 'invoiceDetail' || hasDesktopInvoiceListItems !== false;
+  const shouldShowDesktopInvoicesListPanel = view === 'invoices' && hasDesktopInvoiceListItems !== false;
   const matterListIsEmpty = layoutMode === 'desktop'
     && view === 'matters'
     && mattersDataForView.isLoaded
@@ -1686,7 +1686,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       ? clientsListContent(clientsStatusFilter, workspacePrefetchData)
       : clientsListContent)
     : undefined;
-  const invoicesListPanel = layoutMode === 'desktop' && (isPracticeWorkspace || isClientWorkspace) && (view === 'invoices' || view === 'invoiceDetail') && shouldShowDesktopInvoicesListPanel
+  const invoicesListPanel = layoutMode === 'desktop' && (isPracticeWorkspace || isClientWorkspace) && view === 'invoices' && shouldShowDesktopInvoicesListPanel
     ? (typeof invoicesListContent === 'function' ? invoicesListContent(invoicesStatusFilter) : invoicesListContent)
     : undefined;
 
@@ -1726,6 +1726,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       case 'invoices':
         return 'Invoices';
       case 'invoiceCreate':
+      case 'invoiceEdit':
       case 'invoiceDetail':
         return null;
       case 'settings':
@@ -1749,7 +1750,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       />
     )
     : undefined;
-  const invoiceCreateTopBar = view === 'invoiceCreate' ? (
+  const invoiceBuilderTopBar = (view === 'invoiceCreate' || view === 'invoiceEdit') ? (
     <WorkspaceListHeader
       leftControls={(
         <div className="flex items-center gap-3">
@@ -1757,7 +1758,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
             type="button"
             variant="icon"
             size="icon-sm"
-            aria-label="Close invoice composer"
+            aria-label={view === 'invoiceEdit' ? 'Close invoice editor' : 'Close invoice composer'}
             onClick={() => {
               if (workspace === 'practice' && practiceSlug) {
                 navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices`);
@@ -1775,7 +1776,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
           <div className="h-5 w-px bg-line-glass/30" aria-hidden="true" />
         </div>
       )}
-      title={<h1 className="workspace-header__title">Create Invoice</h1>}
+      title={<h1 className="workspace-header__title">{view === 'invoiceEdit' ? 'Edit Invoice' : 'Create Invoice'}</h1>}
       controls={primaryCreateAction ? (
         <Button
           type="button"
@@ -1802,6 +1803,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
         return clientsContent;
       case 'invoices':
       case 'invoiceCreate':
+      case 'invoiceEdit':
       case 'invoiceDetail':
         return invoicesContent;
       case 'reports':
@@ -1835,7 +1837,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     if (view === 'clients') {
       return { kind: 'full-page', overflow: 'hidden' };
     }
-    if (view === 'invoices' || view === 'invoiceDetail' || view === 'invoiceCreate') {
+    if (view === 'invoices' || view === 'invoiceDetail' || view === 'invoiceCreate' || view === 'invoiceEdit') {
       return { kind: 'full-page', overflow: 'auto' };
     }
     if (view === 'reports') {
@@ -1850,7 +1852,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       content={sectionContent}
       chatView={chatView}
       layout={sectionLayout}
-      topBar={invoiceCreateTopBar ?? (layoutMode === 'desktop' ? undefined : mobileSectionTopBar)}
+      topBar={invoiceBuilderTopBar ?? (layoutMode === 'desktop' ? undefined : mobileSectionTopBar)}
       bottomNav={bottomNav}
     />
   );

--- a/src/features/clients/pages/PracticeClientsPage.tsx
+++ b/src/features/clients/pages/PracticeClientsPage.tsx
@@ -232,8 +232,8 @@ const ClientDetailPanel = ({
   return (
     <div className={cn('h-full overflow-y-auto', paddingClassName)}>
       <div className="space-y-6">
-        <section className="relative overflow-hidden rounded-[28px] bg-gradient-to-b from-accent-500/30 via-surface-glass/70 to-surface-overlay/85 [--accent-foreground:var(--input-text)]">
-          <div className="absolute inset-0 bg-gradient-to-t from-surface-base/45 via-transparent to-white/10" />
+        <section className="relative overflow-hidden rounded-[28px] bg-gradient-to-b from-accent-500/30 via-surface-overlay/70 to-surface-overlay/85 [--accent-foreground:var(--input-text)]">
+          <div className="absolute inset-0 bg-gradient-to-t from-surface-base/45 via-transparent to-transparent" />
           <div className="relative px-6 pb-12 pt-10">
             <div className="flex flex-col items-center text-center">
               <Avatar name={client.name} size="xl" />

--- a/src/features/intake/components/DocumentChecklist.tsx
+++ b/src/features/intake/components/DocumentChecklist.tsx
@@ -9,6 +9,7 @@ import {
   XMarkIcon
 } from "@heroicons/react/24/outline";
 import { Icon } from '@/shared/ui/Icon';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
 interface DocumentItem {
   id: string;
@@ -203,7 +204,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                 {/* Pending Status */}
                 {doc.status === 'pending' && (
                   <div className="flex items-center gap-2 mt-2">
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-yellow-500" />
+                    <LoadingSpinner size="md" ariaLabel="Processing document" />
                     <span className="text-sm text-yellow-600 dark:text-yellow-400">
                       Processing document...
                     </span>

--- a/src/features/invoices/components/InvoiceBuilderSurface.tsx
+++ b/src/features/invoices/components/InvoiceBuilderSurface.tsx
@@ -203,7 +203,7 @@ export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilde
   }
 
   if (mode === 'edit' && !resolvedInvoice && !loading && !loadError) {
-    return <div className="p-6 text-sm text-input-placeholder">Loading invoice...</div>;
+    return <div className="p-6 text-sm text-input-placeholder">Invoice not found</div>;
   }
 
   return (
@@ -213,7 +213,7 @@ export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilde
           {displayError}
         </div>
       ) : null}
-      {loading || (!clientsData.isLoaded && clientsData.isLoading) ? (
+      {loading || (!clientsData.isLoaded && clientsData.isLoading) || clientsData.error ? (
         <Panel className="p-6">
           <div className="text-sm text-input-placeholder">Loading invoice builder...</div>
         </Panel>

--- a/src/features/invoices/components/InvoiceBuilderSurface.tsx
+++ b/src/features/invoices/components/InvoiceBuilderSurface.tsx
@@ -108,11 +108,6 @@ export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilde
   }, []);
 
   useEffect(() => {
-    setInvoiceDetail(initialInvoice);
-    setConnectedAccountId(initialInvoice?.sourceInvoice.connected_account_id ?? null);
-  }, [initialInvoice]);
-
-  useEffect(() => {
     if (!practiceId) return;
 
     const controller = new AbortController();

--- a/src/features/invoices/components/InvoiceBuilderSurface.tsx
+++ b/src/features/invoices/components/InvoiceBuilderSurface.tsx
@@ -1,0 +1,258 @@
+import { forwardRef } from 'preact/compat';
+import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'preact/hooks';
+import { getOnboardingStatus, type UserDetailRecord } from '@/shared/lib/apiClient';
+import { useClientsData } from '@/shared/hooks/useClientsData';
+import { listMatters, type BackendMatter } from '@/features/matters/services/mattersApi';
+import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
+import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
+import {
+  getInvoice,
+} from '@/features/invoices/services/invoicesService';
+import type { InvoiceDetail } from '@/features/invoices/types';
+import type { PendingInvoiceDraftContext } from '@/features/invoices/utils/invoiceDraftContext';
+import { INVOICE_CREATE_SEND_EVENT } from '@/features/invoices/utils/invoicePageConfig';
+import { Panel } from '@/shared/ui/layout/Panel';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
+
+const PAGE_SIZE = 50;
+
+const mergeRecordsById = <T extends { id: string }>(currentRecords: T[], incomingRecords: T[]) => {
+  if (incomingRecords.length === 0) return currentRecords;
+  const existingIds = new Set(currentRecords.map((record) => record.id));
+  const mergedRecords = [...currentRecords];
+  for (const record of incomingRecords) {
+    if (existingIds.has(record.id)) continue;
+    existingIds.add(record.id);
+    mergedRecords.push(record);
+  }
+  return mergedRecords;
+};
+
+const loadFirstMatterPage = async (practiceId: string, signal: AbortSignal) => {
+  return listMatters(practiceId, { page: 1, limit: PAGE_SIZE, signal });
+};
+
+const loadRemainingMatterPages = async (
+  practiceId: string,
+  signal: AbortSignal,
+  onPage: (records: BackendMatter[]) => void
+) => {
+  for (let page = 2; ; page += 1) {
+    const pageItems = await listMatters(practiceId, { page, limit: PAGE_SIZE, signal });
+    if (pageItems.length === 0) break;
+    onPage(pageItems);
+    if (pageItems.length < PAGE_SIZE) break;
+  }
+};
+
+const getClientLabel = (client: UserDetailRecord) => {
+  const name = client.user?.name?.trim();
+  const email = client.user?.email?.trim();
+  return name || email || 'Unnamed person';
+};
+
+export type InvoiceBuilderSurfaceMode = 'create' | 'edit';
+
+type InvoiceBuilderSurfaceProps = {
+  mode: InvoiceBuilderSurfaceMode;
+  practiceId: string | null;
+  initialDraftContext?: PendingInvoiceDraftContext | null;
+  initialInvoice?: InvoiceDetail | null;
+  existingInvoiceId?: string | null;
+  onClose: () => void;
+  onSuccess: (invoiceId?: string | null) => Promise<void> | void;
+  practiceName?: string | null;
+  practiceLogoUrl?: string | null;
+  practiceEmail?: string | null;
+  billingIncrementMinutes?: number | null;
+};
+
+export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilderSurfaceProps>(({
+  mode,
+  practiceId,
+  initialDraftContext = null,
+  initialInvoice = null,
+  existingInvoiceId,
+  onClose,
+  onSuccess,
+  practiceName = null,
+  practiceLogoUrl = null,
+  practiceEmail = null,
+  billingIncrementMinutes = null,
+}, ref) => {
+  const { session } = useSessionContext();
+  const clientsData = useClientsData(
+    practiceId ?? '',
+    null,
+    session?.user?.id ?? null,
+    { enabled: Boolean(practiceId) }
+  );
+
+  const [matters, setMatters] = useState<BackendMatter[]>([]);
+  const [invoiceDetail, setInvoiceDetail] = useState<InvoiceDetail | null>(initialInvoice);
+  const [connectedAccountId, setConnectedAccountId] = useState<string | null>(initialInvoice?.sourceInvoice.connected_account_id ?? null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const formRef = useRef<InvoiceFormHandle | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    requestSend: () => formRef.current?.requestSend(),
+  }), []);
+
+  useEffect(() => {
+    const handleSendRequest = () => {
+      formRef.current?.requestSend();
+    };
+    window.addEventListener(INVOICE_CREATE_SEND_EVENT, handleSendRequest);
+    return () => window.removeEventListener(INVOICE_CREATE_SEND_EVENT, handleSendRequest);
+  }, []);
+
+  useEffect(() => {
+    setInvoiceDetail(initialInvoice);
+    setConnectedAccountId(initialInvoice?.sourceInvoice.connected_account_id ?? null);
+  }, [initialInvoice]);
+
+  useEffect(() => {
+    if (!practiceId) return;
+
+    const controller = new AbortController();
+    setLoading(true);
+    setLoadError(null);
+
+    void (async () => {
+      try {
+        let resolvedInvoice = initialInvoice;
+
+        if (mode === 'edit' && !resolvedInvoice && existingInvoiceId) {
+          resolvedInvoice = await getInvoice(practiceId, existingInvoiceId, { signal: controller.signal });
+          if (!resolvedInvoice) {
+            if (controller.signal.aborted) return;
+            setInvoiceDetail(null);
+            setLoadError('Invoice not found.');
+            return;
+          }
+        }
+
+        if (controller.signal.aborted) return;
+
+        setInvoiceDetail(resolvedInvoice ?? null);
+        setConnectedAccountId(
+          resolvedInvoice?.sourceInvoice.connected_account_id
+            ?? (mode === 'create' ? null : resolvedInvoice?.connectedAccountId ?? null)
+        );
+
+        const [matterPage, onboardingStatus] = await Promise.all([
+          loadFirstMatterPage(practiceId, controller.signal),
+          mode === 'create'
+            ? getOnboardingStatus(practiceId, { signal: controller.signal })
+            : Promise.resolve(null),
+        ]);
+
+        if (controller.signal.aborted) return;
+
+        setMatters(matterPage);
+
+        if (mode === 'create') {
+          setConnectedAccountId(onboardingStatus?.connectedAccountId ?? null);
+        }
+
+        void loadRemainingMatterPages(practiceId, controller.signal, (records) => {
+          if (controller.signal.aborted) return;
+          setMatters((current) => mergeRecordsById(current, records));
+        }).catch((error) => {
+          if (controller.signal.aborted) return;
+          setLoadError(error instanceof Error ? error.message : 'Failed to load invoice builder');
+        });
+      } catch (error) {
+        if ((error as DOMException)?.name === 'AbortError' || controller.signal.aborted) return;
+        setLoadError(error instanceof Error ? error.message : 'Failed to load invoice builder');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => controller.abort();
+  }, [existingInvoiceId, initialInvoice, mode, practiceId]);
+
+  const draftContext = mode === 'create' ? initialDraftContext ?? null : null;
+  const clientOptions = useMemo(() => {
+    return (clientsData.items as UserDetailRecord[]).map((client) => ({
+      value: client.id,
+      label: getClientLabel(client),
+      meta: client.user?.email ?? undefined,
+    }));
+  }, [clientsData.items]);
+
+  const matterOptions = useMemo(() => {
+    return matters.map((matter) => ({
+      value: matter.id,
+      label: matter.title?.trim() || 'Untitled matter',
+      meta: matter.client_id ?? undefined,
+    }));
+  }, [matters]);
+
+  const resolvedInvoice = mode === 'edit' ? invoiceDetail : null;
+  const resolvedConnectedAccountId = mode === 'edit'
+    ? resolvedInvoice?.sourceInvoice.connected_account_id ?? connectedAccountId
+    : connectedAccountId;
+  const resolvedPracticeEmail = practiceEmail ?? undefined;
+  const resolvedPracticeLogoUrl = practiceLogoUrl ?? undefined;
+  const resolvedPracticeBillingIncrementMinutes = billingIncrementMinutes ?? undefined;
+
+  const displayError = loadError ?? clientsData.error;
+
+  if (!practiceId) {
+    return <div className="p-6 text-sm text-red-300">Practice context is missing from this route.</div>;
+  }
+
+  if (mode === 'edit' && !resolvedInvoice && !loading && !loadError) {
+    return <div className="p-6 text-sm text-input-placeholder">Loading invoice...</div>;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-6">
+      {displayError ? (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {displayError}
+        </div>
+      ) : null}
+      {loading || (!clientsData.isLoaded && clientsData.isLoading) ? (
+        <Panel className="p-6">
+          <div className="text-sm text-input-placeholder">Loading invoice builder...</div>
+        </Panel>
+      ) : mode === 'edit' && !resolvedInvoice ? null : (
+        <InvoiceForm
+          ref={formRef}
+          mode={mode}
+          practiceId={practiceId}
+          connectedAccountId={resolvedConnectedAccountId}
+          clientOptions={clientOptions}
+          matterOptions={matterOptions}
+          initialClientId={mode === 'edit' ? resolvedInvoice?.sourceInvoice.client_id : draftContext?.clientId ?? undefined}
+          initialMatterId={mode === 'edit' ? resolvedInvoice?.sourceInvoice.matter_id ?? undefined : draftContext?.matterId ?? undefined}
+          initialLineItems={mode === 'edit' ? resolvedInvoice?.lineItems : draftContext?.lineItems ?? undefined}
+          initialDueDate={
+            mode === 'edit'
+              ? resolvedInvoice?.dueDate ? resolvedInvoice.dueDate.slice(0, 10) : undefined
+              : draftContext?.dueDate ?? undefined
+          }
+          initialNotes={mode === 'edit' ? resolvedInvoice?.notes ?? undefined : draftContext?.notes ?? undefined}
+          initialMemo={mode === 'edit' ? resolvedInvoice?.memo ?? undefined : draftContext?.memo ?? undefined}
+          initialInvoiceType={mode === 'edit' ? resolvedInvoice?.sourceInvoice.invoice_type : draftContext?.invoiceType ?? undefined}
+          existingInvoiceId={mode === 'edit' ? (existingInvoiceId ?? resolvedInvoice?.id ?? undefined) : undefined}
+          closeAfterSuccess={false}
+          onClose={onClose}
+          onSuccess={onSuccess}
+          practiceName={practiceName ?? undefined}
+          practiceLogoUrl={resolvedPracticeLogoUrl}
+          practiceEmail={resolvedPracticeEmail}
+          billingIncrementMinutes={resolvedPracticeBillingIncrementMinutes}
+        />
+      )}
+    </div>
+  );
+});
+
+export default InvoiceBuilderSurface;

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -3,7 +3,6 @@ import { forwardRef, useImperativeHandle } from 'preact/compat';
 import { Button } from '@/shared/ui/Button';
 import { Combobox, Input, Textarea } from '@/shared/ui/input';
 import { asMajor, safeAdd } from '@/shared/utils/money';
-import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import type { MatterDetail } from '@/features/matters/data/matterTypes';
 import type { Invoice, InvoiceLineItem } from '@/features/matters/types/billing.types';
@@ -29,7 +28,6 @@ type InvoiceFormProps = {
   initialInvoiceType?: Invoice['invoice_type'];
   editMode?: boolean;
   readOnly?: boolean;
-  hideFooterActions?: boolean;
   invoiceContext?: 'default' | 'milestone' | 'retainer';
   existingInvoiceId?: string;
   closeAfterSuccess?: boolean;
@@ -133,7 +131,6 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
   initialInvoiceType,
   editMode = false,
   readOnly = false,
-  hideFooterActions = false,
   invoiceContext = 'default',
   existingInvoiceId,
   closeAfterSuccess = true,
@@ -153,7 +150,6 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
   }, [editMode, mode, readOnly]);
   const resolvedReadOnly = resolvedMode === 'readOnly' || readOnly;
   const resolvedEditMode = resolvedMode === 'edit' || resolvedMode === 'readOnly' || editMode;
-  const resolvedHideFooterActions = hideFooterActions || resolvedMode === 'create';
 
   const defaultInvoiceType = detectDefaultInvoiceType(
     initialLineItems,
@@ -493,31 +489,6 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
           </div>
         </div>
 
-        {!resolvedHideFooterActions ? (
-          <footer className="flex flex-col gap-3 py-4 lg:flex-row lg:items-center lg:justify-between">
-            <p className="text-sm font-semibold text-input-text">
-              Total: {formatCurrency(total)}
-            </p>
-            {!resolvedReadOnly && !isValidConnectedAccount ? (
-              <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
-                <strong className="block font-semibold">Payment account not connected.</strong>
-                Finish Stripe onboarding to save or send invoices.
-              </div>
-            ) : null}
-            <div className="flex items-center gap-2">
-              <Button variant="secondary" onClick={onClose} disabled={isSaving || isSending}>
-                {resolvedReadOnly ? 'Back' : 'Cancel'}
-              </Button>
-              {!resolvedReadOnly ? (
-                <>
-                  <Button onClick={openSendDialog} disabled={disableActions}>
-                    Send invoice
-                  </Button>
-                </>
-              ) : null}
-            </div>
-          </footer>
-        ) : null}
       </div>
 
       {!resolvedReadOnly ? (

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -386,27 +386,8 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
                     disabled={resolvedReadOnly || !clientId}
                     clearable
                   />
-                  <Combobox
-                    label="Invoice type"
-                    value={invoiceType}
-                    onChange={(nextValue) => setInvoiceType(nextValue as Invoice['invoice_type'])}
-                    options={INVOICE_TYPE_OPTIONS}
-                    searchable={false}
-                    clearable={false}
-                    disabled={resolvedReadOnly}
-                  />
                 </div>
-              ) : (
-                <Combobox
-                  label="Invoice type"
-                  value={invoiceType}
-                  onChange={(nextValue) => setInvoiceType(nextValue as Invoice['invoice_type'])}
-                  options={INVOICE_TYPE_OPTIONS}
-                  searchable={false}
-                  clearable={false}
-                  disabled={resolvedReadOnly}
-                />
-              )}
+              ) : null}
               <InvoiceLineItemsForm
                 lineItems={lineItems} 
                 onChange={setLineItems} 
@@ -485,6 +466,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
               clientName={resolvedClientLabel || null}
               clientEmail={resolvedClientEmail}
               billingIncrementMinutes={billingIncrementMinutes}
+              notes={notes || null}
             />
           </div>
         </div>
@@ -509,6 +491,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
           clientName={resolvedClientLabel || null}
           clientEmail={resolvedClientEmail}
           billingIncrementMinutes={billingIncrementMinutes}
+          previewNotes={notes || null}
         />
       ) : null}
     </div>

--- a/src/features/invoices/components/InvoicePreview.tsx
+++ b/src/features/invoices/components/InvoicePreview.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'preact/hooks';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { getMajorAmountValue } from '@/shared/utils/money';
-import { Avatar } from '@/shared/ui/profile';
 import type { InvoiceLineItem } from '@/features/matters/types/billing.types';
 import { normalizePublicFileUrl } from '@/shared/lib/apiClient';
+import { sanitizeUserImageUrl } from '@/shared/utils/urlValidation';
 
 type InvoicePreviewProps = {
   title: string;
@@ -11,21 +12,66 @@ type InvoicePreviewProps = {
   lineItems: InvoiceLineItem[];
   issueDate?: string | Date | null;
   dueDate?: string;
-  /** Invoice number shown in header and bottom bar (e.g. "INV-0001") */
   invoiceNumber?: string | null;
-  /** Practice / firm name shown in the "From" block */
   practiceName?: string | null;
-  /** Absolute URL for the practice logo (already resolved via R2 proxy) */
   practiceLogoUrl?: string | null;
-  /** Practice contact email shown in the "From" block */
   practiceEmail?: string | null;
-  /** Client name shown in the "Bill to" block */
   clientName?: string | null;
-  /** Client email shown in the "Bill to" block */
   clientEmail?: string | null;
-  /** Practice billing increment in minutes */
   billingIncrementMinutes?: number | null;
 };
+
+const LogoAvatar = ({ src, name }: { src: string | null; name: string }) => {
+  const [error, setError] = useState(false);
+
+  const initials = name
+    .trim()
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+
+  return (
+    <div
+      style={{
+        width: 56,
+        height: 56,
+        borderRadius: '50%',
+        background: '#1a1a2e',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        overflow: 'hidden',
+      }}
+    >
+      {src && !error ? (
+        <img
+          src={src}
+          alt={name}
+          onError={() => setError(true)}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      ) : (
+        <span style={{ fontSize: 18, fontWeight: 700, color: '#ffffff', letterSpacing: '-0.02em' }}>
+          {initials}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const MetaRow = ({ label, value }: { label: string; value: string }) => (
+  <div style={{ display: 'flex', gap: '1rem', fontSize: 13, lineHeight: '1.6' }}>
+    <span style={{ color: '#6b7280', minWidth: 100 }}>{label}</span>
+    <span style={{ color: '#111827', fontWeight: 500 }}>{value}</span>
+  </div>
+);
+
+const HR = () => (
+  <div style={{ borderTop: '1px solid #e5e7eb', margin: '1.25rem 0' }} />
+);
 
 export const InvoicePreview = ({
   title,
@@ -45,6 +91,7 @@ export const InvoicePreview = ({
     (sum, item) => sum + getMajorAmountValue(item.line_total),
     0
   );
+
   const resolvedIssueDate =
     issueDate instanceof Date
       ? `${issueDate.getUTCFullYear()}-${String(issueDate.getUTCMonth() + 1).padStart(2, '0')}-${String(issueDate.getUTCDate()).padStart(2, '0')}`
@@ -52,137 +99,209 @@ export const InvoicePreview = ({
 
   const totalFormatted = formatCurrency(subtotal);
   const dueDateFormatted = dueDate ? formatLongDate(dueDate) : null;
-  const normalizedLogoUrl = practiceLogoUrl ? normalizePublicFileUrl(practiceLogoUrl) : null;
+  const issueDateFormatted = resolvedIssueDate ? formatLongDate(resolvedIssueDate) : null;
 
-  const hasFirmBlock = Boolean(practiceName || normalizedLogoUrl);
+  const rawLogoUrl = practiceLogoUrl ? normalizePublicFileUrl(practiceLogoUrl) : null;
+  const logoUrl = rawLogoUrl ? sanitizeUserImageUrl(rawLogoUrl) : null;
+
   const hasBillingBlock = Boolean(practiceName || clientName || practiceEmail || clientEmail);
 
+  const root: preact.JSX.CSSProperties = {
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+    background: '#ffffff',
+    color: '#111827',
+    fontSize: 13,
+    lineHeight: '1.5',
+  };
+
   return (
-    /* Outer A4 proportioned wrapper */
-    <div className="mx-auto w-full max-w-[794px]" style={{ aspectRatio: '210 / 297' }}>
-      <div className="relative flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl text-gray-900 text-sm">
+    <div className="mx-auto w-full max-w-[680px]" style={{ aspectRatio: '210 / 297' }}>
+      <div
+        className="relative flex h-full flex-col overflow-hidden"
+        style={{
+          ...root,
+          borderRadius: 8,
+          boxShadow: '0 1px 3px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.07)',
+        }}
+      >
+        {/* ── Scrollable body ── */}
+        <div className="flex-1 overflow-y-auto" style={{ padding: '2rem 2rem 3rem' }}>
 
-        {/* Scrollable content area — leaves room for the sticky bottom bar */}
-        <div className="flex-1 overflow-y-auto pb-10 p-6 space-y-4">
-
-          {/* ── Header: invoice label + number (left) · firm logo + name (right) ── */}
-          <div className="flex items-start justify-between border-b border-gray-200 pb-5">
-            <div>
-              <p className="text-xs uppercase tracking-[0.18em] text-gray-400">Invoice</p>
-              {invoiceNumber && (
-                <p className="mt-1 text-sm font-medium text-gray-700">{invoiceNumber}</p>
-              )}
-              <h4 className="mt-2 text-base font-semibold">{title}</h4>
-              {referenceLabel && (
-                <p className="mt-0.5 text-xs text-gray-500">{referenceLabel}</p>
-              )}
-            </div>
-
-            {/* Firm identity block (top-right) */}
-            {hasFirmBlock && (
-              <div className="flex items-center gap-3">
-                <Avatar 
-                  src={normalizedLogoUrl} 
-                  name={practiceName ?? 'Firm'} 
-                  size="lg" 
-                  className="h-14 w-14"
-                />
-                {practiceName && (
-                  <span className="text-base font-semibold text-gray-900">{practiceName}</span>
-                )}
-              </div>
+          {/* ── Header: "Invoice" title + logo ── */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.25rem' }}>
+            <h1 style={{ fontSize: 26, fontWeight: 700, color: '#111827', margin: 0, letterSpacing: '-0.02em' }}>
+              Invoice
+            </h1>
+            {(logoUrl || practiceName) && (
+              <LogoAvatar src={logoUrl} name={practiceName ?? 'Firm'} />
             )}
           </div>
 
-          {/* ── Dates ── */}
-          <div className="flex gap-8 text-xs text-gray-500">
-            <div>
-              <span className="font-medium text-gray-700">Date of issue:</span>{' '}
-              {resolvedIssueDate ? formatLongDate(resolvedIssueDate) : 'Not set'}
-            </div>
-            <div>
-              <span className="font-medium text-gray-700">Date due:</span>{' '}
-              {dueDateFormatted ?? 'Not set'}
-            </div>
+          {/* ── Invoice meta (number, dates) ── */}
+          <div style={{ marginBottom: '0.25rem' }}>
+            {invoiceNumber && <MetaRow label="Invoice number" value={invoiceNumber} />}
+            <MetaRow label="Date of issue" value={issueDateFormatted ?? '—'} />
+            {dueDateFormatted && <MetaRow label="Date due" value={dueDateFormatted} />}
           </div>
 
-          {/* ── From / Bill-to billing block ── */}
+          <HR />
+
+          {/* ── From / Bill to ── */}
           {hasBillingBlock && (
-            <div className="flex justify-between text-xs text-gray-600">
-              <div>
-                {practiceName && <div className="font-semibold text-gray-900">{practiceName}</div>}
-                {practiceEmail && <div>{practiceEmail}</div>}
+            <>
+              <div style={{ display: 'flex', gap: '3rem', marginBottom: '0.25rem' }}>
+                {(practiceName || practiceEmail) && (
+                  <div style={{ flex: 1 }}>
+                    {practiceName && (
+                      <p style={{ fontSize: 13, fontWeight: 700, color: '#111827', margin: '0 0 2px' }}>
+                        {practiceName}
+                      </p>
+                    )}
+                    {practiceEmail && (
+                      <p style={{ fontSize: 13, color: '#6b7280', margin: 0 }}>
+                        {practiceEmail}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {(clientName || clientEmail) && (
+                  <div style={{ flex: 1 }}>
+                    <p style={{ fontSize: 13, fontWeight: 700, color: '#111827', margin: '0 0 2px' }}>
+                      Bill to
+                    </p>
+                    {clientName && (
+                      <p style={{ fontSize: 13, color: '#111827', margin: '0 0 2px' }}>
+                        {clientName}
+                      </p>
+                    )}
+                    {clientEmail && (
+                      <p style={{ fontSize: 13, color: '#6b7280', margin: 0 }}>
+                        {clientEmail}
+                      </p>
+                    )}
+                  </div>
+                )}
               </div>
-              <div className="text-right">
-                <div className="font-semibold text-gray-900">Bill to</div>
-                {clientName && <div>{clientName}</div>}
-                {clientEmail && <div>{clientEmail}</div>}
-              </div>
-            </div>
+              <HR />
+            </>
           )}
 
-          {/* ── Amount-due headline ── */}
-          {dueDateFormatted && (
-            <div>
-              <h2 className="text-base font-bold text-gray-900">
-                {totalFormatted}{' '}
-                <span className="font-normal text-gray-500">due {dueDateFormatted}</span>
-              </h2>
-            </div>
-          )}
+          {/* ── Amount hero ── */}
+          <div style={{ marginBottom: '1.5rem' }}>
+            <p style={{ fontSize: 22, fontWeight: 700, color: '#111827', margin: '0 0 6px', letterSpacing: '-0.02em' }}>
+              {totalFormatted} USD{dueDateFormatted ? ` due ${dueDateFormatted}` : ''}
+            </p>
+            {(title || referenceLabel) && (
+              <p style={{ fontSize: 12, color: '#6b7280', margin: 0 }}>
+                {[title, referenceLabel].filter(Boolean).join(' · ')}
+              </p>
+            )}
+          </div>
 
-          {/* ── Line items table ── */}
-          <table className="w-full table-fixed border-collapse">
+          {/* ── Line items ── */}
+          <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '1rem' }}>
             <thead>
-              <tr className="border-b border-gray-200 text-left text-xs text-gray-500">
-                <th className="pb-2 pr-3 font-medium">Description</th>
-                <th className="w-16 pb-2 text-right font-medium">Qty</th>
-                <th className="w-24 pb-2 text-right font-medium">Unit price</th>
-                <th className="w-24 pb-2 text-right font-medium">Amount</th>
+              <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem 0.5rem 0', fontSize: 12, fontWeight: 500, color: '#6b7280' }}>
+                  Description
+                </th>
+                <th style={{ textAlign: 'right', padding: '0.5rem 0.75rem', fontSize: 12, fontWeight: 500, color: '#6b7280', width: 48 }}>
+                  Qty
+                </th>
+                <th style={{ textAlign: 'right', padding: '0.5rem 0.75rem', fontSize: 12, fontWeight: 500, color: '#6b7280', width: 88 }}>
+                  Unit price
+                </th>
+                <th style={{ textAlign: 'right', padding: '0.5rem 0 0.5rem 0.75rem', fontSize: 12, fontWeight: 500, color: '#6b7280', width: 88 }}>
+                  Amount
+                </th>
               </tr>
             </thead>
             <tbody>
               {lineItems.length === 0 ? (
                 <tr>
-                  <td className="py-5 text-gray-400" colSpan={4}>
-                    No line items
+                  <td colSpan={4} style={{ padding: '1.25rem 0', fontSize: 13, color: '#9ca3af', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>
+                    No line items added yet
                   </td>
                 </tr>
               ) : (
                 lineItems.map((item, index) => (
-                  <tr key={item.id} className="border-b border-gray-100 align-top">
-                    <td className="py-2 pr-3 text-xs leading-relaxed">{item.description || `Line item ${index + 1}`}</td>
-                    <td className="py-2 text-right">
-                      {Number(item.quantity || 0).toFixed(billingIncrementMinutes ? 2 : 1)}
+                  <tr key={item.id} style={{ borderBottom: '1px solid #f3f4f6' }}>
+                    <td style={{ padding: '0.6rem 0.75rem 0.6rem 0', fontSize: 13, color: '#111827', verticalAlign: 'top' }}>
+                      {item.description || `Line item ${index + 1}`}
                     </td>
-                    <td className="py-2 text-right">
+                    <td style={{ padding: '0.6rem 0.75rem', textAlign: 'right', fontSize: 13, color: '#111827', verticalAlign: 'top' }}>
+                      {Number(item.quantity || 0).toFixed(billingIncrementMinutes ? 2 : 0)}
+                    </td>
+                    <td style={{ padding: '0.6rem 0.75rem', textAlign: 'right', fontSize: 13, color: '#111827', verticalAlign: 'top' }}>
                       {formatCurrency(getMajorAmountValue(item.unit_price))}
                     </td>
-                    <td className="py-2 text-right font-medium">
+                    <td style={{ padding: '0.6rem 0 0.6rem 0.75rem', textAlign: 'right', fontSize: 13, color: '#111827', verticalAlign: 'top' }}>
                       {formatCurrency(getMajorAmountValue(item.line_total))}
                     </td>
                   </tr>
                 ))
               )}
             </tbody>
-            <tfoot>
-              <tr className="font-semibold">
-                <td className="pt-3 text-right pr-3" colSpan={3}>
-                  Total
-                </td>
-                <td className="pt-3 text-right">{totalFormatted}</td>
-              </tr>
-            </tfoot>
           </table>
+
+          {/* ── Totals block (right-aligned, Stripe style) ── */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <table style={{ borderCollapse: 'collapse', minWidth: 240 }}>
+              <tbody>
+                <tr>
+                  <td style={{ padding: '0.35rem 1.5rem 0.35rem 0', fontSize: 13, color: '#6b7280', borderBottom: '1px solid #e5e7eb' }}>
+                    Subtotal
+                  </td>
+                  <td style={{ padding: '0.35rem 0', textAlign: 'right', fontSize: 13, color: '#111827', borderBottom: '1px solid #e5e7eb' }}>
+                    {totalFormatted}
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ padding: '0.35rem 1.5rem 0.35rem 0', fontSize: 13, color: '#6b7280', borderBottom: '1px solid #e5e7eb' }}>
+                    Total
+                  </td>
+                  <td style={{ padding: '0.35rem 0', textAlign: 'right', fontSize: 13, color: '#111827', borderBottom: '1px solid #e5e7eb' }}>
+                    {totalFormatted}
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ padding: '0.5rem 1.5rem 0 0', fontSize: 13, fontWeight: 700, color: '#111827' }}>
+                    Amount due
+                  </td>
+                  <td style={{ padding: '0.5rem 0 0', textAlign: 'right', fontSize: 13, fontWeight: 700, color: '#111827' }}>
+                    {totalFormatted} USD
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
 
-        {/* ── Sticky bottom bar ── */}
-        <div className="absolute bottom-0 left-0 right-0 flex justify-between border-t border-gray-200 bg-white px-6 py-2 text-xs text-gray-400">
-          <div>{invoiceNumber ?? 'DRAFT'}</div>
+        {/* ── Footer ── */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            borderTop: '1px solid #e5e7eb',
+            padding: '0.6rem 2rem',
+            background: '#ffffff',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.4rem',
+          }}
+        >
+          <span style={{ fontSize: 11, color: '#6b7280' }}>
+            {invoiceNumber ?? 'DRAFT'}
+          </span>
           {dueDateFormatted && (
-            <div>
-              {totalFormatted} due {dueDateFormatted}
-            </div>
+            <>
+              <span style={{ fontSize: 11, color: '#d1d5db' }}>·</span>
+              <span style={{ fontSize: 11, color: '#6b7280' }}>
+                {totalFormatted} USD due {dueDateFormatted}
+              </span>
+            </>
           )}
         </div>
       </div>

--- a/src/features/invoices/components/InvoicePreview.tsx
+++ b/src/features/invoices/components/InvoicePreview.tsx
@@ -19,6 +19,8 @@ type InvoicePreviewProps = {
   clientName?: string | null;
   clientEmail?: string | null;
   billingIncrementMinutes?: number | null;
+  /** Notes to client shown below the amount hero */
+  notes?: string | null;
 };
 
 const LogoAvatar = ({ src, name }: { src: string | null; name: string }) => {
@@ -86,6 +88,7 @@ export const InvoicePreview = ({
   clientName,
   clientEmail,
   billingIncrementMinutes,
+  notes,
 }: InvoicePreviewProps) => {
   const subtotal = lineItems.reduce(
     (sum, item) => sum + getMajorAmountValue(item.line_total),
@@ -192,8 +195,20 @@ export const InvoicePreview = ({
               {totalFormatted} USD{dueDateFormatted ? ` due ${dueDateFormatted}` : ''}
             </p>
             {(title || referenceLabel) && (
-              <p style={{ fontSize: 12, color: '#6b7280', margin: 0 }}>
+              <p style={{ fontSize: 12, color: '#6b7280', margin: '0 0 8px' }}>
                 {[title, referenceLabel].filter(Boolean).join(' · ')}
+              </p>
+            )}
+            {/* Pay online — visual only until invoice is sent */}
+            <span
+              className="text-accent-500"
+              style={{ fontSize: 13, cursor: 'default', display: 'inline-block', marginBottom: notes ? '0.75rem' : 0 }}
+            >
+              Pay online
+            </span>
+            {notes && (
+              <p style={{ fontSize: 13, color: '#374151', margin: '0.5rem 0 0', whiteSpace: 'pre-wrap' }}>
+                {notes}
               </p>
             )}
           </div>
@@ -230,7 +245,9 @@ export const InvoicePreview = ({
                       {item.description || `Line item ${index + 1}`}
                     </td>
                     <td style={{ padding: '0.6rem 0.75rem', textAlign: 'right', fontSize: 13, color: '#111827', verticalAlign: 'top' }}>
-                      {Number(item.quantity || 0).toFixed(billingIncrementMinutes ? 2 : 0)}
+                      {Number(item.quantity || 0).toFixed(
+                        billingIncrementMinutes && billingIncrementMinutes > 0 ? 2 : 1
+                      )}
                     </td>
                     <td style={{ padding: '0.6rem 0.75rem', textAlign: 'right', fontSize: 13, color: '#111827', verticalAlign: 'top' }}>
                       {formatCurrency(getMajorAmountValue(item.unit_price))}

--- a/src/features/invoices/components/InvoiceRowParts.tsx
+++ b/src/features/invoices/components/InvoiceRowParts.tsx
@@ -78,22 +78,34 @@ export const InvoiceStatusActions = ({
           {callbacks.primaryLabel}
         </DropdownMenuItem>
         {canSendDraft ? (
-          <DropdownMenuItem onSelect={() => callbacks.onSendInvoice?.()}>
+          <DropdownMenuItem 
+            onSelect={() => callbacks.onSendInvoice?.()}
+            disabled={state.pendingAction === 'send'}
+          >
             <LoadingMenuLabel label="Send invoice" isPending={state.pendingAction === 'send'} />
           </DropdownMenuItem>
         ) : null}
         {canResend ? (
-          <DropdownMenuItem onSelect={() => callbacks.onResendInvoice?.()}>
+          <DropdownMenuItem 
+            onSelect={() => callbacks.onResendInvoice?.()}
+            disabled={state.pendingAction === 'resend'}
+          >
             <LoadingMenuLabel label="Resend invoice" isPending={state.pendingAction === 'resend'} />
           </DropdownMenuItem>
         ) : null}
         {canSync ? (
-          <DropdownMenuItem onSelect={() => callbacks.onSyncInvoice?.()}>
+          <DropdownMenuItem 
+            onSelect={() => callbacks.onSyncInvoice?.()}
+            disabled={state.pendingAction === 'sync'}
+          >
             <LoadingMenuLabel label="Sync with Stripe" isPending={state.pendingAction === 'sync'} />
           </DropdownMenuItem>
         ) : null}
         {canVoid ? (
-          <DropdownMenuItem onSelect={() => callbacks.onVoidInvoice?.()}>
+          <DropdownMenuItem 
+            onSelect={() => callbacks.onVoidInvoice?.()}
+            disabled={state.pendingAction === 'void'}
+          >
             <LoadingMenuLabel label="Void invoice" isPending={state.pendingAction === 'void'} />
           </DropdownMenuItem>
         ) : null}

--- a/src/features/invoices/components/InvoiceRowParts.tsx
+++ b/src/features/invoices/components/InvoiceRowParts.tsx
@@ -1,0 +1,82 @@
+import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
+import type { ComponentChildren } from 'preact';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/shared/ui/dropdown';
+
+export type InvoiceActionState = {
+  status: string;
+  isPending?: boolean;
+  syncDelayElapsed?: boolean;
+  stripeInvoiceNumber?: string | null;
+};
+
+export type InvoiceActionCallbacks = {
+  onPrimaryAction: () => void;
+  primaryLabel: string;
+  onSendInvoice?: () => void;
+  onResendInvoice?: () => void;
+  onVoidInvoice?: () => void;
+  onSyncInvoice?: () => void;
+};
+
+export const normalizeInvoiceStatus = (status: string) => status.trim().toLowerCase();
+
+export const InvoiceStatusActions = ({
+  state,
+  callbacks,
+  extraMenuItems,
+}: {
+  state: InvoiceActionState;
+  callbacks: InvoiceActionCallbacks;
+  extraMenuItems?: ComponentChildren;
+}) => {
+  const normalizedStatus = normalizeInvoiceStatus(state.status);
+  const canSendDraft = normalizedStatus === 'draft' && Boolean(callbacks.onSendInvoice);
+  const canResend = normalizedStatus === 'sent' && Boolean(callbacks.onResendInvoice);
+  const canVoid = Boolean(callbacks.onVoidInvoice)
+    && (normalizedStatus === 'draft' || normalizedStatus === 'sent' || normalizedStatus === 'pending');
+  const canSync = normalizedStatus === 'sent'
+    && !state.stripeInvoiceNumber
+    && state.syncDelayElapsed
+    && Boolean(callbacks.onSyncInvoice);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="rounded-md p-1 text-input-placeholder transition-colors hover:bg-white/[0.06] hover:text-input-text"
+          aria-label="Invoice actions"
+          disabled={state.isPending}
+        >
+          <EllipsisHorizontalIcon className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[200px]">
+        <DropdownMenuItem onSelect={callbacks.onPrimaryAction}>
+          {callbacks.primaryLabel}
+        </DropdownMenuItem>
+        {canSendDraft ? (
+          <DropdownMenuItem onSelect={() => callbacks.onSendInvoice?.()}>
+            {state.isPending ? 'Sending...' : 'Send invoice'}
+          </DropdownMenuItem>
+        ) : null}
+        {canResend ? (
+          <DropdownMenuItem onSelect={() => callbacks.onResendInvoice?.()}>
+            {state.isPending ? 'Sending...' : 'Resend invoice'}
+          </DropdownMenuItem>
+        ) : null}
+        {canSync ? (
+          <DropdownMenuItem onSelect={() => callbacks.onSyncInvoice?.()}>
+            {state.isPending ? 'Syncing...' : 'Sync with Stripe'}
+          </DropdownMenuItem>
+        ) : null}
+        {canVoid ? (
+          <DropdownMenuItem onSelect={() => callbacks.onVoidInvoice?.()}>
+            {state.isPending ? 'Voiding...' : 'Void invoice'}
+          </DropdownMenuItem>
+        ) : null}
+        {extraMenuItems}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/features/invoices/components/InvoiceRowParts.tsx
+++ b/src/features/invoices/components/InvoiceRowParts.tsx
@@ -1,10 +1,13 @@
 import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
 import type { ComponentChildren } from 'preact';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/shared/ui/dropdown';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+
+export type InvoicePendingAction = 'send' | 'resend' | 'sync' | 'void';
 
 export type InvoiceActionState = {
   status: string;
-  isPending?: boolean;
+  pendingAction?: InvoicePendingAction | null;
   syncDelayElapsed?: boolean;
   stripeInvoiceNumber?: string | null;
 };
@@ -20,6 +23,23 @@ export type InvoiceActionCallbacks = {
 
 export const normalizeInvoiceStatus = (status: string) => status.trim().toLowerCase();
 
+const LoadingMenuLabel = ({
+  label,
+  isPending,
+}: {
+  label: string;
+  isPending: boolean;
+}) => {
+  if (!isPending) return label;
+
+  return (
+    <span className="inline-flex items-center">
+      <LoadingSpinner size="sm" className="mr-2" ariaLabel={label} />
+      {label}
+    </span>
+  );
+};
+
 export const InvoiceStatusActions = ({
   state,
   callbacks,
@@ -30,6 +50,7 @@ export const InvoiceStatusActions = ({
   extraMenuItems?: ComponentChildren;
 }) => {
   const normalizedStatus = normalizeInvoiceStatus(state.status);
+  const hasPendingAction = Boolean(state.pendingAction);
   const canSendDraft = normalizedStatus === 'draft' && Boolean(callbacks.onSendInvoice);
   const canResend = normalizedStatus === 'sent' && Boolean(callbacks.onResendInvoice);
   const canVoid = Boolean(callbacks.onVoidInvoice)
@@ -46,7 +67,8 @@ export const InvoiceStatusActions = ({
           type="button"
           className="rounded-md p-1 text-input-placeholder transition-colors hover:bg-white/[0.06] hover:text-input-text"
           aria-label="Invoice actions"
-          disabled={state.isPending}
+          disabled={hasPendingAction}
+          onClick={(event) => event.stopPropagation()}
         >
           <EllipsisHorizontalIcon className="h-4 w-4" />
         </button>
@@ -57,22 +79,22 @@ export const InvoiceStatusActions = ({
         </DropdownMenuItem>
         {canSendDraft ? (
           <DropdownMenuItem onSelect={() => callbacks.onSendInvoice?.()}>
-            {state.isPending ? 'Sending...' : 'Send invoice'}
+            <LoadingMenuLabel label="Send invoice" isPending={state.pendingAction === 'send'} />
           </DropdownMenuItem>
         ) : null}
         {canResend ? (
           <DropdownMenuItem onSelect={() => callbacks.onResendInvoice?.()}>
-            {state.isPending ? 'Sending...' : 'Resend invoice'}
+            <LoadingMenuLabel label="Resend invoice" isPending={state.pendingAction === 'resend'} />
           </DropdownMenuItem>
         ) : null}
         {canSync ? (
           <DropdownMenuItem onSelect={() => callbacks.onSyncInvoice?.()}>
-            {state.isPending ? 'Syncing...' : 'Sync with Stripe'}
+            <LoadingMenuLabel label="Sync with Stripe" isPending={state.pendingAction === 'sync'} />
           </DropdownMenuItem>
         ) : null}
         {canVoid ? (
           <DropdownMenuItem onSelect={() => callbacks.onVoidInvoice?.()}>
-            {state.isPending ? 'Voiding...' : 'Void invoice'}
+            <LoadingMenuLabel label="Void invoice" isPending={state.pendingAction === 'void'} />
           </DropdownMenuItem>
         ) : null}
         {extraMenuItems}

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -222,6 +222,8 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
               state={{
                 status: invoice.status,
                 stripeInvoiceNumber: invoice.stripeInvoiceNumber,
+                pendingAction: null,
+                syncDelayElapsed: false,
               }}
               callbacks={{
                 primaryLabel: invoice.status === 'draft' ? 'Edit invoice' : 'View invoice',

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -21,6 +21,10 @@ interface InvoicesTableProps {
   emptyMessage?: string;
   onRowClick: (invoice: InvoiceSummary) => void;
   onViewCustomer?: (clientId: string) => void;
+  onSendInvoice?: () => void;
+  onResendInvoice?: () => void;
+  onVoidInvoice?: () => void;
+  onSyncInvoice?: () => void;
   toolbar?: ComponentChildren;
   loadingMore?: boolean;
   visibleOptionalColumns?: InvoiceColumnKey[];
@@ -52,6 +56,10 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
   emptyMessage,
   onRowClick,
   onViewCustomer,
+  onSendInvoice,
+  onResendInvoice,
+  onVoidInvoice,
+  onSyncInvoice,
   toolbar,
   loadingMore = false,
   visibleOptionalColumns = [],
@@ -218,6 +226,10 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
               callbacks={{
                 primaryLabel: invoice.status === 'draft' ? 'Edit invoice' : 'View invoice',
                 onPrimaryAction: () => onRowClick(invoice),
+                onSendInvoice,
+                onResendInvoice,
+                onVoidInvoice,
+                onSyncInvoice,
               }}
               extraMenuItems={(
                 <>

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -21,10 +21,10 @@ interface InvoicesTableProps {
   emptyMessage?: string;
   onRowClick: (invoice: InvoiceSummary) => void;
   onViewCustomer?: (clientId: string) => void;
-  onSendInvoice?: () => void;
-  onResendInvoice?: () => void;
-  onVoidInvoice?: () => void;
-  onSyncInvoice?: () => void;
+  onSendInvoice?: (invoice: InvoiceSummary) => void;
+  onResendInvoice?: (invoice: InvoiceSummary) => void;
+  onVoidInvoice?: (invoice: InvoiceSummary) => void;
+  onSyncInvoice?: (invoice: InvoiceSummary) => void;
   toolbar?: ComponentChildren;
   loadingMore?: boolean;
   visibleOptionalColumns?: InvoiceColumnKey[];
@@ -228,10 +228,10 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
               callbacks={{
                 primaryLabel: invoice.status === 'draft' ? 'Edit invoice' : 'View invoice',
                 onPrimaryAction: () => onRowClick(invoice),
-                onSendInvoice,
-                onResendInvoice,
-                onVoidInvoice,
-                onSyncInvoice,
+                onSendInvoice: onSendInvoice ? () => onSendInvoice(invoice) : undefined,
+                onResendInvoice: onResendInvoice ? () => onResendInvoice(invoice) : undefined,
+                onVoidInvoice: onVoidInvoice ? () => onVoidInvoice(invoice) : undefined,
+                onSyncInvoice: onSyncInvoice ? () => onSyncInvoice(invoice) : undefined,
               }}
               extraMenuItems={(
                 <>

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -1,22 +1,16 @@
 import type { ComponentChildren, FunctionComponent } from 'preact';
 import { useMemo } from 'preact/hooks';
-import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import type { InvoiceSummary } from '@/features/invoices/types';
 import { InvoiceStatusBadge } from '@/features/invoices/components/InvoiceStatusBadge';
+import { InvoiceStatusActions } from '@/features/invoices/components/InvoiceRowParts';
 import {
   DEFAULT_INVOICE_COLUMNS,
-  OPTIONAL_INVOICE_COLUMNS,
   type InvoiceColumnKey,
 } from '@/features/invoices/config/invoiceCollection';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/shared/ui/dropdown';
+import { DropdownMenuItem } from '@/shared/ui/dropdown';
 import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table';
 import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
@@ -35,7 +29,6 @@ interface InvoicesTableProps {
 
 const textValue = (value: string | null | undefined) => value && value.trim().length > 0 ? value : '—';
 const dateValue = (value: string | null | undefined) => value ? formatLongDate(value) : '—';
-const optionalColumnLabels = new Map(OPTIONAL_INVOICE_COLUMNS.map((column) => [column.key, column.label] as const));
 
 const renderUrlCell = (value: string | null | undefined) => {
   if (!value) return '—';
@@ -159,65 +152,6 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
     }]);
   }, [visibleOptionalColumns]);
 
-  const renderOptionalMobileValue = (invoice: InvoiceSummary, key: InvoiceColumnKey) => {
-    switch (key) {
-      case 'paidAt':
-        return dateValue(invoice.paidAt);
-      case 'subtotal':
-        return formatCurrency(invoice.subtotal ?? 0);
-      case 'taxAmount':
-        return formatCurrency(invoice.taxAmount ?? 0);
-      case 'discountAmount':
-        return formatCurrency(invoice.discountAmount ?? 0);
-      case 'amountPaid':
-        return formatCurrency(invoice.amountPaid);
-      case 'amountDue':
-        return formatCurrency(invoice.amountDue);
-      case 'issueDate':
-        return dateValue(invoice.issueDate);
-      case 'invoiceType':
-        return textValue(invoice.invoiceType);
-      case 'notes':
-        return textValue(invoice.notes);
-      case 'memo':
-        return textValue(invoice.memo);
-      case 'fundDestination':
-        return textValue(invoice.fundDestination);
-      case 'updatedAt':
-        return dateValue(invoice.updatedAt);
-      case 'clientId':
-        return textValue(invoice.clientId);
-      case 'matterId':
-        return textValue(invoice.matterId);
-      case 'connectedAccountId':
-        return textValue(invoice.connectedAccountId);
-      case 'matterTitle':
-        return textValue(invoice.matterTitle);
-      case 'matterBillingType':
-        return textValue(invoice.matterBillingType);
-      case 'clientStatus':
-        return textValue(invoice.clientStatus);
-      case 'stripeInvoiceNumber':
-        return textValue(invoice.stripeInvoiceNumber);
-      case 'stripeInvoiceId':
-        return textValue(invoice.stripeInvoiceId);
-      case 'stripeChargeId':
-        return textValue(invoice.stripeChargeId);
-      case 'stripeTransferId':
-        return textValue(invoice.stripeTransferId);
-      case 'stripePaymentIntentId':
-        return textValue(invoice.stripePaymentIntentId);
-      case 'stripeHostedInvoiceUrl':
-        return invoice.stripeHostedInvoiceUrl ? 'Open hosted invoice' : '—';
-      case 'connectedAccountEmail':
-        return textValue(invoice.connectedAccountEmail);
-      case 'connectedAccountStripeAccountId':
-        return textValue(invoice.connectedAccountStripeAccountId);
-      default:
-        return null;
-    }
-  };
-
   const rows: DataTableRow[] = invoices.map((invoice) => {
     const clientId = invoice.clientId;
     const hostedInvoiceUrl = invoice.stripeHostedInvoiceUrl;
@@ -226,90 +160,90 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
       id: invoice.id,
       onClick: () => onRowClick(invoice),
       cells: {
-      total: (
-        <div className="flex items-center gap-2">
-          <span className="font-semibold text-input-text">{formatCurrency(invoice.total)}</span>
-        </div>
-      ),
-      status: <InvoiceStatusBadge status={invoice.status} />,
-      invoiceNumber: (
-        <button
-          type="button"
-          className="truncate text-left text-sm font-semibold text-input-text hover:underline"
-          onClick={(event) => {
-            event.stopPropagation();
-            onRowClick(invoice);
-          }}
-        >
-          {textValue(invoice.invoiceNumber || null)}
-        </button>
-      ),
-      clientName: textValue(invoice.clientName),
-      clientEmail: textValue(invoice.clientEmail),
-      dueDate: dateValue(invoice.dueDate),
-      createdAt: dateValue(invoice.createdAt),
-      paidAt: dateValue(invoice.paidAt),
-      subtotal: <span className="text-input-text">{formatCurrency(invoice.subtotal ?? 0)}</span>,
-      taxAmount: <span className="text-input-text">{formatCurrency(invoice.taxAmount ?? 0)}</span>,
-      discountAmount: <span className="text-input-text">{formatCurrency(invoice.discountAmount ?? 0)}</span>,
-      amountPaid: <span className="text-input-text">{formatCurrency(invoice.amountPaid)}</span>,
-      amountDue: <span className="text-input-text">{formatCurrency(invoice.amountDue)}</span>,
-      issueDate: dateValue(invoice.issueDate),
-      invoiceType: textValue(invoice.invoiceType),
-      notes: textValue(invoice.notes),
-      memo: textValue(invoice.memo),
-      fundDestination: textValue(invoice.fundDestination),
-      updatedAt: dateValue(invoice.updatedAt),
-      clientId: textValue(invoice.clientId),
-      matterId: textValue(invoice.matterId),
-      connectedAccountId: textValue(invoice.connectedAccountId),
-      matterTitle: textValue(invoice.matterTitle),
-      matterBillingType: textValue(invoice.matterBillingType),
-      clientStatus: textValue(invoice.clientStatus),
-      stripeInvoiceNumber: textValue(invoice.stripeInvoiceNumber),
-      stripeInvoiceId: textValue(invoice.stripeInvoiceId),
-      stripeChargeId: textValue(invoice.stripeChargeId),
-      stripeTransferId: textValue(invoice.stripeTransferId),
-      stripePaymentIntentId: textValue(invoice.stripePaymentIntentId),
-      stripeHostedInvoiceUrl: renderUrlCell(invoice.stripeHostedInvoiceUrl),
-      connectedAccountEmail: textValue(invoice.connectedAccountEmail),
-      connectedAccountStripeAccountId: textValue(invoice.connectedAccountStripeAccountId),
+        total: (
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-input-text">{formatCurrency(invoice.total)}</span>
+          </div>
+        ),
+        status: <InvoiceStatusBadge status={invoice.status} />,
+        invoiceNumber: (
+          <button
+            type="button"
+            className="truncate text-left text-sm font-semibold text-input-text hover:underline"
+            onClick={(event) => {
+              event.stopPropagation();
+              onRowClick(invoice);
+            }}
+          >
+            {textValue(invoice.invoiceNumber || null)}
+          </button>
+        ),
+        clientName: textValue(invoice.clientName),
+        clientEmail: textValue(invoice.clientEmail),
+        dueDate: dateValue(invoice.dueDate),
+        createdAt: dateValue(invoice.createdAt),
+        paidAt: dateValue(invoice.paidAt),
+        subtotal: <span className="text-input-text">{formatCurrency(invoice.subtotal ?? 0)}</span>,
+        taxAmount: <span className="text-input-text">{formatCurrency(invoice.taxAmount ?? 0)}</span>,
+        discountAmount: <span className="text-input-text">{formatCurrency(invoice.discountAmount ?? 0)}</span>,
+        amountPaid: <span className="text-input-text">{formatCurrency(invoice.amountPaid)}</span>,
+        amountDue: <span className="text-input-text">{formatCurrency(invoice.amountDue)}</span>,
+        issueDate: dateValue(invoice.issueDate),
+        invoiceType: textValue(invoice.invoiceType),
+        notes: textValue(invoice.notes),
+        memo: textValue(invoice.memo),
+        fundDestination: textValue(invoice.fundDestination),
+        updatedAt: dateValue(invoice.updatedAt),
+        clientId: textValue(invoice.clientId),
+        matterId: textValue(invoice.matterId),
+        connectedAccountId: textValue(invoice.connectedAccountId),
+        matterTitle: textValue(invoice.matterTitle),
+        matterBillingType: textValue(invoice.matterBillingType),
+        clientStatus: textValue(invoice.clientStatus),
+        stripeInvoiceNumber: textValue(invoice.stripeInvoiceNumber),
+        stripeInvoiceId: textValue(invoice.stripeInvoiceId),
+        stripeChargeId: textValue(invoice.stripeChargeId),
+        stripeTransferId: textValue(invoice.stripeTransferId),
+        stripePaymentIntentId: textValue(invoice.stripePaymentIntentId),
+        stripeHostedInvoiceUrl: renderUrlCell(invoice.stripeHostedInvoiceUrl),
+        connectedAccountEmail: textValue(invoice.connectedAccountEmail),
+        connectedAccountStripeAccountId: textValue(invoice.connectedAccountStripeAccountId),
         actions: (
           <div className="flex justify-end">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="rounded-md p-1 text-input-placeholder transition-colors hover:bg-white/[0.06] hover:text-input-text"
-                  onClick={(event) => event.stopPropagation()}
-                  aria-label="Invoice actions"
-                >
-                  <EllipsisHorizontalIcon className="h-4 w-4" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[200px]">
-                {clientId && onViewCustomer ? (
-                  <DropdownMenuItem onSelect={() => onViewCustomer(clientId)}>
-                    View customer
-                  </DropdownMenuItem>
-                ) : null}
-                {hostedInvoiceUrl ? (
-                  <DropdownMenuItem onSelect={() => window.open(hostedInvoiceUrl, '_blank', 'noopener,noreferrer')}>
-                    Open hosted invoice
-                  </DropdownMenuItem>
-                ) : null}
-                {invoice.id ? (
-                  <DropdownMenuItem onSelect={() => void copyText('Invoice ID', invoice.id)}>
-                    Copy invoice ID
-                  </DropdownMenuItem>
-                ) : null}
-                {invoice.invoiceNumber ? (
-                  <DropdownMenuItem onSelect={() => void copyText('Invoice number', invoice.invoiceNumber)}>
-                    Copy invoice number
-                  </DropdownMenuItem>
-                ) : null}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <InvoiceStatusActions
+              state={{
+                status: invoice.status,
+                stripeInvoiceNumber: invoice.stripeInvoiceNumber,
+              }}
+              callbacks={{
+                primaryLabel: invoice.status === 'draft' ? 'Edit invoice' : 'View invoice',
+                onPrimaryAction: () => onRowClick(invoice),
+              }}
+              extraMenuItems={(
+                <>
+                  {clientId && onViewCustomer ? (
+                    <DropdownMenuItem onSelect={() => onViewCustomer(clientId)}>
+                      View customer
+                    </DropdownMenuItem>
+                  ) : null}
+                  {hostedInvoiceUrl ? (
+                    <DropdownMenuItem onSelect={() => window.open(hostedInvoiceUrl, '_blank', 'noopener,noreferrer')}>
+                      Open hosted invoice
+                    </DropdownMenuItem>
+                  ) : null}
+                  {invoice.id ? (
+                    <DropdownMenuItem onSelect={() => void copyText('Invoice ID', invoice.id)}>
+                      Copy invoice ID
+                    </DropdownMenuItem>
+                  ) : null}
+                  {invoice.invoiceNumber ? (
+                    <DropdownMenuItem onSelect={() => void copyText('Invoice number', invoice.invoiceNumber)}>
+                      Copy invoice number
+                    </DropdownMenuItem>
+                  ) : null}
+                </>
+              )}
+            />
           </div>
         ),
       },
@@ -337,84 +271,6 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         bodyClassName="bg-transparent"
         stickyHeader
         density="compact"
-        renderMobileRow={(row) => {
-          const invoice = invoices.find((item) => item.id === row.id);
-          if (!invoice) return null;
-
-          const clientId = invoice.clientId;
-          const hostedInvoiceUrl = invoice.stripeHostedInvoiceUrl;
-
-          return (
-            <div className="glass-panel rounded-xl p-4">
-              <div className="flex items-start justify-between gap-3">
-                <button
-                  type="button"
-                  className="min-w-0 flex-1 text-left"
-                  onClick={() => onRowClick(invoice)}
-                >
-                  <p className="truncate text-sm font-semibold text-input-text">{textValue(invoice.invoiceNumber || null)}</p>
-                  <p className="mt-2 truncate text-sm text-input-text">{textValue(invoice.clientName)}</p>
-                  <p className="mt-1 truncate text-xs text-input-placeholder">{textValue(invoice.clientEmail)}</p>
-                  <p className="mt-2 text-xs text-input-placeholder">Due {dateValue(invoice.dueDate)}</p>
-                  <p className="mt-1 text-xs text-input-placeholder">Created {dateValue(invoice.createdAt)}</p>
-                  {visibleOptionalColumns.length > 0 ? (
-                    <dl className="mt-3 grid gap-2">
-                      {visibleOptionalColumns.map((key) => {
-                        const value = renderOptionalMobileValue(invoice, key);
-                        if (value == null) return null;
-                        return (
-                          <div key={`${invoice.id}-${key}`} className="grid gap-1">
-                            <dt className="text-[11px] font-medium uppercase tracking-[0.12em] text-input-placeholder">
-                              {optionalColumnLabels.get(key) ?? key}
-                            </dt>
-                            <dd className="truncate text-xs text-input-text">{value}</dd>
-                          </div>
-                        );
-                      })}
-                    </dl>
-                  ) : null}
-                </button>
-                <div className="flex shrink-0 flex-col items-end gap-2">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className="rounded-md p-1 text-input-placeholder transition-colors hover:bg-white/[0.06] hover:text-input-text"
-                        aria-label="Invoice actions"
-                      >
-                        <EllipsisHorizontalIcon className="h-4 w-4" />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="min-w-[200px]">
-                      {clientId && onViewCustomer ? (
-                        <DropdownMenuItem onSelect={() => onViewCustomer(clientId)}>
-                          View customer
-                        </DropdownMenuItem>
-                      ) : null}
-                      {hostedInvoiceUrl ? (
-                        <DropdownMenuItem onSelect={() => window.open(hostedInvoiceUrl, '_blank', 'noopener,noreferrer')}>
-                          Open hosted invoice
-                        </DropdownMenuItem>
-                      ) : null}
-                      {invoice.id ? (
-                        <DropdownMenuItem onSelect={() => void copyText('Invoice ID', invoice.id)}>
-                          Copy invoice ID
-                        </DropdownMenuItem>
-                      ) : null}
-                      {invoice.invoiceNumber ? (
-                        <DropdownMenuItem onSelect={() => void copyText('Invoice number', invoice.invoiceNumber)}>
-                          Copy invoice number
-                        </DropdownMenuItem>
-                      ) : null}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                  <InvoiceStatusBadge status={invoice.status} />
-                  <p className="text-sm font-semibold text-input-text">{formatCurrency(invoice.total)}</p>
-                </div>
-              </div>
-            </div>
-          );
-        }}
       />
       {loadingMore ? (
         <div className="flex justify-center px-4 py-3">

--- a/src/features/invoices/components/SendInvoiceDialog.tsx
+++ b/src/features/invoices/components/SendInvoiceDialog.tsx
@@ -23,6 +23,8 @@ type SendInvoiceDialogProps = {
   clientName?: string | null;
   clientEmail?: string | null;
   billingIncrementMinutes?: number | null;
+  /** Notes to client forwarded into the preview */
+  previewNotes?: string | null;
 };
 
 export const SendInvoiceDialog = ({
@@ -42,6 +44,7 @@ export const SendInvoiceDialog = ({
   clientName,
   clientEmail,
   billingIncrementMinutes,
+  previewNotes,
 }: SendInvoiceDialogProps) => {
   const hasPreview = Array.isArray(lineItems) && lineItems.length > 0;
 
@@ -87,6 +90,7 @@ export const SendInvoiceDialog = ({
               clientName={clientName}
               clientEmail={clientEmail}
               billingIncrementMinutes={billingIncrementMinutes}
+              notes={previewNotes}
             />
           </div>
         )}

--- a/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { useToastContext } from '@/shared/contexts/ToastContext';
@@ -143,7 +144,7 @@ export function ClientInvoiceDetailPage({
   }, [invoiceId, loadDetail, practiceId, requestAmount, requestReason, showError, showInfo, showSuccess]);
 
   if (loading) {
-    return <div className="p-6 text-sm text-input-placeholder">Loading invoice...</div>;
+    return <LoadingBlock className="flex-1 p-6" label="Loading invoice..." />;
   }
 
   if (error) {

--- a/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
@@ -1,63 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { useStore } from '@nanostores/preact';
+import { useCallback, useMemo } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { Page } from '@/shared/ui/layout/Page';
-import { Panel } from '@/shared/ui/layout/Panel';
 import { useNavigation } from '@/shared/utils/navigation';
 import { useToastContext } from '@/shared/contexts/ToastContext';
-import { useSessionContext } from '@/shared/contexts/SessionContext';
-import {
-  getOnboardingStatus,
-  type UserDetailRecord,
-} from '@/shared/lib/apiClient';
-import { useClientsData } from '@/shared/hooks/useClientsData';
-import { listMatters, type BackendMatter, updateMatterMilestone } from '@/features/matters/services/mattersApi';
-import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
-import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
+import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
+import { updateMatterMilestone } from '@/features/matters/services/mattersApi';
+import { InvoiceBuilderSurface } from '@/features/invoices/components/InvoiceBuilderSurface';
 import {
   clearPendingInvoiceDraftContext,
   readPendingInvoiceDraftContext,
 } from '@/features/invoices/utils/invoiceDraftContext';
-import { INVOICE_CREATE_SEND_EVENT } from '@/features/invoices/utils/invoicePageConfig';
-import { practiceDetailsStore } from '@/shared/stores/practiceDetailsStore';
-import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
-
-const PAGE_SIZE = 50;
-
-const mergeRecordsById = <T extends { id: string }>(currentRecords: T[], incomingRecords: T[]) => {
-  if (incomingRecords.length === 0) return currentRecords;
-  const existingIds = new Set(currentRecords.map((record) => record.id));
-  const mergedRecords = [...currentRecords];
-  for (const record of incomingRecords) {
-    if (existingIds.has(record.id)) continue;
-    existingIds.add(record.id);
-    mergedRecords.push(record);
-  }
-  return mergedRecords;
-};
-
-const loadFirstMatterPage = async (practiceId: string, signal: AbortSignal) => {
-  return listMatters(practiceId, { page: 1, limit: PAGE_SIZE, signal });
-};
-
-const loadRemainingMatterPages = async (
-  practiceId: string,
-  signal: AbortSignal,
-  onPage: (records: BackendMatter[]) => void
-) => {
-  for (let page = 2; ; page += 1) {
-    const pageItems = await listMatters(practiceId, { page, limit: PAGE_SIZE, signal });
-    if (pageItems.length === 0) break;
-    onPage(pageItems);
-    if (pageItems.length < PAGE_SIZE) break;
-  }
-};
-
-const getClientLabel = (client: UserDetailRecord) => {
-  const name = client.user?.name?.trim();
-  const email = client.user?.email?.trim();
-  return name || email || 'Unnamed person';
-};
 
 export function PracticeInvoiceCreatePage({
   practiceId,
@@ -69,26 +21,10 @@ export function PracticeInvoiceCreatePage({
   const location = useLocation();
   const { navigate } = useNavigation();
   const { showError } = useToastContext();
-  const [matters, setMatters] = useState<BackendMatter[]>([]);
-  const [connectedAccountId, setConnectedAccountId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const builderRef = useRef<InvoiceFormHandle | null>(null);
-  const { session } = useSessionContext();
-  const clientsData = useClientsData(
-    practiceId ?? '',
-    null,
-    session?.user?.id ?? null,
-    { enabled: Boolean(practiceId) }
-  );
-
-  // Read cached practice identity — no extra requests; usePracticeManagement uses shared snapshot cache
   const { currentPractice } = usePracticeManagement({
     practiceSlug: practiceSlug ?? undefined,
     fetchPracticeDetails: true,
   });
-  const practiceDetailsMap = useStore(practiceDetailsStore);
-  const cachedDetails = practiceId ? (practiceDetailsMap[practiceId] ?? null) : null;
 
   const draftId = useMemo(() => {
     const value = location.query?.draft;
@@ -105,72 +41,7 @@ export function PracticeInvoiceCreatePage({
     return `/practice/${encodeURIComponent(practiceSlug)}/invoices`;
   }, [practiceSlug]);
   const returnPath = draftContext?.returnPath?.trim() || invoicesPath;
-  const missingDraftError = draftId && !draftContext
-    ? 'Invoice draft context was not found. Start invoice creation from the matter or invoices page again.'
-    : null;
-  const displayError = loadError ?? clientsData.error ?? missingDraftError;
-
-  useEffect(() => {
-    if (!practiceId) return;
-    const controller = new AbortController();
-    setLoading(true);
-    setLoadError(null);
-
-    void (async () => {
-      try {
-        const [matterPage, onboardingStatus] = await Promise.all([
-          loadFirstMatterPage(practiceId, controller.signal),
-          getOnboardingStatus(practiceId, { signal: controller.signal }),
-        ]);
-
-        if (controller.signal.aborted) return;
-
-        setMatters(matterPage);
-        setConnectedAccountId(onboardingStatus.connectedAccountId ?? null);
-
-        void loadRemainingMatterPages(practiceId, controller.signal, (records) => {
-            if (controller.signal.aborted) return;
-            setMatters((current) => mergeRecordsById(current, records));
-        }).catch((error) => {
-          if (controller.signal.aborted) return;
-          setLoadError(error instanceof Error ? error.message : 'Failed to load invoice builder');
-        });
-      } catch (error) {
-        if ((error as DOMException)?.name === 'AbortError' || controller.signal.aborted) return;
-        setLoadError(error instanceof Error ? error.message : 'Failed to load invoice builder');
-      } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
-      }
-    })();
-
-    return () => controller.abort();
-  }, [practiceId]);
-
-  useEffect(() => {
-    const handleSendRequest = () => {
-      builderRef.current?.requestSend();
-    };
-    window.addEventListener(INVOICE_CREATE_SEND_EVENT, handleSendRequest);
-    return () => window.removeEventListener(INVOICE_CREATE_SEND_EVENT, handleSendRequest);
-  }, []);
-
-  const clientOptions = useMemo(() => {
-    return (clientsData.items as UserDetailRecord[]).map((client) => ({
-      value: client.id,
-      label: getClientLabel(client),
-      meta: client.user?.email ?? undefined,
-    }));
-  }, [clientsData.items]);
-
-  const matterOptions = useMemo(() => {
-    return matters.map((matter) => ({
-      value: matter.id,
-      label: matter.title?.trim() || 'Untitled matter',
-      meta: matter.client_id ?? undefined,
-    }));
-  }, [matters]);
+  const canRenderBuilder = Boolean(practiceId) && (!draftId || Boolean(draftContext));
 
   const handleBackToInvoices = useCallback(() => {
     if (!returnPath) return;
@@ -219,40 +90,24 @@ export function PracticeInvoiceCreatePage({
   return (
     <Page className="min-h-full">
       <div className="mx-auto flex max-w-7xl flex-col gap-6">
-        {displayError ? (
+        {draftId && !draftContext ? (
           <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
-            {displayError}
+            Invoice draft context was not found. Start invoice creation from the matter or invoices page again.
           </div>
         ) : null}
-        {loading || (!clientsData.isLoaded && clientsData.isLoading) ? (
-          <Panel className="p-6">
-            <div className="text-sm text-input-placeholder">Loading invoice builder...</div>
-          </Panel>
-        ) : missingDraftError || !practiceId ? null : (
-          <InvoiceForm
-            ref={builderRef}
+        {canRenderBuilder ? (
+          <InvoiceBuilderSurface
             mode="create"
             practiceId={practiceId}
-            connectedAccountId={connectedAccountId}
-            clientOptions={clientOptions}
-            matterOptions={matterOptions}
-            initialClientId={draftContext?.clientId ?? undefined}
-            initialMatterId={draftContext?.matterId ?? undefined}
-            initialLineItems={draftContext?.lineItems ?? undefined}
-            initialDueDate={draftContext?.dueDate ?? undefined}
-            initialNotes={draftContext?.notes ?? undefined}
-            initialMemo={draftContext?.memo ?? undefined}
-            initialInvoiceType={draftContext?.invoiceType ?? undefined}
-            invoiceContext={draftContext?.invoiceContext ?? 'default'}
+            initialDraftContext={draftContext}
             onClose={handleBackToInvoices}
             onSuccess={handleCreated}
-            closeAfterSuccess={false}
             practiceName={currentPractice?.name ?? undefined}
             practiceLogoUrl={currentPractice?.logo ?? undefined}
-            practiceEmail={currentPractice?.businessEmail ?? cachedDetails?.businessEmail ?? undefined}
+            practiceEmail={currentPractice?.businessEmail ?? undefined}
             billingIncrementMinutes={currentPractice?.billingIncrementMinutes ?? undefined}
           />
-        )}
+        ) : null}
       </div>
     </Page>
   );

--- a/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
@@ -1,16 +1,13 @@
 import type { ComponentChildren } from 'preact';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { Dialog } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
-import { WorkspaceListHeader } from '@/shared/ui/layout/WorkspaceListHeader';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useNavigation } from '@/shared/utils/navigation';
 import { InvoiceForm } from '@/features/invoices/components/InvoiceForm';
-import type { InvoiceFormHandle } from '@/features/invoices/components/InvoiceForm';
 import {
   getInvoice,
   syncInvoice,
@@ -18,6 +15,7 @@ import {
 } from '@/features/invoices/services/invoicesService';
 import type { InvoiceDetail } from '@/features/invoices/types';
 import { resolveInvoicePageMode } from '@/features/invoices/utils/invoicePageConfig';
+import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 
 const isActionableOpenStatus = (status: string): boolean => {
   return ['sent', 'pending', 'open', 'overdue'].includes(status);
@@ -50,6 +48,10 @@ export function PracticeInvoiceDetailPage({
 }) {
   const { navigate } = useNavigation();
   const { showError, showInfo, showSuccess } = useToastContext();
+  const { currentPractice } = usePracticeManagement({
+    practiceSlug: practiceSlug ?? undefined,
+    fetchPracticeDetails: true,
+  });
   const [detail, setDetail] = useState<InvoiceDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,7 +60,6 @@ export function PracticeInvoiceDetailPage({
   const [refundReason, setRefundReason] = useState('');
   const [refundAmount, setRefundAmount] = useState('');
   const [submittingMockRefund, setSubmittingMockRefund] = useState(false);
-  const formRef = useRef<InvoiceFormHandle | null>(null);
 
   const loadDetail = useCallback((signal?: AbortSignal) => {
     if (!practiceId || !invoiceId) return Promise.resolve();
@@ -90,21 +91,8 @@ export function PracticeInvoiceDetailPage({
 
   const status = useMemo(() => (detail?.status ?? 'draft').toLowerCase(), [detail?.status]);
   const mode = useMemo(() => resolveInvoicePageMode(status), [status]);
-  const isDraft = mode === 'edit';
   const hasHostedUrl = Boolean(detail?.stripeHostedInvoiceUrl);
   const canMockRefund = Boolean(detail && isRefundEligibleStatus(status) && detail.amountPaid > 0);
-
-  const builderClientOptions = useMemo(() => {
-    if (!detail) return [];
-    const label = detail.clientName?.trim() || 'Person';
-    return [{ value: detail.sourceInvoice.client_id, label }];
-  }, [detail]);
-
-  const builderMatterOptions = useMemo(() => {
-    if (!detail?.sourceInvoice.matter_id) return [];
-    const label = detail.matterTitle?.trim() || 'Matter';
-    return [{ value: detail.sourceInvoice.matter_id, label, meta: detail.sourceInvoice.client_id }];
-  }, [detail]);
 
   const handleOpenHostedInvoice = useCallback(() => {
     if (!detail?.stripeHostedInvoiceUrl) {
@@ -119,14 +107,10 @@ export function PracticeInvoiceDetailPage({
     navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices`);
   }, [navigate, practiceSlug]);
 
-  const handleBuilderSuccess = useCallback(async (updatedInvoiceId?: string | null) => {
-    const safeInvoiceId = updatedInvoiceId?.trim();
-    if (safeInvoiceId && safeInvoiceId !== detail?.id && practiceSlug) {
-      navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices/${encodeURIComponent(safeInvoiceId)}`);
-      return;
-    }
-    await loadDetail();
-  }, [detail?.id, loadDetail, navigate, practiceSlug]);
+  const handleOpenEditor = useCallback(() => {
+    if (!practiceSlug || !invoiceId) return;
+    navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices/${encodeURIComponent(invoiceId)}/edit`);
+  }, [invoiceId, navigate, practiceSlug]);
 
   const handleSync = useCallback(async () => {
     if (!practiceId || !invoiceId) return;
@@ -201,66 +185,44 @@ export function PracticeInvoiceDetailPage({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
-      {isDraft ? (
-        <WorkspaceListHeader
-          leftControls={(
-            <div className="flex items-center gap-3">
-              <Button
-                type="button"
-                variant="icon"
-                size="icon-sm"
-                aria-label="Close invoice composer"
-                onClick={handleBackToList}
-                icon={XMarkIcon}
-                iconClassName="h-5 w-5"
-              />
-              <div className="h-5 w-px bg-line-glass/30" aria-hidden="true" />
-            </div>
-          )}
-          title={<h1 className="workspace-header__title">Edit Invoice</h1>}
-          controls={(
-            <Button type="button" size="sm" onClick={() => formRef.current?.requestSend()}>
-              Send Invoice
-            </Button>
-          )}
-          className="px-0 py-0"
-        />
-      ) : (
-        <DetailHeader
-          title={detail.invoiceNumber}
-          subtitle={`Issued ${renderEventDate(detail.issueDate)} • Due ${renderEventDate(detail.dueDate)} • Paid ${renderEventDate(detail.paidAt)}`}
-          showBack={showBack}
-          onBack={handleBackToList}
-          leadingAction={leadingAction}
-          onInspector={onInspector}
-          inspectorOpen={inspectorOpen}
-          actions={(
-            <div className="flex flex-wrap items-center gap-2">
-              {isActionableOpenStatus(status) ? (
-                <>
-                  <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
-                  <Button variant="secondary" onClick={() => void handleSync()}>Sync</Button>
-                  <Button variant="danger-ghost" onClick={() => void handleVoid()}>Void</Button>
-                </>
-              ) : null}
-              {status === 'paid' ? (
+      <DetailHeader
+        title={detail.invoiceNumber}
+        subtitle={`Issued ${renderEventDate(detail.issueDate)} • Due ${renderEventDate(detail.dueDate)} • Paid ${renderEventDate(detail.paidAt)}`}
+        showBack={showBack}
+        onBack={handleBackToList}
+        leadingAction={leadingAction}
+        onInspector={onInspector}
+        inspectorOpen={inspectorOpen}
+        actions={(
+          <div className="flex flex-wrap items-center gap-2">
+            {mode === 'edit' ? (
+              <Button variant="secondary" onClick={handleOpenEditor}>Edit invoice</Button>
+            ) : null}
+            {isActionableOpenStatus(status) ? (
+              <>
                 <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
-              ) : null}
-              {canMockRefund ? (
-                <Button variant="secondary" onClick={() => setRefundModalOpen(true)}>Issue refund (Mock)</Button>
-              ) : null}
-            </div>
-          )}
-        />
-      )}
+                <Button variant="secondary" onClick={() => void handleSync()}>Sync</Button>
+                <Button variant="danger-ghost" onClick={() => void handleVoid()}>Void</Button>
+              </>
+            ) : null}
+            {status === 'paid' ? (
+              <Button variant="secondary" onClick={handleOpenHostedInvoice} disabled={!hasHostedUrl}>Open Stripe hosted invoice</Button>
+            ) : null}
+            {canMockRefund ? (
+              <Button variant="secondary" onClick={() => setRefundModalOpen(true)}>Issue refund (Mock)</Button>
+            ) : null}
+          </div>
+        )}
+      />
 
       <InvoiceForm
-        ref={formRef}
-        mode={mode}
+        mode="readOnly"
         practiceId={practiceId}
         connectedAccountId={detail.sourceInvoice.connected_account_id}
-        clientOptions={builderClientOptions}
-        matterOptions={builderMatterOptions}
+        clientOptions={[{ value: detail.sourceInvoice.client_id, label: detail.clientName?.trim() || 'Person' }]}
+        matterOptions={detail.sourceInvoice.matter_id
+          ? [{ value: detail.sourceInvoice.matter_id, label: detail.matterTitle?.trim() || 'Matter', meta: detail.sourceInvoice.client_id }]
+          : []}
         initialClientId={detail.sourceInvoice.client_id}
         initialMatterId={detail.sourceInvoice.matter_id ?? undefined}
         initialLineItems={detail.lineItems}
@@ -270,9 +232,12 @@ export function PracticeInvoiceDetailPage({
         initialInvoiceType={detail.sourceInvoice.invoice_type}
         existingInvoiceId={detail.id}
         closeAfterSuccess={false}
-        hideFooterActions
         onClose={handleBackToList}
-        onSuccess={handleBuilderSuccess}
+        onSuccess={() => undefined}
+        practiceName={currentPractice?.name ?? undefined}
+        practiceLogoUrl={currentPractice?.logo ?? undefined}
+        practiceEmail={currentPractice?.businessEmail ?? undefined}
+        billingIncrementMinutes={currentPractice?.billingIncrementMinutes ?? undefined}
       />
 
       <Dialog

--- a/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useNavigation } from '@/shared/utils/navigation';
@@ -168,7 +169,7 @@ export function PracticeInvoiceDetailPage({
   }, [detail, refundAmount, refundReason, showError, showSuccess]);
 
   if (loading) {
-    return <div className="p-6 text-sm text-input-placeholder">Loading invoice...</div>;
+    return <LoadingBlock className="flex-1 p-6" label="Loading invoice..." />;
   }
 
   if (error) {

--- a/src/features/invoices/pages/PracticeInvoiceEditPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceEditPage.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useMemo } from 'preact/hooks';
+import { useNavigation } from '@/shared/utils/navigation';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
+import { InvoiceBuilderSurface } from '@/features/invoices/components/InvoiceBuilderSurface';
+
+export function PracticeInvoiceEditPage({
+  practiceId,
+  practiceSlug,
+  invoiceId,
+}: {
+  practiceId: string | null;
+  practiceSlug: string | null;
+  invoiceId: string | null;
+}) {
+  const { navigate } = useNavigation();
+  const { showError } = useToastContext();
+  const { currentPractice } = usePracticeManagement({
+    practiceSlug: practiceSlug ?? undefined,
+    fetchPracticeDetails: true,
+  });
+
+  const invoicesPath = useMemo(() => {
+    if (!practiceSlug) return null;
+    return `/practice/${encodeURIComponent(practiceSlug)}/invoices`;
+  }, [practiceSlug]);
+
+  const handleBackToList = useCallback(() => {
+    if (!invoicesPath) {
+      showError('Invoices', 'Practice slug is missing from route context.');
+      return;
+    }
+    navigate(invoicesPath);
+  }, [invoicesPath, navigate, showError]);
+
+  const handleSuccess = useCallback(async (updatedInvoiceId?: string | null) => {
+    const nextInvoiceId = updatedInvoiceId?.trim() || invoiceId;
+    if (!invoicesPath || !nextInvoiceId) {
+      showError('Invoices', 'Invoice route context is missing.');
+      return;
+    }
+    navigate(`${invoicesPath}/${encodeURIComponent(nextInvoiceId)}`);
+  }, [invoiceId, invoicesPath, navigate, showError]);
+
+  if (!practiceId) {
+    return <div className="p-6 text-sm text-red-300">Practice context is missing from this route.</div>;
+  }
+
+  if (!invoiceId) {
+    return <div className="p-6 text-sm text-red-300">Invoice ID is missing from this route.</div>;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+      <InvoiceBuilderSurface
+        mode="edit"
+        practiceId={practiceId}
+        existingInvoiceId={invoiceId}
+        onClose={handleBackToList}
+        onSuccess={handleSuccess}
+        practiceName={currentPractice?.name ?? undefined}
+        practiceLogoUrl={currentPractice?.logo ?? undefined}
+        practiceEmail={currentPractice?.businessEmail ?? undefined}
+        billingIncrementMinutes={currentPractice?.billingIncrementMinutes ?? undefined}
+      />
+    </div>
+  );
+}
+
+export default PracticeInvoiceEditPage;

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -92,7 +92,8 @@ export function PracticeInvoicesPage({
       showError('Invoices', 'Practice slug is missing from route context.');
       return;
     }
-    navigate(`/practice/${encodeURIComponent(practiceSlug)}/invoices/${encodeURIComponent(invoice.id)}`);
+    const basePath = `/practice/${encodeURIComponent(practiceSlug)}/invoices/${encodeURIComponent(invoice.id)}`;
+    navigate(invoice.status === 'draft' ? `${basePath}/edit` : basePath);
   }, [navigate, practiceSlug, showError]);
 
   const handleViewCustomer = useCallback((clientId: string) => {

--- a/src/features/invoices/pages/__tests__/InvoicesPages.test.tsx
+++ b/src/features/invoices/pages/__tests__/InvoicesPages.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@/__tests__/test-utils';
 import { PracticeInvoicesPage } from '@/features/invoices/pages/PracticeInvoicesPage';
+import { PracticeInvoiceEditPage } from '@/features/invoices/pages/PracticeInvoiceEditPage';
 import { PracticeInvoiceDetailPage } from '@/features/invoices/pages/PracticeInvoiceDetailPage';
 import { ClientInvoicesPage } from '@/features/invoices/pages/ClientInvoicesPage';
 import { ClientInvoiceDetailPage } from '@/features/invoices/pages/ClientInvoiceDetailPage';
@@ -55,6 +56,24 @@ const mockDeletePracticeInvoice = vi.fn();
 const mockUpdatePracticeInvoice = vi.fn();
 const mockGetClientInvoiceDetail = vi.fn();
 const mockRequestClientInvoiceRefund = vi.fn();
+const mockUseClientsData = vi.fn(() => ({
+  items: [
+    {
+      id: 'client-1',
+      user: {
+        id: 'client-1',
+        name: 'Client One',
+        email: 'client.one@example.com',
+        image: null,
+      },
+    },
+  ],
+  isLoaded: true,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+}));
+const mockListMatters = vi.fn(() => Promise.resolve([]));
 
 vi.mock('@/features/invoices/services/invoicesService', () => ({
   listInvoices: (...args: unknown[]) => mockListPracticeInvoiceSummaries(...args),
@@ -67,6 +86,15 @@ vi.mock('@/features/invoices/services/invoicesService', () => ({
   getClientInvoice: (...args: unknown[]) => mockGetClientInvoiceDetail(...args),
   createRefundRequest: (...args: unknown[]) => mockRequestClientInvoiceRefund(...args),
   listClientInvoices: (...args: unknown[]) => mockListClientInvoiceSummaries(...args),
+}));
+
+vi.mock('@/shared/hooks/useClientsData', () => ({
+  useClientsData: mockUseClientsData,
+}));
+
+vi.mock('@/features/matters/services/mattersApi', () => ({
+  listMatters: mockListMatters,
+  updateMatterMilestone: vi.fn(),
 }));
 
 let routePath = '/';
@@ -209,7 +237,7 @@ describe('Invoices pages', () => {
     });
 
     fireEvent.click(screen.getByText('INV-1001'));
-    expect(mockNavigate).toHaveBeenCalledWith('/practice/demo-practice/invoices/inv-1');
+    expect(mockNavigate).toHaveBeenCalledWith('/practice/demo-practice/invoices/inv-1/edit');
   });
 
   it('handles practice detail sync action', async () => {
@@ -255,11 +283,11 @@ describe('Invoices pages', () => {
     });
   });
 
-  it('handles practice draft send action', async () => {
+  it('handles practice draft send action from edit route', async () => {
     mockGetPracticeInvoiceDetail.mockResolvedValue(makeDetail('draft', null));
 
     render(
-      <PracticeInvoiceDetailPage
+      <PracticeInvoiceEditPage
         practiceId="practice-1"
         practiceSlug="demo-practice"
         invoiceId="inv-1"
@@ -267,10 +295,10 @@ describe('Invoices pages', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Send' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /send invoice/i })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    fireEvent.click(screen.getByRole('button', { name: /send invoice/i }));
     await waitFor(() => {
       expect(mockSendPracticeInvoice).toHaveBeenCalledWith('practice-1', 'inv-1');
     });
@@ -338,9 +366,23 @@ describe('Invoices pages', () => {
     mockGetPracticeInvoiceDetail.mockResolvedValue(makeDetail('draft', null));
 
     const PracticeRouteHarness = () => {
-      const invoiceId = routePath.startsWith('/practice/demo-practice/invoices/')
-        ? routePath.replace('/practice/demo-practice/invoices/', '')
-        : null;
+      const editPrefix = '/practice/demo-practice/invoices/';
+      const editSuffix = '/edit';
+      const isEditRoute = routePath.startsWith(editPrefix) && routePath.endsWith(editSuffix);
+      const invoiceId = isEditRoute
+        ? routePath.slice(editPrefix.length, -editSuffix.length)
+        : routePath.startsWith(editPrefix)
+          ? routePath.replace(editPrefix, '')
+          : null;
+      if (isEditRoute && invoiceId) {
+        return (
+          <PracticeInvoiceEditPage
+            practiceId="practice-1"
+            practiceSlug="demo-practice"
+            invoiceId={invoiceId}
+          />
+        );
+      }
       return invoiceId
         ? (
           <PracticeInvoiceDetailPage
@@ -360,9 +402,9 @@ describe('Invoices pages', () => {
     });
 
     fireEvent.click(screen.getByText('INV-1001'));
-    expect(mockNavigate).toHaveBeenCalledWith('/practice/demo-practice/invoices/inv-1');
+    expect(mockNavigate).toHaveBeenCalledWith('/practice/demo-practice/invoices/inv-1/edit');
 
-    setRoutePath('/practice/demo-practice/invoices/inv-1');
+    setRoutePath('/practice/demo-practice/invoices/inv-1/edit');
     rendered.rerender(<PracticeRouteHarness />);
 
     await waitFor(() => {

--- a/src/features/invoices/services/invoicesService.ts
+++ b/src/features/invoices/services/invoicesService.ts
@@ -108,16 +108,20 @@ export const getInvoice = async (
   options: FetchOptions = {}
 ): Promise<InvoiceDetail | null> => {
   if (!practiceId || !invoiceId) return null;
-  const response = await apiClient.get(urls.invoices(practiceId), {
-    params: { invoice_id: invoiceId },
+  const response = await apiClient.get(urls.invoice(practiceId, invoiceId), {
     signal: options.signal,
   });
   const data = response.data;
-  const invoiceRecord = extractInvoicesArray(data)[0];
+  // The detail endpoint returns a single invoice object (not wrapped in an array),
+  // so prefer extractInvoiceRecord first; fall back to extractInvoicesArray for
+  // any backend that wraps it.
+  const rawInvoice = extractInvoiceRecord(data);
+  const invoiceRecord = rawInvoice
+    ? extractInvoicesArray(rawInvoice)[0] ?? extractInvoicesArray(data)[0]
+    : extractInvoicesArray(data)[0];
   if (!invoiceRecord) return null;
 
   const invoice = normalizeInvoice(invoiceRecord);
-  const rawInvoice = extractInvoiceRecord(data);
   return normalizeInvoiceDetail(invoice, rawInvoice);
 };
 

--- a/src/features/invoices/services/invoicesService.ts
+++ b/src/features/invoices/services/invoicesService.ts
@@ -10,6 +10,7 @@ import {
   updateInvoice as updateMatterInvoice,
   normalizeInvoice,
   extractInvoicesArray,
+  type BackendInvoice,
 } from '@/features/matters/services/invoicesApi';
 import type { CreateInvoicePayload } from '@/features/matters/types/billing.types';
 import {
@@ -112,16 +113,11 @@ export const getInvoice = async (
     signal: options.signal,
   });
   const data = response.data;
-  // The detail endpoint returns a single invoice object (not wrapped in an array),
-  // so prefer extractInvoiceRecord first; fall back to extractInvoicesArray for
-  // any backend that wraps it.
+  // The detail endpoint returns a single invoice object (not wrapped in an array)
   const rawInvoice = extractInvoiceRecord(data);
-  const invoiceRecord = rawInvoice
-    ? extractInvoicesArray(rawInvoice)[0] ?? extractInvoicesArray(data)[0]
-    : extractInvoicesArray(data)[0];
-  if (!invoiceRecord) return null;
+  if (!rawInvoice) return null;
 
-  const invoice = normalizeInvoice(invoiceRecord);
+  const invoice = normalizeInvoice(rawInvoice as BackendInvoice);
   return normalizeInvoiceDetail(invoice, rawInvoice);
 };
 

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -35,8 +35,8 @@ interface MatterSummaryCardsProps {
 }
 
 const summaryItemBase = 'min-w-0 flex flex-col gap-1';
-const gridBase = 'grid grid-cols-2 gap-x-4 gap-y-5 @xl:grid-cols-4 @xl:gap-x-6';
-const wrapperBase = 'glass-panel p-4 sm:p-5 @container';
+const gridBase = 'grid grid-cols-2 gap-x-4 gap-y-5 md:grid-cols-4 md:gap-x-6';
+const wrapperBase = 'glass-panel p-4 sm:p-5';
 
 const formatDurationFromSeconds = (totalSeconds?: number | null) => {
   if (!totalSeconds || totalSeconds <= 0) return '0:00 hrs';
@@ -134,8 +134,8 @@ export const MatterSummaryCards = ({
       ];
 
       const fixedGridClass = hasMilestones
-        ? 'grid grid-cols-2 gap-x-4 gap-y-5 @xl:grid-cols-5 @xl:gap-x-6'
-        : 'grid grid-cols-2 gap-x-4 gap-y-5 @xl:grid-cols-3 @xl:gap-x-6';
+        ? 'grid grid-cols-2 gap-x-4 gap-y-5 md:grid-cols-5 md:gap-x-6'
+        : 'grid grid-cols-2 gap-x-4 gap-y-5 md:grid-cols-3 md:gap-x-6';
 
       return (
         <section className={wrapperBase}>
@@ -143,7 +143,7 @@ export const MatterSummaryCards = ({
             {fixedCards.map((card, index) => {
               const isFirst = index === 0;
               const isLast = index === fixedCards.length - 1;
-              const spanClass = isFirst || isLast ? 'col-span-2 @xl:col-span-1' : 'col-span-1';
+              const spanClass = isFirst || isLast ? 'col-span-2 md:col-span-1' : 'col-span-1';
               return (
                 <div key={card.label} className={cn(summaryItemBase, spanClass)}>
                   <p className="text-xs font-medium text-input-placeholder leading-tight">{card.label}</p>
@@ -154,7 +154,7 @@ export const MatterSummaryCards = ({
                 </div>
               );
             })}
-            <div className="col-span-2 flex flex-col gap-2 @xl:col-span-1 @xl:justify-start">
+            <div className="col-span-2 flex flex-col gap-2 md:col-span-1 md:justify-start">
               <Button
                 size="xs"
                 onClick={() => onCreateInvoice?.()}
@@ -163,7 +163,7 @@ export const MatterSummaryCards = ({
               >
                 Invoice
               </Button>
-              <div className="text-center @xl:text-left">
+              <div className="text-center md:text-left">
                 {onViewTimesheet ? (
                   <button
                     type="button"
@@ -185,7 +185,7 @@ export const MatterSummaryCards = ({
     return (
       <section className={wrapperBase}>
         <div className={gridBase}>
-          <div className={cn(summaryItemBase, 'col-span-2 @xl:col-span-1')}>
+          <div className={cn(summaryItemBase, 'col-span-2 md:col-span-1')}>
             <p className="text-xs font-medium text-input-placeholder leading-tight">Billable time this week</p>
             <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{billableDisplay}</p>
             <p className="mt-1 text-xs text-input-placeholder leading-tight">
@@ -222,7 +222,7 @@ export const MatterSummaryCards = ({
             <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{totalDisplay}</p>
             <p className="mt-1 text-xs text-input-placeholder leading-tight">Across all logged entries this week</p>
           </div>
-          <div className="col-span-2 flex flex-col gap-2 @xl:col-span-1">
+              <div className="col-span-2 flex flex-col gap-2 md:col-span-1">
             <Button
               size="xs"
               onClick={() => onCreateInvoice?.()}
@@ -231,7 +231,7 @@ export const MatterSummaryCards = ({
             >
               Invoice
             </Button>
-            <div className="text-center @xl:text-left">
+            <div className="text-center md:text-left">
               {onViewTimesheet ? (
                 <button
                   type="button"

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -134,16 +134,15 @@ export const MatterSummaryCards = ({
       ];
 
       const fixedGridClass = hasMilestones
-        ? 'grid grid-cols-2 gap-x-4 gap-y-5 md:grid-cols-5 md:gap-x-6'
-        : 'grid grid-cols-2 gap-x-4 gap-y-5 md:grid-cols-3 md:gap-x-6';
+        ? 'grid grid-cols-4 gap-x-4 gap-y-5 md:grid-cols-6 md:gap-x-6'
+        : 'grid grid-cols-4 gap-x-4 gap-y-5 md:grid-cols-6 md:gap-x-6';
 
       return (
         <section className={wrapperBase}>
           <div className={fixedGridClass}>
             {fixedCards.map((card, index) => {
               const isFirst = index === 0;
-              const isLast = index === fixedCards.length - 1;
-              const spanClass = isFirst || isLast ? 'col-span-2 md:col-span-1' : 'col-span-1';
+              const spanClass = isFirst ? 'col-span-2 md:col-span-4' : 'col-span-1';
               return (
                 <div key={card.label} className={cn(summaryItemBase, spanClass)}>
                   <p className="text-xs font-medium text-input-placeholder leading-tight">{card.label}</p>
@@ -154,7 +153,7 @@ export const MatterSummaryCards = ({
                 </div>
               );
             })}
-            <div className="col-span-2 flex flex-col gap-2 md:col-span-1 md:justify-start">
+            <div className="col-span-2 flex flex-col gap-2 md:col-span-2 md:justify-start">
               <Button
                 size="xs"
                 onClick={() => onCreateInvoice?.()}

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/shared/ui/Button';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { getMajorAmountValue, type MajorAmount } from '@/shared/utils/money';
+import { cn } from '@/shared/utils/cn';
 
 type SummaryTab = 'overview' | 'time' | 'messages';
 
@@ -33,9 +34,9 @@ interface MatterSummaryCardsProps {
   } | null;
 }
 
-const summaryItemBase = 'min-w-0 py-1 flex flex-col gap-1';
-const gridBase = 'grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-4';
-const wrapperBase = 'glass-panel p-4 sm:p-5';
+const summaryItemBase = 'min-w-0 flex flex-col gap-1';
+const gridBase = 'grid grid-cols-2 gap-x-4 gap-y-5 @xl:grid-cols-4 @xl:gap-x-6';
+const wrapperBase = 'glass-panel p-4 sm:p-5 @container';
 
 const formatDurationFromSeconds = (totalSeconds?: number | null) => {
   if (!totalSeconds || totalSeconds <= 0) return '0:00 hrs';
@@ -133,21 +134,49 @@ export const MatterSummaryCards = ({
       ];
 
       const fixedGridClass = hasMilestones
-        ? 'grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2 xl:grid-cols-5'
-        : 'grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2 xl:grid-cols-3';
+        ? 'grid grid-cols-2 gap-x-4 gap-y-5 @xl:grid-cols-5 @xl:gap-x-6'
+        : 'grid grid-cols-2 gap-x-4 gap-y-5 @xl:grid-cols-3 @xl:gap-x-6';
 
       return (
         <section className={wrapperBase}>
           <div className={fixedGridClass}>
-            {fixedCards.map((card) => (
-              <div key={card.label} className={`${summaryItemBase} text-center`}>
-                <p className="text-xs font-medium text-input-placeholder leading-tight">{card.label}</p>
-                <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{card.value}</p>
-                {card.helper ? (
-                  <p className="mt-1 text-xs text-input-placeholder leading-tight">{card.helper}</p>
-                ) : null}
+            {fixedCards.map((card, index) => {
+              const isFirst = index === 0;
+              const isLast = index === fixedCards.length - 1;
+              const spanClass = isFirst || isLast ? 'col-span-2 @xl:col-span-1' : 'col-span-1';
+              return (
+                <div key={card.label} className={cn(summaryItemBase, spanClass)}>
+                  <p className="text-xs font-medium text-input-placeholder leading-tight">{card.label}</p>
+                  <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{card.value}</p>
+                  {card.helper ? (
+                    <p className="mt-1 text-xs text-input-placeholder leading-tight">{card.helper}</p>
+                  ) : null}
+                </div>
+              );
+            })}
+            <div className="col-span-2 flex flex-col gap-2 @xl:col-span-1 @xl:justify-start">
+              <Button
+                size="xs"
+                onClick={() => onCreateInvoice?.()}
+                disabled={!onCreateInvoice}
+                className="w-full justify-center"
+              >
+                Invoice
+              </Button>
+              <div className="text-center @xl:text-left">
+                {onViewTimesheet ? (
+                  <button
+                    type="button"
+                    onClick={() => onViewTimesheet()}
+                    className="text-xs font-medium text-accent-500 hover:underline"
+                  >
+                    View timesheet
+                  </button>
+                ) : (
+                  <span className="text-xs font-medium text-input-placeholder/60">View timesheet</span>
+                )}
               </div>
-            ))}
+            </div>
           </div>
         </section>
       );
@@ -156,25 +185,25 @@ export const MatterSummaryCards = ({
     return (
       <section className={wrapperBase}>
         <div className={gridBase}>
-          <div className={summaryItemBase}>
-          <p className="text-xs font-medium text-input-placeholder leading-tight">Billable time this week</p>
-          <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{billableDisplay}</p>
-          <p className="mt-1 text-xs text-input-placeholder leading-tight">
-            Based on recorded billable entries this week.
-          </p>
-          {onLearnMore ? (
-            <button
-              type="button"
-              className="mt-2 text-xs font-medium text-accent-500 hover:underline"
-              onClick={onLearnMore}
-            >
-              Learn more
-            </button>
-          ) : (
-            <span className="mt-2 text-xs font-medium text-input-placeholder/60">
-              Learn more (coming soon)
-            </span>
-          )}
+          <div className={cn(summaryItemBase, 'col-span-2 @xl:col-span-1')}>
+            <p className="text-xs font-medium text-input-placeholder leading-tight">Billable time this week</p>
+            <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{billableDisplay}</p>
+            <p className="mt-1 text-xs text-input-placeholder leading-tight">
+              Based on recorded billable entries this week.
+            </p>
+            {onLearnMore ? (
+              <button
+                type="button"
+                className="mt-2 text-xs font-medium text-accent-500 hover:underline"
+                onClick={onLearnMore}
+              >
+                Learn more
+              </button>
+            ) : (
+              <span className="mt-2 text-xs font-medium text-input-placeholder/60">
+                Learn more (coming soon)
+              </span>
+            )}
           </div>
           <div className={summaryItemBase}>
             <p className="text-xs font-medium text-input-placeholder leading-tight">{billingTypeLabel}</p>
@@ -193,18 +222,16 @@ export const MatterSummaryCards = ({
             <p className="mt-2 text-lg font-semibold text-input-text leading-tight break-words">{totalDisplay}</p>
             <p className="mt-1 text-xs text-input-placeholder leading-tight">Across all logged entries this week</p>
           </div>
-          <div className={`${summaryItemBase} items-center text-center`}>
-            <div className="mt-3 flex flex-col items-center gap-2">
-              <Button
-                size="xs"
-                onClick={() => onCreateInvoice?.()}
-                disabled={!onCreateInvoice}
-                className="w-auto"
-              >
-                Invoice
-              </Button>
-            </div>
-            <div className="mt-2 flex justify-center">
+          <div className="col-span-2 flex flex-col gap-2 @xl:col-span-1">
+            <Button
+              size="xs"
+              onClick={() => onCreateInvoice?.()}
+              disabled={!onCreateInvoice}
+              className="w-full justify-center"
+            >
+              Invoice
+            </Button>
+            <div className="text-center @xl:text-left">
               {onViewTimesheet ? (
                 <button
                   type="button"

--- a/src/features/matters/components/billing/InvoicesSection.tsx
+++ b/src/features/matters/components/billing/InvoicesSection.tsx
@@ -27,7 +27,7 @@ const toInvoiceSummary = (invoice: Invoice): InvoiceSummary => ({
   matterId: invoice.matter_id ?? null,
   matterStatus: invoice.matter?.status ?? null,
   matterBillingType: invoice.matter?.billing_type ?? null,
-  matterRetainerBalance: invoice.matter?.retainer_balance ? getMajorAmountValue(invoice.matter.retainer_balance) : null,
+  matterRetainerBalance: invoice.matter?.retainer_balance != null ? getMajorAmountValue(invoice.matter.retainer_balance) : null,
   total: getMajorAmountValue(invoice.total),
   amountDue: getMajorAmountValue(invoice.amount_due),
   amountPaid: getMajorAmountValue(invoice.amount_paid),

--- a/src/features/matters/components/billing/InvoicesSection.tsx
+++ b/src/features/matters/components/billing/InvoicesSection.tsx
@@ -1,154 +1,77 @@
-import { useEffect, useState } from 'preact/hooks';
-import { Button } from '@/shared/ui/Button';
-import { Panel } from '@/shared/ui/layout/Panel';
-import { formatCurrency } from '@/shared/utils/currencyFormatter';
-import { formatLongDate } from '@/shared/utils/dateFormatter';
+import { useMemo } from 'preact/hooks';
+import { getMajorAmountValue } from '@/shared/utils/money';
+import type { InvoiceSummary } from '@/features/invoices/types';
+import { InvoicesTable } from '@/features/invoices/components/InvoicesTable';
 import type { Invoice } from '@/features/matters/types/billing.types';
 
 type InvoicesSectionProps = {
   invoices: Invoice[];
   loading?: boolean;
   error?: string | null;
-  onCreateInvoice: () => void;
-  onSendInvoice: (invoice: Invoice) => Promise<void> | void;
   onViewInvoice: (invoice: Invoice) => void;
-  onResendInvoice: (invoice: Invoice) => Promise<void> | void;
-  onVoidInvoice: (invoice: Invoice) => Promise<void> | void;
-  onEditDraft?: (invoice: Invoice) => void;
-  onSyncInvoice?: (invoice: Invoice) => Promise<void> | void;
 };
 
-const statusClass: Record<Invoice['status'], string> = {
-  draft: 'bg-white/[0.06] text-input-text border border-white/10',
-  pending: 'bg-white/[0.06] text-input-text border border-white/10',
-  sent: 'status-warning',
-  paid: 'status-success',
-  overdue: 'status-error',
-  cancelled: 'bg-white/[0.04] text-input-placeholder border border-white/10'
-};
+const toInvoiceSummary = (invoice: Invoice): InvoiceSummary => ({
+  id: invoice.id,
+  invoiceNumber: invoice.stripe_invoice_number || invoice.invoice_number || 'Draft',
+  stripeInvoiceNumber: invoice.stripe_invoice_number ?? null,
+  status: invoice.status,
+  subtotal: getMajorAmountValue(invoice.subtotal),
+  taxAmount: getMajorAmountValue(invoice.tax_amount),
+  discountAmount: getMajorAmountValue(invoice.discount_amount),
+  clientName: invoice.client?.name ?? null,
+  clientEmail: invoice.client?.email ?? null,
+  clientStatus: invoice.client?.status ?? null,
+  clientId: invoice.client_id,
+  matterTitle: invoice.matter?.title ?? null,
+  matterId: invoice.matter_id ?? null,
+  matterStatus: invoice.matter?.status ?? null,
+  matterBillingType: invoice.matter?.billing_type ?? null,
+  matterRetainerBalance: invoice.matter?.retainer_balance ? getMajorAmountValue(invoice.matter.retainer_balance) : null,
+  total: getMajorAmountValue(invoice.total),
+  amountDue: getMajorAmountValue(invoice.amount_due),
+  amountPaid: getMajorAmountValue(invoice.amount_paid),
+  invoiceType: invoice.invoice_type,
+  notes: invoice.notes,
+  memo: invoice.memo,
+  fundDestination: invoice.fund_destination ?? null,
+  paymentFromRetainer: invoice.payment_from_retainer ?? null,
+  issueDate: invoice.issue_date,
+  dueDate: invoice.due_date,
+  paidAt: invoice.paid_at,
+  connectedAccountId: invoice.connected_account_id,
+  connectedAccountEmail: invoice.connectedAccount?.email ?? null,
+  connectedAccountStripeAccountId: invoice.connectedAccount?.stripe_account_id ?? null,
+  stripeInvoiceId: invoice.stripe_invoice_id,
+  stripeChargeId: invoice.stripe_charge_id ?? null,
+  stripeTransferId: invoice.stripe_transfer_id ?? null,
+  stripePaymentIntentId: invoice.stripe_payment_intent_id ?? null,
+  stripeHostedInvoiceUrl: invoice.stripe_hosted_invoice_url,
+  createdAt: invoice.created_at,
+  updatedAt: invoice.updated_at,
+});
 
 export const InvoicesSection = ({
   invoices,
   loading = false,
   error = null,
-  onCreateInvoice,
-  onSendInvoice,
   onViewInvoice,
-  onResendInvoice,
-  onVoidInvoice,
-  onEditDraft,
-  onSyncInvoice
 }: InvoicesSectionProps) => {
-  const [syncDelayElapsed, setSyncDelayElapsed] = useState(false);
-  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const timer = window.setTimeout(() => setSyncDelayElapsed(true), 5000);
-    return () => window.clearTimeout(timer);
-  }, []);
-
-  const handleAction = async (id: string, action: (invoice: Invoice) => Promise<void> | void, invoice: Invoice) => {
-    if (pendingIds.has(id)) return;
-    setPendingIds((prev) => {
-      const next = new Set(prev);
-      next.add(id);
-      return next;
-    });
-    try {
-      await action(invoice);
-    } finally {
-      setPendingIds((prev) => {
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
-    }
-  };
-
-  const handlePrimaryAction = (invoice: Invoice) => {
-    if (invoice.status === 'draft' && onEditDraft) {
-      onEditDraft(invoice);
-      return;
-    }
-    onViewInvoice(invoice);
-  };
+  const summaries = useMemo(() => invoices.map(toInvoiceSummary), [invoices]);
+  const invoiceById = useMemo(() => new Map(invoices.map((invoice) => [invoice.id, invoice] as const)), [invoices]);
 
   return (
-    <Panel>
-      <header className="flex items-center justify-between border-b border-line-glass/30 px-6 py-4">
-        <div>
-          <h3 className="text-sm font-semibold text-input-text">Invoices</h3>
-          <p className="text-xs text-input-placeholder">{invoices.length} total</p>
-        </div>
-        <Button size="sm" onClick={onCreateInvoice}>Create invoice</Button>
-      </header>
-
-      {error ? (
-        <div className="px-6 py-5 text-sm text-red-400">{error}</div>
-      ) : loading ? (
-        <div className="px-6 py-5 text-sm text-input-placeholder">Loading invoices...</div>
-      ) : invoices.length === 0 ? (
-        <div className="px-6 py-5 text-sm text-input-placeholder">No invoices yet for this matter.</div>
-      ) : (
-        <ul className="divide-y divide-line-default">
-          {invoices.map((invoice) => {
-            const isPending = pendingIds.has(invoice.id);
-            return (
-              <li key={invoice.id} className="flex items-center justify-between gap-4 px-6 py-4">
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-input-text">
-                    {invoice.stripe_invoice_number || invoice.invoice_number || 'Draft'}
-                  </p>
-                  <p className="mt-1 text-xs text-input-placeholder">
-                    {invoice.issue_date ? `Issued ${formatLongDate(invoice.issue_date)}` : 'Not issued'}
-                  </p>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className={`rounded-md px-2 py-1 text-xs font-medium ${statusClass[invoice.status]}`}>
-                    {invoice.status.replace('_', ' ')}
-                  </span>
-                  {invoice.status === 'sent' && !invoice.stripe_invoice_number ? (
-                    <div className="flex items-center gap-2 text-xs text-input-placeholder">
-                      <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-400" aria-hidden="true" />
-                      <span>(Syncing with Stripe...)</span>
-                      {syncDelayElapsed && onSyncInvoice ? (
-                        <Button
-                          size="xs"
-                          variant="secondary"
-                          onClick={() => void handleAction(invoice.id, onSyncInvoice, invoice)}
-                          disabled={isPending}
-                        >
-                          {isPending ? '...' : 'Sync now'}
-                        </Button>
-                      ) : null}
-                    </div>
-                  ) : null}
-                  <p className="text-sm font-semibold text-input-text">{formatCurrency(invoice.total)}</p>
-                  <Button size="xs" variant="secondary" onClick={() => handlePrimaryAction(invoice)} disabled={isPending}>
-                    {invoice.status === 'draft' ? 'Edit' : 'View'}
-                  </Button>
-                  {invoice.status === 'draft' ? (
-                    <Button size="xs" onClick={() => void handleAction(invoice.id, onSendInvoice, invoice)} disabled={isPending}>
-                      {isPending ? 'Sending...' : 'Send'}
-                    </Button>
-                  ) : null}
-                  {invoice.status === 'sent' ? (
-                    <Button size="xs" variant="secondary" onClick={() => void handleAction(invoice.id, onResendInvoice, invoice)} disabled={isPending}>
-                      {isPending ? 'Sending...' : 'Resend'}
-                    </Button>
-                  ) : null}
-                  {(invoice.status === 'draft' || invoice.status === 'sent' || invoice.status === 'pending') ? (
-                    <Button size="xs" variant="danger-ghost" onClick={() => void handleAction(invoice.id, onVoidInvoice, invoice)} disabled={isPending}>
-                      {isPending ? 'Voiding...' : 'Void'}
-                    </Button>
-                  ) : null}
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </Panel>
+    <InvoicesTable
+      invoices={summaries}
+      loading={loading}
+      error={error}
+      emptyMessage="No invoices yet for this matter."
+      onRowClick={(invoice) => {
+        const sourceInvoice = invoiceById.get(invoice.id);
+        if (sourceInvoice) {
+          onViewInvoice(sourceInvoice);
+        }
+      }}
+    />
   );
 };

--- a/src/features/matters/components/billing/InvoicesSection.tsx
+++ b/src/features/matters/components/billing/InvoicesSection.tsx
@@ -9,6 +9,11 @@ type InvoicesSectionProps = {
   loading?: boolean;
   error?: string | null;
   onViewInvoice: (invoice: Invoice) => void;
+  onViewCustomer?: (clientId: string) => void;
+  onSendInvoice?: () => void;
+  onResendInvoice?: () => void;
+  onVoidInvoice?: () => void;
+  onSyncInvoice?: () => void;
 };
 
 const toInvoiceSummary = (invoice: Invoice): InvoiceSummary => ({
@@ -56,6 +61,11 @@ export const InvoicesSection = ({
   loading = false,
   error = null,
   onViewInvoice,
+  onViewCustomer,
+  onSendInvoice,
+  onResendInvoice,
+  onVoidInvoice,
+  onSyncInvoice,
 }: InvoicesSectionProps) => {
   const summaries = useMemo(() => invoices.map(toInvoiceSummary), [invoices]);
   const invoiceById = useMemo(() => new Map(invoices.map((invoice) => [invoice.id, invoice] as const)), [invoices]);
@@ -72,6 +82,11 @@ export const InvoicesSection = ({
           onViewInvoice(sourceInvoice);
         }
       }}
+      onViewCustomer={onViewCustomer}
+      onSendInvoice={onSendInvoice}
+      onResendInvoice={onResendInvoice}
+      onVoidInvoice={onVoidInvoice}
+      onSyncInvoice={onSyncInvoice}
     />
   );
 };

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -78,7 +78,6 @@ import {
   updateMatterTask,
   updateMatterTimeEntry
 } from '@/features/matters/services/mattersApi';
-import { sendInvoice, syncInvoice, voidInvoice as voidInvoiceRequest } from '@/features/matters/services/invoicesApi';
 import { useBillingData } from '@/features/matters/hooks/useBillingData';
 import type { Invoice, InvoiceLineItem } from '@/features/matters/types/billing.types';
 import { createPendingInvoiceDraftContext } from '@/features/invoices/utils/invoiceDraftContext';
@@ -1563,10 +1562,6 @@ export const PracticeMattersPage = ({
     navigateToInvoiceCreate(prefilledInvoiceLineItems);
   }, [selectedMatterDetail, navigateToInvoiceCreate, prefilledInvoiceLineItems]);
 
-  const handleEditDraftInvoice = useCallback((invoice: Invoice) => {
-    navigate(`${invoicesBasePath}/${encodeURIComponent(invoice.id)}`);
-  }, [invoicesBasePath, navigate]);
-
   const handleCreateMilestoneInvoice = useCallback((milestoneId: string) => {
     if (!selectedMatterDetail) return;
     const milestone = (selectedMatterDetail.milestones ?? []).find((m) => m.id === milestoneId);
@@ -1623,59 +1618,10 @@ export const PracticeMattersPage = ({
     }
   }, [activePracticeId, selectedMatterId, settlementDraft, selectedMatterDetail, navigateToInvoiceCreate, refreshMatters, showError]);
 
-  const handleSendInvoice = useCallback(async (invoice: Invoice) => {
-    if (!activePracticeId) return;
-    try {
-      await sendInvoice(activePracticeId, invoice.id);
-      await refetchBilling();
-    } catch (error) {
-      showError('Could not send invoice', error instanceof Error ? error.message : 'Please try again.');
-    }
-  }, [activePracticeId, refetchBilling, showError]);
-
   const handleViewInvoice = useCallback((invoice: Invoice) => {
-    if (!invoice.stripe_hosted_invoice_url) {
-      showError('No hosted invoice URL', 'This invoice has not been published to Stripe yet.');
-      return;
-    }
-    window.open(invoice.stripe_hosted_invoice_url, '_blank', 'noopener,noreferrer');
-  }, [showError]);
-
-  const handleResendInvoice = useCallback(async (invoice: Invoice) => {
-    if (!activePracticeId) return;
-    try {
-      const synced = await syncInvoice(activePracticeId, invoice.id);
-      const url = synced?.stripe_hosted_invoice_url ?? invoice.stripe_hosted_invoice_url;
-      if (url && typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(url);
-      }
-      await refetchBilling();
-    } catch (error) {
-      showError('Could not resend invoice', error instanceof Error ? error.message : 'Please try again.');
-    }
-  }, [activePracticeId, refetchBilling, showError]);
-
-  const handleSyncInvoice = useCallback(async (invoice: Invoice) => {
-    if (!activePracticeId) return;
-    try {
-      await syncInvoice(activePracticeId, invoice.id);
-      await refetchBilling();
-    } catch (error) {
-      showError('Could not sync invoice', error instanceof Error ? error.message : 'Please try again.');
-    }
-  }, [activePracticeId, refetchBilling, showError]);
-
-  const handleVoidInvoice = useCallback(async (invoice: Invoice) => {
-    if (!activePracticeId) return;
-    const confirmed = window.confirm('Void this invoice? This cannot be undone.');
-    if (!confirmed) return;
-    try {
-      await voidInvoiceRequest(activePracticeId, invoice.id);
-      await refetchBilling();
-    } catch (error) {
-      showError('Could not void invoice', error instanceof Error ? error.message : 'Please try again.');
-    }
-  }, [activePracticeId, refetchBilling, showError]);
+    const basePath = `${invoicesBasePath}/${encodeURIComponent(invoice.id)}`;
+    navigate(invoice.status === 'draft' ? `${basePath}/edit` : basePath);
+  }, [invoicesBasePath, navigate]);
 
   // ── Patch matter — partial update from inline field groups ───────────────
   const handlePatchMatter = useCallback(async (patch: Partial<MatterFormState>) => {
@@ -1831,10 +1777,10 @@ export const PracticeMattersPage = ({
                 <section className="relative overflow-hidden rounded-[28px] bg-gradient-to-b from-accent-500/30 via-surface-overlay/70 to-surface-overlay/85 [--accent-foreground:var(--input-text)]">
                   <div className="absolute inset-0 bg-gradient-to-t from-surface-base/45 via-transparent to-transparent" />
                   <div className="relative px-4 pb-8 pt-8 sm:px-6 sm:pb-12 sm:pt-10">
-                    <div className="flex flex-col items-center gap-5 text-center @xl:flex-row @xl:items-start @xl:text-left @xl:gap-8">
+                    <div className="flex flex-col items-center gap-5 text-center lg:flex-row lg:items-start lg:text-left lg:gap-8">
                       <Avatar
                         size="xl"
-                        className="mx-auto h-28 w-28 @xl:h-36 @xl:w-36 @xl:mx-0"
+                        className="mx-auto h-28 w-28 lg:h-36 lg:w-36 lg:mx-0"
                         src={detailClientOption?.image ?? null}
                         name={detailClientOption?.name ?? 'Unassigned client'}
                       />
@@ -1879,18 +1825,18 @@ export const PracticeMattersPage = ({
                               </div>
                             ) : (
                               <>
-                                <div className="flex flex-col items-center gap-1 @xl:flex-row @xl:items-baseline @xl:justify-between @xl:gap-3">
-                                  <h4 className="break-words text-center text-2xl font-semibold leading-tight text-[rgb(var(--accent-foreground))] @xl:text-left @xl:text-4xl @2xl:text-5xl">
+                                <div className="flex flex-col items-center gap-1 lg:flex-row lg:items-baseline lg:justify-between lg:gap-3">
+                                  <h4 className="break-words text-center text-2xl font-semibold leading-tight text-[rgb(var(--accent-foreground))] lg:text-left lg:text-4xl xl:text-5xl">
                                     {selectedMatterDetail.title?.trim() || 'Untitled matter'}
                                   </h4>
                                   {selectedMatterDetail.caseNumber?.trim() ? (
-                                    <span className="hidden shrink-0 text-sm font-normal text-[rgb(var(--accent-foreground))]/65 @xl:pt-2 @xl:inline">
+                                    <span className="hidden shrink-0 text-sm font-normal text-[rgb(var(--accent-foreground))]/65 lg:pt-2 lg:inline">
                                       #{selectedMatterDetail.caseNumber.trim()}
                                     </span>
                                   ) : null}
                                 </div>
                                 {selectedMatterDetail.caseNumber?.trim() ? (
-                                  <p className="text-xs font-medium uppercase tracking-[0.16em] text-[rgb(var(--accent-foreground))]/65 @xl:hidden">
+                                  <p className="text-xs font-medium uppercase tracking-[0.16em] text-[rgb(var(--accent-foreground))]/65 lg:hidden">
                                     #{selectedMatterDetail.caseNumber.trim()}
                                   </p>
                                 ) : null}
@@ -1901,7 +1847,7 @@ export const PracticeMattersPage = ({
                             )}
                           </div>
                         ) : null}
-                        <nav className="mt-6 flex flex-wrap items-center justify-center gap-2 @xl:gap-3 @xl:justify-start" aria-label="Matter detail tabs">
+                        <nav className="mt-6 flex flex-wrap items-center justify-center gap-2 lg:gap-3 lg:justify-start" aria-label="Matter detail tabs">
                           {DETAIL_TABS.map((tab) => {
                             const isActive = detailSection === tab.id;
                             const TabIcon = tab.icon;
@@ -1931,7 +1877,7 @@ export const PracticeMattersPage = ({
                           })}
                         </nav>
                         {selectedMatterDetail ? (
-                          <div className="mt-6 grid grid-cols-1 gap-4 text-center @xl:grid-cols-3 @xl:text-left">
+                          <div className="mt-6 grid grid-cols-1 gap-4 text-center lg:grid-cols-3 lg:text-left">
                             <div>
                               <p className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--accent-foreground))]/70">Client</p>
                               <p className="mt-1 text-sm break-words text-[rgb(var(--accent-foreground))]">
@@ -1946,7 +1892,7 @@ export const PracticeMattersPage = ({
                                 const attName = assigneeNameById.get(attId);
                                 if (!attName) return <p className="mt-1 text-sm text-[rgb(var(--accent-foreground))]/60">Not set</p>;
                                 return (
-                                  <div className="mt-1 flex items-center justify-center gap-1.5 @xl:justify-start">
+                                  <div className="mt-1 flex items-center justify-center gap-1.5 lg:justify-start">
                                     <Avatar src={member?.image ?? null} name={attName} size="xs" />
                                     <span className="min-w-0 text-sm text-[rgb(var(--accent-foreground))]">{attName}</span>
                                   </div>
@@ -2238,13 +2184,7 @@ export const PracticeMattersPage = ({
                     invoices={invoices}
                     loading={invoicesLoading}
                     error={invoicesError}
-                    onCreateInvoice={handleCreateInvoiceFromSummary}
-                    onSendInvoice={handleSendInvoice}
                     onViewInvoice={handleViewInvoice}
-                    onResendInvoice={handleResendInvoice}
-                    onVoidInvoice={handleVoidInvoice}
-                    onEditDraft={handleEditDraftInvoice}
-                    onSyncInvoice={handleSyncInvoice}
                   />
                 </div>
               </BillingErrorBoundary>

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -1827,13 +1827,14 @@ export const PracticeMattersPage = ({
               inspectorOpen={detailInspectorOpen}
             />
             {detailHeaderMeta ? (
-              <div className="px-4 py-4">
-                <section className="relative overflow-hidden rounded-[28px] bg-gradient-to-b from-accent-500/30 via-surface-glass/70 to-surface-overlay/85 [--accent-foreground:var(--input-text)]">
-                  <div className="absolute inset-0 bg-gradient-to-t from-surface-base/45 via-transparent to-white/10" />
-                  <div className="relative px-6 pb-12 pt-10">
-                    <div className="flex flex-col items-start gap-6 md:flex-row md:items-start md:gap-8">
+          <div className="px-4 py-4 @container">
+                <section className="relative overflow-hidden rounded-[28px] bg-gradient-to-b from-accent-500/30 via-surface-overlay/70 to-surface-overlay/85 [--accent-foreground:var(--input-text)]">
+                  <div className="absolute inset-0 bg-gradient-to-t from-surface-base/45 via-transparent to-transparent" />
+                  <div className="relative px-4 pb-8 pt-8 sm:px-6 sm:pb-12 sm:pt-10">
+                    <div className="flex flex-col items-center gap-5 text-center @xl:flex-row @xl:items-start @xl:text-left @xl:gap-8">
                       <Avatar
                         size="xl"
+                        className="mx-auto h-28 w-28 @xl:h-36 @xl:w-36 @xl:mx-0"
                         src={detailClientOption?.image ?? null}
                         name={detailClientOption?.name ?? 'Unassigned client'}
                       />
@@ -1878,24 +1879,29 @@ export const PracticeMattersPage = ({
                               </div>
                             ) : (
                               <>
-                                <div className="flex items-baseline justify-between gap-3">
-                                  <h4 className="text-4xl font-semibold leading-tight text-[rgb(var(--accent-foreground))] md:text-5xl">
+                                <div className="flex flex-col items-center gap-1 @xl:flex-row @xl:items-baseline @xl:justify-between @xl:gap-3">
+                                  <h4 className="break-words text-center text-2xl font-semibold leading-tight text-[rgb(var(--accent-foreground))] @xl:text-left @xl:text-4xl @2xl:text-5xl">
                                     {selectedMatterDetail.title?.trim() || 'Untitled matter'}
                                   </h4>
                                   {selectedMatterDetail.caseNumber?.trim() ? (
-                                    <span className="shrink-0 text-sm font-normal text-[rgb(var(--accent-foreground))]/65">
+                                    <span className="hidden shrink-0 text-sm font-normal text-[rgb(var(--accent-foreground))]/65 @xl:pt-2 @xl:inline">
                                       #{selectedMatterDetail.caseNumber.trim()}
                                     </span>
                                   ) : null}
                                 </div>
-                                <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-[rgb(var(--accent-foreground))]/85">
+                                {selectedMatterDetail.caseNumber?.trim() ? (
+                                  <p className="text-xs font-medium uppercase tracking-[0.16em] text-[rgb(var(--accent-foreground))]/65 @xl:hidden">
+                                    #{selectedMatterDetail.caseNumber.trim()}
+                                  </p>
+                                ) : null}
+                                <p className="mt-2 break-words whitespace-pre-wrap text-sm leading-relaxed text-[rgb(var(--accent-foreground))]/85">
                                   {selectedMatterDetail.description?.trim() || 'No description yet.'}
                                 </p>
                               </>
                             )}
                           </div>
                         ) : null}
-                        <nav className="mt-6 flex items-center gap-3" aria-label="Matter detail tabs">
+                        <nav className="mt-6 flex flex-wrap items-center justify-center gap-2 @xl:gap-3 @xl:justify-start" aria-label="Matter detail tabs">
                           {DETAIL_TABS.map((tab) => {
                             const isActive = detailSection === tab.id;
                             const TabIcon = tab.icon;
@@ -1912,7 +1918,7 @@ export const PracticeMattersPage = ({
                                 title={tab.label}
                                 role="tab"
                                 className={[
-                                  'flex h-11 w-11 items-center justify-center rounded-full transition-colors duration-150',
+                                  'flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150 sm:h-11 sm:w-11',
                                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500',
                                   isActive
                                     ? 'bg-white/20 text-[rgb(var(--accent-foreground))]'
@@ -1925,10 +1931,10 @@ export const PracticeMattersPage = ({
                           })}
                         </nav>
                         {selectedMatterDetail ? (
-                          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                          <div className="mt-6 grid grid-cols-1 gap-4 text-center @xl:grid-cols-3 @xl:text-left">
                             <div>
                               <p className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--accent-foreground))]/70">Client</p>
-                              <p className="mt-1 text-sm text-[rgb(var(--accent-foreground))]">
+                              <p className="mt-1 text-sm break-words text-[rgb(var(--accent-foreground))]">
                                 {detailClientOption?.name ?? 'Unassigned client'}
                               </p>
                             </div>
@@ -1940,9 +1946,9 @@ export const PracticeMattersPage = ({
                                 const attName = assigneeNameById.get(attId);
                                 if (!attName) return <p className="mt-1 text-sm text-[rgb(var(--accent-foreground))]/60">Not set</p>;
                                 return (
-                                  <div className="mt-1 flex items-center gap-1.5">
+                                  <div className="mt-1 flex items-center justify-center gap-1.5 @xl:justify-start">
                                     <Avatar src={member?.image ?? null} name={attName} size="xs" />
-                                    <span className="text-sm text-[rgb(var(--accent-foreground))]">{attName}</span>
+                                    <span className="min-w-0 text-sm text-[rgb(var(--accent-foreground))]">{attName}</span>
                                   </div>
                                 );
                               })()}

--- a/src/features/modals/components/WelcomeDialog.tsx
+++ b/src/features/modals/components/WelcomeDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useTranslation, Trans } from '@/shared/i18n/hooks';
 import { InfoListDialog, type InfoListDialogItem } from '@/shared/ui/dialog';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import {
   ChatBubbleLeftRightIcon,
   ShieldCheckIcon,
@@ -126,10 +127,7 @@ const WelcomeDialog = ({ isOpen, onClose, onComplete, workspace }: WelcomeDialog
       items={items}
       actionLabel={isSubmitting ? (
         <span className="inline-flex items-center gap-2">
-          <span
-            aria-hidden="true"
-            className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-          />
+          <LoadingSpinner size="md" ariaLabel={t('common:app.loading', { ns: 'common' })} />
           <span>{t('onboarding.welcome.letsGo')}</span>
         </span>
       ) : (

--- a/src/features/onboarding/components/PersonalInfoStep.tsx
+++ b/src/features/onboarding/components/PersonalInfoStep.tsx
@@ -5,6 +5,7 @@ import { Logo } from '@/shared/ui/Logo';
 import { UserIcon } from '@heroicons/react/24/outline';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, type FormData } from '@/shared/ui/form';
 import { DatePicker, Checkbox, Input } from '@/shared/ui/input';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { schemas } from '@/shared/ui/validation/schemas';
 
 interface PersonalInfoData extends FormData {
@@ -171,7 +172,7 @@ const PersonalInfoStep = ({
                 className="w-full"
               >
                 {(parentSubmitting || localSubmitting) ? (
-                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  <LoadingSpinner size="md" ariaLabel={t('common:app.loading', { ns: 'common' })} />
                 ) : (
                   t('onboarding.step1.continue')
                 )}

--- a/src/features/onboarding/components/UseCaseStep.tsx
+++ b/src/features/onboarding/components/UseCaseStep.tsx
@@ -207,8 +207,7 @@ const UseCaseStep = ({ data, onComplete, isSubmitting: parentSubmitting = false 
             >
               {isFormSubmitting ? (
                   <div className="flex items-center justify-center space-x-2">
-                    <LoadingSpinner size="md" ariaLabel="Submitting" />
-                    <span className="sr-only">Submitting...</span>
+                    <LoadingSpinner size="md" ariaLabel={t('submitting')} />
                   </div>
                 ) : (
                   t('onboarding.step2.next')

--- a/src/features/onboarding/components/UseCaseStep.tsx
+++ b/src/features/onboarding/components/UseCaseStep.tsx
@@ -13,6 +13,7 @@ import {
 import { Icon } from '@/shared/ui/Icon';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
 import { Textarea } from '@/shared/ui/input';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
 interface UseCaseData {
   primaryUseCase: 'messaging' | 'legal_payments' | 'matter_management' | 'intake_forms' | 'other';
@@ -205,11 +206,8 @@ const UseCaseStep = ({ data, onComplete, isSubmitting: parentSubmitting = false 
               className="w-full"
             >
               {isFormSubmitting ? (
-                  <div className="flex items-center justify-center space-x-2" aria-live="polite" role="status">
-                    <div 
-                      className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" 
-                      aria-label="Submitting"
-                    />
+                  <div className="flex items-center justify-center space-x-2">
+                    <LoadingSpinner size="md" ariaLabel="Submitting" />
                     <span className="sr-only">Submitting...</span>
                   </div>
                 ) : (

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -30,6 +30,7 @@ import { SettingSection } from '@/features/settings/components/SettingSection';
 import { PlanFeaturesList, type PlanFeature } from '@/features/settings/components/PlanFeaturesList';
 import { EmailSettingsSection } from '@/features/settings/components/EmailSettingsSection';
 import { ContentPageLayout } from '@/shared/ui/layout';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { SettingsDangerButton } from '@/features/settings/components/SettingsDangerButton';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { getPreferencesCategory, updatePreferencesCategory } from '@/shared/lib/preferencesApi';
@@ -795,11 +796,7 @@ export const AccountPage = ({
   }, [isPending, practiceLoading, subscriptionLoading, authAccountsLoading]);
 
   if ((isPending || practiceLoading || subscriptionLoading || authAccountsLoading) && !loadingTimeout) {
-    return (
-      <div className={`h-full flex items-center justify-center ${className}`}>
-        <div className="w-8 h-8 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
-      </div>
-    );
+    return <LoadingBlock className={className} />;
   }
 
   if (loadingTimeout || error) {

--- a/src/features/settings/pages/GeneralPage.tsx
+++ b/src/features/settings/pages/GeneralPage.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_LOCALE, detectBestLocale, setLocale, SUPPORTED_LOCALES } from '
 import type { Language } from '@/shared/types/user';
 import { SettingSelect } from '@/features/settings/components/SettingSelect';
 import { ContentPageLayout } from '@/shared/ui/layout';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { getPreferencesCategory, preferencesApi } from '@/shared/lib/preferencesApi';
 import type { GeneralPreferences } from '@/shared/types/preferences';
 
@@ -163,11 +164,7 @@ export const GeneralPage = ({
 
   // Show loading state while session is loading
   if (isLoading) {
-    return (
-      <div className={`h-full flex items-center justify-center ${className}`}>
-        <div className="w-8 h-8 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
-      </div>
-    );
+    return <LoadingBlock className={className} />;
   }
 
   // Use same layout for both mobile and desktop

--- a/src/features/settings/pages/MFAEnrollmentPage.tsx
+++ b/src/features/settings/pages/MFAEnrollmentPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/shared/ui/Button';
 import { Input } from '@/shared/ui/input';
 import { SectionDivider } from '@/shared/ui/layout';
 import { ContentPageLayout } from '@/shared/ui/layout';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
@@ -315,10 +316,10 @@ export const MFAEnrollmentPage = ({
               className="w-full"
             >
               {isVerifying ? (
-                <>
-                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
+                <span className="inline-flex items-center">
+                  <LoadingSpinner size="sm" className="mr-2" ariaLabel={t('settings:mfa.verifying')} />
                   {t('settings:mfa.verifying')}
-                </>
+                </span>
               ) : (
                 t('settings:mfa.verifyButton')
               )}

--- a/src/features/settings/pages/NotificationsPage.tsx
+++ b/src/features/settings/pages/NotificationsPage.tsx
@@ -6,6 +6,7 @@ import { getNotificationDisplayText } from '@/shared/ui/validation/defaultValues
 import { SettingRow } from '@/features/settings/components/SettingRow';
 import { NotificationChannelSelector } from '@/features/settings/components/NotificationChannelSelector';
 import { ContentPageLayout } from '@/shared/ui/layout';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { SettingsSubheader } from '@/features/settings/components/SettingsSubheader';
 import {
   useNotificationSettings,
@@ -287,11 +288,7 @@ export const NotificationsPage = ({
   };
 
   if (isLoading) {
-    return (
-      <div className={`h-full flex items-center justify-center ${className}`}>
-        <div className="w-8 h-8 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
-      </div>
-    );
+    return <LoadingBlock className={className} />;
   }
 
   if (error || !settings) {

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -32,6 +32,7 @@ import { getFrontendHost } from '@/config/urls';
 import { normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import { FormGrid, SectionDivider } from '@/shared/ui/layout';
 import { ContentPageLayout } from '@/shared/ui/layout';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { PracticeServicesSummary } from '@/features/settings/components/PracticeServicesSummary';
@@ -560,14 +561,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
   const shouldShowLoading = loading || sessionPending;
 
   if (shouldShowLoading) {
-    return (
-      <div className={`h-full flex items-center justify-center ${className}`}>
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent-500 mx-auto mb-4" />
-          <p className="text-sm text-input-placeholder">Loading practice...</p>
-        </div>
-      </div>
-    );
+    return <LoadingBlock className={className} label="Loading practice..." />;
   }
 
   if (error) {

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -561,7 +561,7 @@ export const PracticePage = ({ className = '', onNavigate }: PracticePageProps) 
   const shouldShowLoading = loading || sessionPending;
 
   if (shouldShowLoading) {
-    return <LoadingBlock className={className} label="Loading practice..." />;
+    return <LoadingBlock className={className} label="Loading practice..." showLabel={true} />;
   }
 
   if (error) {

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -17,6 +17,7 @@ import { SettingToggle } from '@/features/settings/components/SettingToggle';
 import { SettingRow } from '@/features/settings/components/SettingRow';
 import { PasswordChangeForm } from '@/features/settings/components/PasswordChangeForm';
 import { ContentPageLayout } from '@/shared/ui/layout';
+import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { SettingsDangerButton } from '@/features/settings/components/SettingsDangerButton';
 import { SettingsHelperText } from '@/features/settings/components/SettingsHelperText';
 import { getPreferencesCategory, updatePreferencesCategory } from '@/shared/lib/preferencesApi';
@@ -412,11 +413,7 @@ export const SecurityPage = ({
 
   // Show loading state while session or preferences are loading
   if (isPending || isLoading || authAccountsLoading) {
-    return (
-      <div className={`h-full flex items-center justify-center ${className}`}>
-        <div className="w-8 h-8 border-2 border-accent-500 border-t-transparent rounded-full animate-spin" />
-      </div>
-    );
+    return <LoadingBlock className={className} />;
   }
 
   if (authAccountsError) {

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
     --surface-nav-rail: 244 246 251;
     --surface-nav-secondary: 238 241 248;
     --surface-list-panel: 236 239 247;
-    --surface-inspector: 236 239 247;
+    --surface-inspector: 248 250 252;
     --surface-glass: 255 255 255;
     --line-glass: 255 255 255;
     --input-text: 17 24 39;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -270,6 +270,7 @@ function AppShell() {
           <Route path="/practice/:practiceSlug/reports/*" component={PracticeAppRoute} workspaceView="reports" />
           <Route path="/practice/:practiceSlug/invoices" component={PracticeAppRoute} workspaceView="invoices" />
           <Route path="/practice/:practiceSlug/invoices/new" component={PracticeAppRoute} workspaceView="invoiceCreate" />
+          <Route path="/practice/:practiceSlug/invoices/:invoiceId/edit" component={PracticeAppRoute} workspaceView="invoiceEdit" />
           <Route path="/practice/:practiceSlug/invoices/:invoiceId" component={PracticeAppRoute} workspaceView="invoiceDetail" />
           <Route path="/practice/:practiceSlug/settings" component={PracticeAppRoute} workspaceView="settings" settingsView="general" />
           <Route path="/practice/:practiceSlug/settings/general" component={PracticeAppRoute} workspaceView="settings" settingsView="general" />
@@ -372,7 +373,7 @@ function PracticeAppRoute({
   conversationId?: string;
   invoiceId?: string;
   appId?: string;
-  workspaceView?: 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceDetail' | 'reports' | 'settings';
+  workspaceView?: 'home' | 'setup' | 'list' | 'conversation' | 'matters' | 'clients' | 'invoices' | 'invoiceCreate' | 'invoiceEdit' | 'invoiceDetail' | 'reports' | 'settings';
   settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-services' | 'practice-team' | 'practice-pricing' | 'apps' | 'app-detail' | 'security' | 'help';
   practiceSlug?: string;
 }) {

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -4,6 +4,7 @@ import { UserCircleIcon } from '@heroicons/react/24/outline';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
 import { Input, EmailInput, PasswordInput } from '@/shared/ui/input';
 import { Button } from '@/shared/ui/Button';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { handleError } from '@/shared/utils/errorHandler';
 import { getClient } from '@/shared/lib/authClient';
 
@@ -434,7 +435,10 @@ const AuthForm = ({
                 : undefined}
             >
               {loading ? (
-                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                <LoadingSpinner
+                  size="md"
+                  ariaLabel={resolvedMode === 'signup' ? t('signup.submitting') : t('signin.submitting')}
+                />
               ) : (
                 resolvedMode === 'signup' ? t('signup.submit') : t('signin.submit')
               )}

--- a/src/shared/ui/activity/ActivityTimeline.tsx
+++ b/src/shared/ui/activity/ActivityTimeline.tsx
@@ -153,14 +153,14 @@ export const ActivityTimeline = ({
 
   return (
     <div className={cn('space-y-6', className)}>
-    <ul className="space-y-6">
+    <ul className="space-y-5 sm:space-y-6">
       {items.map((item, itemIndex) => {
         const isLast = itemIndex === items.length - 1;
         const actionText = item.action ?? DEFAULT_ACTIONS[item.type];
 
         return (
-          <li key={item.id} className="relative flex gap-x-4">
-            <div className="relative flex w-10 flex-none justify-center pt-0.5">
+          <li key={item.id} className="relative flex gap-x-3 sm:gap-x-4">
+            <div className="relative flex w-8 flex-none justify-center pt-0.5 sm:w-10">
               <div
                 className={cn(
                   'absolute left-1/2 z-0 w-px -translate-x-1/2 bg-line-default',
@@ -169,15 +169,15 @@ export const ActivityTimeline = ({
                 )}
               />
               {item.type === 'commented' ? (
-                <div className="relative z-10 flex h-10 w-10 items-center justify-center">
+                <div className="relative z-10 flex h-8 w-8 items-center justify-center sm:h-10 sm:w-10">
                   <Avatar
                     name={item.person.name}
                     src={item.person.imageUrl}
                     size="md"
                     className="ring-1 ring-black/10 bg-white/10 text-input-text dark:ring-white/20"
                   />
-                  <span className="absolute -right-1 -bottom-1 flex h-5 w-5 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-glass/30 shadow-sm">
-                    <Icon icon={ChatBubbleLeftRightIcon} className="h-3 w-3" aria-hidden="true"  />
+                  <span className="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-glass/30 shadow-sm sm:h-5 sm:w-5">
+                    <Icon icon={ChatBubbleLeftRightIcon} className="h-2.5 w-2.5 sm:h-3 sm:w-3" aria-hidden="true"  />
                   </span>
                 </div>
               ) : (
@@ -200,7 +200,7 @@ export const ActivityTimeline = ({
 
             {item.type === 'commented' ? (
               <>
-                <div className="flex-auto">
+                <div className="flex-auto min-w-0">
                   <div className="text-sm leading-5 text-gray-500 dark:text-gray-400">
                     <div className="font-semibold text-input-text">{item.person.name}</div>
                     <time dateTime={item.dateTime ?? item.date}>Commented {item.date}</time>
@@ -283,7 +283,9 @@ export const ActivityTimeline = ({
               </>
             ) : (
               <>
-                <p className="flex-auto py-0.5 text-sm leading-5 text-input-text">
+                <div className="flex-auto min-w-0">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+                    <p className="flex-1 py-0.5 text-sm leading-5 text-input-text">
                   <span className="font-semibold">{item.person.name}</span>{' '}
                   {item.actionMeta?.type === 'status_change' ? (
                     <>
@@ -331,13 +333,15 @@ export const ActivityTimeline = ({
                       );
                     })()
                   )}
-                </p>
-                <time
-                  dateTime={item.dateTime ?? item.date}
-                  className="flex-none py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-400"
-                >
-                  {item.date}
-                </time>
+                    </p>
+                    <time
+                      dateTime={item.dateTime ?? item.date}
+                      className="shrink-0 py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-400 sm:text-right"
+                    >
+                      {item.date}
+                    </time>
+                  </div>
+                </div>
               </>
             )}
           </li>
@@ -346,12 +350,12 @@ export const ActivityTimeline = ({
     </ul>
 
     {showComposer && (
-      <div className="flex gap-x-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:gap-x-3">
         <Avatar
           name={composerPerson?.name ?? 'You'}
           src={composerPerson?.imageUrl ?? null}
           size="sm"
-          className="mt-1 ring-1 ring-white/15 bg-white/10 text-input-text dark:ring-white/10"
+          className="ring-1 ring-white/15 bg-white/10 text-input-text dark:ring-white/10 sm:mt-1"
         />
         <form className="flex-auto space-y-2" onSubmit={handleSubmit}>
           <MarkdownUploadTextarea

--- a/src/shared/ui/address/AddressFields.tsx
+++ b/src/shared/ui/address/AddressFields.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from 'preact/compat';
 import { useRef, useEffect } from 'preact/hooks';
 import { Input } from '@/shared/ui/input/Input';
 import { Combobox, type ComboboxOption } from '@/shared/ui/input/Combobox';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 import type { Address, AddressSuggestion } from '@/shared/types/address';
@@ -228,9 +229,11 @@ export const AddressFields = forwardRef<HTMLDivElement, AddressFieldsProps>(
 
             {/* Spinner — uses accent token, not hardcoded blue */}
             {streetAddressProps?.isLoading && (
-              <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/10 border-t-accent-500" />
-              </div>
+              <LoadingSpinner
+                size="md"
+                ariaLabel="Loading address suggestions"
+                className="pointer-events-none absolute inset-y-0 right-3 flex items-center"
+              />
             )}
           </div>
 

--- a/src/shared/ui/dropdown/DropdownMenuItem.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuItem.tsx
@@ -1,5 +1,7 @@
 import { ComponentChildren } from 'preact';
+import { useContext } from 'preact/hooks';
 import { cn } from '@/shared/utils/cn';
+import { DropdownContext } from './DropdownMenu';
 
 export interface DropdownMenuItemProps {
   children: ComponentChildren;
@@ -14,9 +16,15 @@ export const DropdownMenuItem = ({
   disabled = false,
   className = ''
 }: DropdownMenuItemProps) => {
+  const context = useContext(DropdownContext);
+
   const handleClick = () => {
     if (!disabled && onSelect) {
       onSelect();
+    }
+
+    if (!disabled) {
+      context?.handleOpenChange(false);
     }
   };
 

--- a/src/shared/ui/input/MarkdownUploadTextarea.tsx
+++ b/src/shared/ui/input/MarkdownUploadTextarea.tsx
@@ -3,6 +3,7 @@ import {
   Bars3BottomLeftIcon,
   CloudArrowUpIcon,
   CodeBracketIcon,
+  EllipsisVerticalIcon,
   DocumentTextIcon,
   LinkIcon,
   ListBulletIcon,
@@ -11,6 +12,7 @@ import {
 import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/shared/ui/dropdown';
 import remarkGfm from 'remark-gfm';
 import { markdownComponents } from '@/shared/ui/markdown/markdownComponents';
 import { uploadFileViaBackend } from '@/shared/lib/uploadsApi';
@@ -255,7 +257,7 @@ export const MarkdownUploadTextarea = ({
     }
   };
   return (
-    <div className={cn('space-y-2', className)}>
+    <div className={cn('@container space-y-2', className)}>
       {showLabel ? (
         <label htmlFor={editorId} className="block text-sm font-medium text-input-text">
           {label}
@@ -264,12 +266,12 @@ export const MarkdownUploadTextarea = ({
 
       <div className="overflow-hidden rounded-2xl border border-line-glass/30 bg-surface-overlay/60 backdrop-blur-xl">
         {showTabs ? (
-          <div className="flex items-center justify-between border-b border-line-glass/30 bg-surface-overlay/70 px-2 py-2">
-            <div className="flex items-center">
+          <div className="flex items-center justify-between gap-3 border-b border-line-glass/30 bg-surface-overlay/70 px-2 py-2">
+            <div className="flex min-w-0 items-center gap-2 @xl:flex @xl:flex-none @xl:items-center @xl:gap-1">
               <button
                 type="button"
                 className={cn(
-                  'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+                  'rounded-lg px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'write'
                     ? 'text-input-text'
                     : 'text-input-placeholder hover:text-input-text'
@@ -281,7 +283,7 @@ export const MarkdownUploadTextarea = ({
               <button
                 type="button"
                 className={cn(
-                  'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+                  'rounded-lg px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'preview'
                     ? 'text-input-text'
                     : 'text-input-placeholder hover:text-input-text'
@@ -291,7 +293,85 @@ export const MarkdownUploadTextarea = ({
                 Preview
               </button>
             </div>
-            <div className="flex items-center gap-2 text-input-placeholder">
+            <div className="ml-auto flex items-center gap-2 @xl:hidden">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-line-glass/25 bg-surface-overlay/40 text-input-placeholder transition-colors hover:text-input-text"
+                    aria-label="Formatting options"
+                  >
+                    <Icon icon={EllipsisVerticalIcon} className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64 p-1.5">
+                  <DropdownMenuItem
+                    onSelect={() => prependToLine('# ', 'Heading')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-glass/20 bg-surface-overlay/50 text-xs font-semibold">H</span>
+                    <span>Heading</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => replaceSelection('**', '**', 'bold text')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-glass/20 bg-surface-overlay/50 text-xs font-semibold">B</span>
+                    <span>Bold</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => replaceSelection('*', '*', 'italic text')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-glass/20 bg-surface-overlay/50 text-xs italic font-semibold">I</span>
+                    <span>Italic</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => prependToLine('> ', 'Quoted text')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Icon icon={Bars3BottomLeftIcon} className="h-4 w-4" aria-hidden="true" />
+                    <span>Quote</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => replaceSelection('```\n', '\n```', 'code')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Icon icon={CodeBracketIcon} className="h-4 w-4" aria-hidden="true" />
+                    <span>Code</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => replaceSelection('[', '](https://)', 'link text')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Icon icon={LinkIcon} className="h-4 w-4" aria-hidden="true" />
+                    <span>Link</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => prependToLine('- ', 'List item')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Icon icon={ListBulletIcon} className="h-4 w-4" aria-hidden="true" />
+                    <span>Bulleted list</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => prependToLine('1. ', 'List item')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Icon icon={NumberedListIcon} className="h-4 w-4" aria-hidden="true" />
+                    <span>Numbered list</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => prependToLine('- [ ] ', 'Task')}
+                    className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  >
+                    <Icon icon={DocumentTextIcon} className="h-4 w-4" aria-hidden="true" />
+                    <span>Task list</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <div className="hidden items-center gap-2 text-input-placeholder @xl:flex @xl:flex-wrap">
               <div className="flex items-center gap-1">
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Insert heading" onClick={() => prependToLine('# ', 'Heading')}>
                   <span className="text-xs font-semibold leading-none">H</span>
@@ -303,28 +383,28 @@ export const MarkdownUploadTextarea = ({
                   <span className="text-xs italic leading-none">I</span>
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Quote" onClick={() => prependToLine('> ', 'Quoted text')}>
-                  <Icon icon={Bars3BottomLeftIcon} className="h-4 w-4" aria-hidden="true"  />
+                  <Icon icon={Bars3BottomLeftIcon} className="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
               <div className="h-4 w-px bg-line-glass/50" />
               <div className="flex items-center gap-1">
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Code block" onClick={() => replaceSelection('```\n', '\n```', 'code')}>
-                  <Icon icon={CodeBracketIcon} className="h-4 w-4" aria-hidden="true"  />
+                  <Icon icon={CodeBracketIcon} className="h-4 w-4" aria-hidden="true" />
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Insert link" onClick={() => replaceSelection('[', '](https://)', 'link text')}>
-                  <Icon icon={LinkIcon} className="h-4 w-4" aria-hidden="true"  />
+                  <Icon icon={LinkIcon} className="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
               <div className="h-4 w-px bg-line-glass/50" />
               <div className="flex items-center gap-1">
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Bulleted list" onClick={() => prependToLine('- ', 'List item')}>
-                  <Icon icon={ListBulletIcon} className="h-4 w-4" aria-hidden="true"  />
+                  <Icon icon={ListBulletIcon} className="h-4 w-4" aria-hidden="true" />
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Numbered list" onClick={() => prependToLine('1. ', 'List item')}>
-                  <Icon icon={NumberedListIcon} className="h-4 w-4" aria-hidden="true"  />
+                  <Icon icon={NumberedListIcon} className="h-4 w-4" aria-hidden="true" />
                 </button>
                 <button type="button" className="rounded p-1 hover:text-input-text" aria-label="Task list" onClick={() => prependToLine('- [ ] ', 'Task')}>
-                  <Icon icon={DocumentTextIcon} className="h-4 w-4" aria-hidden="true"  />
+                  <Icon icon={DocumentTextIcon} className="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
             </div>
@@ -415,7 +495,7 @@ export const MarkdownUploadTextarea = ({
         )}
 
         {showFooter ? (
-          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-line-glass/30 px-4 py-2 text-sm">
+          <div className="flex flex-col gap-2 border-t border-line-glass/30 px-4 py-2 text-sm @xl:flex-row @xl:items-center @xl:justify-between">
             <div className="flex items-center gap-2 text-input-placeholder">
               {uploadsEnabled ? (
                 <>
@@ -429,11 +509,11 @@ export const MarkdownUploadTextarea = ({
                     Paste, drop, or click to add files
                   </button>
                 </>
-              ) : (
-                <span>File uploads unlock after the matter exists</span>
-              )}
+                ) : (
+                  <span>File uploads unlock after the matter exists</span>
+                )}
             </div>
-            <div className="text-input-placeholder">{value.length}/{maxLength}</div>
+            <div className="text-input-placeholder @xl:text-right">{value.length}/{maxLength}</div>
           </div>
         ) : null}
       </div>

--- a/src/shared/ui/layout/WorkspaceMainPane.tsx
+++ b/src/shared/ui/layout/WorkspaceMainPane.tsx
@@ -13,6 +13,7 @@ type WorkspaceView =
   | 'clients'
   | 'invoices'
   | 'invoiceCreate'
+  | 'invoiceEdit'
   | 'invoiceDetail'
   | 'reports'
   | 'settings';

--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -38,7 +38,6 @@ interface DataTableProps {
   stickyHeader?: boolean;
   loading?: boolean;
   loadingLabel?: string;
-  renderMobileRow?: (row: DataTableRow) => ComponentChildren;
   density?: 'regular' | 'compact';
 }
 
@@ -97,7 +96,6 @@ export const DataTable = ({
   stickyHeader = false,
   loading = false,
   loadingLabel,
-  renderMobileRow,
   density = 'regular',
 }: DataTableProps) => {
   const primaryColumn = columns.find((column) => column.isPrimary) ?? columns[0];
@@ -131,7 +129,7 @@ export const DataTable = ({
             <dt className="sr-only">{mobileColumn.label}</dt>
             <dd
               className={cn(
-                'mt-1 truncate text-gray-700 dark:text-gray-300',
+                'mt-1 truncate text-input-text',
                 mobileColumn.mobileClassName
               )}
             >
@@ -145,7 +143,7 @@ export const DataTable = ({
 
   const renderDesktopTable = (tableWrapperClassName: string) => (
     <div className={tableWrapperClassName}>
-      <table className={cn('min-w-full divide-y divide-gray-300 dark:divide-white/15', tableClassName)}>
+      <table className={cn('min-w-full', tableClassName)}>
         {caption ? <caption className="sr-only">{caption}</caption> : null}
         <thead>
           <tr className={cn(stickyHeader && 'sticky top-0 z-10 bg-surface-base')}>
@@ -178,10 +176,10 @@ export const DataTable = ({
             })}
           </tr>
         </thead>
-        <tbody className={cn('divide-y divide-line-default bg-surface-base', bodyClassName)}>
+        <tbody className={cn('bg-surface-base', bodyClassName)}>
           {rows.length === 0 ? (
             <tr>
-              <td colSpan={columns.length} className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400">
+              <td colSpan={columns.length} className="px-4 py-6 text-sm text-input-placeholder">
                 {emptyState ?? 'No results'}
               </td>
             </tr>
@@ -207,7 +205,7 @@ export const DataTable = ({
                         density === 'compact' ? 'py-2.5 pr-3 pl-4' : 'py-3 pr-3 pl-4'
                       )
                       : cn(
-                        'text-sm text-gray-500 dark:text-gray-400',
+                        'text-sm text-input-placeholder',
                         density === 'compact' ? 'px-3 py-2.5' : 'px-3 py-3'
                       );
                     const cellContent = row.isPlaceholder ? '\u00A0' : (row.cells[column.id] ?? '—');
@@ -258,19 +256,6 @@ export const DataTable = ({
         </div>
       ) : errorState ? (
         <div>{errorState}</div>
-      ) : renderMobileRow ? (
-        <>
-          <div className="grid gap-3 sm:hidden">
-            {rows.length === 0 ? (
-              <div className="glass-panel p-4 text-sm text-input-placeholder">
-                {emptyState ?? 'No results'}
-              </div>
-            ) : (
-              rows.map((row) => <div key={`${row.id}-mobile`}>{renderMobileRow(row)}</div>)
-            )}
-          </div>
-          {renderDesktopTable('hidden overflow-x-auto sm:block')}
-        </>
       ) : (
         renderDesktopTable('overflow-x-auto')
       )}

--- a/src/shared/utils/workspaceShell.ts
+++ b/src/shared/utils/workspaceShell.ts
@@ -9,6 +9,7 @@ type WorkspaceView =
   | 'clients'
   | 'invoices'
   | 'invoiceCreate'
+  | 'invoiceEdit'
   | 'invoiceDetail'
   | 'reports'
   | 'settings';
@@ -40,7 +41,7 @@ const normalizeDecodedSegment = (value: string) => {
 
 export const getWorkspaceSection = (view: WorkspaceView): WorkspaceSection => {
   if (view === 'list' || view === 'conversation') return 'conversations';
-  if (view === 'invoiceCreate' || view === 'invoiceDetail') return 'invoices';
+  if (view === 'invoiceCreate' || view === 'invoiceEdit' || view === 'invoiceDetail') return 'invoices';
   if (view === 'setup' || view === 'clients') return 'home';
   return view;
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -410,7 +410,7 @@ export default defineConfig(({ mode }: ConfigEnv) => {
 					'**/.tmp/**',
 					'**/test-results/**',
 					'**/playwright-report/**',
-					'**/.playwright-artifacts-**',
+					'**/.playwright-artifacts-*/**',
 					'**/trace.zip',
 					'**/*.trace',
 					'**/*.network',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,21 +15,6 @@ interface CompressionOptions {
 	threshold?: number;
 }
 
-const VITE_WATCH_IGNORED_SEGMENTS = [
-	'/.tmp/',
-	'/test-results/',
-	'/playwright-report/',
-	'/.playwright-artifacts-',
-	'/trace.zip',
-	'.trace',
-	'.network',
-];
-
-const shouldIgnoreViteWatchPath = (path: string): boolean => {
-	const normalizedPath = path.replace(/\\/g, '/');
-	return VITE_WATCH_IGNORED_SEGMENTS.some((segment) => normalizedPath.includes(segment));
-};
-
 const customCompressionPlugin = (options: CompressionOptions = {}): Plugin => {
 	const {
 		algorithm = 'gzip',
@@ -421,12 +406,15 @@ export default defineConfig(({ mode }: ConfigEnv) => {
 			strictPort: true, // Fail if port is busy (tunnel expects this exact port)
 			allowedHosts: ['local.blawby.com'], // Allow the public tunnel domain
 			watch: {
-				ignored: (path, stats) => {
-					if (stats?.isFile() || stats?.isDirectory()) {
-						return shouldIgnoreViteWatchPath(path);
-					}
-					return shouldIgnoreViteWatchPath(path);
-				},
+				ignored: [
+					'**/.tmp/**',
+					'**/test-results/**',
+					'**/playwright-report/**',
+					'**/.playwright-artifacts-**',
+					'**/trace.zip',
+					'**/*.trace',
+					'**/*.network',
+				],
 			},
 			hmr: {
 				protocol: 'wss',

--- a/worker/routes/aiChat.ts
+++ b/worker/routes/aiChat.ts
@@ -1089,7 +1089,10 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
 
       const aigStep = aiResponse.headers.get('cf-aig-step');
       
-      const shouldStreamTokensToUser = !isOnboardingMode;
+      // In intake mode we buffer the full model reply, sanitize it, and only
+      // then emit user-visible content. This prevents prompt-instruction leaks
+      // from being exposed token-by-token in the SSE stream.
+      const shouldStreamTokensToUser = !isOnboardingMode && !isIntakeMode;
       
       const streamResult = await consumeAiStream(aiResponse, shouldStreamTokensToUser, streamWrite, body.conversationId);
       const conversationTotalResponseMs = Date.now() - conversationRequestStartedAt;
@@ -1124,7 +1127,7 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
       for (const toolCall of streamResult.toolCalls) {
         if (toolCall.name === 'update_practice_fields' && toolCall.arguments.length > 0) {
           try {
-            const rawParams = JSON.parse(toolCall.arguments);
+            const rawParams = JSON.parse(unwrapToolCallJsonArgs(toolCall.arguments));
             onboardingFields = normalizeKeys(rawParams) as Record<string, unknown>;
           } catch (error) {
             Logger.warn('Failed to parse streamed onboarding tool arguments', {

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -170,15 +170,9 @@ const readFiniteNumberField = (record: Record<string, unknown> | null | undefine
 const getResolvedAmountMinor = ({
   intakeSettings,
   fallbackConsultationFeeMinor,
-  conversationId,
-  practiceId,
-  slug,
 }: {
   intakeSettings: IntakeSettings | null;
   fallbackConsultationFeeMinor: number | null;
-  conversationId: string;
-  practiceId: string;
-  slug: string;
 }): number => {
   const prefillAmount = typeof intakeSettings?.prefillAmount === 'number' && Number.isFinite(intakeSettings.prefillAmount)
     ? intakeSettings.prefillAmount
@@ -189,26 +183,6 @@ const getResolvedAmountMinor = ({
 
   if (typeof fallbackConsultationFeeMinor === 'number' && fallbackConsultationFeeMinor > 0) {
     return fallbackConsultationFeeMinor;
-  }
-
-  if (intakeSettings?.paymentLinkEnabled === true) {
-    Logger.warn('[submitIntake] Payment link enabled but no non-zero amount was configured; using safe fallback amount=50', {
-      conversationId,
-      practiceId,
-      slug,
-      prefillAmount,
-      fallbackConsultationFeeMinor,
-    });
-    return 50;
-  }
-
-  if (intakeSettings === null) {
-    Logger.warn('[submitIntake] intakeSettings unavailable (fetch failed); using safe fallback amount=50', {
-      conversationId,
-      practiceId,
-      slug,
-    });
-    return 50;
   }
 
   return 0;
@@ -456,24 +430,8 @@ export async function handleSubmitIntake(
     });
   }
 
-  const intakeSettings = await RemoteApiService.getPracticeClientIntakeSettings(env, slug, request).catch((error) => {
-    Logger.warn('[submitIntake] Failed to load intake settings; using fallback amount', {
-      conversationId,
-      practiceId,
-      slug,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  });
-  const practiceDetails = await fetchPracticeDetailsWithCache(env, request, practiceId, slug).catch((error) => {
-    Logger.warn('[submitIntake] Failed to load practice details for consultation fee fallback', {
-      conversationId,
-      practiceId,
-      slug,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return { details: null, isPublic: false };
-  });
+  const intakeSettings = await RemoteApiService.getPracticeClientIntakeSettings(env, slug, request);
+  const practiceDetails = await fetchPracticeDetailsWithCache(env, request, practiceId, slug);
   const fallbackConsultationFeeMinor = readFiniteNumberField(practiceDetails.details, [
     'paymentLinkPrefillAmount',
     'payment_link_prefill_amount',
@@ -484,21 +442,7 @@ export async function handleSubmitIntake(
   let resolvedAmountMinor = getResolvedAmountMinor({
     intakeSettings,
     fallbackConsultationFeeMinor,
-    conversationId,
-    practiceId,
-    slug,
   });
-  if (settingsPaymentLinkEnabled && resolvedAmountMinor === 0) {
-    Logger.warn('[submitIntake] Payment link enabled but no amount was configured; using safe fallback amount=50', {
-      conversationId,
-      practiceId,
-      slug,
-      intakeSettings,
-      fallbackConsultationFeeMinor,
-      resolvedAmountMinor,
-    });
-    resolvedAmountMinor = 50;
-  }
   const paymentRequiredBeforeSubmit = settingsPaymentLinkEnabled || resolvedAmountMinor > 0;
   const paymentReceived = consultation?.submission?.paymentReceived === true;
   const generatePaymentLinkOnly = new URL(request.url).searchParams.get('generatePaymentLinkOnly') === 'true';
@@ -578,7 +522,7 @@ export async function handleSubmitIntake(
     });
     throw error;
   }
-  const backendPayload = await backendResponse.json().catch(() => null) as BackendIntakeCreateResponse | null;
+  const backendPayload = await backendResponse.json() as BackendIntakeCreateResponse;
 
   if (!backendPayload?.success || !backendPayload.data?.uuid) {
     const errorDetails = backendPayload?.error ?? 'No uuid returned';
@@ -587,9 +531,7 @@ export async function handleSubmitIntake(
       practiceId,
       error: errorDetails,
     });
-    throw HttpErrors.internalServerError(
-      'Failed to create intake — please try again'
-    );
+    throw HttpErrors.internalServerError(`Backend intake creation failed: ${errorDetails}`);
   }
 
   const { uuid: intakeUuid, status, payment_link_url } = backendPayload.data;

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -56,6 +56,8 @@ interface ConversationUserInfo {
   [key: string]: unknown;
 }
 
+type IntakeSettings = NonNullable<Awaited<ReturnType<typeof RemoteApiService.getPracticeClientIntakeSettings>>>;
+
 interface BackendIntakeCreatePayload {
   slug: string;
   amount: number;
@@ -163,6 +165,53 @@ const readFiniteNumberField = (record: Record<string, unknown> | null | undefine
     }
   }
   return null;
+};
+
+const getResolvedAmountMinor = ({
+  intakeSettings,
+  fallbackConsultationFeeMinor,
+  conversationId,
+  practiceId,
+  slug,
+}: {
+  intakeSettings: IntakeSettings | null;
+  fallbackConsultationFeeMinor: number | null;
+  conversationId: string;
+  practiceId: string;
+  slug: string;
+}): number => {
+  const prefillAmount = typeof intakeSettings?.prefillAmount === 'number' && Number.isFinite(intakeSettings.prefillAmount)
+    ? intakeSettings.prefillAmount
+    : null;
+  if (prefillAmount !== null && prefillAmount > 0) {
+    return prefillAmount;
+  }
+
+  if (typeof fallbackConsultationFeeMinor === 'number' && fallbackConsultationFeeMinor > 0) {
+    return fallbackConsultationFeeMinor;
+  }
+
+  if (intakeSettings?.paymentLinkEnabled === true) {
+    Logger.warn('[submitIntake] Payment link enabled but no non-zero amount was configured; using safe fallback amount=50', {
+      conversationId,
+      practiceId,
+      slug,
+      prefillAmount,
+      fallbackConsultationFeeMinor,
+    });
+    return 50;
+  }
+
+  if (intakeSettings === null) {
+    Logger.warn('[submitIntake] intakeSettings unavailable (fetch failed); using safe fallback amount=50', {
+      conversationId,
+      practiceId,
+      slug,
+    });
+    return 50;
+  }
+
+  return 0;
 };
 
 const isCaseInfoComplete = (state: IntakeConversationState | null | undefined, draft?: SlimContactDraft | null): boolean => {
@@ -432,21 +481,24 @@ export async function handleSubmitIntake(
     'consultation_fee',
   ]);
   const settingsPaymentLinkEnabled = intakeSettings?.paymentLinkEnabled === true;
-  const resolvedAmountMinor = typeof intakeSettings?.prefillAmount === 'number' && intakeSettings.prefillAmount > 0
-    ? intakeSettings.prefillAmount
-    : typeof fallbackConsultationFeeMinor === 'number' && fallbackConsultationFeeMinor > 0
-      ? fallbackConsultationFeeMinor
-      : (() => {
-          if (intakeSettings === null) {
-            Logger.warn('[submitIntake] intakeSettings unavailable (fetch failed); using safe fallback amount=50', {
-              conversationId,
-              practiceId,
-              slug,
-            });
-            return 50;
-          }
-          return 0;
-        })();
+  let resolvedAmountMinor = getResolvedAmountMinor({
+    intakeSettings,
+    fallbackConsultationFeeMinor,
+    conversationId,
+    practiceId,
+    slug,
+  });
+  if (settingsPaymentLinkEnabled && resolvedAmountMinor === 0) {
+    Logger.warn('[submitIntake] Payment link enabled but no amount was configured; using safe fallback amount=50', {
+      conversationId,
+      practiceId,
+      slug,
+      intakeSettings,
+      fallbackConsultationFeeMinor,
+      resolvedAmountMinor,
+    });
+    resolvedAmountMinor = 50;
+  }
   const paymentRequiredBeforeSubmit = settingsPaymentLinkEnabled || resolvedAmountMinor > 0;
   const paymentReceived = consultation?.submission?.paymentReceived === true;
   const generatePaymentLinkOnly = new URL(request.url).searchParams.get('generatePaymentLinkOnly') === 'true';

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -18,6 +18,7 @@ import { withPracticeContext, getPracticeId } from '../middleware/practiceContex
 import { Logger } from '../utils/logger.js';
 import type { Env } from '../types.js';
 import { isIntakeReadyForSubmission, resolveConsultationState } from '../../src/shared/utils/consultationState';
+import { fetchPracticeDetailsWithCache } from '../utils/practiceDetailsCache.js';
 
 // ------------------------------------------------------------------
 // Types
@@ -148,6 +149,17 @@ const readStringField = (record: Record<string, unknown> | null | undefined, key
     const value = record[key];
     if (typeof value === 'string' && value.trim().length > 0) {
       return value.trim();
+    }
+  }
+  return null;
+};
+
+const readFiniteNumberField = (record: Record<string, unknown> | null | undefined, keys: string[]): number | null => {
+  if (!record) return null;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
     }
   }
   return null;
@@ -404,7 +416,38 @@ export async function handleSubmitIntake(
     });
     return null;
   });
-  const paymentRequiredBeforeSubmit = Boolean((intakeSettings?.prefillAmount ?? 0) > 0);
+  const practiceDetails = await fetchPracticeDetailsWithCache(env, request, practiceId, slug).catch((error) => {
+    Logger.warn('[submitIntake] Failed to load practice details for consultation fee fallback', {
+      conversationId,
+      practiceId,
+      slug,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { details: null, isPublic: false };
+  });
+  const fallbackConsultationFeeMinor = readFiniteNumberField(practiceDetails.details, [
+    'paymentLinkPrefillAmount',
+    'payment_link_prefill_amount',
+    'consultationFee',
+    'consultation_fee',
+  ]);
+  const settingsPaymentLinkEnabled = intakeSettings?.paymentLinkEnabled === true;
+  const resolvedAmountMinor = typeof intakeSettings?.prefillAmount === 'number' && intakeSettings.prefillAmount > 0
+    ? intakeSettings.prefillAmount
+    : typeof fallbackConsultationFeeMinor === 'number' && fallbackConsultationFeeMinor > 0
+      ? fallbackConsultationFeeMinor
+      : (() => {
+          if (intakeSettings === null) {
+            Logger.warn('[submitIntake] intakeSettings unavailable (fetch failed); using safe fallback amount=50', {
+              conversationId,
+              practiceId,
+              slug,
+            });
+            return 50;
+          }
+          return 0;
+        })();
+  const paymentRequiredBeforeSubmit = settingsPaymentLinkEnabled || resolvedAmountMinor > 0;
   const paymentReceived = consultation?.submission?.paymentReceived === true;
   const generatePaymentLinkOnly = new URL(request.url).searchParams.get('generatePaymentLinkOnly') === 'true';
   const caseInfoComplete = isCaseInfoComplete(intake, draft);
@@ -437,25 +480,10 @@ export async function handleSubmitIntake(
     );
   }
 
-  // Build backend payload.
-  // When intakeSettings is null (fetch failed) and payment IS required, sending
-  // amount: 0 causes the backend to reject the submission. Use 50 minor units
-  // (i.e. $0.50) as a safe non-zero floor so the record is created; the actual
-  // charge will be determined by the Stripe payment-link amount, not this field.
-  const resolvedAmountMinor = typeof intakeSettings?.prefillAmount === 'number'
-    ? intakeSettings.prefillAmount
-    : (() => {
-        // Only use fallback when intakeSettings fetch failed (null), not when it's available but payment isn't required
-        if (intakeSettings === null) {
-          Logger.warn('[submitIntake] intakeSettings unavailable (fetch failed); using safe fallback amount=50', {
-            conversationId,
-            practiceId,
-            slug,
-          });
-          return 50;
-        }
-        return undefined;
-      })();
+  // Build backend payload. Prefer intake-settings prefillAmount, but if the
+  // settings endpoint reports payment enabled with amount=0, fall back to the
+  // consultation fee stored in practice details so we do not send an invalid
+  // zero-dollar payload to createIntake.
   const intakePayload = buildIntakePayload(conversationId, slug, draft, intake, {
     amountMinor: resolvedAmountMinor,
     userId,


### PR DESCRIPTION
## What changed
- Tightened the matter detail hero so it matches the client detail treatment more closely and behaves better when the inspector narrows the workspace.
- Simplified the matter summary cards into one responsive layout so the content no longer duplicates on mobile and the desktop view stays flat.
- Made the markdown composer toolbar mobile-friendly with a compact overflow menu.
- Softened the shared hero gradients so the client and matter panels no longer show a bright white band across the middle.
- Reworked a few worker routes for intake and AI chat handling, plus a small Vite watch typing fix.

## Why
- The matter detail page was not collapsing cleanly when the inspector was open.
- The previous mobile summary card and composer treatments were too busy and duplicated content.
- The hero streak was coming from the shared gradient stack, not just the overlay.

## Validation
- `npm run type-check`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added invoice editing workflow and builder surface; invoice preview now accepts notes.

* **Bug Fixes**
  - Dropdowns now close after selection.
  - Intake payment resolution improved with safer fallbacks.
  - Token-by-token streaming disabled during intake mode.

* **Style**
  - Refined responsive layouts, spacing, header gradient and inspector surface color.
  - Mobile/table detail styling updated and many inline spinners replaced with a shared loading component.

* **Chores**
  - Updated dev-server file-watching and linting config.

* **Tests**
  - Invoice tests updated to exercise the new edit-route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->