### PR TITLE
[codex] Fix intake conversation handoff and system events

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -684,6 +684,7 @@ export function MainApp({
               conversationMetadata ?? null,
               conversationMetadata?.title ?? ''
             )}
+            viewerContext={isPracticeWorkspace ? 'practice' : isClientWorkspace ? 'client' : 'public'}
             onSendMessage={handleSendMessage}
             onAddMessage={addMessage}
             conversationMode={conversationMode}
@@ -1006,6 +1007,9 @@ export function MainApp({
                 practiceId={effectivePracticeId ?? practiceId}
                 activeTriageFilter={activeFilter}
                 basePath={practiceIntakesPath ?? '/practice/intakes'}
+                conversationsBasePath={conversationsBasePath}
+                practiceName={resolvedPracticeName}
+                practiceLogo={resolvedPracticeLogo}
               />
             </Suspense>
           )

--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -70,6 +70,9 @@ export const clientIntake = (
 export const clientIntakeStatus = (intakeId: string): string =>
 	`/api/practice-client-intakes/${encodeSegment(intakeId)}/status`;
 
+export const clientIntakeInvite = (intakeId: string): string =>
+	`/api/practice-client-intakes/${encodeSegment(intakeId)}/invite`;
+
 
 export const matterCollectionPath = (practiceId: string): string => `/api/matters/${encodeSegment(practiceId)}`;
 
@@ -255,6 +258,7 @@ export const urls = {
 	clientIntakes,
 	clientIntake,
 	clientIntakeStatus,
+	clientIntakeInvite,
 	invoices: (practiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}`,
 	invoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}`,
 	createInvoice: (practiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}`,

--- a/src/features/chat/components/ChatContainer.tsx
+++ b/src/features/chat/components/ChatContainer.tsx
@@ -21,6 +21,7 @@ import { features } from '@/config/features';
 export interface ChatContainerProps {
   messages: ChatMessageUI[];
   conversationTitle?: string | null;
+  viewerContext?: 'practice' | 'client' | 'public';
   onSendMessage: (
     message: string,
     attachments: FileAttachment[],
@@ -110,6 +111,7 @@ export interface ChatContainerProps {
 const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   messages,
   conversationTitle,
+  viewerContext,
   onSendMessage,
   onAddMessage: _onAddMessage,
   conversationMode,
@@ -449,6 +451,7 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
                 <VirtualMessageList
                   messages={messagesReady ? filteredMessages : []}
                   conversationTitle={conversationTitle}
+                  viewerContext={viewerContext}
                   practiceConfig={practiceConfig}
                   isPublicWorkspace={isPublicWorkspace}
                   onOpenSidebar={onOpenSidebar}

--- a/src/features/chat/components/ConversationEventRow.tsx
+++ b/src/features/chat/components/ConversationEventRow.tsx
@@ -1,0 +1,23 @@
+import { FunctionComponent } from 'preact';
+
+type ConversationEventRowProps = {
+  content: string;
+  className?: string;
+};
+
+const ConversationEventRow: FunctionComponent<ConversationEventRowProps> = ({
+  content,
+  className = '',
+}) => (
+  <div className={`px-4 py-3 ${className}`.trim()}>
+    <div className="flex items-center gap-3 text-input-placeholder">
+      <div className="h-px flex-1 bg-line-glass/30" />
+      <p className="max-w-full shrink text-center text-xs font-medium tracking-wide text-input-placeholder">
+        {content}
+      </p>
+      <div className="h-px flex-1 bg-line-glass/30" />
+    </div>
+  </div>
+);
+
+export default ConversationEventRow;

--- a/src/features/chat/components/Message.tsx
+++ b/src/features/chat/components/Message.tsx
@@ -8,6 +8,7 @@ import { MessageAvatar } from './MessageAvatar';
 import { MessageContent } from './MessageContent';
 import { MessageAttachments } from './MessageAttachments';
 import { MessageActions } from './MessageActions';
+import ConversationEventRow from './ConversationEventRow';
 import type { ReplyTarget } from '@/features/chat/types';
 import { ArrowUturnLeftIcon } from '@heroicons/react/24/outline';
 import { Icon } from '@/shared/ui/Icon';
@@ -123,6 +124,7 @@ interface MessageProps {
 		};
 	};
 	isLast?: boolean;
+	isSystemEvent?: boolean;
 	// Styling
 	className?: string;
 }
@@ -165,8 +167,18 @@ const Message: FunctionComponent<MessageProps> = memo(({
 	actions,
 	onActionReply,
 	onboardingProfile,
-	isLast
+	isLast,
+	isSystemEvent = false,
 }) => {
+	if (isSystemEvent) {
+		return (
+			<ConversationEventRow
+				content={content}
+				className={className}
+			/>
+		);
+	}
+
 	const hasContent = Boolean(content);
 	const shouldShowIndicator = isLoading && !hasContent;
 	

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -738,6 +738,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
                     const renderKey = stableClientId
                         ? `client-${stableClientId}`
                         : (message.id ? `message-${message.id}` : fallbackIndexKey);
+                    const isSystemEvent = message.role === 'system' && message.metadata?.source !== 'ai';
 
                     return (
                             <Message
@@ -789,6 +790,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
                                 onStrengthenCase={onStrengthenCase}
                                 onboardingProfile={onboardingProfile}
                                 isLast={isLast && !isStreamingMessage}
+                                isSystemEvent={isSystemEvent}
                             />
                         );
                     })}

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -37,6 +37,7 @@ export interface OnboardingActions {
 interface VirtualMessageListProps {
     messages: ChatMessageUI[];
     conversationTitle?: string | null;
+    viewerContext?: 'practice' | 'client' | 'public';
     practiceConfig?: {
         name: string;
         profileImage: string | null;
@@ -86,6 +87,7 @@ const DEBUG_PAGINATION = typeof process !== 'undefined' && process.env.NODE_ENV 
 const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
     messages,
     conversationTitle,
+    viewerContext,
     practiceConfig,
     isPublicWorkspace = false,
     onOpenSidebar,
@@ -117,7 +119,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
         }
     }, []);
 
-    const { session, activeMemberRole } = useSessionContext();
+    const { session } = useSessionContext();
     const { showError } = useToastContext();
     const dedupedMessages = useMemo(() => {
         const seenPaymentConfirm = new Set<string>();
@@ -187,7 +189,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
         src: '/blawby-favicon-iframe.png',
         name: 'Blawby'
     };
-    const isPracticeViewer = Boolean(activeMemberRole && activeMemberRole !== 'client');
+    const resolvedViewerContext = viewerContext ?? (isPublicWorkspace ? 'public' : 'client');
 
     const resolveAvatar = (message: ChatMessageUI) => {
         const mockAvatar = message.metadata?.avatar as { src?: string | null; name: string } | undefined;
@@ -211,7 +213,18 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
         if (message.isUser) {
             return currentUserProfile;
         }
-        return isPracticeViewer ? clientProfile : practiceProfile;
+
+        const senderType = typeof message.metadata?.senderType === 'string'
+            ? message.metadata.senderType
+            : null;
+        if (senderType === 'client') {
+            return clientProfile;
+        }
+        if (senderType === 'team_member') {
+            return practiceProfile;
+        }
+
+        return resolvedViewerContext === 'practice' ? clientProfile : practiceProfile;
     };
 
     const resolveModeSelector = (message: ChatMessageUI) => {

--- a/src/features/intake/api/intakesApi.ts
+++ b/src/features/intake/api/intakesApi.ts
@@ -1,4 +1,4 @@
-import { clientIntakeStatus, clientIntakes } from '@/config/urls';
+import { clientIntake, clientIntakeInvite, clientIntakeStatus, clientIntakes } from '@/config/urls';
 
 export interface IntakeListParams {
   page: number;
@@ -87,6 +87,11 @@ export interface UpdateIntakeTriageStatusResponse {
   triage_reason?: string | null;
 }
 
+export interface TriggerIntakeInviteResponse {
+  success?: boolean;
+  message?: string;
+}
+
 export async function listIntakes(practiceId: string, params: IntakeListParams, options: { signal?: AbortSignal } = {}) {
   if (!practiceId) {
     throw new Error('practiceId is required');
@@ -149,11 +154,7 @@ export async function getPracticeIntake(
   }
 
   const response = await fetch(
-    clientIntakes(practiceId, {
-      intake_id: intakeId,
-      page: '1',
-      limit: '1'
-    }),
+    clientIntake(practiceId, intakeId),
     { credentials: 'include', signal: options.signal }
   );
 
@@ -166,13 +167,11 @@ export async function getPracticeIntake(
   }
   const json = raw as Record<string, unknown>;
   const data = (json.success !== undefined && json.data) ? json.data as Record<string, unknown> : json;
-  const intake = Array.isArray(data.intakes) ? (data.intakes as unknown[])[0] : (data.uuid ? data : null);
-
-  if (json.success === false || !intake) {
+  if (json.success === false || !data || typeof data !== 'object' || !data.uuid) {
     throw new Error('Failed to fetch intake');
   }
 
-  return intake as PracticeIntakeDetail;
+  return data as unknown as PracticeIntakeDetail;
 }
 
 export async function updateIntakeTriageStatus(
@@ -192,8 +191,8 @@ export async function updateIntakeTriageStatus(
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      triage_status: payload.status,
-      triage_reason: payload.reason ?? null,
+      status: payload.status,
+      ...(typeof payload.reason === 'string' ? { reason: payload.reason } : {}),
     }),
   });
 
@@ -205,6 +204,34 @@ export async function updateIntakeTriageStatus(
   }
 
   return (data || null) as UpdateIntakeTriageStatusResponse | null;
+}
+
+export async function triggerIntakeInvite(
+  intakeUuid: string,
+  options: { signal?: AbortSignal } = {}
+) {
+  if (!intakeUuid) {
+    throw new Error('intakeUuid is required');
+  }
+
+  const response = await fetch(clientIntakeInvite(intakeUuid), {
+    method: 'POST',
+    credentials: 'include',
+    signal: options.signal,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+
+  const json = await response.json().catch(() => null) as Record<string, unknown> | null;
+  const data = (json !== null && 'data' in json) ? json.data as Record<string, unknown> | null : json;
+
+  if (!response.ok || (json && json.success === false)) {
+    throw new Error(String(json?.message ?? json?.error ?? `HTTP ${response.status}`));
+  }
+
+  return (data || null) as TriggerIntakeInviteResponse | null;
 }
 
 export interface IntakeStatusResponse {
@@ -233,4 +260,3 @@ export async function getIntakeStatus(intakeUuid: string) {
   const json = await response.json() as { success: boolean; data: IntakeStatusResponse };
   return json.data;
 }
-

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -182,6 +182,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     }
 
     const controller = new AbortController();
+    setPreviewMessages([]);
     setPreviewLoading(true);
 
     fetchConversationMessages(conversationId, targetPracticeId, { limit: 100, signal: controller.signal })

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -99,7 +99,9 @@ function triageLabel(status?: string) {
 type IntakeDetailPageProps = {
   practiceId: string | null;
   intakeId: string;
-  basePath?: string;
+  conversationsBasePath?: string | null;
+  practiceName: string;
+  practiceLogo: string | null;
   onBack: () => void;
   onTriageComplete?: () => void;
 };
@@ -107,7 +109,9 @@ type IntakeDetailPageProps = {
 export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   practiceId,
   intakeId,
-  basePath = '/practice/intakes',
+  conversationsBasePath: conversationsBasePathProp,
+  practiceName,
+  practiceLogo,
   onBack,
   onTriageComplete,
 }) => {
@@ -168,10 +172,6 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     setTriageReason('');
   }, [isSubmitting]);
 
-  const conversationsBasePath = basePath.endsWith('/intakes')
-    ? `${basePath.slice(0, -'/intakes'.length)}/conversations`
-    : `${basePath}/conversations`;
-
   useEffect(() => {
     const conversationId = intake?.conversation_id;
     const targetPracticeId = intake?.organization_id;
@@ -184,7 +184,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     const controller = new AbortController();
     setPreviewLoading(true);
 
-    fetchConversationMessages(conversationId, targetPracticeId, { limit: 100 })
+    fetchConversationMessages(conversationId, targetPracticeId, { limit: 100, signal: controller.signal })
       .then((messages) => {
         if (!isMountedRef.current || controller.signal.aborted) return;
         const mappedMessages = messages.map((message) => ({
@@ -222,6 +222,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         ? reason.trim()
         : undefined;
       let inviteErrorMessage: string | null = null;
+      let participantFailed = false;
       const result = await updateIntakeTriageStatus(intakeId, {
         status: action,
         reason: trimmedReason,
@@ -250,6 +251,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             }
           );
           if (!participantRes.ok) {
+            participantFailed = true;
             console.warn('[IntakeDetailPage] Failed to add participant', {
               status: participantRes.status,
               statusText: participantRes.statusText,
@@ -259,6 +261,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             });
           }
         } catch (participantErr) {
+          participantFailed = true;
           console.warn('[IntakeDetailPage] Failed to add participant', participantErr);
         }
 
@@ -334,14 +337,17 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           showSuccess(
             action === 'accepted' ? 'Consultation accepted' : 'Consultation declined',
             action === 'accepted'
-              ? (trimmedReason
-                ? 'The client has been notified, the conversation is now active, and your note was added.'
-                : 'The client has been notified and the conversation is now active.')
+              ? (participantFailed
+                ? 'The client has been notified and the conversation is now active, but you may need to join the conversation manually.'
+                : (trimmedReason
+                  ? 'The client has been notified, the conversation is now active, and your note was added.'
+                  : 'The client has been notified and the conversation is now active.'))
               : 'The client has been notified.'
           );
         }
         if (action === 'accepted' && responseConversationId) {
-          navigate(`${conversationsBasePath}/${encodeURIComponent(responseConversationId)}`);
+          onTriageComplete?.();
+          navigate(`${conversationsBasePathProp}/${encodeURIComponent(responseConversationId)}`);
           return;
         }
         onTriageComplete?.();
@@ -353,7 +359,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     } finally {
       if (isMountedRef.current) setIsSubmitting(false);
     }
-  }, [conversationsBasePath, intake, intakeId, isSubmitting, navigate, onTriageComplete, session?.user, showError, showSuccess]);
+  }, [conversationsBasePathProp, intake, intakeId, isSubmitting, navigate, onTriageComplete, session?.user, showError, showSuccess]);
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -518,6 +524,13 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                     ) : (
                       <VirtualMessageList
                         messages={previewMessages}
+                        conversationTitle={intake.metadata?.name ?? null}
+                        viewerContext="practice"
+                        practiceConfig={{
+                          name: practiceName,
+                          profileImage: practiceLogo,
+                          practiceId: intake.organization_id,
+                        }}
                         practiceId={intake.organization_id}
                       />
                     )}
@@ -528,7 +541,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                   <Button
                     variant="secondary"
                     className="w-full"
-                    onClick={() => intake.conversation_id && navigate(`${conversationsBasePath}/${encodeURIComponent(intake.conversation_id)}`)}
+                    onClick={() => intake.conversation_id && navigate(`${conversationsBasePathProp}/${encodeURIComponent(intake.conversation_id)}`)}
                     disabled={!intake.conversation_id}
                   >
                     Join conversation

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -15,18 +15,27 @@ import { UserCard } from '@/shared/ui/profile';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
 import { Page } from '@/shared/ui/layout/Page';
 import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
+import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Textarea } from '@/shared/ui/input';
+import { useNavigation } from '@/shared/utils/navigation';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import {
   getPracticeIntake,
+  triggerIntakeInvite,
   updateIntakeTriageStatus,
   type PracticeIntakeDetail,
 } from '@/features/intake/api/intakesApi';
-import { postSystemMessage } from '@/shared/lib/conversationApi';
+import {
+  fetchConversationMessages,
+  postConversationMessage,
+  postSystemMessage,
+  updateConversationMetadata,
+} from '@/shared/lib/conversationApi';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
-import { useConversation } from '@/shared/hooks/useConversation';
 import VirtualMessageList from '@/features/chat/components/VirtualMessageList';
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import type { ChatMessageUI } from '../../../../worker/types';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -98,9 +107,11 @@ type IntakeDetailPageProps = {
 export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   practiceId,
   intakeId,
+  basePath = '/practice/intakes',
   onBack,
   onTriageComplete,
 }) => {
+  const { navigate } = useNavigation();
   const { showSuccess, showError } = useToastContext();
   const { session } = useSessionContext();
 
@@ -109,6 +120,10 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [localTriageStatus, setLocalTriageStatus] = useState<string | null>(null);
+  const [triageDialogAction, setTriageDialogAction] = useState<'accepted' | 'declined' | null>(null);
+  const [triageReason, setTriageReason] = useState('');
+  const [previewMessages, setPreviewMessages] = useState<ChatMessageUI[]>([]);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -141,24 +156,89 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     return () => controller.abort();
   }, [practiceId, intakeId]);
 
-  const runTriage = useCallback(async (action: 'accepted' | 'declined') => {
+  const closeTriageDialog = useCallback(() => {
+    if (isSubmitting) return;
+    setTriageDialogAction(null);
+    setTriageReason('');
+  }, [isSubmitting]);
+
+  const openTriageDialog = useCallback((action: 'accepted' | 'declined') => {
+    if (isSubmitting) return;
+    setTriageDialogAction(action);
+    setTriageReason('');
+  }, [isSubmitting]);
+
+  const conversationsBasePath = basePath.endsWith('/intakes')
+    ? `${basePath.slice(0, -'/intakes'.length)}/conversations`
+    : `${basePath}/conversations`;
+
+  useEffect(() => {
+    const conversationId = intake?.conversation_id;
+    const targetPracticeId = intake?.organization_id;
+    if (!conversationId || !targetPracticeId) {
+      setPreviewMessages([]);
+      setPreviewLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setPreviewLoading(true);
+
+    fetchConversationMessages(conversationId, targetPracticeId, { limit: 100 })
+      .then((messages) => {
+        if (!isMountedRef.current || controller.signal.aborted) return;
+        const mappedMessages = messages.map((message) => ({
+          id: message.id,
+          role: message.role,
+          content: message.content,
+          timestamp: new Date(message.created_at).getTime(),
+          reply_to_message_id: message.reply_to_message_id ?? null,
+          metadata: message.metadata ?? undefined,
+          isUser: message.user_id === session?.user?.id,
+          seq: message.seq,
+        } satisfies ChatMessageUI));
+        setPreviewMessages(mappedMessages);
+      })
+      .catch((err) => {
+        if (!isMountedRef.current || controller.signal.aborted) return;
+        console.warn('[IntakeDetailPage] Failed to load conversation preview', err);
+        setPreviewMessages([]);
+      })
+      .finally(() => {
+        if (isMountedRef.current && !controller.signal.aborted) {
+          setPreviewLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [intake?.conversation_id, intake?.organization_id, session?.user?.id]);
+
+  const runTriage = useCallback(async (action: 'accepted' | 'declined', reason?: string) => {
     if (isSubmitting || !intake) return;
 
     setIsSubmitting(true);
     try {
+      const trimmedReason = typeof reason === 'string' && reason.trim().length > 0
+        ? reason.trim()
+        : undefined;
+      let inviteErrorMessage: string | null = null;
       const result = await updateIntakeTriageStatus(intakeId, {
         status: action,
-        reason: action === 'declined' ? 'Declined by practice.' : undefined,
+        reason: trimmedReason,
       });
 
       const responseConversationId =
         result?.conversation_id ?? result?.conversationId ?? intake.conversation_id;
-
-      // Ensure we use the intake's organization context if available, falling back to current
-      const targetPracticeId = intake.organization_id || practiceId;
+      const targetPracticeId = intake.organization_id;
 
       // On accept: add practitioner as participant and post system message
       if (action === 'accepted' && session?.user?.id && responseConversationId && targetPracticeId) {
+        try {
+          await updateConversationMetadata(responseConversationId, targetPracticeId, { status: 'active' });
+        } catch (conversationErr) {
+          console.warn('[IntakeDetailPage] Failed to mark conversation active', conversationErr);
+        }
+
         try {
           const participantRes = await fetch(
             `/api/conversations/${encodeURIComponent(responseConversationId)}/participants?practiceId=${encodeURIComponent(targetPracticeId)}`,
@@ -186,7 +266,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           const userName = session.user.name?.trim() || session.user.email?.trim() || 'Someone';
           await postSystemMessage(responseConversationId, targetPracticeId, {
             clientId: 'system-lead-accepted',
-            content: `— ${userName} has joined the conversation —`,
+            content: `${userName} has joined the conversation`,
             metadata: {
               systemMessageKey: 'lead_accepted',
               intakeUuid: intakeId,
@@ -196,6 +276,33 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           });
         } catch (msgErr) {
           console.warn('[IntakeDetailPage] Failed to post join message', msgErr);
+        }
+
+        if (trimmedReason) {
+          try {
+            await postConversationMessage(responseConversationId, targetPracticeId, {
+              content: trimmedReason,
+              metadata: {
+                intakeUuid: intakeId,
+                triageStatus: 'accepted',
+                triage_status: 'accepted',
+                triageReason: trimmedReason,
+                triage_reason: trimmedReason,
+                source: 'intake-triage',
+              },
+            });
+          } catch (msgErr) {
+            console.warn('[IntakeDetailPage] Failed to post intake triage note', msgErr);
+          }
+        }
+      }
+
+      if (action === 'accepted') {
+        try {
+          await triggerIntakeInvite(intakeId);
+        } catch (inviteErr) {
+          inviteErrorMessage = inviteErr instanceof Error ? inviteErr.message : 'Failed to send client invite';
+          console.warn('[IntakeDetailPage] Failed to trigger intake invite', inviteErr);
         }
       }
 
@@ -219,12 +326,24 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
       if (isMountedRef.current) {
         setLocalTriageStatus(action);
         setIntake((prev) => prev ? { ...prev, triage_status: action, conversation_id: responseConversationId ?? prev.conversation_id } : prev);
-        showSuccess(
-          action === 'accepted' ? 'Consultation accepted' : 'Consultation declined',
-          action === 'accepted'
-            ? 'The client has been notified and the conversation is now active.'
-            : 'The client has been notified.'
-        );
+        setTriageDialogAction(null);
+        setTriageReason('');
+        if (action === 'accepted' && inviteErrorMessage) {
+          showError('Consultation accepted, but invite failed', inviteErrorMessage);
+        } else {
+          showSuccess(
+            action === 'accepted' ? 'Consultation accepted' : 'Consultation declined',
+            action === 'accepted'
+              ? (trimmedReason
+                ? 'The client has been notified, the conversation is now active, and your note was added.'
+                : 'The client has been notified and the conversation is now active.')
+              : 'The client has been notified.'
+          );
+        }
+        if (action === 'accepted' && responseConversationId) {
+          navigate(`${conversationsBasePath}/${encodeURIComponent(responseConversationId)}`);
+          return;
+        }
         onTriageComplete?.();
       }
     } catch (err) {
@@ -234,22 +353,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     } finally {
       if (isMountedRef.current) setIsSubmitting(false);
     }
-  }, [intake, intakeId, isSubmitting, onTriageComplete, practiceId, session?.user, showError, showSuccess]);
-
-  // Load the conversation history for embedding
-  const {
-    messages,
-    messagesReady: conversationReady,
-    hasMoreMessages,
-    isLoadingMoreMessages,
-    loadMoreMessages,
-    requestMessageReactions,
-    toggleMessageReaction,
-  } = useConversation({
-    practiceId: intake?.organization_id ?? '',
-    conversationId: intake?.conversation_id ?? '',
-    enabled: !!intake?.conversation_id && !!intake?.organization_id,
-  });
+  }, [conversationsBasePath, intake, intakeId, isSubmitting, navigate, onTriageComplete, session?.user, showError, showSuccess]);
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -391,39 +495,46 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
 
             {/* Conversation History Card */}
             {intake.conversation_id && (
-              <section className="glass-card flex flex-col h-[500px] sm:h-[700px] overflow-hidden">
-                <header className="p-4 sm:p-6 lg:p-10 pb-4 sm:pb-6 border-b border-line-glass/10 flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <Icon icon={ChatBubbleLeftRightIcon} className="w-5 h-5 text-input-placeholder" />
-                    <h3 className="text-sm font-semibold text-input-text uppercase tracking-widest">
-                      Intake Conversation
-                    </h3>
+              <div className="space-y-4">
+                <section className="glass-card flex flex-col h-[500px] sm:h-[700px] overflow-hidden">
+                  <header className="p-4 sm:p-6 lg:p-10 pb-4 sm:pb-6 border-b border-line-glass/10 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <Icon icon={ChatBubbleLeftRightIcon} className="w-5 h-5 text-input-placeholder" />
+                      <h3 className="text-sm font-semibold text-input-text uppercase tracking-widest">
+                        Intake Conversation
+                      </h3>
+                    </div>
+                  </header>
+                  <div className="flex-1 min-h-0 overflow-hidden bg-surface-overlay/20 touch-pan-y">
+                    {previewLoading && previewMessages.length === 0 ? (
+                      <div className="h-full flex flex-col items-center justify-center p-6 text-center">
+                        <LoadingBlock />
+                        <p className="text-xs text-input-placeholder mt-4">Loading conversation history...</p>
+                      </div>
+                    ) : previewMessages.length === 0 ? (
+                      <div className="h-full flex flex-col items-center justify-center p-6 text-center">
+                        <p className="text-sm text-input-placeholder">No conversation history found for this intake.</p>
+                      </div>
+                    ) : (
+                      <VirtualMessageList
+                        messages={previewMessages}
+                        practiceId={intake.organization_id}
+                      />
+                    )}
                   </div>
-                </header>
-                <div className="flex-1 min-h-0 bg-surface-overlay/20">
-                  {!conversationReady && messages.length === 0 ? (
-                    <div className="h-full flex flex-col items-center justify-center p-6 text-center">
-                      <LoadingBlock />
-                      <p className="text-xs text-input-placeholder mt-4">Loading conversation history...</p>
-                    </div>
-                  ) : messages.length === 0 ? (
-                    <div className="h-full flex flex-col items-center justify-center p-6 text-center">
-                      <p className="text-sm text-input-placeholder">No conversation history found for this intake.</p>
-                    </div>
-                  ) : (
-                    <VirtualMessageList
-                      messages={messages}
-                      hasMoreMessages={hasMoreMessages}
-                      isLoadingMoreMessages={isLoadingMoreMessages}
-                      onLoadMoreMessages={loadMoreMessages}
-                      onToggleReaction={toggleMessageReaction}
-                      onRequestReactions={requestMessageReactions}
-                      practiceId={intake?.organization_id ?? practiceId ?? ''}
-                      compactLayout
-                    />
-                  )}
+                </section>
+
+                <div>
+                  <Button
+                    variant="secondary"
+                    className="w-full"
+                    onClick={() => intake.conversation_id && navigate(`${conversationsBasePath}/${encodeURIComponent(intake.conversation_id)}`)}
+                    disabled={!intake.conversation_id}
+                  >
+                    Join conversation
+                  </Button>
                 </div>
-              </section>
+              </div>
             )}
           </div>
 
@@ -439,7 +550,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                     variant="primary"
                     className="w-full"
                     disabled={isSubmitting}
-                    onClick={() => void runTriage('accepted')}
+                    onClick={() => openTriageDialog('accepted')}
                   >
                     {isSubmitting ? 'Accepting…' : 'Accept Consultation'}
                   </Button>
@@ -448,7 +559,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                     variant="danger"
                     className="w-full"
                     disabled={isSubmitting}
-                    onClick={() => void runTriage('declined')}
+                    onClick={() => openTriageDialog('declined')}
                   >
                     {isSubmitting ? 'Declining…' : 'Decline'}
                   </Button>
@@ -536,6 +647,59 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           </div>
         </div>
       </div>
+
+      <Dialog
+        isOpen={triageDialogAction !== null}
+        onClose={closeTriageDialog}
+        title={triageDialogAction === 'accepted' ? 'Accept consultation' : 'Decline consultation'}
+        description={
+          triageDialogAction === 'accepted'
+            ? 'You can include an optional note. If you do, it will be posted into the conversation after you join.'
+            : 'You can include an optional reason to send with this triage decision.'
+        }
+        disableBackdropClick={isSubmitting}
+      >
+        <DialogBody className="space-y-4">
+          <div className="rounded-xl border border-line-glass/10 bg-white/[0.03] p-4">
+            <p className="text-sm text-input-placeholder">
+              {triageDialogAction === 'accepted'
+                ? 'Accepting will notify the client and move this conversation into your active inbox.'
+                : 'Declining will notify the client and mark this intake as declined.'}
+            </p>
+          </div>
+
+          <Textarea
+            label={triageDialogAction === 'accepted' ? 'Optional note to client' : 'Optional decline reason'}
+            value={triageReason}
+            onChange={setTriageReason}
+            rows={4}
+            maxLength={1000}
+            showCharCount
+            placeholder={
+              triageDialogAction === 'accepted'
+                ? 'Thanks for reaching out. I just joined this conversation and will review your intake shortly.'
+                : 'We are unable to take this consultation at this time.'
+            }
+          />
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="secondary" onClick={closeTriageDialog} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant={triageDialogAction === 'declined' ? 'danger' : 'primary'}
+            disabled={isSubmitting || !triageDialogAction}
+            onClick={() => {
+              if (!triageDialogAction) return;
+              void runTriage(triageDialogAction, triageReason);
+            }}
+          >
+            {isSubmitting
+              ? (triageDialogAction === 'accepted' ? 'Accepting…' : 'Declining…')
+              : (triageDialogAction === 'accepted' ? 'Confirm acceptance' : 'Confirm decline')}
+          </Button>
+        </DialogFooter>
+      </Dialog>
     </div>
   );
 };

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -345,7 +345,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
               : 'The client has been notified.'
           );
         }
-        if (action === 'accepted' && responseConversationId) {
+        if (action === 'accepted' && responseConversationId && conversationsBasePathProp) {
           onTriageComplete?.();
           navigate(`${conversationsBasePathProp}/${encodeURIComponent(responseConversationId)}`);
           return;
@@ -541,8 +541,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                   <Button
                     variant="secondary"
                     className="w-full"
-                    onClick={() => intake.conversation_id && navigate(`${conversationsBasePathProp}/${encodeURIComponent(intake.conversation_id)}`)}
-                    disabled={!intake.conversation_id}
+                    onClick={() => intake.conversation_id && conversationsBasePathProp && navigate(`${conversationsBasePathProp}/${encodeURIComponent(intake.conversation_id)}`)}
+                    disabled={!intake.conversation_id || !conversationsBasePathProp}
                   >
                     Join conversation
                   </Button>

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -22,6 +22,9 @@ interface PaginatedIntake extends IntakeListItem {
 type IntakesPageProps = {
   practiceId: string | null;
   basePath?: string;
+  conversationsBasePath?: string | null;
+  practiceName: string;
+  practiceLogo: string | null;
   renderMode?: 'full' | 'listOnly' | 'detailOnly';
   activeTriageFilter?: string | null;
   prefetchedItems?: IntakeListItem[];
@@ -76,6 +79,9 @@ const IntakeListItemRow = ({
 export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
   practiceId,
   basePath = '/practice/intakes',
+  conversationsBasePath,
+  practiceName,
+  practiceLogo,
   renderMode = 'full',
   activeTriageFilter = 'all',
   prefetchedItems = [],
@@ -145,7 +151,9 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
       <IntakeDetailPage
         practiceId={practiceId}
         intakeId={selectedIntakeId}
-        basePath={basePath}
+        conversationsBasePath={conversationsBasePath}
+        practiceName={practiceName}
+        practiceLogo={practiceLogo}
         onBack={handleBack}
         onTriageComplete={handleTriageComplete}
       />

--- a/src/shared/lib/conversationApi.ts
+++ b/src/shared/lib/conversationApi.ts
@@ -251,6 +251,77 @@ export const fetchLatestConversationMessage = async (
   return data.data?.messages?.[0] ?? null;
 };
 
+export const postConversationMessage = async (
+  conversationId: string,
+  practiceId: string,
+  payload: {
+    content: string;
+    metadata?: Record<string, unknown>;
+    replyToMessageId?: string | null;
+  }
+): Promise<ConversationMessage | null> => {
+  const params = buildPracticeParams(practiceId);
+  const response = await fetch(
+    `/api/conversations/${encodeURIComponent(conversationId)}/messages?${params.toString()}`,
+    {
+      method: 'POST',
+      headers: withWidgetAuthHeaders({ 'Content-Type': 'application/json' }),
+      credentials: 'include',
+      body: JSON.stringify(payload)
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({})) as { error?: string };
+    throw new Error(errorData.error || `HTTP ${response.status}`);
+  }
+
+  const data = await response.json() as { success: boolean; data?: { message?: ConversationMessage } };
+  return data.data?.message ?? null;
+};
+
+export const fetchConversationMessages = async (
+  conversationId: string,
+  practiceId: string,
+  options: { limit?: number; cursor?: string } = {}
+): Promise<ConversationMessage[]> => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  };
+  const params = buildPracticeParams(practiceId);
+  if (options.limit != null) {
+    params.set('limit', String(options.limit));
+  }
+  if (options.cursor) {
+    params.set('cursor', options.cursor);
+  }
+
+  const response = await fetch(
+    `/api/conversations/${encodeURIComponent(conversationId)}/messages?${params.toString()}`,
+    {
+      method: 'GET',
+      headers,
+      credentials: 'include'
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({})) as { error?: string };
+    throw new Error(errorData.error || `HTTP ${response.status}`);
+  }
+
+  const data = await response.json().catch(() => null) as {
+    success?: boolean;
+    data?: { messages?: ConversationMessage[] };
+  } | null;
+
+  if (!data?.success) {
+    throw new Error('Failed to fetch messages');
+  }
+
+  return data.data?.messages ?? [];
+};
+
 export const fetchMessageReactions = async (
   conversationId: string,
   messageId: string,

--- a/src/shared/lib/conversationApi.ts
+++ b/src/shared/lib/conversationApi.ts
@@ -47,6 +47,8 @@ export const updateConversationMetadata = async (
   practiceId: string,
   metadata: ConversationMetadata
 ): Promise<Conversation | null> => {
+  // The API PATCH endpoint accepts `status` as a top-level field (not inside
+  // `metadata`), so we hoist it out of the metadata object before sending.
   const { status, ...restMetadata } = metadata as Record<string, unknown>;
   const payload: Record<string, unknown> = { metadata: restMetadata };
   if (status !== undefined) {
@@ -224,7 +226,7 @@ export const fetchLatestConversationMessage = async (
     'Content-Type': 'application/json'
   };
   const params = buildPracticeParams(practiceId);
-  params.set('limit', '1');
+  params.set('limit', '5');
   params.set('source', 'preview');
   const response = await fetch(
     `/api/conversations/${encodeURIComponent(conversationId)}/messages?${params.toString()}`,
@@ -248,7 +250,8 @@ export const fetchLatestConversationMessage = async (
     return null;
   }
 
-  return data.data?.messages?.[0] ?? null;
+  const messages = data.data?.messages ?? [];
+  return messages.find((message) => message.role !== 'system') ?? messages[0] ?? null;
 };
 
 export const postConversationMessage = async (
@@ -283,7 +286,7 @@ export const postConversationMessage = async (
 export const fetchConversationMessages = async (
   conversationId: string,
   practiceId: string,
-  options: { limit?: number; cursor?: string } = {}
+  options: { limit?: number; cursor?: string; signal?: AbortSignal } = {}
 ): Promise<ConversationMessage[]> => {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json'
@@ -301,7 +304,8 @@ export const fetchConversationMessages = async (
     {
       method: 'GET',
       headers,
-      credentials: 'include'
+      credentials: 'include',
+      signal: options.signal
     }
   );
 

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -241,6 +241,55 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     return createJsonResponse(result, responseHeaders);
   }
 
+  // POST /api/conversations/:id/messages - Send a chat message
+  if (segments.length === 4 && segments[3] === 'messages' && request.method === 'POST') {
+    const requestWithContext = await withPracticeContext(request, env, {
+      requirePractice: true,
+      authContext,
+      allowAuthenticatedUrlPracticeId: true,
+    });
+    const conversationId = segments[2];
+    const conversationPracticeId = getPracticeId(requestWithContext);
+
+    if (authContext.isAnonymous) {
+      await conversationService.validateParticipantAccess(conversationId, conversationPracticeId, userId, { previousAnonUserId: prevAnonId });
+    } else {
+      const membership = await checkPracticeMembership(request, env, conversationPracticeId, { authContext });
+      if (isStaffMemberRole(membership.memberRole)) {
+        await requirePracticeMember(request, env, conversationPracticeId, 'paralegal');
+      } else {
+        await conversationService.validateParticipantAccess(conversationId, conversationPracticeId, userId, { previousAnonUserId: prevAnonId });
+      }
+    }
+
+    const body = await parseJsonBody(request) as {
+      content?: string;
+      metadata?: Record<string, unknown>;
+      replyToMessageId?: string | null;
+    };
+
+    const content = typeof body.content === 'string' ? body.content.trim() : '';
+    if (!content) {
+      throw HttpErrors.badRequest('content is required');
+    }
+
+    const metadata = (body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata))
+      ? body.metadata as Record<string, unknown>
+      : undefined;
+
+    const storedMessage = await conversationService.sendMessage({
+      conversationId,
+      practiceId: conversationPracticeId,
+      senderUserId: userId,
+      content,
+      metadata,
+      replyToMessageId: typeof body.replyToMessageId === 'string' ? body.replyToMessageId : null,
+      request
+    });
+
+    return createJsonResponse({ message: storedMessage });
+  }
+
   // GET/POST/DELETE /api/conversations/:id/messages/:messageId/reactions
   if (segments.length === 6 && segments[3] === 'messages' && segments[5] === 'reactions') {
     const requestWithContext = await withPracticeContext(request, env, {


### PR DESCRIPTION
## What changed

This PR fixes the intake review flow so accepted intakes hand off cleanly into conversations and lifecycle/system events render with dedicated UI.

## Highlights

- fixes intake triage requests to match backend validation
  - send `status`
  - omit `reason` unless it is a real string
- fixes intake detail loading to use the dedicated single-intake endpoint instead of the paginated list fallback
- fixes accept flow handoff
  - uses `intake.organization_id` directly for conversation calls
  - marks the linked conversation `active`
  - adds the practice participant
  - posts the join system message
  - posts the optional acceptance note as a normal message
  - navigates into the conversation after accept
- adds automatic intake invite triggering on accept
- converts non-AI system messages into reusable conversation event rows with muted divider styling
- makes the intake detail conversation preview read-only and scrollable, with the `Join conversation` CTA below the card

## Why

We were seeing a cluster of intake-review issues:

- wrong triage payload keys/values caused backend validation failures
- intake detail could show the wrong intake because it loaded from the list endpoint and grabbed the first row
- accepted intakes were not reliably appearing in the inbox handoff flow
- system messages like "has joined the conversation" looked like normal chat messages instead of lifecycle events
- the client invite was still a separate manual backend action

## Impact

Practice staff can now accept an intake and be taken directly into the correct active conversation, with cleaner lifecycle messaging and the invite flow triggered automatically.

## Validation

- `npm run lint`
- `npm run type-check`
- reran `tests/e2e/widget-intake-flow.spec.ts` happy path successfully during investigation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System events render as centered divider rows in conversations.
  * Chat gains viewer context (practice/client/public) to improve avatar and rendering.
  * Ability to send and fetch conversation messages (with metadata/replies); server accepts POST message submissions.
  * Intake triage can trigger client invites and post notes when accepting; triage now shows a confirmation dialog.

* **Refactor**
  * Intake and conversation pages updated to use conversation previews and new navigation/props for joining conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->