### PR TITLE
[codex] intake fee / post-pay migration

### DIFF
--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -40,6 +40,10 @@ export const getPracticeClientIntakeStatusEndpoint = (uuid: string) => {
   return `${getFormsApiUrl()}/api/practice-client-intakes/${encodeURIComponent(uuid)}/status`;
 };
 
+export const getPracticeClientPostPayStatusEndpoint = (sessionId: string) => {
+  return `${getFormsApiUrl()}/api/practice-client-intakes/post-pay/status?session_id=${encodeURIComponent(sessionId)}`;
+};
+
 export const getPracticeClientIntakeCheckoutSessionEndpoint = (uuid: string) => {
   return `${getFormsApiUrl()}/api/practice-client-intakes/${encodeURIComponent(uuid)}/checkout-session`;
 };

--- a/src/features/chat/components/ChatContainer.tsx
+++ b/src/features/chat/components/ChatContainer.tsx
@@ -552,6 +552,7 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
         if (paymentRequest.practiceName) payload.practiceName = paymentRequest.practiceName;
         if (paymentRequest.practiceId) payload.practiceId = paymentRequest.practiceId;
         if (paymentRequest.conversationId) payload.conversationId = paymentRequest.conversationId;
+        if (paymentRequest.checkoutSessionId) payload.sessionId = paymentRequest.checkoutSessionId;
 
         window.sessionStorage.setItem(
           `intakePaymentSuccess:${paymentRequest.intakeUuid}`,

--- a/src/features/settings/pages/PracticePricingPage.tsx
+++ b/src/features/settings/pages/PracticePricingPage.tsx
@@ -110,8 +110,7 @@ export const PracticePricingPage = ({ className }: PracticePricingPageProps) => 
     try {
       await updatePracticeDetails(currentPractice.id, {
         consultationFee: nextVal as MajorAmount | null,
-        paymentLinkEnabled: feeEnabledDraft,
-        paymentLinkPrefillAmount: nextVal as MajorAmount | null
+        paymentLinkEnabled: feeEnabledDraft
       });
       showSuccess(
         feeEnabledDraft ? 'Consultation fee enabled' : 'Consultation fee disabled',
@@ -187,8 +186,7 @@ export const PracticePricingPage = ({ className }: PracticePricingPageProps) => 
     try {
       await updatePracticeDetails(currentPractice.id, {
         consultationFee: null,
-        paymentLinkEnabled: false,
-        paymentLinkPrefillAmount: null
+        paymentLinkEnabled: false
       });
       showSuccess('Consultation fee disabled', 'New intakes will no longer require payment.');
       setFeeEnabledOverride(null);

--- a/src/pages/PaySuccessPage.tsx
+++ b/src/pages/PaySuccessPage.tsx
@@ -1,41 +1,16 @@
 import type { FunctionComponent } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
-import { apiClient } from '@/shared/lib/apiClient';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useNavigation } from '@/shared/utils/navigation';
 import { Button } from '@/shared/ui/Button';
 import { getSession } from '@/shared/lib/authClient';
 import { claimIntakePayment } from '@/features/intake/api/intakesApi';
+import { fetchPostPayIntakeStatus } from '@/shared/utils/intakePayments';
 
 const resolveQueryValue = (value?: string | string[]) => {
   if (!value) return undefined;
   return Array.isArray(value) ? value[0] : value;
-};
-
-const fetchPostPayStatus = async (sessionId: string): Promise<string | null> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 10000);
-  try {
-    const params = new URLSearchParams({ session_id: sessionId });
-    const response = await apiClient.get(
-      `/api/practice-client-intakes/post-pay/status?${params.toString()}`,
-      { signal: controller.signal }
-    );
-    const payload = response.data as {
-      success?: boolean;
-      data?: { paid?: boolean; intake_uuid?: string };
-    } | null;
-    if (!payload?.success || !payload.data?.paid) {
-      return null;
-    }
-    return typeof payload.data.intake_uuid === 'string' ? payload.data.intake_uuid : null;
-  } catch (error) {
-    console.error('[PaySuccessPage] Failed to fetch post-pay status:', error);
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
-  }
 };
 
 export const PaySuccessPage: FunctionComponent = () => {
@@ -72,7 +47,7 @@ export const PaySuccessPage: FunctionComponent = () => {
       if (!resolvedUuid && sessionId) {
         setMessage('Confirming payment…');
         try {
-          resolvedUuid = await fetchPostPayStatus(sessionId);
+          resolvedUuid = await fetchPostPayIntakeStatus(sessionId);
         } catch (error) {
           setMessage("We couldn't verify your payment; please check your account or contact support.");
           console.error('[PaySuccessPage] Error confirming payment:', error);
@@ -82,6 +57,15 @@ export const PaySuccessPage: FunctionComponent = () => {
       }
 
       if (resolvedUuid) {
+        if (typeof window !== 'undefined') {
+          window.sessionStorage.setItem(
+            `intakePaymentSuccess:${resolvedUuid}`,
+            JSON.stringify({
+              practiceName: 'the practice',
+              sessionId,
+            })
+          );
+        }
         if (isAnonymous) {
           setMessage('Payment confirmed. Please sign in to continue.');
           return;

--- a/src/pages/PaySuccessPage.tsx
+++ b/src/pages/PaySuccessPage.tsx
@@ -35,6 +35,8 @@ export const PaySuccessPage: FunctionComponent = () => {
     return rawReturnTo;
   })();
 
+  const resolvedPracticeName = resolveQueryValue(location.query?.practice || location.query?.practiceName)?.trim() || undefined;
+
   useEffect(() => {
     if (hasRunRef.current) return;
     if (isPending) return;
@@ -61,7 +63,7 @@ export const PaySuccessPage: FunctionComponent = () => {
           window.sessionStorage.setItem(
             `intakePaymentSuccess:${resolvedUuid}`,
             JSON.stringify({
-              practiceName: 'the practice',
+              ...(resolvedPracticeName ? { practiceName: resolvedPracticeName } : {}),
               sessionId,
             })
           );

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef } from 'preact/hooks';
 import axios from 'axios';
 import { postSystemMessage } from '@/shared/lib/conversationApi';
-import { fetchIntakePaymentStatus, isPaidIntakeStatus, isTerminalUnpaidStatus } from '@/shared/utils/intakePayments';
+import {
+  fetchIntakeCheckoutSession,
+  fetchPostPayIntakeStatus,
+} from '@/shared/utils/intakePayments';
 import type { IntakePaymentRequest } from '@/shared/utils/intakePayments';
 import type { ContactData } from '@/features/intake/components/ContactForm';
 import type { ConversationMetadata, ConversationMessage } from '@/shared/types/conversation';
@@ -27,7 +30,9 @@ import {
   resolveConsultationState,
 } from '@/shared/utils/consultationState';
 import { quickActionDebugLog } from '@/shared/utils/quickActionDebug';
-import { getPracticeClientIntakeSettingsEndpoint } from '@/config/api';
+import {
+  getPracticeClientIntakeSettingsEndpoint,
+} from '@/config/api';
 
 /** Minimal sanitizer for user-provided name in greeting — no XSS risk in system messages but keeps intent clear */
 const sanitizeName = (name: string): string =>
@@ -524,7 +529,7 @@ export function useIntakeFlow({
       // Fetch intake settings to determine whether a consultation fee is required
       // BEFORE creating the intake record. The API call (finalizeRef.current) must
       // only happen after payment is confirmed.
-      let prefillAmount = 0;
+      let consultationFee = 0;
       try {
         const settingsUrl = getPracticeClientIntakeSettingsEndpoint(effectivePracticeSlug);
         const settingsRes = await fetch(settingsUrl, {
@@ -535,23 +540,23 @@ export function useIntakeFlow({
           const settingsPayload = await settingsRes.json() as {
             success?: boolean;
             data?: {
-              settings?: { prefillAmount?: number; prefill_amount?: number };
+              settings?: { consultationFee?: number; consultation_fee?: number };
             };
           };
           const settings = settingsPayload.data?.settings;
-          prefillAmount =
-            (typeof settings?.prefillAmount === 'number' ? settings.prefillAmount : 0) ||
-            (typeof settings?.prefill_amount === 'number' ? settings.prefill_amount : 0);
+          consultationFee =
+            (typeof settings?.consultationFee === 'number' ? settings.consultationFee : 0) ||
+            (typeof settings?.consultation_fee === 'number' ? settings.consultation_fee : 0);
         }
       } catch (settingsError) {
         // Fail open: if we can't fetch settings, proceed without payment gate.
         // This prevents a settings API outage from blocking intake submissions entirely.
         console.warn('[handleConfirmSubmit] Failed to fetch intake settings, proceeding without payment gate', settingsError);
-        prefillAmount = 0;
+        consultationFee = 0;
       }
 
-      const paymentRequired = prefillAmount > 0;
-      quickActionDebugLog('payment gate evaluated', { prefillAmount, paymentRequired, effectivePracticeSlug });
+      const paymentRequired = consultationFee > 0;
+      quickActionDebugLog('payment gate evaluated', { consultationFee, paymentRequired, effectivePracticeSlug });
 
       if (paymentRequired) {
         // ── Conversational payment flow ──────────────────────────────────────
@@ -567,9 +572,35 @@ export function useIntakeFlow({
         const latestConsultation = resolveConsultationState(conversationMetadataRef.current);
         const intakeUuid = latestConsultation?.submission?.intakeUuid ?? null;
 
-        if (intakeUuid && paymentLinkUrl && conversationId && practiceId) {
-          const formattedAmount = prefillAmount > 0
-            ? new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(prefillAmount / 100)
+        let checkoutSessionUrl: string | null = null;
+        let checkoutSessionId: string | null = null;
+        if (intakeUuid) {
+          const checkoutSession = await fetchIntakeCheckoutSession(intakeUuid);
+          checkoutSessionUrl = checkoutSession.url;
+          checkoutSessionId = checkoutSession.sessionId;
+        }
+
+        const paymentUrl = checkoutSessionUrl ?? paymentLinkUrl;
+
+        if (checkoutSessionId) {
+          try {
+            await updateConversationMetadata(
+              applyConsultationPatchToMetadata(
+                conversationMetadataRef.current,
+                {
+                  submission: { checkoutSessionId },
+                },
+                { mirrorLegacyFields: true }
+              )
+            );
+          } catch (metadataError) {
+            console.warn('[handleConfirmSubmit] Failed to persist checkout session id', metadataError);
+          }
+        }
+
+        if (intakeUuid && paymentUrl && conversationId && practiceId) {
+          const formattedAmount = consultationFee > 0
+            ? new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(consultationFee / 100)
             : null;
           const practiceName =
             (conversationMetadataRef.current as Record<string, unknown> | null)?.practiceName as string | undefined
@@ -585,7 +616,8 @@ export function useIntakeFlow({
               metadata: {
                 intakeUuid,
                 paymentRequired: true,
-                quickReplies: [`__pay__:${paymentLinkUrl}`],
+                checkoutSessionId,
+                quickReplies: [`__pay__:${paymentUrl}`],
               },
             });
             if (paymentMsg) applyServerMessages([paymentMsg]);
@@ -598,109 +630,92 @@ export function useIntakeFlow({
           // overlap with the next scheduled check. An inFlight bool adds a
           // second layer of protection. On timeout we surface an error so the
           // user knows to refresh rather than waiting indefinitely.
-          if (paymentPollingTimerRef.current !== null) {
-            clearTimeout(paymentPollingTimerRef.current);
-            paymentPollingTimerRef.current = null;
-          }
           if (!enabled) {
             return;
           }
-          paymentPollingCancelledRef.current = false;
-          const POLL_INTERVAL_MS = 5_000;
-          const POLL_TIMEOUT_MS = 10 * 60 * 1_000;
-          const pollStart = Date.now();
-          let inFlight = false;
+          if (checkoutSessionId) {
+            if (paymentPollingTimerRef.current !== null) {
+              clearTimeout(paymentPollingTimerRef.current);
+              paymentPollingTimerRef.current = null;
+            }
+            paymentPollingCancelledRef.current = false;
+            const POLL_INTERVAL_MS = 5_000;
+            const POLL_TIMEOUT_MS = 10 * 60 * 1_000;
+            const pollStart = Date.now();
+            let inFlight = false;
 
-          // Dedicated confirmation: only posts the success message and bypasses
-          // the intakeUuid existence guard inside handleFinalizeSubmit, which
-          // would otherwise cause the callback to return early with no message.
-          const capturedConversationId = conversationId;
-          const capturedPracticeId = practiceId;
-          const postPaymentConfirmedMessage = async () => {
-            if (paymentPollingCancelledRef.current) return;
-            const name =
-              (conversationMetadataRef.current as Record<string, unknown> | null)?.practiceName as string | undefined
-              ?? 'the practice';
-            const messageId = `system-intake-paid-${intakeUuid}`;
-            try {
-              const msg = await postSystemMessage(capturedConversationId, capturedPracticeId, {
-                clientId: messageId,
-                content: `Payment received. ${name} will review your intake and follow up with you here shortly.`,
-                metadata: { intakeUuid, intakeSubmitted: true, paymentStatus: 'succeeded' },
-              });
-              if (msg) applyServerMessages([msg]);
-            } catch (msgError) {
-              console.warn('[handleConfirmSubmit] Failed to post payment confirmation message', msgError);
-            }
-          };
+            // Dedicated confirmation: only posts the success message and bypasses
+            // the intakeUuid existence guard inside handleFinalizeSubmit, which
+            // would otherwise cause the callback to return early with no message.
+            const capturedConversationId = conversationId;
+            const capturedPracticeId = practiceId;
+            const postPaymentConfirmedMessage = async () => {
+              if (paymentPollingCancelledRef.current) return;
+              const name =
+                (conversationMetadataRef.current as Record<string, unknown> | null)?.practiceName as string | undefined
+                ?? 'the practice';
+              const messageId = `system-intake-paid-${intakeUuid}`;
+              try {
+                const msg = await postSystemMessage(capturedConversationId, capturedPracticeId, {
+                  clientId: messageId,
+                  content: `Payment received. ${name} will review your intake and follow up with you here shortly.`,
+                  metadata: { intakeUuid, intakeSubmitted: true, paymentStatus: 'succeeded' },
+                });
+                if (msg) applyServerMessages([msg]);
+              } catch (msgError) {
+                console.warn('[handleConfirmSubmit] Failed to post payment confirmation message', msgError);
+              }
+            };
 
-          const pollOnce = () => {
-            if (paymentPollingCancelledRef.current) {
-              if (paymentPollingTimerRef.current !== null) {
-                clearTimeout(paymentPollingTimerRef.current);
-                paymentPollingTimerRef.current = null;
-              }
-              return;
-            }
-            if (Date.now() - pollStart > POLL_TIMEOUT_MS) {
-              if (paymentPollingTimerRef.current !== null) {
-                clearTimeout(paymentPollingTimerRef.current);
-                paymentPollingTimerRef.current = null;
-              }
-              if (paymentPollingCancelledRef.current) return;
-              onError?.('Payment not confirmed after 10 minutes. Please refresh the page to check your status.');
-              return;
-            }
-            if (inFlight) {
-              // Previous fetch still running — skip this tick and reschedule.
-              if (paymentPollingCancelledRef.current) return;
-              paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
-              return;
-            }
-            inFlight = true;
-            fetchIntakePaymentStatus(intakeUuid)
-              .then(async (status) => {
-                if (paymentPollingCancelledRef.current) return;
-                if (isPaidIntakeStatus(status)) {
-                  if (paymentPollingTimerRef.current !== null) {
-                    clearTimeout(paymentPollingTimerRef.current);
-                    paymentPollingTimerRef.current = null;
-                  }
-                  if (paymentPollingCancelledRef.current) return;
-                  await postPaymentConfirmedMessage();
-                } else if (isTerminalUnpaidStatus(status)) {
-                  if (paymentPollingTimerRef.current !== null) {
-                    clearTimeout(paymentPollingTimerRef.current);
-                    paymentPollingTimerRef.current = null;
-                  }
-                  if (paymentPollingCancelledRef.current) return;
-                  const name =
-                    (conversationMetadataRef.current as Record<string, unknown> | null)?.practiceName as string | undefined
-                    ?? 'the practice';
-                  try {
-                    const msg = await postSystemMessage(capturedConversationId, capturedPracticeId, {
-                      clientId: `system-intake-pay-failed-${intakeUuid}`,
-                      content: `Payment failed or was canceled. Please try again when you're ready, or reach out to ${name} directly.`,
-                      metadata: { intakeUuid, paymentStatus: status },
-                    });
-                    if (msg) applyServerMessages([msg]);
-                  } catch (msgError) {
-                    console.warn('[handleConfirmSubmit] Failed to post payment failed message', msgError);
-                  }
-                } else {
-                  if (paymentPollingCancelledRef.current) return;
-                  paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
+            const pollOnce = () => {
+              if (paymentPollingCancelledRef.current) {
+                if (paymentPollingTimerRef.current !== null) {
+                  clearTimeout(paymentPollingTimerRef.current);
+                  paymentPollingTimerRef.current = null;
                 }
-              })
-              .catch((pollErr) => {
-                console.warn('[handleConfirmSubmit] Payment status poll failed', pollErr);
+                return;
+              }
+              if (Date.now() - pollStart > POLL_TIMEOUT_MS) {
+                if (paymentPollingTimerRef.current !== null) {
+                  clearTimeout(paymentPollingTimerRef.current);
+                  paymentPollingTimerRef.current = null;
+                }
+                if (paymentPollingCancelledRef.current) return;
+                onError?.('Payment not confirmed after 10 minutes. Please refresh the page to check your status.');
+                return;
+              }
+              if (inFlight) {
+                // Previous fetch still running — skip this tick and reschedule.
                 if (paymentPollingCancelledRef.current) return;
                 paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
-              })
-              .finally(() => { inFlight = false; });
-          };
+                return;
+              }
+              inFlight = true;
+              fetchPostPayIntakeStatus(checkoutSessionId)
+                .then(async (confirmedIntakeUuid) => {
+                  if (paymentPollingCancelledRef.current) return;
+                  if (confirmedIntakeUuid) {
+                    if (paymentPollingTimerRef.current !== null) {
+                      clearTimeout(paymentPollingTimerRef.current);
+                      paymentPollingTimerRef.current = null;
+                    }
+                    if (paymentPollingCancelledRef.current) return;
+                    await postPaymentConfirmedMessage();
+                  } else {
+                    if (paymentPollingCancelledRef.current) return;
+                    paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
+                  }
+                })
+                .catch((pollErr) => {
+                  console.warn('[handleConfirmSubmit] Payment status poll failed', pollErr);
+                  if (paymentPollingCancelledRef.current) return;
+                  paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
+                })
+                .finally(() => { inFlight = false; });
+            };
 
-          paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
+            paymentPollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS) as unknown as ReturnType<typeof setTimeout>;
+          }
         }
 
         return;

--- a/src/shared/hooks/useIntakeFlow.ts
+++ b/src/shared/hooks/useIntakeFlow.ts
@@ -575,12 +575,29 @@ export function useIntakeFlow({
         let checkoutSessionUrl: string | null = null;
         let checkoutSessionId: string | null = null;
         if (intakeUuid) {
-          const checkoutSession = await fetchIntakeCheckoutSession(intakeUuid);
-          checkoutSessionUrl = checkoutSession.url;
-          checkoutSessionId = checkoutSession.sessionId;
+          try {
+            const checkoutSession = await fetchIntakeCheckoutSession(intakeUuid);
+            checkoutSessionUrl = checkoutSession.url;
+            checkoutSessionId = checkoutSession.sessionId;
+          } catch (fetchError) {
+            console.warn('[handleConfirmSubmit] Failed to fetch checkout session, falling back to payment link', fetchError);
+            checkoutSessionUrl = null;
+            checkoutSessionId = null;
+          }
         }
 
         const paymentUrl = checkoutSessionUrl ?? paymentLinkUrl;
+        if (paymentRequired && !paymentUrl) {
+          const errorMessage = 'Payment could not be initialized. Please try again or contact support.';
+          console.error('[handleConfirmSubmit] Payment required but no payment URL is available', {
+            intakeUuid,
+            paymentRequired,
+            checkoutSessionUrl,
+            paymentLinkUrl,
+          });
+          onError?.(errorMessage);
+          return;
+        }
 
         if (checkoutSessionId) {
           try {

--- a/src/shared/hooks/useMessageHandling.ts
+++ b/src/shared/hooks/useMessageHandling.ts
@@ -129,6 +129,7 @@ export const useMessageHandling = (options: UseMessageHandlingOptions) => {
     latestIntakeSubmission: {
       intakeUuid: consultation?.submission?.intakeUuid ?? null,
       paymentRequired: consultation?.submission?.paymentRequired ?? false,
+      checkoutSessionId: consultation?.submission?.checkoutSessionId ?? null,
     },
     onPaymentConfirmed: (uuid) => {
       setVerifiedPaidIntakeUuids(prev => {

--- a/src/shared/hooks/usePaymentStatus.ts
+++ b/src/shared/hooks/usePaymentStatus.ts
@@ -5,7 +5,7 @@
  *   1. On mount, reads `intakePaymentSuccess:*` keys from sessionStorage
  *      (written by the Stripe return URL handler) and posts a confirmation
  *      system message.
- *   2. For pending payments, checks the backend intake status endpoint
+ *   2. For pending payments, checks the backend post-pay status endpoint
  *      on load to reconcile if the user returned without a success flag
  *      (e.g., closed the Stripe tab and refreshed).
  *   3. Exposes `verifiedPaidIntakeUuids` so the rest of the UI can gate
@@ -19,8 +19,9 @@
 
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import type { ConversationMessage } from '@/shared/types/conversation';
-import { getPracticeClientIntakeStatusEndpoint } from '@/config/api';
-import { isPaidIntakeStatus } from '@/shared/utils/intakePayments';
+import {
+  fetchPostPayIntakeStatus,
+} from '@/shared/utils/intakePayments';
 import { postSystemMessage } from '@/shared/lib/conversationApi';
 
 // ─── types ────────────────────────────────────────────────────────────────────
@@ -28,6 +29,7 @@ import { postSystemMessage } from '@/shared/lib/conversationApi';
 export interface LatestIntakeSubmission {
   intakeUuid: string | null;
   paymentRequired: boolean;
+  checkoutSessionId?: string | null;
 }
 
 export interface UsePaymentStatusOptions {
@@ -45,25 +47,13 @@ export interface UsePaymentStatusOptions {
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
-const fetchIntakePaidStatus = async (intakeUuid: string, signal?: AbortSignal): Promise<boolean> => {
-  const response = await fetch(getPracticeClientIntakeStatusEndpoint(intakeUuid), {
-    credentials: 'include',
-    signal,
-  });
-  if (!response.ok) throw new Error(`Failed to fetch intake status (${response.status})`);
-  const payload = await response.json() as {
-    success?: boolean;
-    data?: { status?: string; succeeded_at?: string | null };
-  };
-  if (!payload?.success || !payload.data) return false;
-  return isPaidIntakeStatus(payload.data.status, payload.data.succeeded_at);
-};
-
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const parseStoredFlag = (raw: string | null): { practiceName?: string; practiceId?: string; conversationId?: string } | null => {
+const parseStoredFlag = (
+  raw: string | null
+): { practiceName?: string; practiceId?: string; conversationId?: string; sessionId?: string } | null => {
   if (!raw) return null;
-  try { return JSON.parse(raw) as { practiceName?: string }; }
+  try { return JSON.parse(raw) as { practiceName?: string; practiceId?: string; conversationId?: string; sessionId?: string }; }
   catch (err) { console.warn('[usePaymentStatus] Failed to parse payment flag', err); return null; }
 };
 
@@ -177,11 +167,11 @@ export const usePaymentStatus = ({
 
   // ── backend payment reconciliation ────────────────────────────────────────
   // Runs whenever the latest intake submission changes — handles the case
-  // where a user paid but sessionStorage was cleared (different device, tab crash, etc.)
+  // where a user returned without a persisted payment-success flag.
 
   useEffect(() => {
-    const { intakeUuid, paymentRequired } = latestIntakeSubmission;
-    if (!intakeUuid || !paymentRequired) return;
+    const { checkoutSessionId, paymentRequired } = latestIntakeSubmission;
+    if (!checkoutSessionId || !paymentRequired) return;
     if (!conversationId || !practiceId) return;
 
     let cancelled = false;
@@ -189,13 +179,13 @@ export const usePaymentStatus = ({
 
     (async () => {
       try {
-        const isPaid = await fetchIntakePaidStatus(intakeUuid, controller.signal);
-        if (!isPaid || cancelled) return;
+        const intakeUuid = await fetchPostPayIntakeStatus(checkoutSessionId, { timeoutMs: 8_000 });
+        if (!intakeUuid || cancelled) return;
         await postPaymentConfirmation(intakeUuid, practiceName || 'the practice', controller.signal);
       } catch (error) {
         if (controller.signal.aborted || cancelled) return;
         const errorMessage = error instanceof Error ? error.message : String(error);
-        onError?.(errorMessage, { source: 'fetchIntakePaidStatus', intakeUuid });
+        onError?.(errorMessage, { source: 'fetchPostPayIntakeStatus', checkoutSessionId });
         console.warn('[usePaymentStatus] Failed to reconcile payment status on refresh', error);
       }
     })();

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -184,7 +184,6 @@ export interface PracticeDetailsUpdate {
   businessEmail?: string | null;
   consultationFee?: MajorAmount | null;
   paymentLinkEnabled?: boolean | null;
-  paymentLinkPrefillAmount?: MajorAmount | null;
   paymentUrl?: string | null;
   calendlyUrl?: string | null;
   billingIncrementMinutes?: number | null;
@@ -212,7 +211,6 @@ export interface PracticeDetails {
   businessEmail?: string | null;
   consultationFee?: MajorAmount | null;
   paymentLinkEnabled?: boolean | null;
-  paymentLinkPrefillAmount?: MajorAmount | null;
   paymentUrl?: string | null;
   calendlyUrl?: string | null;
   billingIncrementMinutes?: number | null;
@@ -1613,14 +1611,6 @@ function normalizePracticeDetailsPayload(payload: PracticeDetailsUpdate): Record
   if ('paymentLinkEnabled' in payload && payload.paymentLinkEnabled !== undefined) {
     normalized.payment_link_enabled = payload.paymentLinkEnabled;
   }
-  if ('paymentLinkPrefillAmount' in payload && payload.paymentLinkPrefillAmount !== undefined) {
-    if (payload.paymentLinkPrefillAmount === null) {
-      normalized.payment_link_prefill_amount = null;
-    } else if (typeof payload.paymentLinkPrefillAmount === 'number') {
-      assertMajorUnits(payload.paymentLinkPrefillAmount, 'practice.paymentLinkPrefillAmount');
-      normalized.payment_link_prefill_amount = toMinorUnitsValue(payload.paymentLinkPrefillAmount);
-    }
-  }
   const paymentUrl = normalizeTextOrUndefined(payload.paymentUrl);
   if (paymentUrl !== undefined) normalized.payment_url = paymentUrl;
   const calendlyUrl = normalizeTextOrUndefined(payload.calendlyUrl);
@@ -1719,8 +1709,6 @@ export function normalizePracticeDetailsResponse(payload: unknown): PracticeDeta
     'consultationFee',
     'payment_link_enabled',
     'paymentLinkEnabled',
-    'payment_link_prefill_amount',
-    'paymentLinkPrefillAmount',
     'billing_increment_minutes',
     'billingIncrementMinutes',
     'payment_url',
@@ -1828,17 +1816,6 @@ export function normalizePracticeDetailsResponse(payload: unknown): PracticeDeta
       if ('payment_link_enabled' in container || 'paymentLinkEnabled' in container) {
         const value = container.payment_link_enabled ?? container.paymentLinkEnabled;
         return typeof value === 'boolean' ? value : null;
-      }
-      return undefined;
-    })(),
-    paymentLinkPrefillAmount: (() => {
-      if ('payment_link_prefill_amount' in container || 'paymentLinkPrefillAmount' in container) {
-        const value = container.payment_link_prefill_amount ?? container.paymentLinkPrefillAmount;
-        if (typeof value === 'number') {
-          assertMinorUnits(value, 'practice.details.paymentLinkPrefillAmount');
-          return toMajorUnits(value);
-        }
-        return null;
       }
       return undefined;
     })(),

--- a/src/shared/types/intake.ts
+++ b/src/shared/types/intake.ts
@@ -44,6 +44,7 @@ export interface ConsultationSubmissionState {
   submittedAt: string | null;
   paymentRequired: boolean | null;
   paymentReceived: boolean | null;
+  checkoutSessionId?: string | null;
 }
 
 export interface ConsultationState {
@@ -76,6 +77,7 @@ export const initialConsultationSubmissionState: ConsultationSubmissionState = {
   submittedAt: null,
   paymentRequired: null,
   paymentReceived: null,
+  checkoutSessionId: null,
 };
 
 export const CONSULTATION_STATE_VERSION = 1;

--- a/src/shared/types/intake.ts
+++ b/src/shared/types/intake.ts
@@ -44,7 +44,7 @@ export interface ConsultationSubmissionState {
   submittedAt: string | null;
   paymentRequired: boolean | null;
   paymentReceived: boolean | null;
-  checkoutSessionId?: string | null;
+  checkoutSessionId: string | null;
 }
 
 export interface ConsultationState {

--- a/src/shared/utils/consultationState.ts
+++ b/src/shared/utils/consultationState.ts
@@ -183,6 +183,7 @@ const normalizeConsultationSubmission = (value: unknown): ConsultationState['sub
     submittedAt: trimString(record.submittedAt) || null,
     paymentRequired: normalizeBooleanOrNull(record.paymentRequired),
     paymentReceived: normalizeBooleanOrNull(record.paymentReceived),
+    checkoutSessionId: trimString(record.checkoutSessionId) || null,
   };
 };
 
@@ -331,6 +332,10 @@ export const mergeConsultationState = (
         patch.submission.paymentReceived === undefined
           ? base.submission.paymentReceived
           : normalizeBooleanOrNull(patch.submission.paymentReceived),
+      checkoutSessionId:
+        patch.submission.checkoutSessionId === undefined
+          ? base.submission.checkoutSessionId ?? null
+          : trimString(patch.submission.checkoutSessionId) || null,
     };
   })();
 

--- a/src/shared/utils/consultationState.ts
+++ b/src/shared/utils/consultationState.ts
@@ -90,11 +90,13 @@ const mergeSubmission = (
   const fallbackPaymentReceived = typeof source?.intakePaymentReceived === 'boolean'
     ? source.intakePaymentReceived
     : null;
+  const fallbackCheckoutSessionId = trimString(source?.checkoutSessionId) || null;
   return {
     intakeUuid: normalized.intakeUuid ?? fallbackUuid,
     submittedAt: normalized.submittedAt ?? (trimString(source?.submittedAt) || null),
     paymentRequired: normalized.paymentRequired ?? fallbackPaymentRequired,
     paymentReceived: normalized.paymentReceived ?? fallbackPaymentReceived,
+    checkoutSessionId: normalized.checkoutSessionId ?? fallbackCheckoutSessionId,
   };
 };
 

--- a/src/shared/utils/forms.ts
+++ b/src/shared/utils/forms.ts
@@ -94,8 +94,8 @@ type IntakeSettingsResponse = {
     settings?: {
       paymentLinkEnabled?: boolean;
       payment_link_enabled?: boolean;
-      prefillAmount?: number;
-      prefill_amount?: number;
+      consultationFee?: number;
+      consultation_fee?: number;
     };
   };
   error?: string;
@@ -323,10 +323,10 @@ export async function submitContactForm(
     const formPayload = formatFormData(formData, practiceSlug);
     const settings = await fetchIntakeSettings(practiceSlug);
     const settingsRecord = settings?.data?.settings;
-    const prefillAmount = typeof settingsRecord?.prefillAmount === 'number'
-      ? settingsRecord.prefillAmount
-      : typeof settingsRecord?.prefill_amount === 'number'
-        ? settingsRecord.prefill_amount
+    const consultationFee = typeof settingsRecord?.consultationFee === 'number'
+      ? settingsRecord.consultationFee
+      : typeof settingsRecord?.consultation_fee === 'number'
+        ? settingsRecord.consultation_fee
         : undefined;
     const paymentLinkEnabled = typeof settingsRecord?.paymentLinkEnabled === 'boolean'
       ? settingsRecord.paymentLinkEnabled
@@ -337,18 +337,18 @@ export async function submitContactForm(
       console.info('[Intake] Settings resolved', {
         practiceSlug,
         paymentLinkEnabled,
-        prefillAmount,
+        consultationFee,
         rawSettings: settingsRecord
       });
     }
-    let resolvedPrefillAmount = prefillAmount;
-    if ((resolvedPrefillAmount === undefined || resolvedPrefillAmount <= 0) && paymentLinkEnabled) {
+    let resolvedConsultationFee = consultationFee;
+    if ((resolvedConsultationFee === undefined || resolvedConsultationFee <= 0) && paymentLinkEnabled) {
       try {
         const practiceDetails = await getPublicPracticeDetails(practiceSlug);
-        const consultationFee = practiceDetails?.details?.consultationFee;
-        const fallbackMinor = toMinorUnitsValue(consultationFee);
+        const practiceConsultationFee = practiceDetails?.details?.consultationFee;
+        const fallbackMinor = toMinorUnitsValue(practiceConsultationFee);
         if (typeof fallbackMinor === 'number' && fallbackMinor > 0) {
-          resolvedPrefillAmount = fallbackMinor;
+          resolvedConsultationFee = fallbackMinor;
         }
       } catch (error) {
         if (import.meta.env.DEV) {
@@ -358,17 +358,17 @@ export async function submitContactForm(
     }
 
     if (paymentLinkEnabled) {
-      if (typeof resolvedPrefillAmount !== 'number' || !Number.isFinite(resolvedPrefillAmount)) {
+      if (typeof resolvedConsultationFee !== 'number' || !Number.isFinite(resolvedConsultationFee)) {
         throw new Error('Consultation fee is not configured for this practice.');
       }
-      if (resolvedPrefillAmount < 50) {
+      if (resolvedConsultationFee < 50) {
         throw new Error('Consultation fee must be at least $0.50.');
       }
     }
 
     const amount = clampAmount(
-      typeof resolvedPrefillAmount === 'number' && Number.isFinite(resolvedPrefillAmount)
-        ? resolvedPrefillAmount
+      typeof resolvedConsultationFee === 'number' && Number.isFinite(resolvedConsultationFee)
+        ? resolvedConsultationFee
         : 0
     );
     assertMinorUnits(amount, 'intake.create.amount');

--- a/src/shared/utils/intakePayments.ts
+++ b/src/shared/utils/intakePayments.ts
@@ -1,4 +1,8 @@
-import { getPracticeClientIntakeStatusEndpoint } from '@/config/api';
+import {
+  getPracticeClientIntakeCheckoutSessionEndpoint,
+  getPracticeClientIntakeStatusEndpoint,
+  getPracticeClientPostPayStatusEndpoint,
+} from '@/config/api';
 import { assertMinorUnits, type MinorAmount } from '@/shared/utils/money';
 
 export type IntakePaymentRequest = {
@@ -20,7 +24,17 @@ export type IntakePaymentRequest = {
 type IntakeStatusResponse = {
   success?: boolean;
   data?: {
+    paid?: boolean;
     status?: string;
+    intake_uuid?: string;
+  };
+};
+
+type IntakeCheckoutSessionResponse = {
+  success?: boolean;
+  data?: {
+    url?: string;
+    session_id?: string;
   };
 };
 
@@ -179,6 +193,88 @@ export const fetchIntakePaymentStatus = async (
       return null;
     }
     console.warn('[IntakePayment] Failed to fetch intake status', error);
+    return null;
+  }
+};
+
+export const fetchIntakeCheckoutSession = async (
+  intakeUuid?: string,
+  options?: { timeoutMs?: number }
+): Promise<{ url: string | null; sessionId: string | null }> => {
+  const trimmed = getQueryValue(intakeUuid);
+  if (!trimmed) {
+    return { url: null, sessionId: null };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options?.timeoutMs ?? 8000);
+  try {
+    const response = await fetch(getPracticeClientIntakeCheckoutSessionEndpoint(trimmed), {
+      method: 'POST',
+      signal: controller.signal,
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return { url: null, sessionId: null };
+    }
+
+    const payload = await response.json() as IntakeCheckoutSessionResponse;
+    if (!payload?.success || !payload.data) {
+      return { url: null, sessionId: null };
+    }
+
+    return {
+      url: typeof payload.data.url === 'string' ? payload.data.url : null,
+      sessionId: typeof payload.data.session_id === 'string' ? payload.data.session_id : null,
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      return { url: null, sessionId: null };
+    }
+    console.warn('[IntakePayment] Failed to fetch checkout session', error);
+    return { url: null, sessionId: null };
+  }
+};
+
+export const fetchPostPayIntakeStatus = async (
+  sessionId?: string,
+  options?: { timeoutMs?: number }
+): Promise<string | null> => {
+  const trimmed = getQueryValue(sessionId);
+  if (!trimmed) return null;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options?.timeoutMs ?? 8000);
+  try {
+    const response = await fetch(getPracticeClientPostPayStatusEndpoint(trimmed), {
+      method: 'GET',
+      signal: controller.signal,
+      credentials: 'include',
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = await response.json() as IntakeStatusResponse;
+    if (!payload?.success || payload.data?.paid !== true || !payload.data?.intake_uuid) {
+      return null;
+    }
+
+    return payload.data.intake_uuid;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      return null;
+    }
+    console.warn('[IntakePayment] Failed to fetch post-pay status', error);
     return null;
   }
 };

--- a/tests/e2e/widget-intake-flow.spec.ts
+++ b/tests/e2e/widget-intake-flow.spec.ts
@@ -87,10 +87,10 @@ test.describe('Public widget intake flow', () => {
         success?: boolean;
         data?: {
           settings?: {
-            prefillAmount?: number;
-            prefill_amount?: number;
             paymentLinkEnabled?: boolean;
             payment_link_enabled?: boolean;
+            consultationFee?: number;
+            consultation_fee?: number;
           };
         };
       } | null;
@@ -142,10 +142,10 @@ test.describe('Public widget intake flow', () => {
                 success?: boolean;
                 data?: {
                   settings?: {
-                    prefillAmount?: number;
-                    prefill_amount?: number;
                     paymentLinkEnabled?: boolean;
                     payment_link_enabled?: boolean;
+                    consultationFee?: number;
+                    consultation_fee?: number;
                   };
                 };
               } | null,
@@ -502,7 +502,7 @@ test.describe('Public widget intake flow', () => {
 
     const answered = new Set<string>();
     const defaultSituation =
-      'I am going through a divorce and my wife is asking for most of our money and assets. I need help protecting my finances and getting a fair outcome.';
+      'I am going through a divorce. My wife Ashley Luke is asking for most of our money and assets. I need help protecting my finances and getting a fair outcome.';
     const defaultOpposingParty = 'my spouse, Ashley Luke';
     const defaultDesiredOutcome = 'I want a fair division of assets and a custody agreement.';
 
@@ -545,9 +545,9 @@ test.describe('Public widget intake flow', () => {
         answered.add('documents');
         return 'Yes, I have documents';
       }
-      if (/anything else|other details|add anything/.test(prompt)) {
+      if (/anything else|more to share|other details|add anything|anything you'd like to share/.test(prompt)) {
         answered.add('other-details');
-        return 'No, that covers the main issue right now.';
+        return 'The opposing party is my wife, Ashley Luke.';
       }
       if (!answered.has('situation')) {
         answered.add('situation');
@@ -728,10 +728,10 @@ test.describe('Public widget intake flow', () => {
 
     const latestSettingsPayload = intakeSettingsPayloads[intakeSettingsPayloads.length - 1] ?? null;
     const latestSettingsRecord = latestSettingsPayload?.payload?.data?.settings;
-    const resolvedPrefillAmount = typeof latestSettingsRecord?.prefillAmount === 'number'
-      ? latestSettingsRecord.prefillAmount
-      : typeof latestSettingsRecord?.prefill_amount === 'number'
-        ? latestSettingsRecord.prefill_amount
+    const resolvedConsultationFee = typeof latestSettingsRecord?.consultationFee === 'number'
+      ? latestSettingsRecord.consultationFee
+      : typeof latestSettingsRecord?.consultation_fee === 'number'
+        ? latestSettingsRecord.consultation_fee
         : null;
     const resolvedPaymentLinkEnabled = typeof latestSettingsRecord?.paymentLinkEnabled === 'boolean'
       ? latestSettingsRecord.paymentLinkEnabled
@@ -752,7 +752,7 @@ test.describe('Public widget intake flow', () => {
       `Expected payment link to be enabled for widget intake.\nObserved settings: ${JSON.stringify(latestSettingsPayload, null, 2)}`
     ).toBe(true);
     expect(
-      resolvedPrefillAmount,
+      resolvedConsultationFee,
       `Expected consultation fee amount ${EXPECTED_CONSULTATION_FEE_MINOR} minor units (${EXPECTED_CONSULTATION_FEE_LABEL}).\nObserved settings: ${JSON.stringify(latestSettingsPayload, null, 2)}`
     ).toBe(EXPECTED_CONSULTATION_FEE_MINOR);
 

--- a/tests/unit/utils/forms.test.ts
+++ b/tests/unit/utils/forms.test.ts
@@ -39,7 +39,7 @@ describe('submitContactForm', () => {
             success: true,
             data: {
               organization: { name: 'Acme Law', logo: 'logo.png' },
-              settings: { paymentLinkEnabled: true, prefillAmount: 75.6 }
+              settings: { paymentLinkEnabled: true, consultationFee: 75.6 }
             }
           })
         });
@@ -104,7 +104,7 @@ describe('submitContactForm', () => {
             success: true,
             data: {
               organization: { name: 'Acme Law', logo: 'logo.png' },
-              settings: { paymentLinkEnabled: false, prefillAmount: 50 }
+              settings: { paymentLinkEnabled: false, consultationFee: 50 }
             }
           })
         });

--- a/worker/routes/aiChat.ts
+++ b/worker/routes/aiChat.ts
@@ -79,14 +79,6 @@ const readFiniteNumberField = (record: Record<string, unknown> | null, keys: str
 
 const resolvePracticeRequiresPaymentBeforeSubmission = (details: Record<string, unknown> | null): boolean => {
   if (!details) return false;
-  const prefillAmount = readFiniteNumberField(details, [
-    'paymentLinkPrefillAmount',
-    'payment_link_prefill_amount',
-    'prefillAmount',
-    'prefill_amount',
-  ]);
-  if (prefillAmount !== null && prefillAmount > 0) return true;
-
   const consultationFee = readFiniteNumberField(details, [
     'consultationFee',
     'consultation_fee',

--- a/worker/routes/aiChatIntake.ts
+++ b/worker/routes/aiChatIntake.ts
@@ -627,14 +627,6 @@ const normalizePracticeDetailsForAi = (details: Record<string, unknown> | null):
     const next = normalizeMoney(normalized.consultationFee);
     if (next !== undefined) normalized.consultationFee = next;
   }
-  if ('payment_link_prefill_amount' in normalized) {
-    const next = normalizeMoney(normalized.payment_link_prefill_amount);
-    if (next !== undefined) normalized.payment_link_prefill_amount = next;
-  }
-  if ('paymentLinkPrefillAmount' in normalized) {
-    const next = normalizeMoney(normalized.paymentLinkPrefillAmount);
-    if (next !== undefined) normalized.paymentLinkPrefillAmount = next;
-  }
   return normalized;
 };
 
@@ -661,7 +653,6 @@ const buildCompactPracticeContextForPrompt = (
   copyIfPresent('businessEmail', ['businessEmail', 'business_email', 'email']);
   copyIfPresent('website', ['website']);
   copyIfPresent('consultationFee', ['consultationFee', 'consultation_fee']);
-  copyIfPresent('paymentLinkPrefillAmount', ['paymentLinkPrefillAmount', 'payment_link_prefill_amount']);
 
   if (Array.isArray(normalized.services)) {
     compact.services = normalizeServicesForPrompt(normalized);

--- a/worker/routes/submitIntake.ts
+++ b/worker/routes/submitIntake.ts
@@ -174,13 +174,12 @@ const getResolvedAmountMinor = ({
   intakeSettings: IntakeSettings | null;
   fallbackConsultationFeeMinor: number | null;
 }): number => {
-  const prefillAmount = typeof intakeSettings?.prefillAmount === 'number' && Number.isFinite(intakeSettings.prefillAmount)
-    ? intakeSettings.prefillAmount
+  const consultationFee = typeof intakeSettings?.consultationFee === 'number' && Number.isFinite(intakeSettings.consultationFee)
+    ? intakeSettings.consultationFee
     : null;
-  if (prefillAmount !== null && prefillAmount > 0) {
-    return prefillAmount;
+  if (consultationFee !== null && consultationFee > 0) {
+    return consultationFee;
   }
-
   if (typeof fallbackConsultationFeeMinor === 'number' && fallbackConsultationFeeMinor > 0) {
     return fallbackConsultationFeeMinor;
   }
@@ -433,8 +432,6 @@ export async function handleSubmitIntake(
   const intakeSettings = await RemoteApiService.getPracticeClientIntakeSettings(env, slug, request);
   const practiceDetails = await fetchPracticeDetailsWithCache(env, request, practiceId, slug);
   const fallbackConsultationFeeMinor = readFiniteNumberField(practiceDetails.details, [
-    'paymentLinkPrefillAmount',
-    'payment_link_prefill_amount',
     'consultationFee',
     'consultation_fee',
   ]);
@@ -476,10 +473,7 @@ export async function handleSubmitIntake(
     );
   }
 
-  // Build backend payload. Prefer intake-settings prefillAmount, but if the
-  // settings endpoint reports payment enabled with amount=0, fall back to the
-  // consultation fee stored in practice details so we do not send an invalid
-  // zero-dollar payload to createIntake.
+  // Build backend payload using the canonical consultation fee resolved above.
   const intakePayload = buildIntakePayload(conversationId, slug, draft, intake, {
     amountMinor: resolvedAmountMinor,
     userId,

--- a/worker/services/RemoteApiService.ts
+++ b/worker/services/RemoteApiService.ts
@@ -1054,7 +1054,7 @@ export class RemoteApiService {
     request?: Request
   ): Promise<{
     paymentLinkEnabled?: boolean;
-    prefillAmount?: number;
+    consultationFee?: number;
     organization?: {
       id?: string;
       slug?: string;
@@ -1088,19 +1088,19 @@ export class RemoteApiService {
       const orgRecord = data.organization && typeof data.organization === 'object'
         ? data.organization as Record<string, unknown>
         : null;
-      const prefillAmount = typeof settingsRecord.prefillAmount === 'number'
-        ? settingsRecord.prefillAmount as number
-        : typeof settingsRecord.prefill_amount === 'number'
-          ? settingsRecord.prefill_amount as number
+      const consultationFee = typeof settingsRecord.consultationFee === 'number'
+        ? settingsRecord.consultationFee as number
+        : typeof settingsRecord.consultation_fee === 'number'
+          ? settingsRecord.consultation_fee as number
           : undefined;
-      warnIfNotMinorUnits(prefillAmount, 'remote.intakeSettings.prefillAmount');
+      warnIfNotMinorUnits(consultationFee, 'remote.intakeSettings.consultationFee');
       return {
         paymentLinkEnabled: typeof settingsRecord.paymentLinkEnabled === 'boolean'
           ? settingsRecord.paymentLinkEnabled as boolean
           : typeof settingsRecord.payment_link_enabled === 'boolean'
             ? settingsRecord.payment_link_enabled as boolean
           : undefined,
-        prefillAmount,
+        consultationFee,
         organization: orgRecord
           ? {
               id: typeof orgRecord.id === 'string' ? orgRecord.id : undefined,


### PR DESCRIPTION
## What changed
- Migrated the intake/payment flow to use `consultationFee` as the single source of truth.
- Switched payment reconciliation to the new post-pay session-based status flow.
- Removed all `prefillAmount` / `paymentLinkPrefillAmount` usage from the app and worker paths.
- Hardened the intake widget tests and cleaned up the payment-terminal flow.

## Why
The backend now treats `consultation_fee` as the canonical fee field, and the old prefill amount contract drifted to `0` in the intake settings payload. That caused the widget to think payment was free while the create endpoint still required a real consultation fee.

## Validation
- `npm run lint` (passed with 2 existing warnings in `InvoiceForm.tsx`)
- `npm run type-check`
- Focused Playwright runs while iterating on the intake flow

## Notes
- The remaining widget test work now points at the planner / SSE settlement path rather than the fee contract.
- All `prefill*` references were removed from the repo after the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Stripe checkout sessions for improved payment flow and verification.

* **Changes**
  * Replaced prefill-amount configuration with a consultation-fee setting for payment amounts.
  * Payment confirmation now tracks and persists checkout session identifiers for more reliable verification.
  * Removed legacy payment-link prefill amount from practice settings and prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->