### PR TITLE
fix(widget): correct nav active state and add sliding pill animation

### DIFF
--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -830,6 +830,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
               icon: HomeIcon,
               href: '#home',
               isAction: true,
+              isActive: view === 'home',
               onClick: () => {
                 setConversationMode(null);
                 setView('home');
@@ -841,6 +842,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
               icon: ChatBubbleLeftRightIcon,
               href: '#list',
               isAction: true,
+              isActive: view === 'list',
               onClick: () => setView('list')
             }
           ]}

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -822,7 +822,6 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
         
         <NavRail
           variant="bottom"
-          activeHref={view === 'home' ? '#home' : '#list'}
           items={[
             {
               id: 'home',

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -79,6 +79,9 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
     ? items.findIndex(getIsActive)
     : -1;
 
+  const isRTL = typeof document !== 'undefined' && document.documentElement.dir === 'rtl';
+  const directionMultiplier = isRTL ? -1 : 1;
+
   const baseButtonClass = 'relative z-10 flex items-center justify-center rounded-xl font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50';
   const layoutClass = variant === 'rail'
     ? 'h-11 w-11'
@@ -93,10 +96,13 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
       {variant === 'bottom' && activeIndex >= 0 && (
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-y-1.5 rounded-2xl bg-[rgb(var(--nav-active-bg))] transition-transform duration-300 ease-out"
+          className="pointer-events-none absolute rounded-2xl bg-[rgb(var(--nav-active-bg))] transition-transform duration-300 ease-out"
           style={{
             width: `${100 / items.length}%`,
-            transform: `translateX(${activeIndex * 100}%)`,
+            top: '0.375rem',
+            bottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)',
+            insetInlineStart: 0,
+            transform: `translateX(${activeIndex * 100 * directionMultiplier}%)`,
           }}
         />
       )}
@@ -120,7 +126,7 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
                 : variant === 'bottom'
                   ? isActive
                     ? 'text-[rgb(var(--nav-active-text))]'
-                    : 'text-[rgb(var(--input-text)_/_0.75)]'
+                    : 'text-[rgb(var(--input-text)_/_0.75)] hover:text-[rgb(var(--input-text))] hover:bg-[rgb(255_255_255_/_0.06)]'
                   : isActive
                     ? 'nav-item-active'
                     : 'nav-item-inactive',

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -78,9 +78,7 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
 
   const activeIndex = variant === 'bottom' ? items.findIndex(getIsActive) : -1;
 
-  const isRTL = typeof document !== 'undefined' && document.documentElement.dir === 'rtl';
   const baseW = 100 / items.length;
-  const side = isRTL ? 'right' : 'left';
 
   const baseButtonClass = 'relative z-10 flex items-center justify-center rounded-xl font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50';
   const layoutClass = variant === 'rail'
@@ -99,11 +97,11 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
           className="pointer-events-none absolute rounded-2xl bg-[rgb(var(--nav-active-bg))]"
           style={{
             width: `${baseW}%`,
-            [side]: `${activeIndex * baseW}%`,
-            [isRTL ? 'left' : 'right']: 'auto',
+            insetInlineStart: `${activeIndex * baseW}%`,
+            insetInlineEnd: 'auto',
             top: '0.375rem',
             bottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)',
-            transition: `${side} 250ms cubic-bezier(0.4, 0, 0.2, 1)`,
+            transition: 'inset-inline-start 250ms cubic-bezier(0.4, 0, 0.2, 1)',
           }}
         />
       )}

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -1,4 +1,5 @@
 import type { FunctionComponent } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { Icon, type IconComponent } from '@/shared/ui/Icon';
 import { useNavigation } from '@/shared/utils/navigation';
@@ -49,6 +50,9 @@ const getBestMatchScore = (currentPath: string, item: NavRailItem): number => {
   return bestScore;
 };
 
