### PR TITLE
Fix country-code phone input behavior

### DIFF
--- a/src/shared/ui/address/AddressExperienceForm.tsx
+++ b/src/shared/ui/address/AddressExperienceForm.tsx
@@ -10,7 +10,7 @@ import { AddressInput } from '@/shared/ui/address/AddressInput';
 import { Button } from '@/shared/ui/Button';
 import { cn } from '@/shared/utils/cn';
 import { isAddressEmpty } from '@/shared/utils/addressFormat';
-import { commonSchemas } from '@/shared/ui/validation/schemas';
+import { commonSchemas, isValidPhoneNumber } from '@/shared/ui/validation/schemas';
 import { addressLooseSchema, addressStrictWithCountrySchema } from '@/shared/ui/validation/schemas/address';
 import type { Address } from '@/shared/types/address';
 import { STATUS_OPTIONS } from '@/shared/forms/fieldRegistry';
@@ -178,9 +178,9 @@ const optionalEmail = z.string().email('Please enter a valid email address').opt
 const optionalPhone = z.string().optional().or(z.literal('')).refine(
   (val) => {
     if (!val || val === '') return true;
-    return /^\+?[\d\s\-()]+$/.test(val) && val.replace(/\D/g, '').length >= 10;
+    return isValidPhoneNumber(val);
   },
-  'Please enter a valid phone number (at least 10 digits)'
+  'Please enter a valid phone number'
 );
 
 const buildSchema = (fields: AddressExperienceField[], required: AddressExperienceField[]) => {

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -327,6 +327,20 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         return;
       }
 
+      const droppedUnsupportedPrefix =
+        parsedPhoneValue?.kind === 'unsupported' &&
+        parsedRawValue.kind === 'none' &&
+        !rawValue.trimStart().startsWith('+');
+
+      if (droppedUnsupportedPrefix) {
+        manualSelectionRef.current = null;
+        if (manualCountryCode !== null) {
+          setManualCountryCode(null);
+        }
+        onChange?.(rawValue);
+        return;
+      }
+
       const effectiveManualCountryCode =
         parsedRawValue.kind === 'supported' ? parsedRawValue.prefix : manualCountryCode;
       if (parsedRawValue.kind === 'supported' && parsedRawValue.prefix !== selectedCountryCode) {
@@ -397,6 +411,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
               ref={buttonRef}
               type="button"
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              onKeyDown={handleKeyDown}
               disabled={disabled}
               aria-expanded={isDropdownOpen}
               aria-haspopup="menu"

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -138,48 +138,23 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const manualSelectionRef = useRef<{ value: string; countryCode: string } | null>(null);
 
   const normalizedCountryCode = normalizeSupportedCountryCode(countryCode);
   const parsedPhoneValue = showCountryCode ? splitCombinedPhoneValue(value) : null;
   const [manualCountryCode, setManualCountryCode] = useState<string | null>(null);
-  const previousValueRef = useRef(value);
-  const previousCountryCodeRef = useRef(normalizedCountryCode);
+  const activeManualCountryCode =
+    showCountryCode &&
+    parsedPhoneValue?.kind === 'none' &&
+    manualSelectionRef.current?.value === value &&
+    manualSelectionRef.current?.countryCode === normalizedCountryCode
+      ? manualCountryCode
+      : null;
   const selectedCountryCode = parsedPhoneValue?.kind === 'supported'
     ? parsedPhoneValue.prefix
-    : manualCountryCode ?? normalizedCountryCode;
+    : activeManualCountryCode ?? normalizedCountryCode;
 
   const currentCountry = countries.find(c => c.code === selectedCountryCode) || countries[0];
-
-  useEffect(() => {
-    const valueChanged = previousValueRef.current !== value;
-    const countryCodeChanged = previousCountryCodeRef.current !== normalizedCountryCode;
-
-    previousValueRef.current = value;
-    previousCountryCodeRef.current = normalizedCountryCode;
-
-    if (!showCountryCode) {
-      if (manualCountryCode !== null) {
-        setManualCountryCode(null);
-      }
-      return;
-    }
-
-    if (manualCountryCode === null) return;
-
-    if (valueChanged && !value.trim()) {
-      setManualCountryCode(null);
-      return;
-    }
-
-    if (valueChanged && parsedPhoneValue?.kind !== 'none') {
-      setManualCountryCode(null);
-      return;
-    }
-
-    if (countryCodeChanged) {
-      setManualCountryCode(null);
-    }
-  }, [manualCountryCode, normalizedCountryCode, parsedPhoneValue?.kind, showCountryCode, value]);
   
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -200,16 +175,21 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   }, [isDropdownOpen]);
 
   const handleCountrySelect = useCallback((country: typeof countries[0]) => {
-    setManualCountryCode(country.code);
-    onCountryChange?.(country.code);
     if (showCountryCode) {
       const nextValue = buildCombinedPhoneValue(country.code, parsedPhoneValue?.localValue ?? '');
-      onChange?.(nextValue || country.code);
+      const emittedValue = nextValue || country.code;
+      manualSelectionRef.current = {
+        value: emittedValue,
+        countryCode: normalizedCountryCode,
+      };
+      setManualCountryCode(country.code);
+      onCountryChange?.(country.code);
+      onChange?.(emittedValue);
     }
     setIsDropdownOpen(false);
     setFocusedIndex(-1);
     buttonRef.current?.focus();
-  }, [onChange, onCountryChange, parsedPhoneValue?.localValue, showCountryCode]);
+  }, [normalizedCountryCode, onChange, onCountryChange, parsedPhoneValue?.localValue, showCountryCode]);
 
   // Keyboard navigation handler
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -339,6 +319,10 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         rawValue.trimStart().startsWith('+') && parsedRawValue.kind !== 'supported';
 
       if (isRawInternationalEntry) {
+        manualSelectionRef.current = null;
+        if (manualCountryCode !== null) {
+          setManualCountryCode(null);
+        }
         onChange?.(rawValue);
         return;
       }
