### PR TITLE
fix: widget post-payment close tab, practice WS auth race, chat input lock

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -284,7 +284,7 @@ export function MainApp({
   });
 
   const {
-    messages, conversationMetadata, sendMessage, addMessage, clearMessages,
+    messages, conversationMetadata, sendMessage, addMessage: _addMessage, clearMessages,
     requestMessageReactions, toggleMessageReaction,
     intakeStatus, intakeConversationState, handleIntakeCtaResponse,
     slimContactDraft, handleSlimFormContinue, handleBuildBrief, handleSubmitNow, handleFinalizeSubmit: _handleFinalizeSubmit,
@@ -686,7 +686,6 @@ export function MainApp({
             )}
             viewerContext={isPracticeWorkspace ? 'practice' : isClientWorkspace ? 'client' : 'public'}
             onSendMessage={handleSendMessage}
-            onAddMessage={addMessage}
             conversationMode={conversationMode}
             onSelectMode={(mode, source) => { void handleModeSelection(mode, source); }}
             onToggleReaction={features.enableMessageReactions ? toggleMessageReaction : undefined}
@@ -710,7 +709,6 @@ export function MainApp({
               slug: resolvedPracticeSlug,
             }}
             practiceId={practiceId}
-            conversationId={activeConversationId ?? null}
             previewFiles={previewFiles}
             uploadingFiles={uploadingFiles}
             removePreviewFile={removePreviewFile}

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -604,7 +604,6 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
               }}
               onOpenSidebar={() => setIsInspectorOpen(true)}
               practiceId={practiceId}
-              conversationId={activeConversationId ?? null}
               previewFiles={previewFiles}
               uploadingFiles={uploadingFiles}
               removePreviewFile={removePreviewFile}

--- a/src/features/chat/components/ChatContainer.tsx
+++ b/src/features/chat/components/ChatContainer.tsx
@@ -28,7 +28,6 @@ export interface ChatContainerProps {
     replyToMessageId?: string | null,
     options?: { mentionedUserIds?: string[] }
   ) => void;
-  onAddMessage?: (message: ChatMessageUI) => void;
   conversationMode?: ConversationMode | null;
   onSelectMode?: (mode: ConversationMode, source?: 'intro_gate' | 'composer_footer' | 'home_cta' | 'chat_intro' | 'slim_form_dismiss' | 'chat_selector') => void;
   onToggleReaction?: (messageId: string, emoji: string) => void;