+const getDocumentSide = (): 'left' | 'right' =>
+  typeof document !== 'undefined' && document.documentElement.dir === 'rtl' ? 'right' : 'left';
+
 export const NavRail: FunctionComponent<NavRailProps> = ({
   items,
   activeHref,
@@ -61,26 +65,56 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
   const location = useLocation();
   const { navigate } = useNavigation();
   const resolvedPath = normalizePath(activeHref || location.path);
-  if (hidden) return null;
+
   const activeItemId = items.reduce<{ id: string | null; score: number }>((best, item) => {
     if (item.isAction) return best;
     const score = getBestMatchScore(resolvedPath, item);
     if (score < 0) return best;
-    if (score > best.score) {
-      return { id: item.id, score };
-    }
+    if (score > best.score) return { id: item.id, score };
     return best;
   }, { id: null, score: -1 }).id;
 
   const getIsActive = (item: NavRailItem) =>
     item.isActive !== undefined ? item.isActive : (!item.isAction && activeItemId === item.id);
 
-  const activeIndex = variant === 'bottom'
-    ? items.findIndex(getIsActive)
-    : -1;
+  const activeIndex = variant === 'bottom' ? items.findIndex(getIsActive) : -1;
 
-  const isRTL = typeof document !== 'undefined' && document.documentElement.dir === 'rtl';
-  const directionMultiplier = isRTL ? -1 : 1;
+  const baseW = 100 / items.length;
+  const prevIndexRef = useRef(activeIndex);
+
+  const [pillStyle, setPillStyle] = useState<Record<string, string>>(() => {
+    const side = getDocumentSide();
+    const opp = side === 'left' ? 'right' : 'left';
+    const idx = activeIndex >= 0 ? activeIndex : 0;
+    return { [side]: `${idx * baseW}%`, [opp]: 'auto', width: `${baseW}%` };
+  });
+
+  useEffect(() => {
+    if (variant !== 'bottom') return;
+    if (activeIndex < 0) { prevIndexRef.current = -1; return; }
+    if (prevIndexRef.current === activeIndex) return;
+
+    const side = getDocumentSide();
+    const opp = side === 'left' ? 'right' : 'left';
+    const prevIdx = prevIndexRef.current >= 0 ? prevIndexRef.current : activeIndex;
+    const minIdx = Math.min(prevIdx, activeIndex);
+    const spanCount = Math.abs(activeIndex - prevIdx) + 1;
+
+    prevIndexRef.current = activeIndex;
+
+    // Phase 1: stretch pill to span source → destination tabs
+    setPillStyle({ [side]: `${minIdx * baseW}%`, [opp]: 'auto', width: `${spanCount * baseW}%` });
+
+    // Phase 2: contract to destination tab
+    const timer = setTimeout(() => {
+      setPillStyle({ [side]: `${activeIndex * baseW}%`, [opp]: 'auto', width: `${baseW}%` });
+    }, 160);
+
+    return () => clearTimeout(timer);
+  }, [activeIndex, variant, baseW]);
+
+  // All hooks above — early return must come after
+  if (hidden) return null;
 
   const baseButtonClass = 'relative z-10 flex items-center justify-center rounded-xl font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50';
   const layoutClass = variant === 'rail'
@@ -96,13 +130,12 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
       {variant === 'bottom' && activeIndex >= 0 && (
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute rounded-2xl bg-[rgb(var(--nav-active-bg))] transition-transform duration-300 ease-out"
+          className="pointer-events-none absolute rounded-2xl bg-[rgb(var(--nav-active-bg))]"
           style={{
-            width: `${100 / items.length}%`,
+            ...pillStyle,
             top: '0.375rem',
             bottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)',
-            insetInlineStart: 0,
-            transform: `translateX(${activeIndex * 100 * directionMultiplier}%)`,
+            transition: 'left 150ms ease-in-out, right 150ms ease-in-out, width 150ms ease-in-out',
           }}
         />
       )}

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -1,5 +1,4 @@
 import type { FunctionComponent } from 'preact';
-import { useEffect, useRef, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { Icon, type IconComponent } from '@/shared/ui/Icon';
 import { useNavigation } from '@/shared/utils/navigation';
@@ -50,9 +49,6 @@ const getBestMatchScore = (currentPath: string, item: NavRailItem): number => {
   return bestScore;
 };
 
-const getDocumentSide = (): 'left' | 'right' =>
-  typeof document !== 'undefined' && document.documentElement.dir === 'rtl' ? 'right' : 'left';
-
 export const NavRail: FunctionComponent<NavRailProps> = ({
   items,
   activeHref,
@@ -64,6 +60,9 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
 }) => {
   const location = useLocation();
   const { navigate } = useNavigation();
+
+  if (hidden) return null;
+
   const resolvedPath = normalizePath(activeHref || location.path);
 
   const activeItemId = items.reduce<{ id: string | null; score: number }>((best, item) => {
@@ -79,42 +78,9 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
 
   const activeIndex = variant === 'bottom' ? items.findIndex(getIsActive) : -1;
 
+  const isRTL = typeof document !== 'undefined' && document.documentElement.dir === 'rtl';
   const baseW = 100 / items.length;
-  const prevIndexRef = useRef(activeIndex);
-
-  const [pillStyle, setPillStyle] = useState<Record<string, string>>(() => {
-    const side = getDocumentSide();
-    const opp = side === 'left' ? 'right' : 'left';
-    const idx = activeIndex >= 0 ? activeIndex : 0;
-    return { [side]: `${idx * baseW}%`, [opp]: 'auto', width: `${baseW}%` };
-  });
-
-  useEffect(() => {
-    if (variant !== 'bottom') return;
-    if (activeIndex < 0) { prevIndexRef.current = -1; return; }
-    if (prevIndexRef.current === activeIndex) return;
-
-    const side = getDocumentSide();
-    const opp = side === 'left' ? 'right' : 'left';
-    const prevIdx = prevIndexRef.current >= 0 ? prevIndexRef.current : activeIndex;
-    const minIdx = Math.min(prevIdx, activeIndex);
-    const spanCount = Math.abs(activeIndex - prevIdx) + 1;
-
-    prevIndexRef.current = activeIndex;
-
-    // Phase 1: stretch pill to span source → destination tabs
-    setPillStyle({ [side]: `${minIdx * baseW}%`, [opp]: 'auto', width: `${spanCount * baseW}%` });
-
-    // Phase 2: contract to destination tab
-    const timer = setTimeout(() => {
-      setPillStyle({ [side]: `${activeIndex * baseW}%`, [opp]: 'auto', width: `${baseW}%` });
-    }, 160);
-
-    return () => clearTimeout(timer);
-  }, [activeIndex, variant, baseW]);
-
-  // All hooks above — early return must come after
-  if (hidden) return null;
+  const side = isRTL ? 'right' : 'left';
 
   const baseButtonClass = 'relative z-10 flex items-center justify-center rounded-xl font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50';
   const layoutClass = variant === 'rail'
@@ -132,10 +98,12 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
           aria-hidden="true"
           className="pointer-events-none absolute rounded-2xl bg-[rgb(var(--nav-active-bg))]"
           style={{
-            ...pillStyle,
+            width: `${baseW}%`,
+            [side]: `${activeIndex * baseW}%`,
+            [isRTL ? 'left' : 'right']: 'auto',
             top: '0.375rem',
             bottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)',
-            transition: 'left 150ms ease-in-out, right 150ms ease-in-out, width 150ms ease-in-out',
+            transition: `${side} 250ms cubic-bezier(0.4, 0, 0.2, 1)`,
           }}
         />
       )}

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -13,6 +13,7 @@ export interface NavRailItem {
   badge?: number | null;
   variant?: 'default' | 'danger';
   isAction?: boolean;
+  isActive?: boolean;
   onClick?: () => void;
 }
 
@@ -71,20 +72,37 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
     return best;
   }, { id: null, score: -1 }).id;
 
