### PR TITLE
fix(dashboard): convert intake amount from cents in recent intakes grid

### DIFF
--- a/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
@@ -3,6 +3,7 @@ import { Avatar } from '@/shared/ui/profile';
 import { SkeletonLoader } from '@/shared/ui/layout/SkeletonLoader';
 import { Button } from '@/shared/ui/Button';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import { fromMinorUnits } from '@/shared/utils/money';
 import { formatDate } from '@/shared/utils/dateTime';
 import type { IntakeListItem } from '@/features/intake/api/intakesApi';
 import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
@@ -117,7 +118,7 @@ export const RecentIntakesGrid = ({
                   <dt className="text-input-placeholder">Amount</dt>
                   <dd className="flex items-start gap-x-2">
                     <div className="font-medium text-input-text">
-                      {formatCurrency(intake.amount, intake.currency)}
+                      {formatCurrency(fromMinorUnits(intake.amount), intake.currency)}
                     </div>
                   </dd>
                 </div>


### PR DESCRIPTION
## Summary

- `RecentIntakesGrid` was passing `intake.amount` (in minor units/cents from the API) directly to `formatCurrency`, which expects major units (dollars)
- This caused intake amounts to display as 100× their actual value — e.g. a $75.00 intake showed as $7,500
- Fix: wrap `intake.amount` with `fromMinorUnits()` before formatting, consistent with how `IntakeDetailPage` already handles this via its local `formatAmount(amount / 100)` helper

Closes #517

## Test plan

- [ ] Navigate to the practice workspace home dashboard
- [ ] Verify the "Recent Intakes" section shows correct dollar amounts (e.g. a $75 intake shows $75.00, not $7,500)
- [ ] Verify the intake detail page amount still shows correctly (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect amount calculations in the recent intakes display to ensure currency values are accurately formatted and presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->