@@ -48,8 +47,6 @@ export interface ChatContainerProps {
   layoutMode?: LayoutMode;
   onOpenSidebar?: () => void;
   practiceId?: string;
-  conversationId?: string | null;
-
   // File handling props
   previewFiles: FileAttachment[];
   uploadingFiles: UploadingFile[];
@@ -113,7 +110,6 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   conversationTitle,
   viewerContext,
   onSendMessage,
-  onAddMessage: _onAddMessage,
   conversationMode,
   isPublicWorkspace = false,
   practiceConfig,
@@ -123,7 +119,6 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   layoutMode,
   onOpenSidebar,
   practiceId,
-  conversationId: _conversationId,
   onToggleReaction,
   onRequestReactions,
   previewFiles,
@@ -170,7 +165,7 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
   const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
   const composerDockRef = useRef<HTMLDivElement>(null);
   const [composerInsetPx, setComposerInsetPx] = useState(104);
-  const isChatInputLocked = Boolean(composerDisabled) || isSessionReady === false || isSocketReady === false || intakeStatus?.step === 'contact_form_slim';
+  const isChatInputLocked = Boolean(composerDisabled) || isSessionReady === false || isSocketReady === false || (isPublicWorkspace && intakeStatus?.step === 'contact_form_slim');
   const baseMessages = isPublicWorkspace
     ? messages.filter((message) => message.metadata?.systemMessageKey !== 'ask_question_help')
     : messages;
@@ -179,16 +174,10 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
     ? baseMessages.filter((message) => message.metadata?.systemMessageKey !== 'intro')
     : baseMessages;
   
-  const hasContactInfoSubmitted = Boolean(
-    intakeStatus?.intakeUuid || 
-    intakeStatus?.step === 'completed' || 
-    intakeStatus?.step === 'pending_review'
-  );
-
-  const shouldShowSlimForm = isPublicWorkspace && 
-    intakeStatus?.step === 'contact_form_slim' && 
-    conversationMode === 'REQUEST_CONSULTATION' && 
-    !hasContactInfoSubmitted &&
+  const shouldShowSlimForm = isPublicWorkspace &&
+    intakeStatus?.step === 'contact_form_slim' &&
+    conversationMode === 'REQUEST_CONSULTATION' &&
+    !intakeStatus?.intakeUuid &&
     typeof onSlimFormContinue === 'function';
   const [isDismissingSlimDrawer, setIsDismissingSlimDrawer] = useState(false);
 
@@ -268,7 +257,7 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
     const attachments = [...previewFiles];
     const replyToMessageId = replyTarget?.messageId ?? null;
 
-    const canHandleCta = isIntakeSubmittable(intakeConversationState, {
+    const canHandleCta = isPublicWorkspace && isIntakeSubmittable(intakeConversationState, {
       paymentRequired: intakeStatus?.paymentRequired ?? null,
       paymentReceived: intakeStatus?.paymentReceived ?? null,
     }) && intakeConversationState?.ctaResponse !== 'ready';
@@ -524,12 +513,13 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
                   isReadyToUpload={isReadyToUpload}
                   isSessionReady={isSessionReady}
                   isSocketReady={isSocketReady}
-                  intakeStatus={intakeStatus}
-                  disabled={composerDisabled || intakeStatus?.step === 'contact_form_slim'}
+                  intakeStatus={isPublicWorkspace ? intakeStatus : undefined}
+                  disabled={composerDisabled || (isPublicWorkspace && intakeStatus?.step === 'contact_form_slim')}
                   replyTo={replyTarget}
                   onCancelReply={handleCancelReply}
                   mentionCandidates={mentionCandidates}
                   hideAttachmentControls={!features.enableFileAttachments}
+                  isPublicWorkspace={isPublicWorkspace}
                 />
               )}
             </div>

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -9,9 +9,8 @@ import { ArrowUpIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { features } from '@/config/features';
 import { FileAttachment } from '../../../../worker/types';
 import type { UploadingFile } from '@/shared/types/upload';
-import { Trans } from '@/shared/i18n/hooks';
+import { Trans, useTranslation } from '@/shared/i18n/hooks';
 import type { ReplyTarget } from '@/features/chat/types';
-import { useTranslation } from 'react-i18next';
 
 interface MessageComposerProps {
   inputValue: string;
@@ -41,9 +40,8 @@ interface MessageComposerProps {
   disabled?: boolean;
   replyTo?: ReplyTarget | null;
   onCancelReply?: () => void;
-  footerActions?: preact.ComponentChildren;
   hideAttachmentControls?: boolean;
-  hideMediaControls?: boolean;
+  isPublicWorkspace?: boolean;
   mentionCandidates?: Array<{
     userId: string;
     name: string;
@@ -77,9 +75,8 @@ const MessageComposer = ({
   disabled,
   replyTo,
   onCancelReply,
-  footerActions,
   hideAttachmentControls = false,
-  hideMediaControls = false,
+  isPublicWorkspace = false,
   mentionCandidates = [],
 }: MessageComposerProps) => {
   const { t } = useTranslation('common');
@@ -96,11 +93,24 @@ const MessageComposer = ({
   const highlighterRef = useRef<HTMLDivElement>(null);
   const getMentionLabel = useCallback((candidate: { name: string }) => candidate.name.trim(), []);
 
+  const getSanitizedMentionIds = useCallback(() =>
+    selectedMentionUserIds.filter(id => {
+      const candidate = mentionCandidates.find(c => c.userId === id);
+      if (!candidate) return false;
+      const label = getMentionLabel(candidate);
+      if (!label) return false;
+      const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(`(^|\\s)@${escapedLabel}(?:\\s|$)`);
+      return regex.test(inputValue);
+    }),
+  [getMentionLabel, inputValue, mentionCandidates, selectedMentionUserIds]);
+
   const intakeStep = intakeStatus?.step;
-  const isIntakeLocked =
+  const isIntakeLocked = isPublicWorkspace && (
     intakeStep === 'pending_review' ||
     intakeStep === 'accepted' ||
-    intakeStep === 'rejected';
+    intakeStep === 'rejected'
+  );
   const isComposerDisabled = Boolean(disabled) || isSessionReady === false || isSocketReady === false || isIntakeLocked;
   const attachmentCount = uploadingFiles.length + previewFiles.length;
   const shouldWrapAttachments = attachmentCount > 4;
@@ -207,18 +217,7 @@ const MessageComposer = ({
     if (!inputValue.trim() && previewFiles.length === 0) return;
     if (isComposerDisabled) return;
 
-    // Validate and sanitize selectedMentionUserIds before sending
-    const sanitizedMentionIds = selectedMentionUserIds.filter(id => {
-      const candidate = mentionCandidates.find(c => c.userId === id);
-      if (!candidate) return false;
-      const label = getMentionLabel(candidate);
-      if (!label) return false;
-      // Use a more robust check that handles multi-word names and word boundaries
-      const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const regex = new RegExp(`(^|\\s)@${escapedLabel}(?:\\s|$)`);
-      return regex.test(inputValue);
-    });
-
+    const sanitizedMentionIds = getSanitizedMentionIds();
     onSubmit(sanitizedMentionIds.length > 0 ? sanitizedMentionIds : undefined);
     const el = textareaRef.current;
     if (el) {
@@ -439,18 +438,7 @@ const MessageComposer = ({
                       }
                     }
                     
-                    // Validate and sanitize selectedMentionUserIds before forwarding
-                    const sanitizedMentionIds = selectedMentionUserIds.filter(id => {
-                      const candidate = mentionCandidates.find(c => c.userId === id);
-                      if (!candidate) return false;
-                      const label = getMentionLabel(candidate);
-                      if (!label) return false;
-                      const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                      const regex = new RegExp(`(^|\\s)@${escapedLabel}(?:\\s|$)`);
-                      return regex.test(inputValue);
-                    });
-                    
-                    onKeyDown(event, sanitizedMentionIds);
+                    onKeyDown(event, getSanitizedMentionIds());
                   }}
                   aria-label="Message input"
                   aria-controls={mentionMenuOpen ? "mention-listbox" : undefined}
@@ -507,7 +495,7 @@ const MessageComposer = ({
             </div>
 
             <div className="col-start-3 flex items-center gap-2 flex-shrink-0 self-end">
-              {!hideMediaControls && features.enableAudioRecording && (
+              {features.enableAudioRecording && (
                 <MediaControls onMediaCapture={handleMediaCapture} onRecordingStateChange={setIsRecording} />
               )}
             </div>
@@ -516,7 +504,6 @@ const MessageComposer = ({
         </div>
 
       </form>
-      {footerActions}
     </div>
   );
 };

--- a/src/pages/PaymentResultPage.tsx
+++ b/src/pages/PaymentResultPage.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'preact';
 import { useEffect } from 'preact/hooks';
-import { useLocation } from 'preact-iso';
 import { CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { PAYMENT_CONFIRMED_STORAGE_KEY } from '@/shared/utils/intakePayments';
 import { Button } from '@/shared/ui/Button';
@@ -57,7 +56,6 @@ const OUTCOMES: Record<PaymentOutcome, OutcomeConfig> = {
 };
 
 const PaymentResultPage: FunctionComponent<{ practiceSlug?: string }> = ({ practiceSlug }) => {
-  const location = useLocation();
   const params = typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search)
     : new URLSearchParams();
@@ -94,13 +92,7 @@ const PaymentResultPage: FunctionComponent<{ practiceSlug?: string }> = ({ pract
   const { Icon } = config;
 
   const handleClose = () => {
-    if (typeof window !== 'undefined' && window.opener) {
-      window.close();
-    } else if (conversationId && practiceSlug) {
-      location.route(`/client/${encodeURIComponent(practiceSlug)}`);
-    } else {
-      window.history.back();
-    }
+    window.close();
   };
 
 

--- a/worker/durable-objects/ChatRoom.ts
+++ b/worker/durable-objects/ChatRoom.ts
@@ -170,11 +170,10 @@ export class ChatRoom {
       throw error;
     }
 
-    const isMember = await this.isConversationMember(conversationId, auth.user.id);
-    let isPracticeMember = false;
-    if (!isMember) {
-      isPracticeMember = await this.isPracticeMember(request, conversationId);
-      if (!isPracticeMember) {
+    const isPracticeMember = await this.isPracticeMember(request, conversationId);
+    if (!isPracticeMember) {
+      const isMember = await this.isConversationMember(conversationId, auth.user.id);
+      if (!isMember) {
         return new Response('Forbidden', { status: 403 });
       }
     }
@@ -327,22 +326,6 @@ export class ChatRoom {
     attachment: ConnectionAttachment,
     frame: ClientFrame
   ): Promise<void> {
-    try {
-      const rawConversationId = this.readString(frame.data.conversation_id);
-      const rawClientId = this.readString(frame.data.client_id);
-      const rawContent = typeof frame.data.content === 'string' ? frame.data.content : '';
-      console.warn('[ChatRoom] message.send received', {
-        conversationId: rawConversationId ?? null,
-        clientId: rawClientId ?? null,
-        contentLength: rawContent.length,
-        hasAttachments: Array.isArray(frame.data.attachments) ? frame.data.attachments.length : 0,
-        hasMetadata: frame.data.metadata !== undefined && frame.data.metadata !== null,
-        requestId: frame.request_id ?? null
-      });
-    } catch {
-      console.warn('[ChatRoom] message.send received (log failure)');
-    }
-
     const conversationId = this.readString(frame.data.conversation_id);
     if (!conversationId || conversationId !== attachment.conversationId) {
       this.rejectInvalidPayload(ws, frame.request_id, 'conversation_id mismatch');
@@ -762,11 +745,11 @@ export class ChatRoom {
     const metadataJson = sanitizedMetadata ? JSON.stringify(sanitizedMetadata) : null;
 
     const shouldUpdateContent = role !== 'system' && content.trim().length > 0;
-    const persistBatch = async (includeLastMessageContent: boolean) => {
-      const convSql = shouldUpdateContent && includeLastMessageContent
+    const persistBatch = async () => {
+      const convSql = shouldUpdateContent
         ? 'UPDATE conversations SET latest_seq = ?, updated_at = ?, last_message_at = ?, last_message_content = ? WHERE id = ?'
         : 'UPDATE conversations SET latest_seq = ?, updated_at = ?, last_message_at = ? WHERE id = ?';
-      const convBindings = shouldUpdateContent && includeLastMessageContent
+      const convBindings = shouldUpdateContent
         ? [pending.allocated_seq, serverTs, serverTs, content, conversationId]
         : [pending.allocated_seq, serverTs, serverTs, conversationId];
 
@@ -806,21 +789,8 @@ export class ChatRoom {
       ]);
     };
 
-    const isMissingLastMessageContentColumn = (error: unknown): boolean => {
-      const message = error instanceof Error ? error.message : String(error);
-      return /no such column:\s*last_message_content/i.test(message);
-    };
-
     try {
-      try {
-        await persistBatch(true);
-      } catch (error) {
-        if (shouldUpdateContent && isMissingLastMessageContentColumn(error)) {
-          await persistBatch(false);
-        } else {
-          throw error;
-        }
-      }
+      await persistBatch();
     } catch (error) {
       if (this.isUniqueConstraintError(error)) {
         const existing = await this.fetchExistingMessage(conversationId, clientId);
@@ -937,18 +907,8 @@ export class ChatRoom {
     return Boolean(record);
   }
 
-  private async fetchConversationPracticeId(conversationId: string): Promise<string | null> {
-    const record = await this.env.DB.prepare(`
-      SELECT practice_id
-      FROM conversations
-      WHERE id = ?
-    `).bind(conversationId).first<{ practice_id: string } | null>();
-
-    return record?.practice_id ?? null;
-  }
-
   private async isPracticeMember(request: Request, conversationId: string): Promise<boolean> {
-    const practiceId = await this.fetchConversationPracticeId(conversationId);
+    const practiceId = await this.getPracticeId(conversationId);
     if (!practiceId) {
       return false;
     }
@@ -967,7 +927,7 @@ export class ChatRoom {
   }
 
   private async revalidatePracticeMembership(attachment: ConnectionAttachment): Promise<boolean> {
-    const practiceId = await this.fetchConversationPracticeId(attachment.conversationId);
+    const practiceId = await this.getPracticeId(attachment.conversationId);
     if (!practiceId) {
       return false;
     }
@@ -1617,7 +1577,10 @@ export class ChatRoom {
       return null;
     }
 
-    let model = DEFAULT_AI_MODEL;
+    let model = this.env.AI_MODEL || DEFAULT_AI_MODEL;
+    if (!this.env.AI_MODEL && aiClient.provider === 'cloudflare_gateway') {
+      model = 'openai/gpt-4o-mini';
+    }
 
     const response = await aiClient.requestChatCompletions({
       model,

--- a/worker/durable-objects/ChatRoom.ts
+++ b/worker/durable-objects/ChatRoom.ts
@@ -1577,10 +1577,7 @@ export class ChatRoom {
       return null;
     }
 
-    let model = this.env.AI_MODEL || DEFAULT_AI_MODEL;
-    if (!this.env.AI_MODEL && aiClient.provider === 'cloudflare_gateway') {
-      model = 'openai/gpt-4o-mini';
-    }
+    const model = this.env.AI_MODEL || DEFAULT_AI_MODEL;
 
     const response = await aiClient.requestChatCompletions({
       model,

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -154,6 +154,9 @@ export interface Env {
   CLOUDFLARE_API_TOKEN?: string;
   CLOUDFLARE_PUBLIC_URL?: string;
   CF_AIG_TOKEN?: string;
+  CF_AIG_GATEWAY_NAME?: string;
+  AI_PROVIDER?: string;
+  AI_MODEL?: string;
   DOMAIN?: string;
   BETTER_AUTH_URL?: string;
   WIDGET_AUTH_TOKEN_SECRET?: string;


### PR DESCRIPTION
## Summary

### PaymentResultPage
- Removed 2-fallback chain (`window.opener` → `location.route` → `history.back`); now just `window.close()`

### ChatRoom (Durable Object)
- **WS auth race fix**: check `isPracticeMember` first — reads from `conversations.practice_id` (stable, race-free) before checking `conversation_participants` (D1 write may not yet be visible). Eliminates 403 for practice users joining accepted conversations.
- Use `env.AI_MODEL || DEFAULT_AI_MODEL` for title generation (consistent with all other AI routes)
- Remove `fetchConversationPracticeId` (consolidated into cached `getPracticeId`)
- Remove `isMissingLastMessageContentColumn` retry fallback (column confirmed stable)
- Simplify `persistBatch` signature, remove debug `console.log`/`console.warn`

### ChatContainer
- Gate `isChatInputLocked` and `canHandleCta` behind `isPublicWorkspace` — practice users were getting locked out of the composer after accepting an intake
- Remove dead `onAddMessage` prop; inline `shouldShowSlimForm`

### MessageComposer
- Gate `isIntakeLocked` behind `isPublicWorkspace` — practice context never locks
- Extract `getSanitizedMentionIds` (was duplicated in `handleSubmit` and `onKeyDown`)
- Fix `useTranslation` import to use local `@/shared/i18n/hooks`
- Remove dead `footerActions` and `hideMediaControls` props

### worker/types
- Add `AI_PROVIDER`, `AI_MODEL`, `CF_AIG_GATEWAY_NAME` to `Env` interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat input locking for contact forms now applies only in appropriate workspace contexts.
  * Payment result page now closes reliably when finished.

* **New Features**
  * Added AI model configuration support for improved AI behavior.

* **Refactor**
  * Removed footer actions from the message composer UI.
  * Streamlined intake form visibility and locking.
  * Improved membership verification flow.
  * Simplified media control rendering based on feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->