@@ -362,6 +346,13 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
           ? nextPhonePrefix
           : buildCombinedPhoneValue(nextPhonePrefix, parsedRawValue.localValue);
 
+      manualSelectionRef.current =
+        parsedRawValue.kind === 'supported'
+          ? {
+              value: nextCombinedValue,
+              countryCode: normalizedCountryCode,
+            }
+          : null;
       onChange?.(nextCombinedValue);
       return;
     }

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useCallback, useState, useEffect, useRef } from 'preact/compat';
 import { PhoneIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
-import { Icon } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 
@@ -416,10 +415,10 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
                 sizeClasses[size],
                 disabled && 'opacity-50 cursor-not-allowed'
               )}
-            >
+              >
               <span className="text-base mr-1">{currentCountry.emoji}</span>
               <span className="text-sm">{currentCountry.code}</span>
-              <Icon icon={ChevronDownIcon} className="w-3 h-3 ml-1"  />
+              <ChevronDownIcon className="w-3 h-3 ml-1 shrink-0" aria-hidden="true" />
             </button>
             
             {isDropdownOpen && (
@@ -457,7 +456,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         <div className="relative flex-1">
           {!showCountryCode ? (
             <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-              <Icon icon={PhoneIcon} className="w-4 h-4 text-input-placeholder"  />
+              <PhoneIcon className="w-4 h-4 text-input-placeholder shrink-0" aria-hidden="true" />
             </div>
           ) : null}
           

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -32,6 +32,29 @@ const normalizeSupportedCountryCode = (value?: string): string => {
 
 const splitCombinedPhoneValue = (value: string): ParsedPhoneValue => {
   const trimmedStart = value.trimStart();
+  const leadingDigitTokenMatch = trimmedStart.match(/^(\+\d{1,3})(.*)$/);
+
+  if (leadingDigitTokenMatch) {
+    const rawPrefix = leadingDigitTokenMatch[1];
+    const remainder = leadingDigitTokenMatch[2].trimStart();
+    const exactCountryMatch = countryCodeMatchOrder.find((country) => country.code === rawPrefix);
+    const candidateMatches = countryCodeMatchOrder.filter((country) => country.code.startsWith(rawPrefix));
+
+    if (exactCountryMatch || candidateMatches.length === 1) {
+      return {
+        kind: 'supported',
+        prefix: exactCountryMatch?.code ?? candidateMatches[0].code,
+        localValue: remainder,
+      };
+    }
+
+    return {
+      kind: 'unsupported',
+      prefix: rawPrefix,
+      localValue: remainder,
+    };
+  }
+
   const matchedCountry = countryCodeMatchOrder.find((country) => trimmedStart.startsWith(country.code));
   if (!matchedCountry) {
     const unsupportedPrefixMatch = trimmedStart.match(unsupportedInternationalPrefixPattern);
@@ -245,13 +268,13 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
 
   // Add keyboard event listener
   useEffect(() => {
-    const dropdownElement = dropdownRef.current;
-    if (!isDropdownOpen || !dropdownElement) return;
+    const listElement = listRef.current;
+    if (!isDropdownOpen || !listElement) return;
 
-    dropdownElement.addEventListener('keydown', handleKeyDown);
+    listElement.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      dropdownElement.removeEventListener('keydown', handleKeyDown);
+      listElement.removeEventListener('keydown', handleKeyDown);
     };
   }, [isDropdownOpen, handleKeyDown]);
   

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -377,13 +377,16 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         normalizedCountryCode
       );
 
+      const isPrefixOnlyState =
+        !parsedRawValue.localValue.trim() &&
+        (parsedRawValue.kind === 'supported' || parsedPhoneValue?.kind === 'supported');
       const nextCombinedValue =
-        parsedRawValue.kind === 'supported' && !parsedRawValue.localValue.trim()
+        isPrefixOnlyState
           ? nextPhonePrefix
           : buildCombinedPhoneValue(nextPhonePrefix, parsedRawValue.localValue);
 
       manualSelectionRef.current =
-        parsedRawValue.kind === 'supported'
+        parsedRawValue.kind === 'supported' || isPrefixOnlyState
           ? {
               value: nextCombinedValue,
               countryCode: normalizedCountryCode,

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -37,14 +37,13 @@ const splitCombinedPhoneValue = (value: string): ParsedPhoneValue => {
   if (leadingDigitTokenMatch) {
     const rawPrefix = leadingDigitTokenMatch[1];
     const remainder = leadingDigitTokenMatch[2].trimStart();
-    const exactCountryMatch = countryCodeMatchOrder.find((country) => country.code === rawPrefix);
-    const candidateMatches = countryCodeMatchOrder.filter((country) => country.code.startsWith(rawPrefix));
+    const matchedCountry = countryCodeMatchOrder.find((country) => country.code === rawPrefix);
 
-    if (exactCountryMatch || candidateMatches.length === 1) {
+    if (matchedCountry) {
       return {
         kind: 'supported',
-        prefix: exactCountryMatch?.code ?? candidateMatches[0].code,
-        localValue: remainder,
+        prefix: matchedCountry.code,
+        localValue: trimmedStart.slice(matchedCountry.code.length).trimStart(),
       };
     }
 

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -18,6 +18,75 @@ const countries = [
   { code: '+39', emoji: '🇮🇹', name: 'Italy' },
 ];
 
+const countryCodeMatchOrder = [...countries].sort((left, right) => right.code.length - left.code.length);
+const unsupportedInternationalPrefixPattern = /^(\+\d{1,3})(?=$|[\s(-])(?:[\s-]*)/;
+
+type ParsedPhoneValue =
+  | { kind: 'supported'; prefix: string; localValue: string }
+  | { kind: 'unsupported'; prefix: string; localValue: string }
+  | { kind: 'none'; prefix: null; localValue: string };
+
+const normalizeSupportedCountryCode = (value?: string): string => {
+  const supportedCountry = countries.find((country) => country.code === value);
+  return supportedCountry?.code ?? countries[0].code;
+};
+
+const splitCombinedPhoneValue = (value: string): ParsedPhoneValue => {
+  const trimmedStart = value.trimStart();
+  const matchedCountry = countryCodeMatchOrder.find((country) => trimmedStart.startsWith(country.code));
+  if (!matchedCountry) {
+    const unsupportedPrefixMatch = trimmedStart.match(unsupportedInternationalPrefixPattern);
+    if (!unsupportedPrefixMatch) {
+      return { kind: 'none', prefix: null, localValue: value };
+    }
+
+    return {
+      kind: 'unsupported',
+      prefix: unsupportedPrefixMatch[1],
+      localValue: trimmedStart.slice(unsupportedPrefixMatch[0].length).trimStart(),
+    };
+  }
+
+  return {
+    kind: 'supported',
+    prefix: matchedCountry.code,
+    localValue: trimmedStart.slice(matchedCountry.code.length).trimStart(),
+  };
+};
+
+const buildCombinedPhoneValue = (prefix: string, localValue: string): string => {
+  const trimmedLocalValue = localValue.trim();
+  if (!trimmedLocalValue) return '';
+  return `${prefix} ${trimmedLocalValue}`;
+};
+
+const resolvePhonePrefix = (
+  manualCountryCode: string | null,
+  currentPhoneValue: ParsedPhoneValue | null,
+  nextPhoneValue: ParsedPhoneValue | null,
+  normalizedCountryCode: string
+): string => {
+  if (manualCountryCode) return manualCountryCode;
+  if (nextPhoneValue?.kind === 'supported' || nextPhoneValue?.kind === 'unsupported') {
+    return nextPhoneValue.prefix;
+  }
+  if (currentPhoneValue?.kind === 'supported' || currentPhoneValue?.kind === 'unsupported') {
+    return currentPhoneValue.prefix;
+  }
+  return normalizedCountryCode;
+};
+
+const getPhoneInputPlaceholder = (placeholder?: string): string | undefined => {
+  if (!placeholder) return placeholder;
+
+  const trimmedStart = placeholder.trimStart();
+  const matchedCountry = countryCodeMatchOrder.find((country) => trimmedStart.startsWith(country.code));
+  if (!matchedCountry) return placeholder;
+
+  const localPlaceholder = trimmedStart.slice(matchedCountry.code.length).trimStart();
+  return localPlaceholder || placeholder;
+};
+
 export interface PhoneInputProps {
   id?: string;
   value?: string;
@@ -70,14 +139,48 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  
-  const [selectedCountryCode, setSelectedCountryCode] = useState(countryCode);
 
-  useEffect(() => {
-    setSelectedCountryCode(countryCode);
-  }, [countryCode]);
+  const normalizedCountryCode = normalizeSupportedCountryCode(countryCode);
+  const parsedPhoneValue = showCountryCode ? splitCombinedPhoneValue(value) : null;
+  const [manualCountryCode, setManualCountryCode] = useState<string | null>(null);
+  const previousValueRef = useRef(value);
+  const previousCountryCodeRef = useRef(normalizedCountryCode);
+  const selectedCountryCode = parsedPhoneValue?.kind === 'supported'
+    ? parsedPhoneValue.prefix
+    : manualCountryCode ?? normalizedCountryCode;
 
   const currentCountry = countries.find(c => c.code === selectedCountryCode) || countries[0];
+
+  useEffect(() => {
+    const valueChanged = previousValueRef.current !== value;
+    const countryCodeChanged = previousCountryCodeRef.current !== normalizedCountryCode;
+
+    previousValueRef.current = value;
+    previousCountryCodeRef.current = normalizedCountryCode;
+
+    if (!showCountryCode) {
+      if (manualCountryCode !== null) {
+        setManualCountryCode(null);
+      }
+      return;
+    }
+
+    if (manualCountryCode === null) return;
+
+    if (valueChanged && !value.trim()) {
+      setManualCountryCode(null);
+      return;
+    }
+
+    if (valueChanged && parsedPhoneValue?.kind !== 'none') {
+      setManualCountryCode(null);
+      return;
+    }
+
+    if (countryCodeChanged) {
+      setManualCountryCode(null);
+    }
+  }, [manualCountryCode, normalizedCountryCode, parsedPhoneValue?.kind, showCountryCode, value]);
   
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -98,12 +201,16 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   }, [isDropdownOpen]);
 
   const handleCountrySelect = useCallback((country: typeof countries[0]) => {
-    setSelectedCountryCode(country.code);
+    setManualCountryCode(country.code);
     onCountryChange?.(country.code);
+    if (showCountryCode) {
+      const nextValue = buildCombinedPhoneValue(country.code, parsedPhoneValue?.localValue ?? '');
+      onChange?.(nextValue || country.code);
+    }
     setIsDropdownOpen(false);
     setFocusedIndex(-1);
     buttonRef.current?.focus();
-  }, [onCountryChange]);
+  }, [onChange, onCountryChange, parsedPhoneValue?.localValue, showCountryCode]);
 
   // Keyboard navigation handler
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -159,12 +266,13 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
 
   // Add keyboard event listener
   useEffect(() => {
-    if (isDropdownOpen) {
-      document.addEventListener('keydown', handleKeyDown);
-    }
+    const dropdownElement = dropdownRef.current;
+    if (!isDropdownOpen || !dropdownElement) return;
+
+    dropdownElement.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      document.removeEventListener('keydown', handleKeyDown);
+      dropdownElement.removeEventListener('keydown', handleKeyDown);
     };
   }, [isDropdownOpen, handleKeyDown]);
   
@@ -177,7 +285,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   
   const displayLabel = label;
   const displayDescription = description;
-  const displayPlaceholder = placeholder;
+  const displayPlaceholder = showCountryCode ? getPhoneInputPlaceholder(placeholder) : placeholder;
   const displayError = error;
 
   // Generate stable IDs for accessibility
@@ -225,15 +333,58 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   const handleChange = useCallback((e: Event) => {
     const target = e.target as HTMLInputElement;
     const rawValue = target.value;
+
+    if (showCountryCode) {
+      const parsedRawValue = splitCombinedPhoneValue(rawValue);
+      const isRawInternationalEntry =
+        rawValue.trimStart().startsWith('+') && parsedRawValue.kind !== 'supported';
+
+      if (isRawInternationalEntry) {
+        onChange?.(rawValue);
+        return;
+      }
+
+      const effectiveManualCountryCode =
+        parsedRawValue.kind === 'supported' ? parsedRawValue.prefix : manualCountryCode;
+      if (parsedRawValue.kind === 'supported' && parsedRawValue.prefix !== selectedCountryCode) {
+        setManualCountryCode(parsedRawValue.prefix);
+        onCountryChange?.(parsedRawValue.prefix);
+      }
+
+      const nextPhonePrefix = resolvePhonePrefix(
+        effectiveManualCountryCode,
+        parsedPhoneValue,
+        parsedRawValue,
+        normalizedCountryCode
+      );
+
+      const nextCombinedValue =
+        parsedRawValue.kind === 'supported' && !parsedRawValue.localValue.trim()
+          ? nextPhonePrefix
+          : buildCombinedPhoneValue(nextPhonePrefix, parsedRawValue.localValue);
+
+      onChange?.(nextCombinedValue);
+      return;
+    }
+
     const formattedValue = formatPhoneNumber(rawValue);
     onChange?.(formattedValue);
-  }, [onChange, formatPhoneNumber]);
+  }, [
+    formatPhoneNumber,
+    manualCountryCode,
+    normalizedCountryCode,
+    onChange,
+    onCountryChange,
+    parsedPhoneValue,
+    selectedCountryCode,
+    showCountryCode,
+  ]);
 
   const inputClasses = cn(
     'w-full border rounded-lg text-input-text placeholder:text-input-placeholder',
     'focus:outline-none focus:ring-2 focus:ring-offset-0 transition-colors',
     sizeClasses[size],
-    iconPaddingClasses[size],
+    showCountryCode ? null : iconPaddingClasses[size],
     variantClasses[variant],
     disabled && 'opacity-50 cursor-not-allowed',
     variant === 'default' ? 'glass-input' : 'bg-input-bg',
@@ -304,15 +455,21 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         )}
         
         <div className="relative flex-1">
-          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-            <Icon icon={PhoneIcon} className="w-4 h-4 text-input-placeholder"  />
-          </div>
+          {!showCountryCode ? (
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+              <Icon icon={PhoneIcon} className="w-4 h-4 text-input-placeholder"  />
+            </div>
+          ) : null}
           
           <input
             ref={ref}
             id={inputId}
             type="tel"
-            value={value}
+            value={showCountryCode
+              ? parsedPhoneValue?.kind === 'supported'
+                ? parsedPhoneValue.localValue
+                : value
+              : value}
             onChange={handleChange}
             placeholder={displayPlaceholder}
             disabled={disabled}

--- a/src/shared/ui/validation/schemas.ts
+++ b/src/shared/ui/validation/schemas.ts
@@ -2,6 +2,17 @@ import { z } from 'zod';
 
 // Common validation schemas
 const FileClass = typeof File !== 'undefined' ? File : undefined;
+const PHONE_INPUT_PATTERN = /^\+?[\d\s\-()]+$/;
+const MIN_PHONE_DIGITS = 7;
+const MAX_PHONE_DIGITS = 15;
+
+export const isValidPhoneNumber = (value: string): boolean => {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed || !PHONE_INPUT_PATTERN.test(trimmed)) return false;
+  const digitCount = trimmed.replace(/\D/g, '').length;
+  return digitCount >= MIN_PHONE_DIGITS && digitCount <= MAX_PHONE_DIGITS;
+};
 
 export const commonSchemas = {
   // Text validation
@@ -20,8 +31,7 @@ export const commonSchemas = {
   
   // Phone validation
   phone: z.string()
-    .regex(/^\+?[\d\s\-()]+$/, 'Please enter a valid phone number')
-    .min(10, 'Phone number must be at least 10 digits'),
+    .refine(isValidPhoneNumber, 'Please enter a valid phone number'),
   
   // URL validation
   url: z.string().url('Please enter a valid URL'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		"noEmit": true,
 		"allowJs": true,
 		"checkJs": true,
+		"ignoreDeprecations": "5.0",
 		"resolveJsonModule": true,
 		"downlevelIteration": true,
 		"baseUrl": ".",


### PR DESCRIPTION
## Summary
- remove the redundant leading phone icon when the country selector is shown
- make selector-enabled phone fields preserve and round-trip supported, unsupported, and partially typed international prefixes correctly
- align shared phone validation with the updated international phone input behavior

## Details
- update PhoneInput to parse combined phone values, keep the selector synchronized with supported prefixes, preserve raw +country input while typing, and reset transient manual country selection when parent-controlled values rehydrate
- emit prefix-only values when the selected country changes without local digits so parent state stays in sync with the dropdown
- reuse the shared isValidPhoneNumber validator in AddressExperienceForm and relax common phone validation to a permissive international digit-range check

## Verification
- 
pm run lint
- 
pm run type-check

Closes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter phone input: parses/composes country code + local part, preserves manual country override, and shows local segment when applicable; selecting a country updates the emitted value.
* **Bug Fixes / UX**
  * Unified phone validation with a clearer message ("Please enter a valid phone number") and more consistent handling of international/unsupported prefixes.
  * Improved dropdown keyboard behavior and input placeholder/visual handling.
* **Chores**
  * Adjusted TypeScript compiler setting for deprecation diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->