-  const baseButtonClass = 'relative flex items-center justify-center rounded-xl font-medium transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50';
+  const getIsActive = (item: NavRailItem) =>
+    item.isActive !== undefined ? item.isActive : (!item.isAction && activeItemId === item.id);
+
+  const activeIndex = variant === 'bottom'
+    ? items.findIndex(getIsActive)
+    : -1;
+
+  const baseButtonClass = 'relative z-10 flex items-center justify-center rounded-xl font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50';
   const layoutClass = variant === 'rail'
     ? 'h-11 w-11'
     : 'min-w-0 flex-1 flex-col gap-1 rounded-2xl px-2 py-2 text-xs';
 
   const containerClass = variant === 'rail'
     ? 'flex h-full flex-col items-center gap-2 bg-[rgb(var(--nav-surface))] px-3 py-4'
-    : 'flex w-full items-center justify-around bg-[rgb(var(--nav-surface))] px-4 py-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] nav-rail--bottom';
+    : 'relative flex w-full items-center bg-[rgb(var(--nav-surface))] py-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] nav-rail--bottom';
 
   return (
     <div className={cn(containerClass, className)}>
+      {variant === 'bottom' && activeIndex >= 0 && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-1.5 rounded-2xl bg-[rgb(var(--nav-active-bg))] transition-transform duration-300 ease-out"
+          style={{
+            width: `${100 / items.length}%`,
+            transform: `translateX(${activeIndex * 100}%)`,
+          }}
+        />
+      )}
       {items.map((item) => {
         const icon = item.icon;
-        const isActive = !item.isAction && activeItemId === item.id;
+        const isActive = getIsActive(item);
         const isDanger = item.variant === 'danger';
 
         return (
@@ -99,9 +117,13 @@ export const NavRail: FunctionComponent<NavRailProps> = ({
               layoutClass,
               isDanger
                 ? 'text-red-400 hover:bg-red-500/10'
-                : isActive
-                  ? 'nav-item-active'
-                  : 'nav-item-inactive',
+                : variant === 'bottom'
+                  ? isActive
+                    ? 'text-[rgb(var(--nav-active-text))]'
+                    : 'text-[rgb(var(--input-text)_/_0.75)]'
+                  : isActive
+                    ? 'nav-item-active'
+                    : 'nav-item-inactive',
             )}
             onClick={() => {
               if (item.isAction) {

--- a/src/shared/ui/nav/NavRail.tsx
+++ b/src/shared/ui/nav/NavRail.tsx
@@ -19,7 +19,7 @@ export interface NavRailItem {
 
 export interface NavRailProps {
   items: NavRailItem[];
-  activeHref: string;
+  activeHref?: string;
   variant: 'rail' | 'bottom';
   showLabels?: boolean;
   hidden?: boolean;


### PR DESCRIPTION
## Summary
- Fixes #477 — widget bottom nav always highlighted Home regardless of active tab
- Adds `isActive` prop to `NavRailItem` for explicit active state control, bypassing path matching for view-state-driven navs
- Replaces per-button background toggling with a single sliding pill animation on all `variant="bottom"` NavRail instances

## Root cause
`NavRail` skipped `isAction` items in its active state calculation, and hash-only hrefs (`#home`, `#list`) both normalise to `/`, making path matching useless for the widget's view-based navigation.

## Test plan
- [ ] Open widget at `/widget-test.html` and switch between Home and Messages tabs — pill should slide smoothly between icons
- [ ] Confirm correct icon is highlighted on each tab
- [ ] Check workspace mobile nav (narrow viewport) still highlights the correct section when navigating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Each navigation item can now be explicitly marked active, improving accuracy of the active-tab display.

* **Style**
  * Bottom navigation gains a smooth, animated highlight that moves to the active tab.
  * Updated button layering and color/hover states for clearer active/inactive contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->