### PR TITLE
feat(messages): draft conversation flow, presence over WS, file-only sends

### DIFF
--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,46 +1,74 @@
 #!/usr/bin/env node
 // Checks gzip sizes of dist chunks against budgets. Exit 1 on violation.
-import { readdirSync, statSync } from 'fs';
+//
+// "First-load" = the entry script + every chunk modulepreloaded by the
+// generated dist/index.html. Lazy-loaded route chunks (matters, intakes,
+// settings, etc.) are reported separately and do NOT count toward the
+// first-load budget — they're paid for at navigation time, not on cold start.
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { gzipSync } from 'zlib';
-import { readFileSync } from 'fs';
 
 const DIST = 'dist/assets';
+const HTML = 'dist/index.html';
 const BUDGETS = {
   vendor: 80 * 1024,  // 80KB gz
   main:   180 * 1024, // 180KB gz
-  total:  300 * 1024, // 300KB gz total JS first-load
+  total:  300 * 1024, // 300KB gz first-load JS
 };
 
-function gzSize(filePath) {
-  return gzipSync(readFileSync(filePath), { level: 9 }).length;
+const gzSize = (filePath) => gzipSync(readFileSync(filePath), { level: 9 }).length;
+
+// Parse the prerendered HTML for first-load JS — the <script type="module">
+// entry plus every <link rel="modulepreload"> chunk vite emits. This is the
+// JS browsers download before idle.
+const html = readFileSync(HTML, 'utf8');
+const firstLoadAssets = new Set();
+for (const re of [
+  /<script[^>]+src="\/assets\/([^"]+\.js)"/g,
+  /<link[^>]+rel="modulepreload"[^>]+href="\/assets\/([^"]+\.js)"/g,
+]) {
+  for (const match of html.matchAll(re)) firstLoadAssets.add(match[1]);
 }
 
+if (firstLoadAssets.size === 0) {
+  console.error('❌ Could not find any first-load chunks in dist/index.html — was the build run?');
+  process.exit(1);
+}
+
+const allFiles = readdirSync(DIST).filter((f) => f.endsWith('.js'));
 let failed = false;
-let totalJs = 0;
+let firstLoadTotal = 0;
+let lazyTotal = 0;
 
-const files = readdirSync(DIST).filter(f => f.endsWith('.js'));
-
-for (const file of files) {
+console.log('First-load chunks:');
+for (const file of allFiles) {
   const gz = gzSize(join(DIST, file));
-  totalJs += gz;
   const kb = (gz / 1024).toFixed(1);
-
-  if (file.startsWith('vendor') && gz > BUDGETS.vendor) {
-    console.error(`❌ vendor chunk ${file}: ${kb}KB gz > ${BUDGETS.vendor / 1024}KB budget`);
-    failed = true;
-  } else if (file.startsWith('index') && gz > BUDGETS.main) {
-    console.error(`❌ main chunk ${file}: ${kb}KB gz > ${BUDGETS.main / 1024}KB budget`);
-    failed = true;
+  if (firstLoadAssets.has(file)) {
+    firstLoadTotal += gz;
+    console.log(`  ${file}: ${kb}KB gz`);
+    if (file.startsWith('vendor') && gz > BUDGETS.vendor) {
+      console.error(`❌ vendor chunk ${file}: ${kb}KB gz > ${BUDGETS.vendor / 1024}KB budget`);
+      failed = true;
+    } else if (file.startsWith('index') && gz > BUDGETS.main) {
+      console.error(`❌ main chunk ${file}: ${kb}KB gz > ${BUDGETS.main / 1024}KB budget`);
+      failed = true;
+    }
+  } else {
+    lazyTotal += gz;
   }
 }
 
-const totalKb = (totalJs / 1024).toFixed(1);
-if (totalJs > BUDGETS.total) {
-  console.error(`❌ Total JS: ${totalKb}KB gz > ${BUDGETS.total / 1024}KB budget`);
+const firstLoadKb = (firstLoadTotal / 1024).toFixed(1);
+const lazyKb = (lazyTotal / 1024).toFixed(1);
+console.log(`Lazy-loaded chunks (not in first-load): ${lazyKb}KB gz across ${allFiles.length - firstLoadAssets.size} files`);
+
+if (firstLoadTotal > BUDGETS.total) {
+  console.error(`❌ First-load JS: ${firstLoadKb}KB gz > ${BUDGETS.total / 1024}KB budget`);
   failed = true;
 } else {
-  console.log(`✅ Total JS: ${totalKb}KB gz (budget: ${BUDGETS.total / 1024}KB)`);
+  console.log(`✅ First-load JS: ${firstLoadKb}KB gz (budget: ${BUDGETS.total / 1024}KB)`);
 }
 
 if (failed) process.exit(1);

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -3,10 +3,12 @@ import type { ComponentChildren } from 'preact';
 import { useLocation } from 'preact-iso';
 import ChatContainer from '@/features/chat/components/ChatContainer';
 import DragDropOverlay from '@/shared/ui/DragDropOverlay';
+import { Avatar } from '@/shared/ui/profile/atoms/Avatar';
 import WorkspacePage from '@/features/chat/pages/WorkspacePage';
 import { useSessionContext, useMemberRoleContext } from '@/shared/contexts/SessionContext';
 import { RoutePracticeProvider } from '@/shared/contexts/RoutePracticeContext';
 import { IntakeProvider } from '@/shared/contexts/IntakeContext';
+import { PresenceProvider } from '@/shared/contexts/PresenceContext';
 import type { UIPracticeConfig } from '@/shared/hooks/usePracticeConfig';
 import type { WorkspaceType } from '@/shared/types/workspace';
 import { useMessageHandling } from '@/shared/hooks/useMessageHandling';
@@ -25,7 +27,7 @@ import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 import type { ConversationMode } from '@/shared/types/conversation';
 import { lazy } from 'preact/compat';
-import { Info, Send, Plus } from 'lucide-preact';
+import { Send, Plus, Mail, Phone, Briefcase } from 'lucide-preact';
 import { INVOICE_CREATE_SEND_EVENT } from '@/features/invoices/utils/invoicePageConfig';
 const PracticeMattersPage = lazy(() => import('@/features/matters/pages/PracticeMattersPage').then(m => ({ default: m.PracticeMattersPage })));
 const PracticeContactsPage = lazy(() => import('@/features/clients/pages/PracticeContactsPage').then(m => ({ default: m.PracticeContactsPage })));
@@ -46,13 +48,12 @@ import { Button } from '@/shared/ui/Button';
 import { Icon } from '@/shared/ui/Icon';
 import { shouldShowWorkspaceDetailBack } from '@/shared/utils/workspaceDetailNavigation';
 import {
-  resolveConversationCaseTitle,
   resolveConversationContactName,
   resolveConversationDisplayTitle,
+  resolveConversationPresence,
 } from '@/shared/utils/conversationDisplay';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
 import { LazyRouteBoundary } from '@/shared/ui/layout/LazyRouteBoundary';
-import { resolveStrengthStyle, resolveStrengthTier } from '@/shared/utils/intakeStrength';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { features } from '@/config/features';
 
@@ -234,6 +235,7 @@ export function MainApp({
     conversationId: setupConversationId,
     setConversationId: _setConversationId,
     isCreatingConversation,
+    createConversation,
     ensureConversation,
     applyConversationMode,
   } = useConversationSetup({
@@ -341,7 +343,12 @@ export function MainApp({
   const handleStartNewConversation = useCallback(async (
     nextMode: ConversationMode,
     preferredConversationId?: string,
-    options?: { forceCreate?: boolean; silentSessionNotReady?: boolean }
+    options?: {
+      forceCreate?: boolean;
+      silentSessionNotReady?: boolean;
+      additionalParticipantUserIds?: string[];
+      additionalMetadata?: Record<string, unknown>;
+    }
   ): Promise<string> => {
     try {
       if (!practiceId) throw new Error('Practice context is required');
@@ -359,8 +366,17 @@ export function MainApp({
       }
 
       // ── Create new conversation ─────────────────────────────────────────────
-      // ensureConversation waits for the session to settle before creating.
-      const newConversationId = await ensureConversation();
+      // forceCreate must skip ensureConversation (which short-circuits to the
+      // current active id) and call createConversation directly. The
+      // allowPracticeWorkspace flag opts out of the staff-auto-create guard so
+      // the explicit "New conversation" affordance works for practice users too.
+      const newConversationId = options?.forceCreate
+        ? await createConversation({
+            allowPracticeWorkspace: true,
+            additionalParticipantUserIds: options.additionalParticipantUserIds,
+            additionalMetadata: options.additionalMetadata,
+          })
+        : await ensureConversation();
 
       if (!newConversationId) {
         // Practice workspace or other condition where creation is not applicable.
@@ -376,7 +392,7 @@ export function MainApp({
       console.warn('[MainApp] Failed to start new conversation', error);
       throw error;
     }
-  }, [activeConversationId, applyConversationMode, ensureConversation, practiceId, startConsultFlow]);
+  }, [activeConversationId, applyConversationMode, createConversation, ensureConversation, practiceId, startConsultFlow]);
 
   // ── send message ───────────────────────────────────────────────────────────
   const handleSendMessage = useCallback(async (
@@ -411,9 +427,55 @@ export function MainApp({
     conversationId: activeConversationId ?? undefined,
     enabled: features.enableFileAttachments && isAuthenticatedWorkspace,
   });
-  const isDragging = features.enableFileAttachments && isAuthenticatedWorkspace
-    ? uploadingFiles.length > 0 || previewFiles.length > 0
-    : false;
+
+  // Page-level drop handler. Tracks real drag state via window listeners
+  // (matters pattern: depth ref to debounce nested enter/leave from children)
+  // and drives the page-wide DragDropOverlay's visibility.
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const dragDepthRef = useRef(0);
+  useEffect(() => {
+    if (!features.enableFileAttachments || !isAuthenticatedWorkspace || isWidget) return;
+    const hasDraggedFiles = (event: DragEvent) => {
+      const types = event.dataTransfer?.types;
+      return Boolean(types && Array.from(types).includes('Files'));
+    };
+    const onDragEnter = (event: DragEvent) => {
+      if (!hasDraggedFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current += 1;
+      setIsDraggingFiles(true);
+    };
+    const onDragOver = (event: DragEvent) => {
+      if (!hasDraggedFiles(event)) return;
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+      setIsDraggingFiles(true);
+    };
+    const onDragLeave = (event: DragEvent) => {
+      if (!hasDraggedFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) setIsDraggingFiles(false);
+    };
+    const onDrop = (event: DragEvent) => {
+      if (!hasDraggedFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current = 0;
+      setIsDraggingFiles(false);
+      const dropped = event.dataTransfer?.files ? Array.from(event.dataTransfer.files) : [];
+      if (dropped.length > 0) void handleFileSelect(dropped);
+    };
+    window.addEventListener('dragenter', onDragEnter);
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('dragleave', onDragLeave);
+    window.addEventListener('drop', onDrop);
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter);
+      window.removeEventListener('dragover', onDragOver);
+      window.removeEventListener('dragleave', onDragLeave);
+      window.removeEventListener('drop', onDrop);
+    };
+  }, [features.enableFileAttachments, isAuthenticatedWorkspace, isWidget, handleFileSelect]);
 
   // ── welcome modals ─────────────────────────────────────────────────────────
   const { shouldShow: shouldShowWelcome, markAsShown: markWelcomeAsShown } = useWelcomeDialog({ enabled: workspace !== 'public' });
@@ -477,22 +539,26 @@ export function MainApp({
     return hasNonSystem ? base.filter((message) => message.metadata?.systemMessageKey !== 'intro') : base;
   }, [messages]);
 
-  const conversationHeaderActiveLabel = useMemo(() => {
-    if (isSocketReady) return 'Active';
-    const lastTimestamp = [...filteredMessagesForHeader].reverse().find((message) => typeof message.timestamp === 'number')?.timestamp;
-    if (!lastTimestamp) return 'Inactive';
-    const relative = formatRelativeTime(new Date(lastTimestamp));
-    return relative ? `Active ${relative}` : 'Inactive';
+  // Resolve presence (active | offline) for the conversation header. We can't
+  // read PresenceContext from this scope (MainApp renders the provider, so
+  // hooks here resolve outside it) — the list view does that. Fall back to
+  // the timestamp proxy + socket-ready as a "this thread is live" hint.
+  const conversationHeaderPresence = useMemo(() => {
+    const lastTimestamp = [...filteredMessagesForHeader].reverse()
+      .find((message) => typeof message.timestamp === 'number')?.timestamp;
+    return resolveConversationPresence(lastTimestamp ?? null, isSocketReady);
   }, [filteredMessagesForHeader, isSocketReady]);
-  const conversationCaseTitle = useMemo(() => (
-    resolveConversationCaseTitle(
-      conversationMetadata ?? null,
-      resolveConversationDisplayTitle(conversationMetadata ?? null, resolvedPracticeName)
-    )
-  ), [conversationMetadata, resolvedPracticeName]);
+  const conversationHeaderActiveLabel = conversationHeaderPresence.label;
   const conversationContactName = useMemo(() => (
     resolveConversationContactName(conversationMetadata ?? null)
   ), [conversationMetadata]);
+  // Conversation header always shows the contact name (the person being
+  // chatted with). No fallback to metadata.title or the practice name —
+  // those leak case-internal labels into the header. If the contact is
+  // unknown, render a generic placeholder rather than a misleading fallback.
+  const conversationCaseTitle = useMemo(() => (
+    conversationContactName?.trim() || 'Conversation'
+  ), [conversationContactName]);
 
   const isConsultConversation = useMemo(
     () => conversationMode === 'REQUEST_CONSULTATION'
@@ -514,52 +580,148 @@ export function MainApp({
     [conversationMetadata, conversationMode, intakeConversationState, intakeStatus, slimContactDraft]
   );
 
-  const conversationStrengthAction = useMemo(() => {
-    if (!isConsultConversation) return null;
+  // On desktop practice/client surfaces the inspector panel is open by default,
+  // so the 3-dot inspector toggle in the conversation header would be redundant
+  // chrome. Mobile keeps it (the inspector is a drawer there) and the public
+  // widget is left untouched.
+  const hideInspectorChrome = layoutMode === 'desktop' && isAuthenticatedWorkspace;
 
-    const tier = resolveStrengthTier(intakeConversationState);
-    const { percent, ringClass } = resolveStrengthStyle(tier);
-    const radius = 9;
-    const circumference = 2 * Math.PI * radius;
-    const dashOffset = circumference - (percent / 100) * circumference;
-
+  // Pencil rxzde detail header: practice viewers see a primary "Create
+  // Engagement" CTA. The CTA jumps to the engagements page where the existing
+  // creation flow lives. Hidden on non-desktop layouts (Pencil d08Mpc keeps the
+  // mobile detail header spartan — only back + title + overflow menu).
+  const createEngagementAction = useMemo(() => {
+    if (!isPracticeWorkspace) return null;
+    if (!practiceEngagementsPath) return null;
+    if (layoutMode !== 'desktop') return null;
     return (
       <Button
         type="button"
-        variant="icon"
-        size="icon-sm"
-        onClick={() => {
-          if (typeof window === 'undefined') return;
-          window.dispatchEvent(new CustomEvent('workspace:open-inspector'));
-        }}
-        aria-label="Case strength"
+        variant="primary"
+        size="sm"
+        onClick={() => navigate(practiceEngagementsPath)}
+        icon={Plus}
+        iconClassName="h-4 w-4"
+        iconPosition="left"
       >
-        <span className="relative flex h-6 w-6 items-center justify-center">
-          <svg className="-rotate-90 absolute inset-0 h-6 w-6" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r={radius} strokeWidth="2" fill="none" className="text-line-glass/30" stroke="currentColor" />
-            <circle
-              cx="12" cy="12" r={radius} strokeWidth="2" fill="none" strokeLinecap="round"
-              className={`transition-all duration-300 ${ringClass}`} stroke="currentColor"
-              strokeDasharray={circumference} strokeDashoffset={dashOffset}
-            />
-          </svg>
-          <Icon icon={Info} className="relative z-10 h-3.5 w-3.5" aria-hidden="true" />
-        </span>
+        Create Engagement
       </Button>
     );
-  }, [intakeConversationState, isConsultConversation]);
+  }, [isPracticeWorkspace, layoutMode, practiceEngagementsPath, navigate]);
+
+  const conversationHeaderActions = useMemo(() => {
+    if (!createEngagementAction) return null;
+    return (
+      <div className="flex items-center gap-2">
+        {createEngagementAction}
+      </div>
+    );
+  }, [createEngagementAction]);
+
+  // Pencil rxzde header strip: email + phone + linked-matter chip rendered as a
+  // second row below the main header. Email/phone come from the same intake
+  // sources used by ConversationContextPanel — keep both surfaces aligned so a
+  // value visible in the right panel is also visible up here.
+  const conversationHeaderEmail = useMemo(() => {
+    const intake = (intakeConversationState ?? null) as Record<string, unknown> | null;
+    if (typeof intake?.email === 'string' && intake.email.trim()) return intake.email.trim();
+    if (typeof slimContactDraft?.email === 'string' && slimContactDraft.email.trim()) return slimContactDraft.email.trim();
+    return '';
+  }, [intakeConversationState, slimContactDraft]);
+  const conversationHeaderPhone = useMemo(() => {
+    const intake = (intakeConversationState ?? null) as Record<string, unknown> | null;
+    if (typeof intake?.phone === 'string' && intake.phone.trim()) return intake.phone.trim();
+    if (typeof slimContactDraft?.phone === 'string' && slimContactDraft.phone.trim()) return slimContactDraft.phone.trim();
+    return '';
+  }, [intakeConversationState, slimContactDraft]);
+  const conversationHeaderMatterLabel = useMemo(() => {
+    const meta = conversationMetadata as Record<string, unknown> | null | undefined;
+    const candidates = [
+      meta?.matter_title,
+      meta?.matterTitle,
+      meta?.matter_name,
+      meta?.matterName,
+    ];
+    for (const value of candidates) {
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+    return '';
+  }, [conversationMetadata]);
+
+  const conversationHeaderSecondaryRow = useMemo(() => {
+    if (!isPracticeWorkspace) return undefined;
+    if (layoutMode !== 'desktop') return undefined;
+    if (!conversationHeaderEmail && !conversationHeaderPhone && !conversationHeaderMatterLabel) return undefined;
+    return (
+      <>
+        {conversationHeaderEmail ? (
+          <a
+            href={`mailto:${conversationHeaderEmail}`}
+            className="inline-flex min-w-0 items-center gap-1.5 truncate hover:text-input-text"
+          >
+            <Icon icon={Mail} className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{conversationHeaderEmail}</span>
+          </a>
+        ) : null}
+        {conversationHeaderPhone ? (
+          <a
+            href={`tel:${conversationHeaderPhone.replace(/[^0-9+]/g, '')}`}
+            className="inline-flex min-w-0 items-center gap-1.5 truncate hover:text-input-text"
+          >
+            <Icon icon={Phone} className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{conversationHeaderPhone}</span>
+          </a>
+        ) : null}
+        {conversationHeaderMatterLabel ? (
+          <span className="inline-flex min-w-0 items-center gap-1.5 truncate rounded-full bg-accent-500/10 px-2 py-0.5 text-accent-utility">
+            <Icon icon={Briefcase} className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{conversationHeaderMatterLabel}</span>
+          </span>
+        ) : null}
+      </>
+    );
+  }, [
+    conversationHeaderEmail, conversationHeaderMatterLabel, conversationHeaderPhone,
+    isPracticeWorkspace, layoutMode,
+  ]);
+
+  // Pencil rxzde inline "• Unread" pill next to the title — only shown when the
+  // active conversation hasn't been read yet (socket marks it read once messages
+  // are loaded, so this is mostly a transient state on initial open).
+  const conversationHeaderUnreadBadge = useMemo(() => {
+    if (!isPracticeWorkspace) return undefined;
+    if (isSocketReady) return undefined;
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-accent-500/15 px-2 py-0.5 text-[11px] font-semibold text-accent-utility">
+        <span className="h-1.5 w-1.5 rounded-full bg-accent-500" aria-hidden="true" />
+        Unread
+      </span>
+    );
+  }, [isPracticeWorkspace, isSocketReady]);
 
   const conversationHeaderContent = useMemo(() => {
     if (!conversationsBasePath || !activeConversationId) return undefined;
     const showConversationBack = shouldShowWorkspaceDetailBack(layoutMode, Boolean(conversationBackPath));
+    const headerAvatar = (
+      <Avatar
+        src={null}
+        name={conversationCaseTitle}
+        size="sm"
+        className="ring-1 ring-line-glass/10"
+        status={conversationHeaderPresence.status}
+      />
+    );
     return (
       <DetailHeader
         title={conversationCaseTitle}
         subtitle={conversationHeaderActiveLabel}
         showBack={showConversationBack}
         onBack={showConversationBack ? () => navigate(conversationBackPath) : undefined}
-        actions={conversationStrengthAction}
-        onInspector={() => {
+        leadingAction={headerAvatar}
+        actions={conversationHeaderActions}
+        titleBadge={conversationHeaderUnreadBadge}
+        secondaryRow={conversationHeaderSecondaryRow}
+        onInspector={hideInspectorChrome ? undefined : () => {
           if (typeof window === 'undefined') return;
           window.dispatchEvent(new CustomEvent('workspace:open-inspector'));
         }}
@@ -568,8 +730,9 @@ export function MainApp({
     );
   }, [
     activeConversationId, conversationBackPath, conversationsBasePath,
-    conversationCaseTitle, conversationHeaderActiveLabel, conversationStrengthAction,
-    layoutMode, navigate,
+    conversationCaseTitle, conversationHeaderActiveLabel, conversationHeaderActions,
+    conversationHeaderPresence, conversationHeaderSecondaryRow, conversationHeaderUnreadBadge,
+    hideInspectorChrome, layoutMode, navigate,
   ]);
   const showWorkspaceDetailBack = useMemo(
     () => shouldShowWorkspaceDetailBack(layoutMode),
@@ -718,6 +881,19 @@ export function MainApp({
       }}
       practiceDetails={practiceDetails}
       chatView={chatPanel}
+      fileUploadProps={{
+        previewFiles,
+        uploadingFiles,
+        isReadyToUpload,
+        handleFileSelect,
+        handleCameraCapture,
+        removePreviewFile,
+        clearPreviewFiles,
+        cancelUpload,
+        handleMediaCapture,
+        isRecording,
+        setIsRecording,
+      }}
       mattersView={
         isPracticeWorkspace
           ? (practiceMattersPath
@@ -985,13 +1161,19 @@ export function MainApp({
 
   return (
     <>
-      {!isWidget && <DragDropOverlay isVisible={isDragging} onClose={() => {}} />}
+      {!isWidget && <DragDropOverlay isVisible={isDraggingFiles} />}
       <IntakeProvider value={intakeProviderValue}>
-        <div className={rootClassName}>
-          <RoutePracticeProvider value={routePracticeContextValue}>
-            {workspacePage}
-          </RoutePracticeProvider>
-        </div>
+        <PresenceProvider
+          practiceId={effectivePracticeId ?? practiceId ?? null}
+          userId={session?.user?.id ?? null}
+          enabled={!isWidget && !isAnonymous}
+        >
+          <div className={rootClassName}>
+            <RoutePracticeProvider value={routePracticeContextValue}>
+              {workspacePage}
+            </RoutePracticeProvider>
+          </div>
+        </PresenceProvider>
       </IntakeProvider>
       {!isWidget && (
         <>

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -778,6 +778,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
                       onClose={() => setIsInspectorOpen(false)}
                       intakeConversationState={intakeConversationState}
                       intakeStatus={intakeStatus}
+                      intake={activeIntake}
                       onIntakeFieldsChange={(patch, options) => {
                         // Remove all null values for IntakeFieldsPayload compatibility
                         const payload: Record<string, unknown> = {};
@@ -809,6 +810,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
                   onClose={() => setIsInspectorOpen(false)}
                   intakeConversationState={intakeConversationState}
                   intakeStatus={intakeStatus}
+                  intake={activeIntake}
                   onIntakeFieldsChange={(patch, options) => {
                     const payload: Record<string, unknown> = {};
                     Object.entries(patch).forEach(([key, value]) => {

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -112,7 +112,7 @@ interface FeatureFlags {
 
 // Immutable base configuration
 const baseFeatureConfig: FeatureFlags = {
-    enableAudioRecording: false, // Set to false to hide voice recording
+    enableAudioRecording: true, // Voice memo button shown inside the composer pill
     enableVideoRecording: false, // Not implemented yet
     enableFileAttachments: true, // Enabled for authenticated (client/practice) workspaces only
     enableMessageFeedback: false, // Disable feedback and copy buttons on messages

--- a/src/features/chat/components/ChatMarkdown.tsx
+++ b/src/features/chat/components/ChatMarkdown.tsx
@@ -1,16 +1,19 @@
 import { memo, useEffect, useMemo, useState } from 'preact/compat';
 import type { FunctionComponent } from 'preact';
-import remarkGfm from 'remark-gfm';
-import { markdownComponents } from '@/shared/ui/markdown/markdownComponents';
 import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
 type UrlTransform = (url: string, key: string, node: unknown) => string;
 
-// Custom hook to dynamically import react-markdown on client
+// Custom hook to dynamically import react-markdown + its plugins + the
+// shared markdownComponents map. All three live in the same lazy chunk so
+// the entire markdown surface stays off the first-load critical path.
 function useReactMarkdown() {
   // dynamic import: type is unknown until loaded, must use any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const [ReactMarkdown, setReactMarkdown] = useState<any>(null);
+  const [remarkGfm, setRemarkGfm] = useState<any>(null);
+  const [components, setComponents] = useState<any>(null);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   const [defaultUrlTransform, setDefaultUrlTransform] = useState<UrlTransform | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,9 +22,15 @@ function useReactMarkdown() {
 
     const loadMarkdown = async () => {
       try {
-        const mod = await import('react-markdown');
+        const [mod, gfm, comps] = await Promise.all([
+          import('react-markdown'),
+          import('remark-gfm'),
+          import('@/shared/ui/markdown/markdownComponents'),
+        ]);
         if (mounted) {
           setReactMarkdown(() => mod.default);
+          setRemarkGfm(() => gfm.default);
+          setComponents(() => comps.markdownComponents);
           setDefaultUrlTransform(() => mod.defaultUrlTransform ?? null);
           setError(null);
         }
@@ -30,6 +39,8 @@ function useReactMarkdown() {
           const errorMsg = err instanceof Error ? err.message : 'Failed to load markdown component';
           setError(errorMsg);
           setReactMarkdown(null);
+          setRemarkGfm(null);
+          setComponents(null);
           setDefaultUrlTransform(null);
         }
       }
@@ -42,7 +53,7 @@ function useReactMarkdown() {
     };
   }, []);
 
-  return { component: ReactMarkdown, defaultUrlTransform, error };
+  return { component: ReactMarkdown, remarkGfm, components, defaultUrlTransform, error };
 }
 
 interface ChatMarkdownProps {
@@ -72,7 +83,7 @@ const ChatMarkdown: FunctionComponent<ChatMarkdownProps> = memo(({
   variant = 'default',
   size = 'md',
 }) => {
-  const { component: ReactMarkdown, defaultUrlTransform, error: markdownError } = useReactMarkdown();
+  const { component: ReactMarkdown, remarkGfm, components: markdownComponents, defaultUrlTransform, error: markdownError } = useReactMarkdown();
   const sourceText = text ?? '';
 
   const classes = [
@@ -116,11 +127,11 @@ const ChatMarkdown: FunctionComponent<ChatMarkdownProps> = memo(({
     <div className={classes}>
       {markdownError ? (
         <div className="text-red-500 text-sm">Failed to load markdown: {markdownError}</div>
-      ) : ReactMarkdown ? (
+      ) : ReactMarkdown && remarkGfm && markdownComponents ? (
         <ReactMarkdown
           components={markdownComponents}
           remarkPlugins={[remarkGfm]}
-          urlTransform={(url, key, node) => {
+          urlTransform={(url: string, key: string, node: unknown) => {
             if (url.startsWith('mention://')) return url;
             return defaultUrlTransform ? defaultUrlTransform(url, key, node) : url;
           }}

--- a/src/features/chat/components/ConversationContextPanel.tsx
+++ b/src/features/chat/components/ConversationContextPanel.tsx
@@ -1,0 +1,307 @@
+import { FunctionComponent } from 'preact';
+import { useMemo } from 'preact/hooks';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, Trash2 } from 'lucide-preact';
+import { Avatar } from '@/shared/ui/profile/atoms/Avatar';
+import { Button } from '@/shared/ui/Button';
+import { DetailRow } from '@/shared/ui/detail/DetailRow';
+import { cn } from '@/shared/utils/cn';
+import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
+import {
+  resolveConversationContactName,
+  resolveConversationDisplayTitle,
+} from '@/shared/utils/conversationDisplay';
+import type { Conversation } from '@/shared/types/conversation';
+import type { BackendMatter } from '@/features/matters/services/mattersApi';
+
+const sectionTitle = 'text-[11px] font-semibold uppercase tracking-[0.08em] text-input-placeholder';
+const sectionDivider = 'border-t border-line-glass/30 pt-4 mt-4';
+
+interface ActivityEntry {
+  id: string;
+  title: string;
+  detail?: string | null;
+  timestamp?: string | null;
+}
+
+interface ConversationContextPanelProps {
+  conversation: Conversation | null;
+  matter?: BackendMatter | null;
+  /** Practice name used as a fallback for the contact label. */
+  practiceName?: string | null;
+  /** Optional callback when the linked-matter row is clicked. */
+  onOpenMatter?: (matterId: string) => void;
+  /** Optional callback to start the delete-conversation flow. When provided,
+   *  renders a "Delete conversation" button at the bottom of the panel. */
+  onDeleteConversation?: () => void;
+  className?: string;
+}
+
+const PRACTICE_AREA_LABELS: Record<string, string> = {
+  family_law: 'Family Law',
+  criminal_defense: 'Criminal Defense',
+  personal_injury: 'Personal Injury',
+  employment_law: 'Employment Law',
+  business_law: 'Business Law',
+  estate_planning: 'Estate Planning',
+  immigration: 'Immigration',
+  real_estate: 'Real Estate',
+  intellectual_property: 'Intellectual Property',
+  general: 'General',
+};
+
+const formatPracticeArea = (value: string | null | undefined): string => {
+  if (!value) return '';
+  if (PRACTICE_AREA_LABELS[value]) return PRACTICE_AREA_LABELS[value];
+  return value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+const STATUS_TONE: Record<string, string> = {
+  active: 'text-emerald-400',
+  pleadings_filed: 'text-emerald-400',
+  discovery: 'text-emerald-400',
+  consultation_scheduled: 'text-amber-300',
+  intake_pending: 'text-amber-300',
+  closed: 'text-input-placeholder',
+  declined: 'text-input-placeholder',
+};
+
+const formatStatusLabel = (status: string | null | undefined): string => {
+  if (!status) return '';
+  return status
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+const formatActivityDate = (timestamp: string | null | undefined): string => {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+const buildActivityEntries = (conversation: Conversation | null): ActivityEntry[] => {
+  if (!conversation) return [];
+  const metadata = conversation.user_info ?? null;
+  const entries: ActivityEntry[] = [];
+  if (metadata?.intakeCompleted || metadata?.intakeSubmitted) {
+    entries.push({
+      id: 'intake-completed',
+      title: 'Intake completed',
+      detail: 'All form fields submitted',
+      timestamp: conversation.first_response_at ?? conversation.updated_at ?? null,
+    });
+  }
+  if (metadata?.intakePaymentReceived) {
+    entries.push({
+      id: 'payment-received',
+      title: 'Payment received',
+      detail: typeof metadata?.intakeRetainerLabel === 'string' ? metadata.intakeRetainerLabel : null,
+      timestamp: conversation.last_message_at ?? null,
+    });
+  }
+  if (conversation.lead?.is_lead && conversation.lead.created_at) {
+    entries.push({
+      id: 'lead-created',
+      title: 'Lead created',
+      detail: typeof conversation.lead.lead_source === 'string' ? conversation.lead.lead_source : null,
+      timestamp: conversation.lead.created_at,
+    });
+  }
+  return entries;
+};
+
+/**
+ * Pencil rxzde right-side context panel. Renders three label-left, value-right
+ * sections (Contact, Linked Matter, Recent Activity) inside a single column.
+ * All data sources are optional — sections gracefully render placeholder rows
+ * when fields are missing rather than collapsing.
+ */
+const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps> = ({
+  conversation,
+  matter,
+  practiceName,
+  onOpenMatter,
+  onDeleteConversation,
+  className,
+}) => {
+  const { t } = useTranslation();
+
+  const contactName = useMemo(() => {
+    if (!conversation) return '';
+    return (
+      resolveConversationContactName(conversation) ||
+      resolveConversationDisplayTitle(conversation, practiceName ?? '') ||
+      ''
+    );
+  }, [conversation, practiceName]);
+
+  const metadata = conversation?.user_info ?? null;
+  const intakeState = (metadata?.intakeConversationState ?? null) as Record<string, unknown> | null;
+  const slimDraft = (metadata?.intakeSlimContactDraft ?? null) as Record<string, unknown> | null;
+
+  const email = useMemo(() => {
+    if (typeof intakeState?.email === 'string' && intakeState.email.trim()) return intakeState.email;
+    if (typeof slimDraft?.email === 'string' && slimDraft.email.trim()) return slimDraft.email;
+    return '';
+  }, [intakeState, slimDraft]);
+
+  const phone = useMemo(() => {
+    if (typeof intakeState?.phone === 'string' && intakeState.phone.trim()) return intakeState.phone;
+    if (typeof slimDraft?.phone === 'string' && slimDraft.phone.trim()) return slimDraft.phone;
+    return '';
+  }, [intakeState, slimDraft]);
+
+  const source = useMemo(() => {
+    const leadSource = conversation?.lead?.lead_source;
+    if (typeof leadSource === 'string' && leadSource.trim()) return leadSource;
+    if (metadata?.mode === 'REQUEST_CONSULTATION') return 'Consultation request';
+    if (metadata?.intakeUuid) return 'Website Intake';
+    return '';
+  }, [conversation, metadata]);
+
+  const matterTitle = matter?.title ?? '';
+  const matterStatus = matter?.status ?? '';
+  const matterPracticeArea = formatPracticeArea(matter?.practice_area ?? null);
+
+  const activity = useMemo(() => buildActivityEntries(conversation), [conversation]);
+
+  const statusToneClass = STATUS_TONE[matterStatus] ?? 'text-input-text';
+  const statusLabel = formatStatusLabel(matterStatus);
+
+  const lastActiveLabel = conversation?.last_message_at
+    ? formatRelativeTime(new Date(conversation.last_message_at))
+    : null;
+
+  return (
+    <aside
+      className={cn(
+        'flex h-full min-h-0 w-full flex-col overflow-y-auto bg-[rgb(var(--surface-card))] px-5 py-5',
+        className
+      )}
+      aria-label={t('workspace.conversationContext.label', { defaultValue: 'Conversation details' })}
+    >
+      {/* Identity header — small avatar + contact name + last-active hint */}
+      <div className="flex flex-col items-center gap-3 pb-4 text-center">
+        <Avatar src={null} name={contactName || (practiceName ?? 'Contact')} size="lg" />
+        <div className="min-w-0">
+          <p className="truncate text-base font-semibold text-input-text">{contactName || '—'}</p>
+          {lastActiveLabel ? (
+            <p className="mt-0.5 text-xs text-input-placeholder">
+              {t('workspace.conversationContext.lastActive', {
+                defaultValue: 'Active {{relative}}',
+                relative: lastActiveLabel,
+              })}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <section className="flex flex-col gap-3 border-t border-line-glass/30 pt-4">
+        <h3 className={sectionTitle}>{t('workspace.conversationContext.contact', { defaultValue: 'Contact' })}</h3>
+        <DetailRow label={t('workspace.conversationContext.name', { defaultValue: 'Name' })} value={contactName} />
+        <DetailRow label={t('workspace.conversationContext.email', { defaultValue: 'Email' })} value={email} />
+        <DetailRow label={t('workspace.conversationContext.phone', { defaultValue: 'Phone' })} value={phone} />
+        <DetailRow label={t('workspace.conversationContext.source', { defaultValue: 'Source' })} value={source} />
+      </section>
+
+      <section className={cn('flex flex-col gap-3', sectionDivider)}>
+        <h3 className={sectionTitle}>
+          {t('workspace.conversationContext.linkedMatter', { defaultValue: 'Linked Matter' })}
+        </h3>
+        <DetailRow
+          label={t('workspace.conversationContext.matter', { defaultValue: 'Matter' })}
+          value={
+            matterTitle ? (
+              onOpenMatter && matter ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 text-right text-input-text hover:text-accent-utility focus:outline-none focus-visible:underline"
+                  onClick={() => onOpenMatter(matter.id)}
+                >
+                  <span className="truncate">{matterTitle}</span>
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                </button>
+              ) : (
+                matterTitle
+              )
+            ) : (
+              ''
+            )
+          }
+          emptyText={t('workspace.conversationContext.noMatter', { defaultValue: 'No linked matter' })}
+        />
+        <DetailRow
+          label={t('workspace.conversationContext.status', { defaultValue: 'Status' })}
+          value={
+            statusLabel ? (
+              <span className={cn('font-medium', statusToneClass)}>{statusLabel}</span>
+            ) : (
+              ''
+            )
+          }
+        />
+        <DetailRow
+          label={t('workspace.conversationContext.practiceArea', { defaultValue: 'Practice Area' })}
+          value={matterPracticeArea}
+        />
+      </section>
+
+      <section className={cn('flex flex-col gap-3', sectionDivider)}>
+        <h3 className={sectionTitle}>
+          {t('workspace.conversationContext.recentActivity', { defaultValue: 'Recent Activity' })}
+        </h3>
+        {activity.length === 0 ? (
+          <p className="text-xs text-input-placeholder">
+            {t('workspace.conversationContext.noActivity', {
+              defaultValue: 'Activity will appear here once the conversation progresses.',
+            })}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {activity.map((entry) => (
+              <li key={entry.id} className="flex items-start justify-between gap-3 text-sm">
+                <div className="min-w-0">
+                  <p className="font-medium text-input-text">{entry.title}</p>
+                  {entry.detail ? (
+                    <p className="mt-0.5 truncate text-xs text-input-placeholder">{entry.detail}</p>
+                  ) : null}
+                </div>
+                {entry.timestamp ? (
+                  <span className="flex-shrink-0 text-xs text-input-placeholder">
+                    {formatActivityDate(entry.timestamp)}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {onDeleteConversation && conversation ? (
+        <section className={cn('flex flex-col gap-3', sectionDivider)}>
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            icon={Trash2}
+            iconClassName="h-4 w-4"
+            iconPosition="left"
+            onClick={onDeleteConversation}
+            className="self-start"
+          >
+            {t('workspace.conversationContext.delete', { defaultValue: 'Delete conversation' })}
+          </Button>
+        </section>
+      ) : null}
+    </aside>
+  );
+};
+
+export default ConversationContextPanel;

--- a/src/features/chat/components/ConversationContextPanel.tsx
+++ b/src/features/chat/components/ConversationContextPanel.tsx
@@ -118,7 +118,7 @@ const buildActivityEntries = (conversation: Conversation | null): ActivityEntry[
 };
 
 /**
- * Pencil rxzde right-side context panel. Renders three label-left, value-right
+ * Right-side context panel. Renders three label-left, value-right
  * sections (Contact, Linked Matter, Recent Activity) inside a single column.
  * All data sources are optional — sections gracefully render placeholder rows
  * when fields are missing rather than collapsing.

--- a/src/features/chat/components/DraftConversationView.tsx
+++ b/src/features/chat/components/DraftConversationView.tsx
@@ -1,0 +1,248 @@
+import { type FunctionComponent } from 'preact';
+import { useMemo, useRef, useState } from 'preact/hooks';
+import { X } from 'lucide-preact';
+import { Avatar } from '@/shared/ui/profile';
+import { Button } from '@/shared/ui/Button';
+import { Combobox, type ComboboxOption } from '@/shared/ui/input/Combobox';
+import { cn } from '@/shared/utils/cn';
+import MessageComposer from '@/features/chat/components/MessageComposer';
+import { usePresenceContext } from '@/shared/contexts/PresenceContext';
+import type { FileAttachment } from '../../../../worker/types';
+import type { UploadingFile } from '@/shared/types/upload';
+
+export type DraftContact = {
+  userId: string;
+  name: string;
+  email?: string;
+} | null;
+
+interface DraftConversationViewProps {
+  contactOptions: ComboboxOption[];
+  pendingInviteOptions?: ComboboxOption[];
+  isLoadingContacts?: boolean;
+  draftContact: DraftContact;
+  onChangeContact: (next: DraftContact) => void;
+  onSendFirstMessage: (message: string, attachments: FileAttachment[]) => Promise<void>;
+  onCancel: () => void;
+  onInviteContact?: () => void;
+  onClickPendingInvite?: (option: ComboboxOption) => void;
+  /** File upload state (lifted from MainApp's useFileUpload). The draft
+   *  composer reuses the same pipeline + preview state as the main chat
+   *  composer, so drag-and-drop and image previews work identically. */
+  fileUploadProps?: {
+    previewFiles: FileAttachment[];
+    uploadingFiles: UploadingFile[];
+    isReadyToUpload: boolean;
+    handleFileSelect: (files: File[]) => Promise<unknown>;
+    handleCameraCapture: (file: File) => Promise<void>;
+    removePreviewFile: (index: number) => void;
+    clearPreviewFiles: () => void;
+    cancelUpload: (fileId: string) => void;
+    handleMediaCapture: (blob: Blob, type: 'audio' | 'video') => void;
+    isRecording: boolean;
+    setIsRecording: (recording: boolean) => void;
+  };
+}
+
+/**
+ * Draft conversation view — shown after the user clicks "New message" but
+ * before any conversation has been persisted. Picks a contact via the
+ * embedded Combobox; the first message send is what actually creates the
+ * conversation in D1, hands the user off to the real conversation thread.
+ */
+export const DraftConversationView: FunctionComponent<DraftConversationViewProps> = ({
+  contactOptions,
+  pendingInviteOptions = [],
+  isLoadingContacts = false,
+  draftContact,
+  onChangeContact,
+  onSendFirstMessage,
+  onCancel,
+  onInviteContact,
+  onClickPendingInvite,
+  fileUploadProps,
+}) => {
+  const [inputValue, setInputValue] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Real presence — option values are userIds for clients/team rows. Pending
+  // invites use a `__pending__:` prefix and can't be online.
+  const { onlineUserIds } = usePresenceContext();
+
+  // Pending-invite rows are tagged with `__pending__` in the option value so
+  // we can intercept onChange and route to the invite-confirmation path
+  // instead of treating them as a real selection.
+  const allOptions = useMemo<ComboboxOption[]>(() => {
+    if (pendingInviteOptions.length === 0) return contactOptions;
+    return [
+      ...contactOptions,
+      ...pendingInviteOptions.map((option) => ({
+        ...option,
+        value: `__pending__:${option.value}`,
+        disabled: false,
+        meta: option.meta ?? 'Invite pending — waiting for accept',
+        description: option.description ?? 'Pending invite',
+      })),
+    ];
+  }, [contactOptions, pendingInviteOptions]);
+
+  const handlePickContact = (rawValue: string) => {
+    if (!rawValue) {
+      onChangeContact(null);
+      return;
+    }
+    if (rawValue.startsWith('__pending__:')) {
+      const realValue = rawValue.slice('__pending__:'.length);
+      const option = pendingInviteOptions.find((opt) => opt.value === realValue);
+      if (option && onClickPendingInvite) onClickPendingInvite(option);
+      return;
+    }
+    const option = contactOptions.find((opt) => opt.value === rawValue);
+    if (!option) return;
+    onChangeContact({
+      userId: option.value,
+      name: option.label,
+      email: typeof option.meta === 'string' ? option.meta : undefined,
+    });
+  };
+
+  const handleComposerSubmit = async () => {
+    if (!draftContact?.userId) return;
+    const trimmed = inputValue.trim();
+    const attachments = fileUploadProps?.previewFiles ?? [];
+    if (!trimmed && attachments.length === 0) return;
+    if (isSending) return;
+    try {
+      setIsSending(true);
+      await onSendFirstMessage(trimmed, attachments);
+      setInputValue('');
+      fileUploadProps?.clearPreviewFiles();
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleComposerKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      void handleComposerSubmit();
+    }
+  };
+
+  const composerDisabled = !draftContact?.userId || isSending;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-surface-workspace">
+      <header className="flex items-center justify-between gap-3 border-b border-line-glass/30 px-4 py-3 sm:px-6">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <Avatar
+            src={null}
+            name={draftContact?.name ?? 'New conversation'}
+            size="md"
+            className="ring-1 ring-line-glass/10"
+            status={draftContact?.userId
+              ? (onlineUserIds.has(draftContact.userId) ? 'active' : 'offline')
+              : undefined}
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="text-xs uppercase tracking-wide text-input-placeholder">
+              New conversation
+            </span>
+            <span className="truncate text-sm font-semibold text-input-text">
+              {draftContact?.name ?? 'Pick a contact below to begin'}
+            </span>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="icon"
+          size="icon-sm"
+          onClick={onCancel}
+          icon={X}
+          iconClassName="h-4 w-4"
+          aria-label="Cancel new conversation"
+        />
+      </header>
+
+      <div className="border-b border-line-glass/30 px-4 py-3 sm:px-6">
+        <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.08em] text-input-placeholder">
+          To
+        </span>
+        <Combobox
+          value={draftContact?.userId ?? ''}
+          onChange={handlePickContact}
+          options={allOptions}
+          searchable
+          placeholder={isLoadingContacts ? 'Loading contacts…' : 'Search clients and team…'}
+          optionLeading={(option) => {
+            const isPending = option.value.startsWith('__pending__:');
+            const isOnline = !isPending && onlineUserIds.has(option.value);
+            return (
+              <Avatar
+                src={null}
+                name={option.label}
+                size="sm"
+                status={isPending ? undefined : isOnline ? 'active' : 'offline'}
+              />
+            );
+          }}
+          optionMeta={(option) => option.meta || option.description || ''}
+          footer={onInviteContact ? (close) => (
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                close();
+                onInviteContact();
+              }}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm',
+                'text-input-text hover:bg-surface-utility/10 focus-visible:bg-surface-utility/10',
+              )}
+            >
+              <span className="text-accent-utility">+ Invite a new contact</span>
+            </button>
+          ) : undefined}
+        />
+      </div>
+
+      <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">
+        <div className="max-w-sm text-center">
+          <p className="text-sm text-input-text">
+            {draftContact
+              ? `Type a message to ${draftContact.name} below to start the conversation.`
+              : 'Pick a contact above, then write the first message.'}
+          </p>
+          <p className="mt-1 text-xs text-input-placeholder">
+            The conversation is created when you send the first message.
+          </p>
+        </div>
+      </div>
+
+      {fileUploadProps ? (
+        <MessageComposer
+          inputValue={inputValue}
+          setInputValue={setInputValue}
+          previewFiles={fileUploadProps.previewFiles}
+          uploadingFiles={fileUploadProps.uploadingFiles}
+          removePreviewFile={fileUploadProps.removePreviewFile}
+          handleFileSelect={fileUploadProps.handleFileSelect}
+          handleCameraCapture={fileUploadProps.handleCameraCapture}
+          cancelUpload={fileUploadProps.cancelUpload}
+          isRecording={fileUploadProps.isRecording}
+          handleMediaCapture={fileUploadProps.handleMediaCapture}
+          setIsRecording={fileUploadProps.setIsRecording}
+          onSubmit={() => { void handleComposerSubmit(); }}
+          onKeyDown={handleComposerKeyDown}
+          textareaRef={textareaRef}
+          isReadyToUpload={fileUploadProps.isReadyToUpload}
+          isSessionReady
+          isSocketReady
+          disabled={composerDisabled}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default DraftConversationView;

--- a/src/features/chat/components/DraftConversationView.tsx
+++ b/src/features/chat/components/DraftConversationView.tsx
@@ -64,6 +64,8 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
 }) => {
   const [inputValue, setInputValue] = useState('');
   const [isSending, setIsSending] = useState(false);
+  // Use a ref to avoid TOCTOU race on isSending
+  const sendingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Real presence — option values are userIds for clients/team rows. Pending
   // invites use a `__pending__:` prefix and can't be online.
@@ -111,14 +113,21 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
     const trimmed = inputValue.trim();
     const attachments = fileUploadProps?.previewFiles ?? [];
     if (!trimmed && attachments.length === 0) return;
-    if (isSending) return;
+    if (sendingRef.current) return;
+    sendingRef.current = true;
+    setIsSending(true);
     try {
-      setIsSending(true);
       await onSendFirstMessage(trimmed, attachments);
       setInputValue('');
       fileUploadProps?.clearPreviewFiles();
+    } catch (err) {
+      // Optionally show user feedback or log
+      // eslint-disable-next-line no-console
+      console.error('Failed to send first message', err);
+      // Optionally: show error to user here
     } finally {
       setIsSending(false);
+      sendingRef.current = false;
     }
   };
 
@@ -186,7 +195,13 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
               />
             );
           }}
-          optionMeta={(option) => option.meta || option.description || ''}
+          optionMeta={(option) =>
+            typeof option.meta === 'string'
+              ? option.meta
+              : typeof option.description === 'string'
+                ? option.description
+                : ''
+          }
           footer={onInviteContact ? (close) => (
             <button
               type="button"

--- a/src/features/chat/components/Message.tsx
+++ b/src/features/chat/components/Message.tsx
@@ -192,15 +192,22 @@ const Message: FunctionComponent<MessageProps> = memo(({
 		? formatRelativeTime(new Date(timestamp))
 		: null;
 
-	// Avatar size based on message size
-	const avatarSize = size === 'sm' ? 'sm' : 'lg';
+	// Pencil rmTOt uses a 28px avatar next to the bubble — `sm` (24px) is the
+	// closest token. `lg` (40px) is reserved for callers that explicitly opt
+	// into the larger size via `size="lg"`.
+	const avatarSize = size === 'lg' ? 'lg' : 'sm';
 	const quickReactions = ['👍', '👀', '😂', '❤️'];
 
 	const showActions = !hideMessageActions && Boolean(onReply || (onToggleReaction && features.enableMessageReactions));
 	const hasReactions = reactions.length > 0 && features.enableMessageReactions;
 	const hasReplyPreview = Boolean(replyPreview);
+	// Sent messages right-align with no avatar (Pencil LymwK); received messages
+	// keep avatar on the left with the bubble flowing to its right (rmTOt).
+	// `justify-start` is set explicitly for received so the row layout is robust
+	// against ancestors that flip flex direction or alignment.
 	const wrapperClassName = [
-		'relative flex items-start gap-3 px-4 py-3 group message-list-item',
+		'relative flex w-full items-start gap-3 px-4 py-3 group message-list-item',
+		isUser ? 'justify-end' : 'justify-start',
 		className
 	].filter(Boolean).join(' ');
 
@@ -210,8 +217,8 @@ const Message: FunctionComponent<MessageProps> = memo(({
 			data-message-id={_id}
 			className={wrapperClassName}
 		>
-			{/* Avatar */}
-			{messageAvatar && (
+			{/* Avatar — hidden for sent (user) messages to match Pencil LymwK. */}
+			{messageAvatar && !isUser && (
 				<MessageAvatar
 					src={messageAvatar.src}
 					name={messageAvatar.name}
@@ -279,7 +286,7 @@ const Message: FunctionComponent<MessageProps> = memo(({
 					</button>
 				)}
 				{showHeader && (
-					<div className="mt-1 flex min-w-0 items-baseline justify-between gap-3 text-left">
+					<div className="flex min-w-0 items-baseline gap-2 text-left">
 						{(authorName || messageAvatar?.name) && (
 							<span className={`min-w-0 truncate leading-none ${chatTypography.headerName}`}>
 								{authorName || messageAvatar?.name}

--- a/src/features/chat/components/MessageBubble.tsx
+++ b/src/features/chat/components/MessageBubble.tsx
@@ -15,7 +15,10 @@ export const MessageBubble: FunctionComponent<MessageBubbleProps> = ({
 	className = '',
 	children
 }) => {
-	const baseClasses = 'flex min-w-0 flex-col max-w-full break-words relative';
+	// `gap-1` puts a 4px breathing room between the author/time header line and
+	// the colored bubble (Pencil LymwK / rmTOt), matching the design's stacked
+	// layout instead of the prior tight-pack.
+	const baseClasses = 'flex min-w-0 flex-col max-w-full break-words relative gap-1';
 	
 	const variantClasses = {
 		default: '',
@@ -23,7 +26,9 @@ export const MessageBubble: FunctionComponent<MessageBubbleProps> = ({
 		detailed: 'px-4 py-3'
 	};
 
-	const messageLayoutClasses = 'mr-0 ml-0 w-full';
+	// Sent messages right-align with a content-fit width (Pencil LymwK);
+	// received messages keep the original full-width column layout.
+	const messageLayoutClasses = isUser ? 'mr-0 ml-auto w-fit max-w-full items-end' : 'mr-0 ml-0 w-full';
 
 	const mediaOnlyClasses = hasOnlyMedia ? 'p-0 m-0 bg-transparent' : '';
 

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -310,8 +310,8 @@ const MessageComposer = ({
   const textareaClasses = "w-full min-h-8 py-2 m-0 text-sm sm:text-base leading-[1.45] text-input-text bg-transparent border-none resize-none outline-none overflow-hidden box-border placeholder:text-input-placeholder transition-all duration-200";
 
   return (
-    <div className="pl-4 pr-4 pb-2 bg-transparent rounded-none border-0 h-auto flex flex-col w-full">
-      <form 
+    <div className="px-4 pt-3 pb-3 bg-transparent rounded-none border-0 h-auto flex flex-col w-full">
+      <form
         className="w-full flex flex-col"
         aria-label="Message composition"
         onSubmit={(e) => {
@@ -371,22 +371,26 @@ const MessageComposer = ({
             </div>
           )}
 
-          <div className="message-composer-input-row">
-            {canShowAttachmentMenu && (
-              <div className="col-start-1 flex-shrink-0 self-end">
-                <FileMenu
-                  onFileSelect={handleFileSelect}
-                  onCameraCapture={handleCameraCapture}
-                  isReadyToUpload
-                />
-              </div>
-            )}
-
-            <div className={`col-start-2 min-w-0 relative flex flex-1 items-end gap-2 glass-input min-h-12 ${isInputExpanded ? 'rounded-2xl py-2 px-3.5' : 'rounded-full py-1 px-3'} ${isInputFocused ? 'ring-2 ring-accent-500/40 border-accent-500/40' : ''}`}>
-              {showScrollFade && (
-                <div className="pointer-events-none absolute left-3 right-12 top-2 h-4 bg-gradient-to-b from-surface-app-frame/60 dark:from-black/20 to-transparent z-10" />
+          {/* Pencil Q7ijvs — single rounded pill. + (FileMenu) sits at the
+              left edge inside the pill, then the textarea, then the voice-memo
+              mic, then the send button. The grid CSS class is intentionally
+              dropped here in favor of inline flex so the icons live inside the
+              pill rather than beside it. */}
+          <div className="w-full">
+            <div className={`min-w-0 relative flex w-full items-end gap-1 glass-input min-h-12 ${isInputExpanded ? 'rounded-2xl py-2 px-2' : 'rounded-full py-1 px-2'} ${isInputFocused ? 'ring-2 ring-accent-500/40 border-accent-500/40' : ''}`}>
+              {canShowAttachmentMenu && (
+                <div className="flex-shrink-0 self-end">
+                  <FileMenu
+                    onFileSelect={handleFileSelect}
+                    onCameraCapture={handleCameraCapture}
+                    isReadyToUpload
+                  />
+                </div>
               )}
-              <div className="relative flex-1 min-w-0 self-stretch flex items-center">
+              {showScrollFade && (
+                <div className="pointer-events-none absolute left-12 right-20 top-2 h-4 bg-gradient-to-b from-surface-app-frame/60 dark:from-black/20 to-transparent z-10" />
+              )}
+              <div className="relative flex-1 min-w-0 self-stretch flex items-center px-1">
                 <div 
                   ref={highlighterRef}
                   className={`${textareaClasses} pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words border-none select-none`}
@@ -475,29 +479,30 @@ const MessageComposer = ({
                   </div>
                 </div>
               ) : null}
-              <Button
-                type="submit"
-                variant={inputValue.trim() || previewFiles.length > 0 ? 'primary' : 'secondary'}
-                size="sm"
-                disabled={sendDisabled}
-                aria-label={
-                  isSessionReady === false
-                    ? 'Send message (waiting for secure session)'
-                    : isSocketReady === false
-                      ? 'Send message (connecting to chat)'
-                      : (!inputValue.trim() && previewFiles.length === 0
-                        ? 'Send message (disabled)'
-                        : 'Send message')}
-                className={`w-8 h-8 p-0 rounded-full shrink-0 ${isInputExpanded ? 'self-end' : 'self-center'} transition ${isInputFocused && !sendDisabled ? 'ring-2 ring-accent-500/50 shadow-[0_0_0_2px_rgba(255,196,0,0.15)]' : ''}`}
-                icon={ArrowUp} iconClassName="w-3.5 h-3.5"
-                data-testid="message-send-button"
-              />
-            </div>
-
-            <div className="col-start-3 flex items-center gap-2 flex-shrink-0 self-end">
-              {features.enableAudioRecording && (
-                <MediaControls onMediaCapture={handleMediaCapture} onRecordingStateChange={setIsRecording} />
-              )}
+              {features.enableAudioRecording ? (
+                <div className="flex-shrink-0 self-end">
+                  <MediaControls onMediaCapture={handleMediaCapture} onRecordingStateChange={setIsRecording} />
+                </div>
+              ) : null}
+              {!isRecording ? (
+                <Button
+                  type="submit"
+                  variant={inputValue.trim() || previewFiles.length > 0 ? 'primary' : 'secondary'}
+                  size="sm"
+                  disabled={sendDisabled}
+                  aria-label={
+                    isSessionReady === false
+                      ? 'Send message (waiting for secure session)'
+                      : isSocketReady === false
+                        ? 'Send message (connecting to chat)'
+                        : (!inputValue.trim() && previewFiles.length === 0
+                          ? 'Send message (disabled)'
+                          : 'Send message')}
+                  className={`w-8 h-8 p-0 rounded-full shrink-0 ${isInputExpanded ? 'self-end' : 'self-center'} transition ${isInputFocused && !sendDisabled ? 'ring-2 ring-accent-500/50 shadow-[0_0_0_2px_rgba(255,196,0,0.15)]' : ''}`}
+                  icon={ArrowUp} iconClassName="w-3.5 h-3.5"
+                  data-testid="message-send-button"
+                />
+              ) : null}
             </div>
           </div>
 

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -388,7 +388,9 @@ const MessageComposer = ({
                 </div>
               )}
               {showScrollFade && (
-                <div className="pointer-events-none absolute left-12 right-20 top-2 h-4 bg-gradient-to-b from-surface-app-frame/60 dark:from-black/20 to-transparent z-10" />
+                <div
+                  className={`pointer-events-none absolute right-20 top-2 h-4 bg-gradient-to-b from-surface-app-frame/60 dark:from-black/20 to-transparent z-10 ${canShowAttachmentMenu ? 'left-12' : 'left-2'}`}
+                />
               )}
               <div className="relative flex-1 min-w-0 self-stretch flex items-center px-1">
                 <div 

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -371,7 +371,7 @@ const MessageComposer = ({
             </div>
           )}
 
-          {/* Pencil Q7ijvs — single rounded pill. + (FileMenu) sits at the
+            {/* Single rounded pill. + (FileMenu) sits at the
               left edge inside the pill, then the textarea, then the voice-memo
               mic, then the send button. The grid CSS class is intentionally
               dropped here in favor of inline flex so the icons live inside the
@@ -389,7 +389,9 @@ const MessageComposer = ({
               )}
               {showScrollFade && (
                 <div
-                  className={`pointer-events-none absolute right-20 top-2 h-4 bg-gradient-to-b from-surface-app-frame/60 dark:from-black/20 to-transparent z-10 ${canShowAttachmentMenu ? 'left-12' : 'left-2'}`}
+                  className={`pointer-events-none absolute top-2 h-4 bg-gradient-to-b from-surface-app-frame/60 dark:from-black/20 to-transparent z-10
+                    ${canShowAttachmentMenu ? (features.enableAudioRecording && !isRecording ? 'right-20 left-12' : 'right-12 left-12') : (features.enableAudioRecording && !isRecording ? 'right-20 left-2' : 'right-12 left-2')}
+                  `}
                 />
               )}
               <div className="relative flex-1 min-w-0 self-stretch flex items-center px-1">
@@ -481,7 +483,7 @@ const MessageComposer = ({
                   </div>
                 </div>
               ) : null}
-              {features.enableAudioRecording ? (
+              {features.enableAudioRecording && !isComposerDisabled ? (
                 <div className="flex-shrink-0 self-end">
                   <MediaControls onMediaCapture={handleMediaCapture} onRecordingStateChange={setIsRecording} />
                 </div>

--- a/src/features/chat/components/MessageContent.tsx
+++ b/src/features/chat/components/MessageContent.tsx
@@ -79,7 +79,7 @@ export const MessageContent: FunctionComponent<MessageContentProps> = ({
   // sharper bottom-right corner; received uses a raised surface with a sharper
   // bottom-left corner. Padding & radius mirror the design components.
   const bubbleClassName = isUser
-    ? 'inline-block max-w-full rounded-2xl rounded-br-[4px] bg-accent-500 px-[14px] py-[10px] text-white shadow-sm'
+    ? 'inline-block max-w-full rounded-2xl rounded-br-[4px] bg-accent-500 px-[14px] py-[10px] text-[rgb(var(--accent-foreground))] shadow-sm'
     : 'inline-block max-w-full rounded-2xl rounded-bl-[4px] bg-[rgb(var(--surface-card-hover))] px-[14px] py-[10px] text-input-text';
 
   // The outer wrapper is a flex row so the inline-block bubble follows the

--- a/src/features/chat/components/MessageContent.tsx
+++ b/src/features/chat/components/MessageContent.tsx
@@ -75,9 +75,24 @@ export const MessageContent: FunctionComponent<MessageContentProps> = ({
     );
   }
 
+  // Chat-bubble surface (Pencil LymwK / rmTOt). Sent uses accent fill with a
+  // sharper bottom-right corner; received uses a raised surface with a sharper
+  // bottom-left corner. Padding & radius mirror the design components.
+  const bubbleClassName = isUser
+    ? 'inline-block max-w-full rounded-2xl rounded-br-[4px] bg-accent-500 px-[14px] py-[10px] text-white shadow-sm'
+    : 'inline-block max-w-full rounded-2xl rounded-bl-[4px] bg-[rgb(var(--surface-card-hover))] px-[14px] py-[10px] text-input-text';
+
+  // The outer wrapper is a flex row so the inline-block bubble follows the
+  // sender alignment even when the column it sits in (MessageBubble) is wider
+  // than the bubble's content — e.g. when the author/time header above is
+  // longer than a short message.
   return (
-    <div className={`min-h-4 min-w-0 max-w-full ${className}`}>
-      <ChatMarkdown text={displayContent} isStreaming={isStreaming} variant={variant} size={size} />
+    <div
+      className={`flex min-h-4 min-w-0 max-w-full ${isUser ? 'justify-end' : 'justify-start'} ${className}`}
+    >
+      <div className={bubbleClassName}>
+        <ChatMarkdown text={displayContent} isStreaming={isStreaming} variant={variant} size={size} />
+      </div>
     </div>
   );
 };

--- a/src/features/chat/components/MessagesListPanel.tsx
+++ b/src/features/chat/components/MessagesListPanel.tsx
@@ -1,0 +1,193 @@
+import type { FunctionComponent } from 'preact';
+import { useMemo, useState } from 'preact/hooks';
+import { useTranslation } from 'react-i18next';
+import { Search, SquarePen } from 'lucide-preact';
+import { Avatar } from '@/shared/ui/profile/atoms/Avatar';
+import { Input } from '@/shared/ui/input/Input';
+import { Button } from '@/shared/ui/Button';
+import { SegmentedToggle, type SegmentedToggleOption } from '@/shared/ui/input/SegmentedToggle';
+import { cn } from '@/shared/utils/cn';
+import ConversationListView from '@/features/chat/views/ConversationListView';
+import type { Conversation } from '@/shared/types/conversation';
+import {
+  resolveConversationContactName,
+  resolveConversationDisplayTitle,
+} from '@/shared/utils/conversationDisplay';
+
+interface ConversationPreview {
+  content: string;
+  role: 'user' | 'system' | 'assistant' | string;
+  createdAt: string;
+}
+
+interface MessagesListPanelTabs<T extends string> {
+  value: T;
+  options: ReadonlyArray<SegmentedToggleOption<T>>;
+  onChange: (value: T) => void;
+}
+
+interface MessagesListPanelProps {
+  conversations: Conversation[];
+  previews: Record<string, ConversationPreview | undefined>;
+  practiceName?: string | null;
+  practiceLogo?: string | null;
+  isLoading?: boolean;
+  error?: unknown;
+  onSelectConversation: (conversationId: string) => void;
+  onCompose?: () => void;
+  /** Optional draft entry rendered as a synthetic row pinned to the top of
+   *  the list. Pass when a draft conversation is in flight; clicking the row
+   *  re-opens the draft view. */
+  draftEntry?: { contactName?: string; contactEmail?: string } | null;
+  onSelectDraftEntry?: () => void;
+  activeConversationId?: string | null;
+  /** Optional segmented filter (Pencil oYsFt mobile tab bar). Pass to render
+   *  segmented tabs above the search input — typically only on mobile where
+   *  the sidebar's secondary-nav filters aren't visible. */
+  tabs?: MessagesListPanelTabs<string> | null;
+}
+
+/**
+ * Pencil rxzde "Messages" list column. Wraps ConversationListView with a header
+ * row (title + count badge + compose action) and a search input that filters
+ * the list client-side by contact name and last-message preview.
+ */
+const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
+  conversations,
+  previews,
+  practiceName,
+  practiceLogo,
+  isLoading = false,
+  error = null,
+  onSelectConversation,
+  onCompose,
+  draftEntry = null,
+  onSelectDraftEntry,
+  activeConversationId = null,
+  tabs = null,
+}) => {
+  const { t } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredConversations = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return conversations;
+    return conversations.filter((conversation) => {
+      const contactName = resolveConversationContactName(conversation) || '';
+      const fallbackTitle = resolveConversationDisplayTitle(conversation, practiceName ?? '') || '';
+      const previewText = (previews[conversation.id]?.content ?? conversation.last_message_content ?? '').toString();
+      return (
+        contactName.toLowerCase().includes(query) ||
+        fallbackTitle.toLowerCase().includes(query) ||
+        previewText.toLowerCase().includes(query)
+      );
+    });
+  }, [conversations, previews, practiceName, searchQuery]);
+
+  const visibleCount = filteredConversations.length;
+  const totalCount = conversations.length;
+  const badgeCount = searchQuery.trim() ? visibleCount : totalCount;
+  const formattedBadge = badgeCount > 99 ? '99+' : String(badgeCount).padStart(2, '0');
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-transparent">
+      <header className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-semibold text-input-text">
+            {t('workspace.conversationList.title', { defaultValue: 'Messages' })}
+          </h2>
+          <span
+            className="inline-flex h-5 min-w-[28px] items-center justify-center rounded-full bg-accent-500/15 px-1.5 text-[11px] font-semibold text-accent-utility"
+            aria-label={t('workspace.conversationList.countLabel', {
+              defaultValue: '{{count}} conversations',
+              count: badgeCount,
+            })}
+          >
+            {formattedBadge}
+          </span>
+        </div>
+        {onCompose ? (
+          <Button
+            type="button"
+            variant="icon"
+            size="icon-sm"
+            onClick={onCompose}
+            icon={SquarePen}
+            iconClassName="h-4 w-4"
+            aria-label={t('workspace.conversationList.compose', { defaultValue: 'New message' })}
+          />
+        ) : null}
+      </header>
+      {tabs && tabs.options.length > 0 ? (
+        <div className="px-4 pb-3">
+          <SegmentedToggle
+            value={tabs.value}
+            options={tabs.options}
+            onChange={tabs.onChange}
+            ariaLabel={t('workspace.conversationList.filterLabel', { defaultValue: 'Filter messages' })}
+            className="flex w-full"
+          />
+        </div>
+      ) : null}
+      <div className="px-4 pb-3">
+        <Input
+          type="search"
+          value={searchQuery}
+          onChange={setSearchQuery}
+          icon={Search}
+          iconPosition="left"
+          size="sm"
+          placeholder={t('workspace.conversationList.searchPlaceholder', { defaultValue: 'Search messages...' })}
+          aria-label={t('workspace.conversationList.searchPlaceholder', { defaultValue: 'Search messages...' })}
+        />
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {draftEntry ? (
+          <button
+            type="button"
+            onClick={() => onSelectDraftEntry?.()}
+            className={cn(
+              'mx-2 mt-2 mb-1 flex w-[calc(100%-1rem)] items-start gap-3 rounded-xl px-3 py-2.5 text-left transition-colors',
+              'nav-item-active'
+            )}
+            aria-current="page"
+          >
+            <Avatar
+              src={null}
+              name={draftEntry.contactName ?? 'New conversation'}
+              size="md"
+              className="ring-1 ring-line-glass/10"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-start justify-between gap-3">
+                <span className="block truncate text-sm font-semibold text-input-text">
+                  {draftEntry.contactName ?? t('workspace.conversationList.draftPlaceholder', { defaultValue: 'New conversation' })}
+                </span>
+                <span className="rounded-full bg-accent-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent-utility">
+                  {t('workspace.conversationList.draftBadge', { defaultValue: 'Draft' })}
+                </span>
+              </div>
+              <div className="mt-0.5 truncate text-xs text-input-placeholder">
+                {draftEntry.contactEmail ?? t('workspace.conversationList.draftHint', { defaultValue: 'Pick a contact and send the first message' })}
+              </div>
+            </div>
+          </button>
+        ) : null}
+        <ConversationListView
+          conversations={filteredConversations}
+          previews={previews}
+          practiceName={practiceName}
+          practiceLogo={practiceLogo}
+          isLoading={isLoading}
+          error={error}
+          onSelectConversation={onSelectConversation}
+          onSendMessage={onCompose ?? (() => undefined)}
+          showSendMessageButton={false}
+          activeConversationId={activeConversationId}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MessagesListPanel;

--- a/src/features/chat/components/MessagesListPanel.tsx
+++ b/src/features/chat/components/MessagesListPanel.tsx
@@ -41,14 +41,14 @@ interface MessagesListPanelProps {
   draftEntry?: { contactName?: string; contactEmail?: string } | null;
   onSelectDraftEntry?: () => void;
   activeConversationId?: string | null;
-  /** Optional segmented filter (Pencil oYsFt mobile tab bar). Pass to render
+  /** Optional segmented filter (mobile tab bar). Pass to render
    *  segmented tabs above the search input — typically only on mobile where
    *  the sidebar's secondary-nav filters aren't visible. */
   tabs?: MessagesListPanelTabs<string> | null;
 }
 
 /**
- * Pencil rxzde "Messages" list column. Wraps ConversationListView with a header
+ * "Messages" list column. Wraps ConversationListView with a header
  * row (title + count badge + compose action) and a search input that filters
  * the list client-side by contact name and last-message preview.
  */
@@ -148,9 +148,9 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
             onClick={() => onSelectDraftEntry?.()}
             className={cn(
               'mx-2 mt-2 mb-1 flex w-[calc(100%-1rem)] items-start gap-3 rounded-xl px-3 py-2.5 text-left transition-colors',
-              'nav-item-active'
+              activeConversationId === null && 'nav-item-active'
             )}
-            aria-current="page"
+            aria-current={activeConversationId === null ? 'page' : undefined}
           >
             <Avatar
               src={null}

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -12,7 +12,7 @@ import { WorkspaceSetupSection } from '@/features/chat/components/WorkspaceSetup
 import MessagesListPanel from '@/features/chat/components/MessagesListPanel';
 import ConversationContextPanel from '@/features/chat/components/ConversationContextPanel';
 import { type ComboboxOption } from '@/shared/ui/input/Combobox';
-import { deleteConversation, postConversationMessage, updateConversationTriage } from '@/shared/lib/conversationApi';
+import { deleteConversation, markAsRead, postConversationMessage, updateConversationTriage } from '@/shared/lib/conversationApi';
 import { AddContactDialog } from '@/shared/ui/contacts/AddContactDialog';
 import { Dialog } from '@/shared/ui/dialog/Dialog';
 import { useClientsData } from '@/shared/hooks/useClientsData';
@@ -246,9 +246,10 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     }
   }, [isDesktopSidebarCollapsed]);
   const [isInspectorOpen, setIsInspectorOpen] = useState(false);
-  const [isAddClientDialogOpen, setIsAddClientDialogOpen] = useState(false);
   const [conversationPendingDelete, setConversationPendingDelete] = useState<Conversation | null>(null);
+  const [optimisticallyReadConversationIds, setOptimisticallyReadConversationIds] = useState<Set<string>>(new Set());
   const [isDeletingConversation, setIsDeletingConversation] = useState(false);
+  const [isAddClientDialogOpen, setIsAddClientDialogOpen] = useState(false);
   // Draft conversation state. When non-null, the chat area renders
   // DraftConversationView and the messages list shows a synthetic "Draft"
   // entry pinned at the top. POST + assignment + first message are deferred
@@ -429,12 +430,30 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     // pinned "Draft" entry stays in the list.
     setDraftConversation(null);
     setPendingInviteOption(null);
+
+    // Mark conversation as read if it has unread messages
+    const conversation = resolvedConversations.find((c) => c.id === conversationId);
+    if (conversation && practiceId && Number(conversation.unread_count ?? 0) > 0) {
+      // Optimistically update UI immediately
+      setOptimisticallyReadConversationIds((prev) => new Set([...prev, conversationId]));
+      // Then call the backend
+      void markAsRead(conversationId, practiceId).catch((error) => {
+        console.warn('[WorkspacePage] Failed to mark conversation as read', error);
+        // Remove from optimistic set on failure
+        setOptimisticallyReadConversationIds((prev) => {
+          const next = new Set(prev);
+          next.delete(conversationId);
+          return next;
+        });
+      });
+    }
+
     if (onSelectConversationOverride) {
       onSelectConversationOverride(conversationId);
       return;
     }
     navigate(withWidgetQuery(`${conversationsPath}/${encodeURIComponent(conversationId)}`));
-  }, [conversationsPath, navigate, onSelectConversationOverride, withWidgetQuery]);
+  }, [conversationsPath, navigate, onSelectConversationOverride, withWidgetQuery, resolvedConversations, practiceId]);
 
 
   useWorkspaceAutoNavigation({
@@ -594,6 +613,16 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
 
   const showSidebarPreview = (previewStrongReady || (onboardingProgress?.completionScore ?? 0) >= 80) && setupSidebarView === 'preview';
 
+  // Apply optimistic read state to conversations for immediate UI feedback
+  const filteredConversationsWithOptimisticRead = useMemo(() => {
+    if (optimisticallyReadConversationIds.size === 0) return filteredConversations;
+    return filteredConversations.map((conversation) =>
+      optimisticallyReadConversationIds.has(conversation.id)
+        ? { ...conversation, unread_count: 0 }
+        : conversation
+    );
+  }, [filteredConversations, optimisticallyReadConversationIds]);
+
   useEffect(() => {
     if (previewStrongReady || (onboardingProgress?.completionScore ?? 0) >= 80) {
       setSetupSidebarView((prev) => (prev === 'info' || prev === 'preview' ? prev : 'preview'));
@@ -711,7 +740,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     if (sessionUserId) {
       const existing = resolvedConversations.find((conversation) => {
         const participants = Array.isArray(conversation.participants) ? conversation.participants : [];
-        return participants.includes(next.userId);
+        return participants.length === 2 && participants.includes(sessionUserId) && participants.includes(next.userId);
       });
       if (existing) {
         setDraftConversation(null);
@@ -765,6 +794,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
         } catch (error) {
           postFailed = true;
           console.warn('[WorkspacePage] Failed to send draft first message', error);
+          throw error;
         }
         if (sessionUserId) {
           try {
@@ -778,7 +808,9 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     if (newConversationId && postFailed) {
       showError('Conversation created, but the first message did not send', 'Try sending it again from the thread.');
     }
-    setDraftConversation(null);
+    if (newConversationId && !postFailed) {
+      setDraftConversation(null);
+    }
   };
 
   const draftView = draftConversation ? (
@@ -1177,7 +1209,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
 
   const listContent = (
     <MessagesListPanel
-      conversations={filteredConversations}
+      conversations={filteredConversationsWithOptimisticRead}
       previews={conversationPreviews}
       practiceName={practiceName}
       practiceLogo={practiceLogo}
@@ -1266,7 +1298,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     <div className="flex h-full min-h-0 flex-1 flex-col gap-2">
       <Panel className="list-panel-card-gradient min-h-0 flex-1 overflow-hidden">
         <MessagesListPanel
-          conversations={filteredConversations}
+          conversations={filteredConversationsWithOptimisticRead}
           previews={conversationPreviews}
           practiceName={practiceName}
           practiceLogo={practiceLogo}

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -808,7 +808,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     if (newConversationId && postFailed) {
       showError('Conversation created, but the first message did not send', 'Try sending it again from the thread.');
     }
-    if (newConversationId && !postFailed) {
+    if (newConversationId) {
       setDraftConversation(null);
     }
   };

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -807,6 +807,10 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     });
     if (newConversationId && postFailed) {
       showError('Conversation created, but the first message did not send', 'Try sending it again from the thread.');
+      // Keep the draft alive so the user's typed message + attachments don't
+      // vanish — the conversation now exists, but the composer state still
+      // belongs to the draft view until the user retries successfully.
+      return;
     }
     if (newConversationId) {
       setDraftConversation(null);

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -9,7 +9,17 @@ import { SessionNotReadyError } from '@/shared/types/errors';
 import WorkspaceHomeView from '@/features/chat/views/WorkspaceHomeView';
 import { WorkspaceHomeSection } from '@/features/chat/components/WorkspaceHomeSection';
 import { WorkspaceSetupSection } from '@/features/chat/components/WorkspaceSetupSection';
-import ConversationListView from '@/features/chat/views/ConversationListView';
+import MessagesListPanel from '@/features/chat/components/MessagesListPanel';
+import ConversationContextPanel from '@/features/chat/components/ConversationContextPanel';
+import { type ComboboxOption } from '@/shared/ui/input/Combobox';
+import { deleteConversation, postConversationMessage, updateConversationTriage } from '@/shared/lib/conversationApi';
+import { AddContactDialog } from '@/shared/ui/contacts/AddContactDialog';
+import { Dialog } from '@/shared/ui/dialog/Dialog';
+import { useClientsData } from '@/shared/hooks/useClientsData';
+import { usePracticeTeam } from '@/shared/hooks/usePracticeTeam';
+import { usePracticeInvitations } from '@/shared/hooks/usePracticeInvitations';
+import { DraftConversationView } from '@/features/chat/components/DraftConversationView';
+import { getPracticeRoleLabel } from '@/shared/utils/practiceRoles';
 import { AppShell } from '@/shared/ui/layout/AppShell';
 import { WorkspaceShellHeader } from '@/shared/ui/layout/WorkspaceShellHeader';
 import { WorkspaceMainPane } from '@/shared/ui/layout/WorkspaceMainPane';
@@ -21,6 +31,7 @@ import { Button } from '@/shared/ui/Button';
 import { useWorkspaceConversations } from './hooks/useWorkspaceConversations';
 import { useWorkspaceNavigation } from './hooks/useWorkspaceNavigation';
 import { resolveConsultationState } from '@/shared/utils/consultationState';
+import { resolveConversationContactName, resolveConversationDisplayTitle } from '@/shared/utils/conversationDisplay';
 import { useWorkspaceSetup } from './hooks/useWorkspaceSetup';
 import { useWorkspaceData } from './hooks/useWorkspaceData';
 import { useConversationPreviews } from './hooks/useConversationPreviews';
@@ -50,7 +61,7 @@ import InspectorPanel from '@/shared/ui/inspector/InspectorPanel';
 import { SettingsContent, type SettingsView } from '@/features/settings/pages/SettingsContent';
 import { PracticeCoveragePage } from '@/features/settings/pages/PracticeCoveragePage';
 import { mockApps } from '@/features/settings/pages/appsData';
-import type { ChatMessageUI } from '../../../../worker/types';
+import type { ChatMessageUI, FileAttachment } from '../../../../worker/types';
 import type { Conversation, ConversationMode } from '@/shared/types/conversation';
 import type { LayoutMode, WorkspaceView } from '@/app/MainApp';
 import type { UserDetailRecord, UserDetailStatus, PracticeDetails } from '@/shared/lib/apiClient';
@@ -96,10 +107,32 @@ interface WorkspacePageProps {
   onStartNewConversation: (
     mode: ConversationMode,
     preferredConversationId?: string,
-    options?: { forceCreate?: boolean; silentSessionNotReady?: boolean }
+    options?: {
+      forceCreate?: boolean;
+      silentSessionNotReady?: boolean;
+      additionalParticipantUserIds?: string[];
+      additionalMetadata?: Record<string, unknown>;
+    }
   ) => Promise<string>;
   activeConversationId?: string | null;
   chatView: ComponentChildren;
+  /** File-upload state from MainApp's useFileUpload, passed through so the
+   *  draft composer reuses the same upload pipeline + preview state as the
+   *  main chat composer. Optional — when omitted, the draft composer falls
+   *  back to a no-attachments mode. */
+  fileUploadProps?: {
+    previewFiles: import('../../../../worker/types').FileAttachment[];
+    uploadingFiles: import('@/shared/types/upload').UploadingFile[];
+    isReadyToUpload: boolean;
+    handleFileSelect: (files: File[]) => Promise<unknown>;
+    handleCameraCapture: (file: File) => Promise<void>;
+    removePreviewFile: (index: number) => void;
+    clearPreviewFiles: () => void;
+    cancelUpload: (fileId: string) => void;
+    handleMediaCapture: (blob: Blob, type: 'audio' | 'video') => void;
+    isRecording: boolean;
+    setIsRecording: (recording: boolean) => void;
+  };
   mattersView?: ComponentChildren | ((statusFilter: string[], prefetchData?: WorkspacePrefetchData, onDetailInspector?: (() => void), detailInspectorOpen?: boolean, detailHeaderLeadingAction?: ComponentChildren) => ComponentChildren);
   mattersListContent?: ComponentChildren | ((statusFilter: string[], prefetchData?: WorkspacePrefetchData) => ComponentChildren);
   contactsView?: ComponentChildren | ((statusFilter: UserDetailStatus | null, prefetchData?: WorkspacePrefetchData, onDetailInspector?: (() => void), detailInspectorOpen?: boolean, detailHeaderLeadingAction?: ComponentChildren) => ComponentChildren);
@@ -171,6 +204,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   onStartNewConversation,
   activeConversationId = null,
   chatView,
+  fileUploadProps,
   mattersView,
   mattersListContent,
   contactsView,
@@ -212,6 +246,19 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     }
   }, [isDesktopSidebarCollapsed]);
   const [isInspectorOpen, setIsInspectorOpen] = useState(false);
+  const [isAddClientDialogOpen, setIsAddClientDialogOpen] = useState(false);
+  const [conversationPendingDelete, setConversationPendingDelete] = useState<Conversation | null>(null);
+  const [isDeletingConversation, setIsDeletingConversation] = useState(false);
+  // Draft conversation state. When non-null, the chat area renders
+  // DraftConversationView and the messages list shows a synthetic "Draft"
+  // entry pinned at the top. POST + assignment + first message are deferred
+  // until the user actually sends from the draft view.
+  const [draftConversation, setDraftConversation] = useState<{
+    contactUserId?: string | null;
+    contactName?: string;
+    contactEmail?: string;
+  } | null>(null);
+  const [pendingInviteOption, setPendingInviteOption] = useState<{ name: string; email: string } | null>(null);
   const navigationInitiatedRef = useRef(false);
   const hasAutoNavigatedRef = useRef(false);
   const filteredMessages = useMemo(() => filterWorkspaceMessages(messages), [messages]);
@@ -303,6 +350,18 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     window.addEventListener('workspace:open-inspector', handleOpenInspector);
     return () => window.removeEventListener('workspace:open-inspector', handleOpenInspector);
   }, [inspectorTarget]);
+  // Practice Messages design (Pencil rxzde) keeps the 320px context panel visible
+  // by default. Auto-open the inspector when a practice user lands on a
+  // conversation on desktop. Re-fires on conversation switch so flipping between
+  // threads brings the panel back even if it was closed for a previous one.
+  const inspectorTargetId = inspectorTarget?.entityType === 'conversation' ? inspectorTarget.entityId : null;
+  useEffect(() => {
+    if (!isPracticeWorkspace) return;
+    if (layoutMode !== 'desktop') return;
+    if (workspaceSection !== 'conversations') return;
+    if (!inspectorTargetId) return;
+    setIsInspectorOpen(true);
+  }, [isPracticeWorkspace, layoutMode, workspaceSection, inspectorTargetId]);
   const {
     mattersStatusFilter,
     contactsStatusFilter,
@@ -365,6 +424,11 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
 
   const handleSelectConversation = useCallback((conversationId: string) => {
     hasAutoNavigatedRef.current = true;
+    // Selecting a real conversation always exits draft mode — otherwise the
+    // draft view stays mounted on top of the chosen thread on mobile and the
+    // pinned "Draft" entry stays in the list.
+    setDraftConversation(null);
+    setPendingInviteOption(null);
     if (onSelectConversationOverride) {
       onSelectConversationOverride(conversationId);
       return;
@@ -463,6 +527,71 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     forcePreviewReload();
   }, [showSuccess, forcePreviewReload]);
 
+  // ── compose picker data ──────────────────────────────────────────────
+  // Loaded as soon as the user enters draft mode so the inline Combobox in
+  // DraftConversationView populates without a perceptible delay.
+  const composePickerEnabled = isPracticeWorkspace && draftConversation !== null;
+  const composeClientsData = useClientsData(practiceId, null, sessionUserId, {
+    enabled: composePickerEnabled,
+  });
+  const composeTeamData = usePracticeTeam(practiceId, sessionUserId, {
+    enabled: composePickerEnabled,
+  });
+  const composePracticeInvitations = usePracticeInvitations(composePickerEnabled ? practiceId : null);
+
+  const composePickerOptions = useMemo<ComboboxOption[]>(() => {
+    if (!composePickerEnabled) return [];
+    const seen = new Set<string>();
+    const rows: ComboboxOption[] = [];
+    // Clients with an account get added to the picker; ones without are
+    // not selectable and are surfaced via the "Invite client" footer action.
+    for (const client of composeClientsData.items) {
+      const userId = (client.user_id ?? client.user?.id ?? '').trim();
+      if (!userId || userId === sessionUserId || seen.has(userId)) continue;
+      seen.add(userId);
+      const name = client.user?.name?.trim() || client.user?.email?.trim() || 'Unnamed client';
+      const email = client.user?.email?.trim() ?? '';
+      rows.push({
+        value: userId,
+        label: name,
+        meta: email,
+        description: 'Client',
+      });
+    }
+    for (const member of composeTeamData.members) {
+      const userId = member.userId?.trim() ?? '';
+      if (!userId || userId === sessionUserId || seen.has(userId)) continue;
+      seen.add(userId);
+      const name = member.name?.trim() || member.email;
+      rows.push({
+        value: userId,
+        label: name,
+        meta: member.email,
+        description: getPracticeRoleLabel(member.role),
+      });
+    }
+    return rows;
+  }, [
+    composePickerEnabled,
+    composeClientsData.items,
+    composeTeamData.members,
+    sessionUserId,
+  ]);
+
+  // Pending invitations: invitees haven't accepted yet so they have no userId
+  // and can't actually receive a message. Surface them in the picker as
+  // distinguished rows so the user knows the invite is in flight.
+  const composePendingInviteOptions = useMemo<ComboboxOption[]>(() => {
+    if (!composePickerEnabled) return [];
+    const pending = composePracticeInvitations.invitations.filter((inv) => inv.status === 'pending');
+    return pending.map((invitation) => ({
+      value: invitation.id,
+      label: invitation.email,
+      description: 'Pending invite',
+      meta: 'Waiting for accept',
+    }));
+  }, [composePickerEnabled, composePracticeInvitations.invitations]);
+
   const showSidebarPreview = (previewStrongReady || (onboardingProgress?.completionScore ?? 0) >= 80) && setupSidebarView === 'preview';
 
   useEffect(() => {
@@ -473,9 +602,22 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     setSetupSidebarView('info');
   }, [previewStrongReady, onboardingProgress?.completionScore]);
 
-  const handleStartConversation = async (mode: ConversationMode) => {
+  const handleStartConversation = async (
+    mode: ConversationMode,
+    options?: {
+      forceNew?: boolean;
+      additionalParticipantUserIds?: string[];
+      additionalMetadata?: Record<string, unknown>;
+      /** Runs after the conversation is created but BEFORE the list refresh
+       *  and URL navigate. Use for follow-up writes (assign, send first
+       *  message, etc.) that need to land before useWorkspaceAutoNavigation
+       *  observes the new active conversation id — otherwise the new thread
+       *  isn't yet in the filtered list and the auto-nav toast fires. */
+      afterCreate?: (conversationId: string) => Promise<void>;
+    }
+  ): Promise<string | undefined> => {
     try {
-      const shouldReuseConversation = mode !== 'REQUEST_CONSULTATION';
+      const shouldReuseConversation = mode !== 'REQUEST_CONSULTATION' && !options?.forceNew;
       const reusableAskQuestionConversations = shouldReuseConversation
         ? resolvedConversations.filter((conversation) => {
             const metadata = conversation.user_info ?? null;
@@ -495,21 +637,47 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       // In embedded public widget mode, reuse the bootstrapped/current conversation
       // to avoid an extra create-conversation round-trip right after bootstrap.
       // Other surfaces keep the fresh-thread behavior for consultation CTA.
-      const forceCreate = mode === 'REQUEST_CONSULTATION'
-        ? !(workspace === 'public' && layoutMode === 'widget')
-        : !preferredConversationId;
+      const forceCreate = options?.forceNew
+        ? true
+        : mode === 'REQUEST_CONSULTATION'
+          ? !(workspace === 'public' && layoutMode === 'widget')
+          : !preferredConversationId;
 
       const conversationId = await onStartNewConversation(
         mode,
         preferredConversationId,
-        forceCreate ? { forceCreate: true } : undefined
+        forceCreate
+          ? {
+              forceCreate: true,
+              additionalParticipantUserIds: options?.additionalParticipantUserIds,
+              additionalMetadata: options?.additionalMetadata,
+            }
+          : undefined
       );
+      // Run caller-provided follow-up writes (assign, post first message, etc.)
+      // before the list refresh + navigate so useWorkspaceAutoNavigation sees a
+      // fully-formed conversation in the filtered inbox.
+      if (options?.afterCreate) {
+        try {
+          await options.afterCreate(conversationId);
+        } catch (afterCreateError) {
+          console.warn('[WorkspacePage] afterCreate hook failed', afterCreateError);
+        }
+      }
+      // When we just forced a brand-new conversation in the practice workspace,
+      // refresh the list before navigating. Otherwise useWorkspaceAutoNavigation
+      // sees a stale list (without the new id) and bumps us to filteredConversations[0].
+      if (options?.forceNew && isPracticeWorkspace) {
+        await refreshConversations();
+      }
       navigate(withWidgetQuery(`${conversationsPath}/${encodeURIComponent(conversationId)}`));
+      return conversationId;
     } catch (error) {
       // "Session not ready" — the toast was already shown by MainApp, so finish gracefully.
-      if (error instanceof SessionNotReadyError) return;
+      if (error instanceof SessionNotReadyError) return undefined;
       console.error('[WorkspacePage] Failed to start conversation:', error);
       showError('Unable to start conversation', 'Please try again in a moment.');
+      return undefined;
     }
   };
 
@@ -520,6 +688,122 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     }
     navigate(withWidgetQuery(conversationsPath));
   };
+
+  const handleEnterDraftMode = () => {
+    setDraftConversation((prev) => prev ?? { contactUserId: null });
+  };
+
+  const handleCancelDraft = () => {
+    setDraftConversation(null);
+    setPendingInviteOption(null);
+  };
+
+  const handleDraftContactChange = (next: { userId: string; name: string; email?: string } | null) => {
+    if (!next) {
+      setDraftConversation((prev) => prev ? { ...prev, contactUserId: null, contactName: undefined, contactEmail: undefined } : null);
+      return;
+    }
+    // If an existing conversation with this contact is already in the
+    // resolved list, jump into it instead of creating a duplicate. We match
+    // any conversation whose participant set includes the picked user — the
+    // current user is always a participant, so a hit means it's a 1-on-1
+    // (or a group containing them) we should reuse.
+    if (sessionUserId) {
+      const existing = resolvedConversations.find((conversation) => {
+        const participants = Array.isArray(conversation.participants) ? conversation.participants : [];
+        return participants.includes(next.userId);
+      });
+      if (existing) {
+        setDraftConversation(null);
+        navigate(withWidgetQuery(`${conversationsPath}/${encodeURIComponent(existing.id)}`));
+        return;
+      }
+    }
+    setDraftConversation({
+      contactUserId: next.userId,
+      contactName: next.name,
+      contactEmail: next.email,
+    });
+  };
+
+  const handleDraftSendFirstMessage = async (message: string, attachments: FileAttachment[] = []) => {
+    if (!draftConversation?.contactUserId || !practiceId) return;
+    const contactName = draftConversation.contactName?.trim();
+    const contactEmail = draftConversation.contactEmail?.trim();
+    const additionalMetadata = (contactName || contactEmail)
+      ? {
+          contactDetails: {
+            ...(contactName ? { name: contactName } : {}),
+            ...(contactEmail ? { email: contactEmail } : {}),
+          },
+        }
+      : undefined;
+    // Attachments go through the same metadata.attachments shape the
+    // WebSocket path uses (see useChatComposer.sendMessageOverWs) so the
+    // worker stores file ids consistently regardless of transport.
+    const attachmentIds = attachments
+      .map((file) => file.id || file.storageKey || '')
+      .filter(Boolean);
+    const messageMetadata: Record<string, unknown> | undefined = attachmentIds.length > 0
+      ? { attachments: attachmentIds }
+      : undefined;
+    let postFailed = false;
+    const newConversationId = await handleStartConversation('ASK_QUESTION', {
+      forceNew: true,
+      additionalParticipantUserIds: [draftConversation.contactUserId],
+      additionalMetadata,
+      // Send the first message AND assign the creator before navigation so the
+      // resulting thread is already in "Your inbox" when useWorkspaceAutoNavigation
+      // observes the new active id. Otherwise the toast "currently hidden by
+      // filters or still loading" fires.
+      afterCreate: async (newId) => {
+        try {
+          await postConversationMessage(newId, practiceId, {
+            content: message,
+            metadata: messageMetadata,
+          });
+        } catch (error) {
+          postFailed = true;
+          console.warn('[WorkspacePage] Failed to send draft first message', error);
+        }
+        if (sessionUserId) {
+          try {
+            await updateConversationTriage(newId, practiceId, { assignedTo: sessionUserId });
+          } catch (error) {
+            console.warn('[WorkspacePage] Failed to assign new conversation', error);
+          }
+        }
+      },
+    });
+    if (newConversationId && postFailed) {
+      showError('Conversation created, but the first message did not send', 'Try sending it again from the thread.');
+    }
+    setDraftConversation(null);
+  };
+
+  const draftView = draftConversation ? (
+    <DraftConversationView
+      contactOptions={composePickerOptions}
+      pendingInviteOptions={composePendingInviteOptions}
+      isLoadingContacts={composeClientsData.isLoading || composeTeamData.isLoading}
+      draftContact={draftConversation.contactUserId
+        ? {
+          userId: draftConversation.contactUserId,
+          name: draftConversation.contactName ?? '',
+          email: draftConversation.contactEmail,
+        }
+        : null}
+      onChangeContact={handleDraftContactChange}
+      onSendFirstMessage={handleDraftSendFirstMessage}
+      onCancel={handleCancelDraft}
+      onInviteContact={() => setIsAddClientDialogOpen(true)}
+      onClickPendingInvite={(option) => setPendingInviteOption({
+        name: option.label,
+        email: typeof option.meta === 'string' && option.meta && option.meta !== 'Waiting for accept' ? option.meta : option.label,
+      })}
+      fileUploadProps={fileUploadProps}
+    />
+  ) : null;
 
   const workspaceFallbackHome = (
     <WorkspaceHomeView
@@ -725,7 +1009,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   // Workspace shell header (Pencil rt13A / RuuTq).
   const SECTION_TITLES: Record<WorkspaceSection, string> = {
     home: 'Home',
-    conversations: 'Inbox',
+    conversations: 'Messages',
     forms: 'Forms',
     intakes: 'Intakes',
     engagements: 'Engagements',
@@ -735,8 +1019,19 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     settings: 'Settings',
     coverage: 'Coverage',
   };
-  const headerTitle = SECTION_TITLES[workspaceSection] ?? 'Home';
-  const headerBreadcrumb = orgDisplayName ? [orgDisplayName, headerTitle] : undefined;
+  const baseHeaderTitle = SECTION_TITLES[workspaceSection] ?? 'Home';
+  // Reflect draft state in the shell header so the user has a clear visual
+  // anchor for "I'm composing a new conversation" — important on mobile where
+  // the listPanel isn't visible alongside the draft view.
+  const draftHeaderLabel = draftConversation
+    ? (draftConversation.contactName?.trim() || 'New conversation')
+    : null;
+  const headerTitle = draftHeaderLabel ?? baseHeaderTitle;
+  const headerBreadcrumb = orgDisplayName
+    ? draftHeaderLabel
+      ? [orgDisplayName, baseHeaderTitle, draftHeaderLabel]
+      : [orgDisplayName, baseHeaderTitle]
+    : undefined;
   const shellHeader = sidebarOrg ? (
     <WorkspaceShellHeader
       orgInitial={sidebarOrg.initial}
@@ -857,8 +1152,31 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     && !mattersDataForView.isLoading
     && !mattersDataForView.error
     && mattersDataForView.items.length === 0;
+  // Pencil oYsFt mobile tab bar — practice mobile sees segmented filters
+  // (Your Messages / Unassigned / All) above the search input. On desktop the
+  // same filters live in the sidebar's secondary nav, so tabs are mobile-only.
+  const mobileMessageTabs = useMemo(() => {
+    if (!isPracticeWorkspace) return null;
+    if (layoutMode === 'desktop') return null;
+    // Short single-word labels keep all three tabs visible without truncation
+    // on a 390-wide viewport ("Your Messages" + "Unassigned" used to overflow).
+    const options = [
+      { value: 'your-inbox', label: 'Yours' },
+      { value: 'unassigned', label: 'Unassigned' },
+      { value: 'all', label: 'All' },
+    ] as const;
+    const value = activeSecondaryFilter && options.some((o) => o.value === activeSecondaryFilter)
+      ? activeSecondaryFilter
+      : 'your-inbox';
+    return {
+      value,
+      options,
+      onChange: (next: string) => handleSecondaryFilterSelect(next),
+    };
+  }, [isPracticeWorkspace, layoutMode, activeSecondaryFilter, handleSecondaryFilterSelect]);
+
   const listContent = (
-    <ConversationListView
+    <MessagesListPanel
       conversations={filteredConversations}
       previews={conversationPreviews}
       practiceName={practiceName}
@@ -866,9 +1184,13 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       isLoading={combinedResolvedConversationsLoading}
       error={combinedResolvedConversationsError}
       onSelectConversation={handleSelectConversation}
-      onSendMessage={() => handleStartConversation('ASK_QUESTION')}
-      showSendMessageButton={false /* Permanent UX decision: conversation creation is initiated from guided entry points, not from list headers. */}
+      onCompose={handleEnterDraftMode}
+      draftEntry={draftConversation
+        ? { contactName: draftConversation.contactName, contactEmail: draftConversation.contactEmail }
+        : null}
+      onSelectDraftEntry={handleEnterDraftMode}
       activeConversationId={activeConversationId}
+      tabs={mobileMessageTabs}
     />
   );
   const desktopCreate = layoutMode === 'desktop' ? desktopCreateButton ?? undefined : undefined;
@@ -927,7 +1249,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   );
   const chatContent = (
     <div className="flex h-full min-h-0 flex-1 flex-col">
-      {chatView}
+      {draftView ?? chatView}
     </div>
   );
   const matterListPanel = layoutMode === 'desktop' && (isPracticeWorkspace || isClientWorkspace) && view === 'matters' && shouldShowDesktopMattersListPanel
@@ -943,7 +1265,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const conversationListView = (
     <div className="flex h-full min-h-0 flex-1 flex-col gap-2">
       <Panel className="list-panel-card-gradient min-h-0 flex-1 overflow-hidden">
-        <ConversationListView
+        <MessagesListPanel
           conversations={filteredConversations}
           previews={conversationPreviews}
           practiceName={practiceName}
@@ -951,8 +1273,11 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
           isLoading={combinedResolvedConversationsLoading}
           error={combinedResolvedConversationsError}
           onSelectConversation={handleSelectConversation}
-          onSendMessage={() => handleStartConversation('ASK_QUESTION')}
-          showSendMessageButton={false /* Permanent UX decision: conversation creation is initiated from guided entry points, not from list headers. */}
+          onCompose={handleEnterDraftMode}
+          draftEntry={draftConversation
+            ? { contactName: draftConversation.contactName, contactEmail: draftConversation.contactEmail }
+            : null}
+          onSelectDraftEntry={handleEnterDraftMode}
           activeConversationId={activeConversationId}
         />
       </Panel>
@@ -1016,6 +1341,12 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     primaryCreateAction,
   });
   const sectionContent = (() => {
+    // On mobile the listPanel is hidden — when in draft mode we want the
+    // draft view to take over the main pane instead of staying on the list.
+    // Desktop keeps the list visible alongside via the dedicated listPanel.
+    if (draftView && layoutMode !== 'desktop' && (view === 'list' || view === 'conversation')) {
+      return draftView;
+    }
     switch (view) {
       case 'setup':
         return setupContent;
@@ -1092,13 +1423,35 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       layoutMode={layoutMode}
       view={view}
       content={sectionContent}
-      chatView={chatView}
+      chatView={draftView ?? chatView}
       layout={sectionLayout}
       topBar={invoiceBuilderTopBar ?? (layoutMode === 'desktop' ? undefined : mobileSectionTopBar)}
       bottomNav={bottomNav}
     />
   );
-  const inspectorPanel = inspectorTarget ? (
+  // Pencil rxzde context panel: when viewing a practice conversation, render a
+  // dedicated three-section panel (Contact / Linked Matter / Recent Activity)
+  // instead of the generic InspectorPanel surface. Other entity types keep
+  // using InspectorPanel.
+  const linkedMatter = useMemo(() => {
+    if (!selectedConversation?.matter_id) return null;
+    return mattersData.items.find((m) => m.id === selectedConversation.matter_id) ?? null;
+  }, [mattersData.items, selectedConversation?.matter_id]);
+  const conversationContextPanel = isPracticeWorkspace
+    && inspectorTarget?.entityType === 'conversation'
+    ? (
+      <ConversationContextPanel
+        conversation={selectedConversation}
+        matter={linkedMatter}
+        practiceName={practiceName}
+        onOpenMatter={(matterId) => navigate(`${normalizedBase}/matters/${encodeURIComponent(matterId)}`)}
+        onDeleteConversation={selectedConversation
+          ? () => setConversationPendingDelete(selectedConversation)
+          : undefined}
+      />
+    )
+    : null;
+  const inspectorPanel = conversationContextPanel ?? (inspectorTarget ? (
     <InspectorPanel
       key={`${inspectorTarget.entityType}:${inspectorTarget.entityId}`}
       entityType={inspectorTarget.entityType}
@@ -1137,27 +1490,123 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
         matterOpposingCounsel: selectedMatterInspectorData.matterOpposingCounsel,
       } : {})}
     />
-  ) : null;
+  ) : null);
   const activeInspector = detailInspectorOpen ? inspectorPanel : null;
+
+  const handleConfirmDeleteConversation = async () => {
+    const target = conversationPendingDelete;
+    if (!target || !practiceId || isDeletingConversation) return;
+    try {
+      setIsDeletingConversation(true);
+      await deleteConversation(target.id, practiceId);
+      setConversationPendingDelete(null);
+      // If the user is currently viewing the deleted conversation, send them
+      // back to the list so we don't 404 on the next /messages call.
+      if (activeConversationId === target.id) {
+        navigate(withWidgetQuery(conversationsPath));
+      }
+      await refreshConversations();
+    } catch (error) {
+      console.error('[WorkspacePage] Failed to delete conversation', error);
+      showError('Could not delete conversation', error instanceof Error ? error.message : 'Please try again.');
+    } finally {
+      setIsDeletingConversation(false);
+    }
+  };
+
   return (
-    <AppShell
-      className="bg-transparent h-dvh"
-      accentBackdropVariant="none"
-      header={shellHeader}
-      sidebar={sidebarNav}
-      desktopSidebarCollapsed={isDesktopSidebarCollapsed}
-      mobileSidebar={mobileSidebarNav}
-      listPanel={conversationListPanel ?? matterListPanel ?? contactsListPanel ?? invoicesListPanel}
-      inspector={activeInspector ?? undefined}
-      inspectorMobileOpen={detailInspectorOpen && isMobileLayout}
-      onInspectorMobileClose={() => setIsInspectorOpen(false)}
-      mobileSidebarOpen={isMobileNavOpen}
-      onMobileSidebarClose={() => setIsMobileNavOpen(false)}
-      main={unifiedMainShell}
-      mainClassName="min-h-0 h-full overflow-hidden"
-      bottomBar={layoutMode === 'desktop' ? bottomNav : undefined}
-      bottomBarClassName={layoutMode === 'desktop' && showBottomNav ? 'md:hidden fixed inset-x-0 bottom-0 z-40 bg-transparent' : undefined}
-    />
+    <>
+      <AppShell
+        className="bg-transparent h-dvh"
+        accentBackdropVariant="none"
+        header={shellHeader}
+        sidebar={sidebarNav}
+        desktopSidebarCollapsed={isDesktopSidebarCollapsed}
+        mobileSidebar={mobileSidebarNav}
+        listPanel={conversationListPanel ?? matterListPanel ?? contactsListPanel ?? invoicesListPanel}
+        inspector={activeInspector ?? undefined}
+        inspectorMobileOpen={detailInspectorOpen && isMobileLayout}
+        onInspectorMobileClose={() => setIsInspectorOpen(false)}
+        mobileSidebarOpen={isMobileNavOpen}
+        onMobileSidebarClose={() => setIsMobileNavOpen(false)}
+        main={unifiedMainShell}
+        mainClassName="min-h-0 h-full overflow-hidden"
+        bottomBar={layoutMode === 'desktop' ? bottomNav : undefined}
+        bottomBarClassName={layoutMode === 'desktop' && showBottomNav ? 'md:hidden fixed inset-x-0 bottom-0 z-40 bg-transparent' : undefined}
+      />
+      <AddContactDialog
+        practiceId={practiceId ?? null}
+        isOpen={isAddClientDialogOpen}
+        onClose={() => setIsAddClientDialogOpen(false)}
+        onSuccess={async () => {
+          // Refresh the picker data so the just-invited contact shows up. The
+          // draft view stays open underneath; the invite is also reflected in
+          // the pending-invitations section since they haven't accepted yet.
+          await composeClientsData.refetch();
+          await composePracticeInvitations.refetch();
+        }}
+      />
+      <Dialog
+        isOpen={Boolean(pendingInviteOption)}
+        onClose={() => setPendingInviteOption(null)}
+        title="Invite still pending"
+        description={pendingInviteOption
+          ? `${pendingInviteOption.email} hasn't accepted the invite yet. They'll be able to chat once they accept.`
+          : ''}
+      >
+        <div className="flex justify-end gap-2 px-6 pb-6">
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={() => setPendingInviteOption(null)}
+          >
+            Got it
+          </Button>
+        </div>
+      </Dialog>
+      <Dialog
+        isOpen={Boolean(conversationPendingDelete)}
+        onClose={() => {
+          if (isDeletingConversation) return;
+          setConversationPendingDelete(null);
+        }}
+        title="Delete conversation"
+        description="This permanently removes the conversation, its messages, reactions, and audit history. This action cannot be undone."
+      >
+        <div className="flex flex-col gap-4 px-6 pb-6">
+          <p className="text-sm text-input-text">
+            Are you sure you want to delete{' '}
+            <span className="font-semibold">
+              {conversationPendingDelete
+                ? (resolveConversationContactName(conversationPendingDelete)
+                  || resolveConversationDisplayTitle(conversationPendingDelete, practiceName ?? 'this conversation'))
+                : 'this conversation'}
+            </span>?
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setConversationPendingDelete(null)}
+              disabled={isDeletingConversation}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="danger"
+              size="sm"
+              onClick={() => { void handleConfirmDeleteConversation(); }}
+              disabled={isDeletingConversation}
+            >
+              {isDeletingConversation ? 'Deleting…' : 'Delete'}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/features/chat/pages/hooks/useWorkspaceConversations.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceConversations.ts
@@ -9,6 +9,20 @@ import {
 } from '@/shared/config/navConfig';
 import type { Conversation } from '@/shared/types/conversation';
 
+// Intake records can reference conversation_ids that no longer exist (orphaned
+// after a conversation was deleted). The list endpoint can't help us — those
+// rows aren't in it. Cache 404s for the session so we don't re-fetch known-dead
+// ids on every list refresh and pollute the worker error log.
+const knownMissingConversationIds = new Set<string>();
+
+// `getConversation` re-wraps HttpError into a plain Error before reaching the
+// caller, so we have to sniff the message. 404s from the worker carry "not
+// found" in the body or fall through to the generic "HTTP 404" fallback.
+const isMissingConversationError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  return /not found/i.test(error.message) || /HTTP 404/i.test(error.message);
+};
+
 type UseWorkspaceConversationsInput = {
   practiceId: string;
   workspace: 'public' | 'practice' | 'client';
@@ -111,7 +125,11 @@ export function useWorkspaceConversations({
       ...resolvedConversations.map((conversation) => conversation.id),
       ...acceptedIntakeConversationsRef.current.map((conversation) => conversation.id),
     ]);
-    const missingConversationIds = acceptedIntakeConversationIds.filter((conversationId) => !knownConversationIds.has(conversationId));
+    const missingConversationIds = acceptedIntakeConversationIds.filter(
+      (conversationId) =>
+        !knownConversationIds.has(conversationId)
+        && !knownMissingConversationIds.has(conversationId),
+    );
     if (missingConversationIds.length === 0) {
       setAcceptedIntakeConversations((prev) => {
         const filtered = prev.filter((conversation) => acceptedIntakeConversationIds.includes(conversation.id));
@@ -136,9 +154,21 @@ export function useWorkspaceConversations({
         if (controller.signal.aborted) break;
         const chunk = missingConversationIds.slice(i, i + chunkSize);
         const results = await Promise.all(
-          chunk.map((conversationId) =>
-            getConversation(conversationId, practiceId, { signal: controller.signal }).catch(() => null)
-          )
+          chunk.map(async (conversationId) => {
+            try {
+              return await getConversation(conversationId, practiceId, { signal: controller.signal });
+            } catch (error) {
+              // Mark as known-missing on 404 only so subsequent list refreshes
+              // skip the lookup and don't 404-storm the worker error log.
+              // Conversations sometimes get deleted while the originating intake
+              // row sticks around. Network/server/abort errors must not poison
+              // the cache — those ids could come back on a later attempt.
+              if (!controller.signal.aborted && isMissingConversationError(error)) {
+                knownMissingConversationIds.add(conversationId);
+              }
+              return null;
+            }
+          })
         );
         loadedConversations.push(...results);
       }

--- a/src/features/chat/pages/hooks/useWorkspaceConversations.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceConversations.ts
@@ -20,7 +20,7 @@ const knownMissingConversationIds = new Set<string>();
 // found" in the body or fall through to the generic "HTTP 404" fallback.
 const isMissingConversationError = (error: unknown): boolean => {
   if (!(error instanceof Error)) return false;
-  return /not found/i.test(error.message) || /HTTP 404/i.test(error.message);
+  return error.message.includes('Conversation not found') || /HTTP 404/i.test(error.message);
 };
 
 type UseWorkspaceConversationsInput = {

--- a/src/features/chat/pages/hooks/useWorkspaceConversations.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceConversations.ts
@@ -11,9 +11,39 @@ import type { Conversation } from '@/shared/types/conversation';
 
 // Intake records can reference conversation_ids that no longer exist (orphaned
 // after a conversation was deleted). The list endpoint can't help us — those
-// rows aren't in it. Cache 404s for the session so we don't re-fetch known-dead
-// ids on every list refresh and pollute the worker error log.
-const knownMissingConversationIds = new Set<string>();
+// rows aren't in it. Cache 404s in localStorage (scoped per-practice) so we
+// don't re-fetch known-dead ids on every list refresh / page reload and
+// pollute the worker error log + browser network tab. Random UUIDs mean a new
+// conversation will never reuse a known-missing id, so caching is safe.
+const KNOWN_MISSING_KEY_PREFIX = 'workspace:knownMissingConversations:';
+const KNOWN_MISSING_LIMIT = 500;
+
+const loadKnownMissing = (practiceId: string): Set<string> => {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(KNOWN_MISSING_KEY_PREFIX + practiceId);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === 'string' && id.length > 0));
+  } catch {
+    return new Set();
+  }
+};
+
+const saveKnownMissing = (practiceId: string, ids: Set<string>): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    // Cap the cache so a long-lived browser doesn't hoard MB of dead UUIDs;
+    // truncation drops the oldest entries (insertion order on Set).
+    const arr = Array.from(ids);
+    const trimmed = arr.length > KNOWN_MISSING_LIMIT ? arr.slice(arr.length - KNOWN_MISSING_LIMIT) : arr;
+    window.localStorage.setItem(KNOWN_MISSING_KEY_PREFIX + practiceId, JSON.stringify(trimmed));
+  } catch {
+    // localStorage may be disabled (private mode, quota exceeded). Cache
+    // becomes session-scoped via the in-memory ref below — best effort.
+  }
+};
 
 // `getConversation` re-wraps HttpError into a plain Error before reaching the
 // caller, so we have to sniff the message. 404s from the worker carry "not
@@ -48,6 +78,16 @@ export function useWorkspaceConversations({
   sessionUserId,
   mockConversations = null,
 }: UseWorkspaceConversationsInput) {
+  // Per-practice cache of conversation_ids we've seen 404 on. Loaded from
+  // localStorage on first render so cold reloads don't re-fetch and re-log
+  // the same orphaned ids. The ref is the live mutable view; saves push to
+  // localStorage on every addition.
+  const knownMissingRef = useRef<Set<string>>(loadKnownMissing(practiceId));
+  // Re-hydrate when practiceId changes (rare, but the cache is per-practice).
+  useEffect(() => {
+    knownMissingRef.current = loadKnownMissing(practiceId);
+  }, [practiceId]);
+
   const conversationAssignedToFilter = workspaceSection === 'conversations'
     ? (isPracticeWorkspace
       ? (activeSecondaryFilter ? PRACTICE_CONVERSATIONS_ASSIGNED_TO_MAP[activeSecondaryFilter] : null)
@@ -128,7 +168,7 @@ export function useWorkspaceConversations({
     const missingConversationIds = acceptedIntakeConversationIds.filter(
       (conversationId) =>
         !knownConversationIds.has(conversationId)
-        && !knownMissingConversationIds.has(conversationId),
+        && !knownMissingRef.current.has(conversationId),
     );
     if (missingConversationIds.length === 0) {
       setAcceptedIntakeConversations((prev) => {
@@ -164,7 +204,8 @@ export function useWorkspaceConversations({
               // row sticks around. Network/server/abort errors must not poison
               // the cache — those ids could come back on a later attempt.
               if (!controller.signal.aborted && isMissingConversationError(error)) {
-                knownMissingConversationIds.add(conversationId);
+                knownMissingRef.current.add(conversationId);
+                saveKnownMissing(practiceId, knownMissingRef.current);
               }
               return null;
             }

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -14,7 +14,10 @@ import { ChatText } from '@/features/chat/components/ChatText';
 import {
   resolveConversationContactName,
   resolveConversationDisplayTitle,
+  resolveConversationPresence,
 } from '@/shared/utils/conversationDisplay';
+import { usePresenceContext } from '@/shared/contexts/PresenceContext';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
 
 /**
  * Placeholder rows shaped like ConversationItem (avatar + title + time +
@@ -94,6 +97,22 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
   const previewText = (preview?.content ?? conversation.last_message_content ?? '').trim();
   const isUnread = Number(conversation.unread_count ?? 0) > 0;
 
+  // Presence: prefer real online state from the practice's PresenceRoom (a
+  // contact-level "is at least one of their tabs connected right now" check).
+  // Fall back to the timestamp proxy on `last_message_at` for accounts that
+  // can't subscribe (e.g. offline contacts that have never reconnected) so
+  // the indicator stays consistent.
+  const { onlineUserIds } = usePresenceContext();
+  const { session } = useSessionContext();
+  const currentUserId = session?.user?.id ?? null;
+  const contactUserId = (Array.isArray(conversation.participants) ? conversation.participants : [])
+    .find((id) => typeof id === 'string' && id !== currentUserId) ?? null;
+  const isContactLive = contactUserId ? onlineUserIds.has(contactUserId) : false;
+  const presence = resolveConversationPresence(
+    conversation.last_message_at ?? conversation.updated_at ?? null,
+    isContactLive,
+  );
+
   return (
     <button
       onClick={() => onSelect(conversation.id)}
@@ -109,6 +128,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
         name={avatarName}
         size="md"
         className="ring-1 ring-line-glass/10"
+        status={presence.status}
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-start justify-between gap-3">
@@ -148,6 +168,15 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
           </div>
         ) : null}
       </div>
+      {/* Unread indicator (Pencil vHO59) — small accent dot anchored to the right edge. */}
+      <span
+        aria-hidden={!isUnread}
+        aria-label={isUnread ? t('conversation.badge.unread', { defaultValue: 'Unread' }) : undefined}
+        className={cn(
+          'mt-2 h-2 w-2 flex-shrink-0 rounded-full transition-opacity',
+          isUnread ? 'bg-accent-500 opacity-100' : 'opacity-0'
+        )}
+      />
     </button>
   );
 });

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -85,9 +85,10 @@ interface ConversationItemProps {
   fallbackName: string;
   isActive: boolean;
   onSelect: (id: string) => void;
+  presence: ReturnType<typeof resolveConversationPresence>;
 }
 
-const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, onSelect }: ConversationItemProps) => {
+const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, onSelect, presence }: ConversationItemProps) => {
   const { t } = useTranslation();
   const contactName = resolveConversationContactName(conversation);
   const fallbackTitle = resolveConversationDisplayTitle(conversation, fallbackName);
@@ -96,22 +97,6 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
   const timeLabel = formatRelativeTime(conversation.updated_at);
   const previewText = (preview?.content ?? conversation.last_message_content ?? '').trim();
   const isUnread = Number(conversation.unread_count ?? 0) > 0;
-
-  // Presence: prefer real online state from the practice's PresenceRoom (a
-  // contact-level "is at least one of their tabs connected right now" check).
-  // Fall back to the timestamp proxy on `last_message_at` for accounts that
-  // can't subscribe (e.g. offline contacts that have never reconnected) so
-  // the indicator stays consistent.
-  const { onlineUserIds } = usePresenceContext();
-  const { session } = useSessionContext();
-  const currentUserId = session?.user?.id ?? null;
-  const contactUserId = (Array.isArray(conversation.participants) ? conversation.participants : [])
-    .find((id) => typeof id === 'string' && id !== currentUserId) ?? null;
-  const isContactLive = contactUserId ? onlineUserIds.has(contactUserId) : false;
-  const presence = resolveConversationPresence(
-    conversation.last_message_at ?? conversation.updated_at ?? null,
-    isContactLive,
-  );
 
   return (
     <button
@@ -170,13 +155,15 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
       </div>
       {/* Unread indicator (Pencil vHO59) — small accent dot anchored to the right edge. */}
       <span
-        aria-hidden={!isUnread}
-        aria-label={isUnread ? t('conversation.badge.unread', { defaultValue: 'Unread' }) : undefined}
+        aria-hidden="true"
         className={cn(
           'mt-2 h-2 w-2 flex-shrink-0 rounded-full transition-opacity',
           isUnread ? 'bg-accent-500 opacity-100' : 'opacity-0'
         )}
       />
+      {isUnread && (
+        <span className="sr-only">Unread</span>
+      )}
     </button>
   );
 });
@@ -215,9 +202,27 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
         ? t('workspace.conversationList.error', { defaultValue: 'Failed to load conversations.' })
         : null;
   const fallbackName = typeof practiceName === 'string' ? practiceName.trim() : '';
+  const { onlineUserIds } = usePresenceContext();
+  const { session } = useSessionContext();
+  const currentUserId = session?.user?.id ?? null;
   const sorted = conversations
     .filter((conversation) => conversation.user_info?.mode !== 'PRACTICE_ONBOARDING')
     .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+
+  // Precompute contactId and presence for each conversation
+  const conversationItems = sorted.map((conversation) => {
+    let contactUserId: string | null = null;
+    if (currentUserId) {
+      contactUserId = (Array.isArray(conversation.participants) ? conversation.participants : [])
+        .find((id) => typeof id === 'string' && id !== currentUserId) ?? null;
+    }
+    const isContactLive = contactUserId ? onlineUserIds.has(contactUserId) : false;
+    const presence = resolveConversationPresence(
+      conversation.last_message_at ?? conversation.updated_at ?? null,
+      isContactLive,
+    );
+    return { conversation, presence };
+  });
 
   return (
     <div className="flex h-full flex-col bg-transparent">
@@ -238,7 +243,7 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
         />
       ) : (
         <VList style={{ flex: 1, minHeight: 0 }} className="px-2 py-2">
-          {sorted.map((conversation) => (
+          {conversationItems.map(({ conversation, presence }) => (
             <div key={conversation.id} className="mb-1">
               <ConversationItem
                 conversation={conversation}
@@ -246,6 +251,7 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
                 fallbackName={fallbackName}
                 isActive={activeConversationId === conversation.id}
                 onSelect={onSelectConversation}
+                presence={presence}
               />
             </div>
           ))}

--- a/src/features/media/components/MediaControls.tsx
+++ b/src/features/media/components/MediaControls.tsx
@@ -150,9 +150,11 @@ const MediaControls: FunctionComponent<MediaControlsProps> = ({
 
 	return (
 		<div className="flex items-center gap-2" role="region" aria-label="Audio recording">
+			{/* Sized to match FileMenu's + trigger (icon-sm = 44×44, 20px icon)
+			    so the two pill-internal controls read as a matched pair. */}
 			<Button
 				variant="icon"
-				size="sm"
+				size="icon-sm"
 				onClick={() => {
 					if (!isRecording) {
 						startRecording();
@@ -163,9 +165,9 @@ const MediaControls: FunctionComponent<MediaControlsProps> = ({
 				aria-label="Record audio message"
 				aria-pressed={isRecording}
 				disabled={permissionDenied}
-				className="w-8 h-8 p-0 rounded-full"
+				className="shadow-lg border bg-surface-utility/10 border-line-glass/20 hover:bg-surface-utility/20 hover:border-line-glass/30 hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-glass/30 focus-visible:ring-offset-0 active:scale-100"
 			>
-				<Icon icon={Mic} className="w-4 h-4" aria-hidden="true"  />
+				<Icon icon={Mic} className="w-5 h-5" aria-hidden="true"  />
 			</Button>
 			{permissionDenied && (
 				<div className="sr-only" role="alert">

--- a/src/index.css
+++ b/src/index.css
@@ -988,7 +988,7 @@
   }
 
   .segmented-toggle-item {
-    @apply relative z-10 rounded-full px-4 py-1.5 text-sm font-medium transition-colors duration-200;
+    @apply relative z-10 rounded-full px-3 py-1.5 text-sm font-medium transition-colors duration-200;
   }
 
   .segmented-toggle-item-active {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,24 +2,10 @@ import { hydrate, prerender as ssr, Router, Route, useLocation, LocationProvider
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { Suspense } from 'preact/compat';
 import { I18nextProvider } from 'react-i18next';
-import AuthPage from '@/pages/AuthPage';
-import AcceptInvitationPage from '@/pages/AcceptInvitationPage';
-import ClientHomePage from '@/pages/ClientHomePage';
-import PracticeHomePage from '@/pages/PracticeHomePage';
-import OnboardingPage from '@/pages/OnboardingPage';
-import PricingPage from '@/pages/PricingPage';
-import PaymentResultPage from '@/pages/PaymentResultPage';
-import DebugStylesPage from '@/pages/DebugStylesPage';
-import DebugDialogsPage from '@/pages/DebugDialogsPage';
-import DebugChatPage from '@/pages/DebugChatPage';
-import DebugConversationsPage from '@/pages/DebugConversationsPage';
-import DebugMatterPage from '@/pages/DebugMatterPage';
-import { ClientEngagementReviewPage } from '@/features/engagements/pages/ClientEngagementReviewPage';
 import { SEOHead } from '@/app/SEOHead';
 import { ToastProvider } from '@/shared/contexts/ToastContext';
 import { SessionProvider, useSessionContext } from '@/shared/contexts/SessionContext';
 import { getSession } from '@/shared/lib/authClient';
-import { MainApp } from '@/app/MainApp';
 import type { WorkspaceView } from '@/shared/utils/workspaceShell';
 import { PublicWorkspaceRoute } from '@/app/PublicWorkspaceRoute';
 import { useNavigation } from '@/shared/utils/navigation';
@@ -57,6 +43,28 @@ import { isWidgetRuntimeContext as _isWidgetRuntimeContext } from '@/shared/util
 import { useTheme } from '@/shared/hooks/useTheme';
 import { setActivePractice } from '@/shared/lib/apiClient';
 import { lazy } from 'preact/compat';
+// Top-level pages are lazy so they don't bloat the entry chunk. Each page
+// loads its own bundle on demand the first time the matching route renders.
+const AuthPage = lazy(() => import('@/pages/AuthPage'));
+const AcceptInvitationPage = lazy(() => import('@/pages/AcceptInvitationPage'));
+const ClientHomePage = lazy(() => import('@/pages/ClientHomePage'));
+const PracticeHomePage = lazy(() => import('@/pages/PracticeHomePage'));
+const OnboardingPage = lazy(() => import('@/pages/OnboardingPage'));
+const PricingPage = lazy(() => import('@/pages/PricingPage'));
+const PaymentResultPage = lazy(() => import('@/pages/PaymentResultPage'));
+// Debug pages — never used in real flows but were eating into the entry
+// chunk because of the static imports. Lazy is the cheapest way to keep
+// them mounted-by-route while excluding their code from first-load.
+const DebugStylesPage = lazy(() => import('@/pages/DebugStylesPage'));
+const DebugDialogsPage = lazy(() => import('@/pages/DebugDialogsPage'));
+const DebugChatPage = lazy(() => import('@/pages/DebugChatPage'));
+const DebugConversationsPage = lazy(() => import('@/pages/DebugConversationsPage'));
+const DebugMatterPage = lazy(() => import('@/pages/DebugMatterPage'));
+const ClientEngagementReviewPage = lazy(() => import('@/features/engagements/pages/ClientEngagementReviewPage').then((m) => ({ default: m.ClientEngagementReviewPage })));
+// MainApp is the workspace shell — it carries the chat composer, file
+// upload pipeline, presence provider, etc. Lazy so the browser only loads
+// it once the user lands on a route that mounts a workspace.
+const MainApp = lazy(() => import('@/app/MainApp').then((m) => ({ default: m.MainApp })));
 const PracticeMatterCreatePage = lazy(() => import('@/features/matters/pages/PracticeMatterCreatePage').then((m) => ({ default: m.PracticeMatterCreatePage })));
 const PracticeContactEditorPage = lazy(() => import('@/features/clients/pages/PracticeContactEditorPage').then((m) => ({ default: m.PracticeContactEditorPage })));
 const PracticeInvoiceCreatePage = lazy(() => import('@/features/invoices/pages/PracticeInvoiceCreatePage').then((m) => ({ default: m.PracticeInvoiceCreatePage })));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -784,18 +784,20 @@ function PracticeAppRoute({
 
   return (
     <>
-      <MainApp
-        practiceId={resolvedPracticeId}
-        practiceConfig={practiceConfig}
-        isPracticeView={true}
-        workspace="practice"
-        routeConversationId={conversationId}
-        routeInvoiceId={invoiceId}
-        routeSettingsView={settingsView}
-        routeSettingsAppId={appId}
-        workspaceView={workspaceView}
-        practiceSlug={normalizedPracticeSlug || undefined}
-      />
+      <Suspense fallback={<LoadingScreen />}>
+        <MainApp
+          practiceId={resolvedPracticeId}
+          practiceConfig={practiceConfig}
+          isPracticeView={true}
+          workspace="practice"
+          routeConversationId={conversationId}
+          routeInvoiceId={invoiceId}
+          routeSettingsView={settingsView}
+          routeSettingsAppId={appId}
+          workspaceView={workspaceView}
+          practiceSlug={normalizedPracticeSlug || undefined}
+        />
+      </Suspense>
       {isMatterCreateRoute ? (
         <Suspense fallback={null}>
           <PracticeMatterCreatePage
@@ -923,18 +925,20 @@ function ClientPracticeRoute({
         practiceConfig={practiceConfig}
         currentUrl={currentUrl}
       />
-      <MainApp
-        practiceId={resolvedPracticeId}
-        practiceConfig={practiceConfig}
-        isPracticeView={true}
-        workspace="client"
-        clientPracticeSlug={slug || undefined}
-        routeConversationId={conversationId}
-        routeInvoiceId={invoiceId}
-        routeSettingsView={settingsView}
-        routeSettingsAppId={appId}
-        workspaceView={workspaceView}
-      />
+      <Suspense fallback={<LoadingScreen />}>
+        <MainApp
+          practiceId={resolvedPracticeId}
+          practiceConfig={practiceConfig}
+          isPracticeView={true}
+          workspace="client"
+          clientPracticeSlug={slug || undefined}
+          routeConversationId={conversationId}
+          routeInvoiceId={invoiceId}
+          routeSettingsView={settingsView}
+          routeSettingsAppId={appId}
+          workspaceView={workspaceView}
+        />
+      </Suspense>
     </>
   );
 }

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -182,7 +182,7 @@ const buildPracticeRail = (basePath: string): NavRailItem[] => [
   },
   {
     id: 'conversations',
-    label: 'Inbox',
+    label: 'Messages',
     icon: MessageSquare,
     href: `${basePath}/conversations`,
     matchHrefs: [`${basePath}/conversations`],
@@ -269,7 +269,7 @@ const buildClientRail = (basePath: string): NavRailItem[] => [
   },
   {
     id: 'conversations',
-    label: 'Inbox',
+    label: 'Messages',
     icon: MessageSquare,
     href: `${basePath}/conversations`,
     matchHrefs: [`${basePath}/conversations`],
@@ -298,9 +298,9 @@ const buildClientRail = (basePath: string): NavRailItem[] => [
 const buildConversationsSecondary = (basePath: string, workspace: 'practice' | 'client'): NavSection[] => {
   if (workspace === 'practice') {
     return [{
-      label: 'Inbox',
+      label: 'Messages',
       items: [
-        { id: 'your-inbox', label: 'Your Inbox', href: `${basePath}/conversations` },
+        { id: 'your-inbox', label: 'Your Messages', href: `${basePath}/conversations` },
         { id: 'assigned-to-me', label: 'Assigned to me', href: `${basePath}/conversations` },
         { id: 'mentions', label: 'Mentions', href: `${basePath}/conversations` },
         { id: 'all', label: 'All', href: `${basePath}/conversations` },
@@ -309,9 +309,9 @@ const buildConversationsSecondary = (basePath: string, workspace: 'practice' | '
     }];
   }
   return [{
-    label: 'Inbox',
+    label: 'Messages',
     items: [
-      { id: 'your-inbox', label: 'Your Inbox', href: `${basePath}/conversations` },
+      { id: 'your-inbox', label: 'Your Messages', href: `${basePath}/conversations` },
       { id: 'all', label: 'All', href: `${basePath}/conversations` },
     ],
   }];
@@ -573,7 +573,7 @@ function flattenSecondary(sections: NavSection[]): SidebarChild[] {
   };
   // Only render group headings when the secondary actually has multiple groups
   // (e.g. Settings: Personal/Account/Practice/Support). For single-group dropdowns
-  // the parent rail item already names them — duplicating "Inbox", "Stage", etc.
+  // the parent rail item already names them — duplicating "Messages", "Stage", etc.
   // above the items adds noise.
   const labeledSectionCount = sections.filter((s) => s.label).length;
   const showGroupLabels = labeledSectionCount > 1;

--- a/src/shared/contexts/PresenceContext.tsx
+++ b/src/shared/contexts/PresenceContext.tsx
@@ -1,0 +1,126 @@
+import { createContext } from 'preact';
+import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+
+interface PresenceContextValue {
+  /** Set of userIds currently online for the active practice. */
+  onlineUserIds: ReadonlySet<string>;
+  /** True once the WebSocket has received its first snapshot. */
+  isReady: boolean;
+}
+
+const EmptyPresenceContext: PresenceContextValue = {
+  onlineUserIds: new Set<string>(),
+  isReady: false,
+};
+
+const PresenceContext = createContext<PresenceContextValue>(EmptyPresenceContext);
+
+export const usePresenceContext = (): PresenceContextValue => useContext(PresenceContext);
+
+/**
+ * Returns true when the given userId has at least one live socket connected
+ * to the practice's PresenceRoom.
+ */
+export const useIsUserOnline = (userId: string | null | undefined): boolean => {
+  const { onlineUserIds } = usePresenceContext();
+  if (!userId) return false;
+  return onlineUserIds.has(userId);
+};
+
+interface PresenceProviderProps {
+  practiceId: string | null | undefined;
+  /** Authenticated userId. When null/empty, the provider is dormant
+   *  (anonymous users don't track presence). */
+  userId: string | null | undefined;
+  enabled?: boolean;
+  children: ComponentChildren;
+}
+
+/**
+ * Holds a single WebSocket to /api/practice/presence/:practiceId/ws and
+ * exposes the most recent presence snapshot via PresenceContext. Reconnects
+ * with exponential backoff if the socket drops.
+ */
+export const PresenceProvider = ({ practiceId, userId, enabled = true, children }: PresenceProviderProps): JSX.Element => {
+  const [onlineUserIds, setOnlineUserIds] = useState<ReadonlySet<string>>(new Set());
+  const [isReady, setIsReady] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    if (!enabled || !practiceId || !userId || typeof WebSocket === 'undefined') {
+      return () => undefined;
+    }
+
+    const buildUrl = (): string => {
+      // Prefer same-origin WS so cookies (better-auth session) flow with the
+      // upgrade. window.location.protocol → ws/wss mapping.
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      return `${proto}//${window.location.host}/api/presence/${encodeURIComponent(practiceId)}/ws`;
+    };
+
+    const connect = () => {
+      if (cancelledRef.current) return;
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(buildUrl());
+      } catch (error) {
+        scheduleReconnect();
+        console.warn('[presence] failed to open socket', error);
+        return;
+      }
+      wsRef.current = socket;
+
+      socket.addEventListener('open', () => {
+        reconnectAttemptsRef.current = 0;
+      });
+      socket.addEventListener('message', (event) => {
+        try {
+          const parsed = JSON.parse(event.data) as { type?: string; online?: unknown };
+          if (parsed?.type === 'presence' && Array.isArray(parsed.online)) {
+            const next = new Set(parsed.online.filter((id): id is string => typeof id === 'string' && id.length > 0));
+            setOnlineUserIds(next);
+            setIsReady(true);
+          }
+        } catch {
+          // Ignore malformed frames — server should never send them.
+        }
+      });
+      socket.addEventListener('close', () => {
+        wsRef.current = null;
+        if (cancelledRef.current) return;
+        scheduleReconnect();
+      });
+      socket.addEventListener('error', () => {
+        // Treat error as a hint to reconnect; close handler will run too.
+      });
+    };
+
+    const scheduleReconnect = () => {
+      if (cancelledRef.current) return;
+      reconnectAttemptsRef.current += 1;
+      const delay = Math.min(15_000, 500 * 2 ** Math.min(reconnectAttemptsRef.current, 5));
+      reconnectTimerRef.current = setTimeout(connect, delay);
+    };
+
+    connect();
+    return () => {
+      cancelledRef.current = true;
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+      const socket = wsRef.current;
+      wsRef.current = null;
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        try { socket.close(1000, 'unmount'); } catch { /* ignore */ }
+      }
+    };
+  }, [enabled, practiceId, userId]);
+
+  const value = useMemo<PresenceContextValue>(() => ({ onlineUserIds, isReady }), [onlineUserIds, isReady]);
+
+  return <PresenceContext.Provider value={value}>{children}</PresenceContext.Provider>;
+};

--- a/src/shared/contexts/PresenceContext.tsx
+++ b/src/shared/contexts/PresenceContext.tsx
@@ -38,7 +38,7 @@ interface PresenceProviderProps {
 }
 
 /**
- * Holds a single WebSocket to /api/practice/presence/:practiceId/ws and
+ * Holds a single WebSocket to /api/presence/:practiceId/ws and
  * exposes the most recent presence snapshot via PresenceContext. Reconnects
  * with exponential backoff if the socket drops.
  */
@@ -50,8 +50,10 @@ export const PresenceProvider = ({ practiceId, userId, enabled = true, children 
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelledRef = useRef(false);
 
+
   useEffect(() => {
     cancelledRef.current = false;
+    reconnectAttemptsRef.current = 0;
     if (!enabled || !practiceId || !userId || typeof WebSocket === 'undefined') {
       return () => undefined;
     }

--- a/src/shared/contexts/PresenceContext.tsx
+++ b/src/shared/contexts/PresenceContext.tsx
@@ -91,8 +91,8 @@ export const PresenceProvider = ({ practiceId, userId, enabled = true, children 
         }
       });
       socket.addEventListener('close', () => {
-        wsRef.current = null;
         if (cancelledRef.current) return;
+        wsRef.current = null;
         scheduleReconnect();
       });
       socket.addEventListener('error', () => {
@@ -114,9 +114,11 @@ export const PresenceProvider = ({ practiceId, userId, enabled = true, children 
       reconnectTimerRef.current = null;
       const socket = wsRef.current;
       wsRef.current = null;
-      if (socket && socket.readyState === WebSocket.OPEN) {
+      if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
         try { socket.close(1000, 'unmount'); } catch { /* ignore */ }
       }
+      setOnlineUserIds(new Set());
+      setIsReady(false);
     };
   }, [enabled, practiceId, userId]);
 

--- a/src/shared/hooks/useChatComposer.ts
+++ b/src/shared/hooks/useChatComposer.ts
@@ -266,8 +266,12 @@ export const useChatComposer = ({
     conversationId?: string | null
   ) => {
     if (!enabled) throw new Error('Chat is suspended.');
-    if (!content.trim()) throw new Error('Message cannot be empty.');
-    
+    // Allow file-only messages: a send is valid if there's text OR at least
+    // one attachment. Mirrors the worker's relaxed validation.
+    if (!content.trim() && attachments.length === 0) {
+      throw new Error('Message cannot be empty.');
+    }
+
     const effectivePracticeId = (practiceIdRef.current ?? '').trim();
     const activeConversationId = conversationId?.trim() || await ensureConversationId();
     if (!effectivePracticeId) throw new Error('practiceId is required');
@@ -590,8 +594,12 @@ export const useChatComposer = ({
     options?: { additionalContext?: string; mentionedUserIds?: string[]; suppressAi?: boolean }
   ) => {
     try {
-      if (!message.trim()) throw new Error('Message cannot be empty.');
-      
+      // Allow file-only messages — same relaxed precondition as
+      // sendMessageOverWs and the worker route.
+      if (!message.trim() && attachments.length === 0) {
+        throw new Error('Message cannot be empty.');
+      }
+
       const resolvedConversationId = await ensureConversationId();
       if (!resolvedConversationId) throw new Error('conversationId is required');
 

--- a/src/shared/hooks/useConversationSetup.ts
+++ b/src/shared/hooks/useConversationSetup.ts
@@ -152,7 +152,7 @@ export function useConversationSetup({
           ...(currentUserId ? [currentUserId] : []),
           ...extraParticipantIds,
         ]));
-        const metadata: Record<string, unknown> = { source: 'chat', ...extraMetadata };
+        const metadata: Record<string, unknown> = { ...extraMetadata, source: 'chat' };
         const params: Record<string, string> = { practiceId };
         if (participantUserIds.length > 0) {
           params.participantUserIds = JSON.stringify(participantUserIds);

--- a/src/shared/hooks/useConversationSetup.ts
+++ b/src/shared/hooks/useConversationSetup.ts
@@ -28,7 +28,11 @@ export interface UseConversationSetupResult {
   conversationMode: ConversationMode | null;
   setConversationMode: (mode: ConversationMode | null) => void;
   isCreatingConversation: boolean;
-  createConversation: () => Promise<string | null>;
+  createConversation: (options?: {
+    allowPracticeWorkspace?: boolean;
+    additionalParticipantUserIds?: string[];
+    additionalMetadata?: Record<string, unknown>;
+  }) => Promise<string | null>;
   ensureConversation: () => Promise<string | null>;
   handleModeSelection: (mode: ConversationMode, source: 'intro_gate' | 'composer_footer', startConsultFlow: (id: string) => void) => Promise<void>;
   handleStartNewConversation: (mode: ConversationMode, startConsultFlow: (id: string) => void) => Promise<string>;
@@ -125,29 +129,43 @@ export function useConversationSetup({
     }
   }, [isPublicWorkspace]);
 
-  const createConversation = useCallback(async (): Promise<string | null> => {
-    if (isPracticeWorkspace) return null;
+  const createConversation = useCallback(async (options?: {
+    allowPracticeWorkspace?: boolean;
+    additionalParticipantUserIds?: string[];
+    additionalMetadata?: Record<string, unknown>;
+  }): Promise<string | null> => {
+    if (isPracticeWorkspace && !options?.allowPracticeWorkspace) return null;
     if (!practiceId || isCreatingRef.current) return null;
+
+    const extraParticipantIds = (options?.additionalParticipantUserIds ?? [])
+      .map((id) => (typeof id === 'string' ? id.trim() : ''))
+      .filter((id) => id.length > 0);
+    const extraMetadata = options?.additionalMetadata ?? {};
 
     try {
       isCreatingRef.current = true;
       setIsCreatingConversation(true);
-      
+
       // Create and track the creation promise
       const creationPromise = (async () => {
+        const participantUserIds = Array.from(new Set([
+          ...(currentUserId ? [currentUserId] : []),
+          ...extraParticipantIds,
+        ]));
+        const metadata: Record<string, unknown> = { source: 'chat', ...extraMetadata };
         const params: Record<string, string> = { practiceId };
-        if (currentUserId) {
-          params.participantUserIds = JSON.stringify([currentUserId]);
+        if (participantUserIds.length > 0) {
+          params.participantUserIds = JSON.stringify(participantUserIds);
         }
-        params.metadata = JSON.stringify({ source: 'chat' });
+        params.metadata = JSON.stringify(metadata);
 
         let envelope: { success: boolean; error?: string; data?: { id: string } };
         try {
           const result = await apiClient.post<{ success: boolean; error?: string; data?: { id: string } }>(
             getConversationsEndpoint(),
             {
-              participantUserIds: currentUserId ? [currentUserId] : [],
-              metadata: { source: 'chat' },
+              participantUserIds,
+              metadata,
               practiceId,
             },
             { params },

--- a/src/shared/lib/conversationApi.ts
+++ b/src/shared/lib/conversationApi.ts
@@ -338,3 +338,19 @@ export const removeMessageReaction = async (
     throw toErrorMessage(error, 'Failed to remove reaction');
   }
 };
+
+export const markAsRead = async (
+  conversationId: string,
+  practiceId: string
+): Promise<{ markedAsRead: boolean; lastReadSeq: number }> => {
+  try {
+    const { data } = await apiClient.post<{ markedAsRead: boolean; lastReadSeq: number }>(
+      `/api/conversations/${encodeURIComponent(conversationId)}/read`,
+      {},
+      { params: { practiceId } },
+    );
+    return data;
+  } catch (error) {
+    throw toErrorMessage(error, 'Failed to mark conversation as read');
+  }
+};

--- a/src/shared/lib/conversationApi.ts
+++ b/src/shared/lib/conversationApi.ts
@@ -339,17 +339,23 @@ export const removeMessageReaction = async (
   }
 };
 
+interface MarkAsReadEnvelope {
+  success: boolean;
+  data?: { markedAsRead: boolean; lastReadSeq: number };
+}
+
 export const markAsRead = async (
   conversationId: string,
   practiceId: string
 ): Promise<{ markedAsRead: boolean; lastReadSeq: number }> => {
   try {
-    const { data } = await apiClient.post<{ markedAsRead: boolean; lastReadSeq: number }>(
+    const { data } = await apiClient.post<MarkAsReadEnvelope>(
       `/api/conversations/${encodeURIComponent(conversationId)}/read`,
       {},
       { params: { practiceId } },
     );
-    return data;
+    if (!data.success || !data.data) throw new Error('Failed to mark as read');
+    return data.data;
   } catch (error) {
     throw toErrorMessage(error, 'Failed to mark conversation as read');
   }

--- a/src/shared/lib/conversationApi.ts
+++ b/src/shared/lib/conversationApi.ts
@@ -103,6 +103,20 @@ export const getConversation = async (
   }
 };
 
+export const deleteConversation = async (
+  conversationId: string,
+  practiceId: string
+): Promise<void> => {
+  try {
+    await apiClient.delete<{ success: boolean; data?: { deleted: boolean } }>(
+      `/api/conversations/${encodeURIComponent(conversationId)}`,
+      { params: { practiceId } },
+    );
+  } catch (error) {
+    throw toErrorMessage(error, 'Failed to delete conversation');
+  }
+};
+
 export const updateConversationTriage = async (
   conversationId: string,
   practiceId: string,

--- a/src/shared/ui/DragDropOverlay.tsx
+++ b/src/shared/ui/DragDropOverlay.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'preact';
 import { useEffect, useRef, useCallback } from 'preact/hooks';
-import { CloudUpload } from 'lucide-preact';
+import { FileText, Image, MessageSquare } from 'lucide-preact';
 
 import { Icon } from '@/shared/ui/Icon';
 
@@ -9,6 +9,11 @@ interface DragDropOverlayProps {
   onClose?: () => void;
 }
 
+/**
+ * Page-wide drop overlay shown while files are being dragged onto the app.
+ * Light, semi-transparent background — no heavy modal — with a centered
+ * "Add anything" prompt that mirrors the reference design.
+ */
 const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, onClose }) => {
   const overlayRef = useRef<HTMLDivElement>(null);
 
@@ -34,21 +39,38 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
   if (!isVisible) return null;
 
   return (
-    <div 
+    <div
       ref={overlayRef}
       tabIndex={-1}
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-gradient-to-br from-surface-workspace/85 to-surface-workspace/95 dark:from-surface-app-frame/70 dark:to-surface-app-frame/80 backdrop-blur-sm" 
+      className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center bg-surface-app-frame/40 backdrop-blur-[2px]"
       role="dialog"
-      aria-label="File upload"
+      aria-label="Drop files to add to the conversation"
       aria-modal="true"
     >
-      <div className="flex flex-col items-center justify-center gap-3 text-input-text text-lg sm:text-xl lg:text-2xl text-center p-6 sm:p-10 rounded-2xl bg-surface-overlay/80 shadow-2xl border border-line-default max-w-[90%] relative z-[10000]">
-        <Icon icon={CloudUpload} className="w-10 h-10 sm:w-14 sm:h-14 text-amber-500 mb-1" aria-hidden="true"  />
-        <h3 className="text-lg sm:text-2xl lg:text-3xl font-semibold m-0 text-input-text">Drop Files to Upload</h3>
-        <p className="text-xs sm:text-sm lg:text-base opacity-80 m-0 text-input-placeholder">We accept images, videos, and document files</p>
+      <div className="flex flex-col items-center gap-4 px-6 text-center">
+        {/* Icon stack — overlapping "talk + image + doc" tiles to mirror the
+            reference. Tilted at slight angles so they read as a sticker stack. */}
+        <div className="relative h-16 w-20">
+          <div className="absolute left-1 top-1 flex h-12 w-12 -rotate-12 items-center justify-center rounded-2xl bg-accent-500/90 shadow-lg ring-1 ring-line-glass/30">
+            <Icon icon={MessageSquare} className="h-6 w-6 text-white" aria-hidden="true" />
+          </div>
+          <div className="absolute right-0 top-0 flex h-12 w-12 rotate-6 items-center justify-center rounded-2xl bg-input-text/85 shadow-lg ring-1 ring-line-glass/30">
+            <Icon icon={FileText} className="h-6 w-6 text-surface-app-frame" aria-hidden="true" />
+          </div>
+          <div className="absolute bottom-0 left-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-accent-500 shadow-lg ring-1 ring-line-glass/30">
+            <Icon icon={Image} className="h-6 w-6 text-white" aria-hidden="true" />
+          </div>
+        </div>
+        <div>
+          <h3 className="m-0 text-2xl font-semibold text-input-text">Add anything</h3>
+          <p className="mt-1 text-sm text-input-placeholder">
+            Drop any file here to add it to the conversation
+          </p>
+        </div>
       </div>
     </div>
   );
 };
 
-export default DragDropOverlay; 
+export default DragDropOverlay;
+

--- a/src/shared/ui/DragDropOverlay.tsx
+++ b/src/shared/ui/DragDropOverlay.tsx
@@ -43,9 +43,10 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
       ref={overlayRef}
       tabIndex={-1}
       className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center bg-surface-app-frame/40 backdrop-blur-[2px]"
-      role="dialog"
+      role="status"
       aria-label="Drop files to add to the conversation"
-      aria-modal="true"
+      aria-live="polite"
+      aria-atomic="true"
     >
       <div className="flex flex-col items-center gap-4 px-6 text-center">
         {/* Icon stack — overlapping "talk + image + doc" tiles to mirror the

--- a/src/shared/ui/input/MarkdownUploadTextarea.tsx
+++ b/src/shared/ui/input/MarkdownUploadTextarea.tsx
@@ -6,15 +6,17 @@ import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { cn } from '@/shared/utils/cn';
 import { useUniqueId } from '@/shared/hooks/useUniqueId';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/shared/ui/dropdown';
-import remarkGfm from 'remark-gfm';
-import { markdownComponents } from '@/shared/ui/markdown/markdownComponents';
 import { uploadFileViaBackend } from '@/shared/lib/uploadsApi';
 
-// Custom hook to dynamically import react-markdown on client
+// Lazy-load react-markdown + remark-gfm + the shared markdownComponents map
+// in the same async block so the entire markdown surface stays off the
+// first-load critical path.
 function useReactMarkdown() {
-  // dynamic import: type is unknown until loaded, must use any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const [ReactMarkdown, setReactMarkdown] = useState<any>(null);
+  const [remarkGfm, setRemarkGfm] = useState<any>(null);
+  const [components, setComponents] = useState<any>(null);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   const [error, setError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
 
@@ -23,9 +25,15 @@ function useReactMarkdown() {
 
     const loadMarkdown = async () => {
       try {
-        const mod = await import('react-markdown');
+        const [mod, gfm, comps] = await Promise.all([
+          import('react-markdown'),
+          import('remark-gfm'),
+          import('@/shared/ui/markdown/markdownComponents'),
+        ]);
         if (mounted) {
           setReactMarkdown(() => mod.default);
+          setRemarkGfm(() => gfm.default);
+          setComponents(() => comps.markdownComponents);
           setError(null);
         }
       } catch (err) {
@@ -33,6 +41,8 @@ function useReactMarkdown() {
           const errorMsg = err instanceof Error ? err.message : 'Failed to load markdown preview';
           setError(errorMsg);
           setReactMarkdown(null);
+          setRemarkGfm(null);
+          setComponents(null);
         }
       }
     };
@@ -48,7 +58,7 @@ function useReactMarkdown() {
     setRetryCount((prev) => prev + 1);
   };
 
-  return { component: ReactMarkdown, error, retry };
+  return { component: ReactMarkdown, remarkGfm, components, error, retry };
 }
 
 type UploadState = {
@@ -103,7 +113,13 @@ export const MarkdownUploadTextarea = ({
   className = '',
   defaultTab = 'write'
 }: MarkdownUploadTextareaProps) => {
-  const { component: ReactMarkdown, error: markdownError, retry: retryMarkdown } = useReactMarkdown();
+  const {
+    component: ReactMarkdown,
+    remarkGfm,
+    components: markdownComponents,
+    error: markdownError,
+    retry: retryMarkdown,
+  } = useReactMarkdown();
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -472,7 +488,7 @@ export const MarkdownUploadTextarea = ({
                       Retry
                     </button>
                   </div>
-                ) : ReactMarkdown ? (
+                ) : ReactMarkdown && remarkGfm && markdownComponents ? (
                   <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkGfm]}>
                     {value}
                   </ReactMarkdown>

--- a/src/shared/ui/input/SegmentedToggle.tsx
+++ b/src/shared/ui/input/SegmentedToggle.tsx
@@ -26,15 +26,19 @@ export const SegmentedToggle = <T extends string>({
   const count = options.length;
   const safeCount = Math.max(1, count);
   const activeIndex = Math.max(0, options.findIndex((option) => option.value === value));
-  const itemWidth = 100 / safeCount;
+  // Outer rail padding (`p-1` on .segmented-toggle = 0.25rem each side) and
+  // the gap between items must be subtracted from the track before splitting
+  // into per-item slots; otherwise the thumb drifts as items shrink for the gap.
   const thumbInsetRem = 0.25;
+  const itemGapRem = 0.25;
   const thumbInset = `${thumbInsetRem}rem`;
-  const thumbTrackWidth = `100% - ${thumbInsetRem * 2}rem`;
+  const trackWidth = `100% - ${thumbInsetRem * 2}rem - ${(safeCount - 1) * itemGapRem}rem`;
+  const slotWidth = `((${trackWidth}) / ${safeCount})`;
 
   return (
       <div
         className={cn(
-        'segmented-toggle',
+        'segmented-toggle gap-1',
         (disabled || options.length === 0) && 'opacity-60',
         className
       )}
@@ -45,8 +49,8 @@ export const SegmentedToggle = <T extends string>({
         aria-hidden="true"
         className="segmented-toggle-thumb"
         style={{
-          left: `calc(${thumbInset} + ((${thumbTrackWidth}) / ${safeCount}) * ${activeIndex})`,
-          width: `calc((${thumbTrackWidth}) / ${safeCount})`
+          left: `calc(${thumbInset} + (${slotWidth} + ${itemGapRem}rem) * ${activeIndex})`,
+          width: `calc(${slotWidth})`
         }}
       />
       {options.map((option) => {
@@ -63,9 +67,8 @@ export const SegmentedToggle = <T extends string>({
                 onChange(option.value);
               }
             }}
-            style={{ width: `${itemWidth}%` }}
             className={cn(
-              'segmented-toggle-item whitespace-nowrap',
+              'segmented-toggle-item flex-1 min-w-0 truncate',
               isActive ? 'segmented-toggle-item-active' : 'segmented-toggle-item-inactive',
               (disabled || option.disabled) && 'cursor-not-allowed'
             )}

--- a/src/shared/ui/input/SegmentedToggle.tsx
+++ b/src/shared/ui/input/SegmentedToggle.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'preact/hooks';
+import { useRef, useState, useLayoutEffect } from 'preact/hooks';
 import { cn } from '@/shared/utils/cn';
 
 export interface SegmentedToggleOption<T extends string> {
@@ -31,11 +31,12 @@ export const SegmentedToggle = <T extends string>({
   // before splitting into per-item slots; otherwise the thumb drifts as items shrink.
   // Read inset from CSS variable to support compact sizing (0.25rem fallback).
   const rootRef = useRef<HTMLDivElement>(null);
-  const thumbInsetRem = useMemo(() => {
-    if (!rootRef.current) return 0.25;
+  const [thumbInsetRem, setThumbInsetRem] = useState(0.25);
+  useLayoutEffect(() => {
+    if (!rootRef.current) return;
     const computed = getComputedStyle(rootRef.current).getPropertyValue('--segmented-toggle-inset');
     const parsed = parseFloat(computed);
-    return isNaN(parsed) ? 0.25 : parsed;
+    setThumbInsetRem(isNaN(parsed) ? 0.25 : parsed);
   }, []);
   const itemGapRem = 0.25;
   const thumbInset = `${thumbInsetRem}rem`;

--- a/src/shared/ui/input/SegmentedToggle.tsx
+++ b/src/shared/ui/input/SegmentedToggle.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useRef } from 'preact/hooks';
 import { cn } from '@/shared/utils/cn';
 
 export interface SegmentedToggleOption<T extends string> {
@@ -26,10 +27,16 @@ export const SegmentedToggle = <T extends string>({
   const count = options.length;
   const safeCount = Math.max(1, count);
   const activeIndex = Math.max(0, options.findIndex((option) => option.value === value));
-  // Outer rail padding (`p-1` on .segmented-toggle = 0.25rem each side) and
-  // the gap between items must be subtracted from the track before splitting
-  // into per-item slots; otherwise the thumb drifts as items shrink for the gap.
-  const thumbInsetRem = 0.25;
+  // Outer rail padding and the gap between items must be subtracted from the track
+  // before splitting into per-item slots; otherwise the thumb drifts as items shrink.
+  // Read inset from CSS variable to support compact sizing (0.25rem fallback).
+  const rootRef = useRef<HTMLDivElement>(null);
+  const thumbInsetRem = useMemo(() => {
+    if (!rootRef.current) return 0.25;
+    const computed = getComputedStyle(rootRef.current).getPropertyValue('--segmented-toggle-inset');
+    const parsed = parseFloat(computed);
+    return isNaN(parsed) ? 0.25 : parsed;
+  }, []);
   const itemGapRem = 0.25;
   const thumbInset = `${thumbInsetRem}rem`;
   const trackWidth = `100% - ${thumbInsetRem * 2}rem - ${(safeCount - 1) * itemGapRem}rem`;
@@ -37,6 +44,7 @@ export const SegmentedToggle = <T extends string>({
 
   return (
       <div
+        ref={rootRef}
         className={cn(
         'segmented-toggle gap-1',
         (disabled || options.length === 0) && 'opacity-60',

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -93,7 +93,6 @@ type InspectorPanelProps = {
   intakeStatus?: DerivedIntakeStatus | null;
   onIntakeFieldsChange?: (patch: Partial<IntakeConversationState>, options?: import('@/shared/types/intake').IntakeFieldChangeOptions) => Promise<void> | void;
   practiceDetails?: PracticeDetails | null;
-  intakeSlimContactDraft?: import('@/shared/types/intake').SlimContactDraft | null;
   conversationMode?: ConversationMode;
   setupFields?: SetupFieldsPayload;
   onSetupFieldsChange?: (patch: Partial<SetupFieldsPayload>, options?: { sendSystemAck?: boolean }) => Promise<void> | void;
@@ -156,7 +155,6 @@ export const InspectorPanel = ({
   intakeStatus,
   onIntakeFieldsChange,
   practiceDetails: propPracticeDetails,
-  intakeSlimContactDraft,
   conversationMode,
   setupFields,
   onSetupFieldsChange,
@@ -990,67 +988,57 @@ export const InspectorPanel = ({
                             </div>
 
                             {/* Contact Information */}
-                            <InspectorGroup 
-                              label="Name" 
-                              onToggle={canEditIntake ? () => setActiveConversationEditor(prev => prev === 'intakeName' ? null : 'intakeName') : undefined}
-                              isOpen={activeConversationEditor === 'intakeName'}
-                            >
-                              <InspectorEditableRow
-                                label=""
-                                summary={intakeSlimContactDraft?.name || 'Not set'}
-                                summaryMuted={!intakeSlimContactDraft?.name}
-                                isOpen={activeConversationEditor === 'intakeName'}
-                              >
-                                <Input
-                                  value={intakeSlimContactDraft?.name ?? ''}
-                                  placeholder="Full name"
-                                  readOnly
-                                  className="w-full"
-                                />
-                              </InspectorEditableRow>
-                            </InspectorGroup>
-
-                            <InspectorGroup 
-                              label="Email" 
-                              onToggle={canEditIntake ? () => setActiveConversationEditor(prev => prev === 'intakeEmail' ? null : 'intakeEmail') : undefined}
-                              isOpen={activeConversationEditor === 'intakeEmail'}
-                            >
-                              <InspectorEditableRow
-                                label=""
-                                summary={intakeSlimContactDraft?.email || 'Not set'}
-                                summaryMuted={!intakeSlimContactDraft?.email}
-                                isOpen={activeConversationEditor === 'intakeEmail'}
-                              >
-                                <Input
-                                  value={intakeSlimContactDraft?.email ?? ''}
-                                  placeholder="Email address"
-                                  readOnly
-                                  className="w-full"
-                                  type="email"
-                                />
-                              </InspectorEditableRow>
-                            </InspectorGroup>
-
-                            <InspectorGroup 
-                              label="Phone" 
-                              onToggle={canEditIntake ? () => setActiveConversationEditor(prev => prev === 'intakePhone' ? null : 'intakePhone') : undefined}
-                              isOpen={activeConversationEditor === 'intakePhone'}
-                            >
-                              <InspectorEditableRow
-                                label=""
-                                summary={intakeSlimContactDraft?.phone || 'Not set'}
-                                summaryMuted={!intakeSlimContactDraft?.phone}
-                                isOpen={activeConversationEditor === 'intakePhone'}
-                              >
-                                <Input
-                                  value={intakeSlimContactDraft?.phone ?? ''}
-                                  placeholder="Phone number"
-                                  readOnly
-                                  className="w-full"
-                                  type="tel"
-                                />
-                              </InspectorEditableRow>
-                            </InspectorGroup>
+                            {canEditIntake ? null : (
+                              <>
+                                <InspectorGroup label="Name">
+                                  <InspectorEditableRow
+                                    label=""
+                                    summary={conversation?.user_info?.consultation?.contact?.name || 'Not set'}
+                                    summaryMuted={!conversation?.user_info?.consultation?.contact?.name}
+                                    isOpen={false}
+                                  >
+                                    <Input
+                                      value={conversation?.user_info?.consultation?.contact?.name ?? ''}
+                                      placeholder="Full name"
+                                      readOnly
+                                      className="w-full"
+                                    />
+                                  </InspectorEditableRow>
+                                </InspectorGroup>
+                                <InspectorGroup label="Email">
+                                  <InspectorEditableRow
+                                    label=""
+                                    summary={conversation?.user_info?.consultation?.contact?.email || 'Not set'}
+                                    summaryMuted={!conversation?.user_info?.consultation?.contact?.email}
+                                    isOpen={false}
+                                  >
+                                    <Input
+                                      value={conversation?.user_info?.consultation?.contact?.email ?? ''}
+                                      placeholder="Email address"
+                                      readOnly
+                                      className="w-full"
+                                      type="email"
+                                    />
+                                  </InspectorEditableRow>
+                                </InspectorGroup>
+                                <InspectorGroup label="Phone">
+                                  <InspectorEditableRow
+                                    label=""
+                                    summary={conversation?.user_info?.consultation?.contact?.phone || 'Not set'}
+                                    summaryMuted={!conversation?.user_info?.consultation?.contact?.phone}
+                                    isOpen={false}
+                                  >
+                                    <Input
+                                      value={conversation?.user_info?.consultation?.contact?.phone ?? ''}
+                                      placeholder="Phone number"
+                                      readOnly
+                                      className="w-full"
+                                      type="tel"
+                                    />
+                                  </InspectorEditableRow>
+                                </InspectorGroup>
+                              </>
+                            )}
 
                             {(() => {
                               const rawPracticeServiceUuid = intakeConversationState.practiceServiceUuid;

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -91,6 +91,7 @@ type InspectorPanelProps = {
   practiceLogo?: string;
   intakeConversationState?: IntakeConversationState | null;
   intakeStatus?: DerivedIntakeStatus | null;
+  intake?: PracticeIntakeDetail | null;
   onIntakeFieldsChange?: (patch: Partial<IntakeConversationState>, options?: import('@/shared/types/intake').IntakeFieldChangeOptions) => Promise<void> | void;
   practiceDetails?: PracticeDetails | null;
   conversationMode?: ConversationMode;
@@ -968,6 +969,21 @@ export const InspectorPanel = ({
                   website={practiceDetail?.website}
                 />
                 <div className="mt-2">
+                  {/* Canonical Intake Status from backend */}
+                  {intake ? (
+                    <div className="mt-4">
+                      <InspectorGroup label="Intake Status">
+                        <InfoRow
+                          label="Status"
+                          value={intake.status || '—'}
+                        />
+                        <InfoRow
+                          label="Triage Status"
+                          value={intake.triage_status || '—'}
+                        />
+                      </InspectorGroup>
+                    </div>
+                  ) : null}
                   {intakeConversationState ? (
                     <div className="mt-4">
                       {(() => {

--- a/src/shared/ui/inspector/MobileInspectorOverlay.tsx
+++ b/src/shared/ui/inspector/MobileInspectorOverlay.tsx
@@ -70,7 +70,8 @@ export const MobileInspectorOverlay: FunctionComponent<MobileInspectorOverlayPro
         type="button"
         className="absolute inset-0 bg-input-text/10 backdrop-blur-[2px]"
         onClick={onClose}
-        aria-label="Close inspector"
+        aria-hidden="true"
+        tabIndex={-1}
       />
       <aside
         ref={asideRef}
@@ -90,7 +91,7 @@ export const MobileInspectorOverlay: FunctionComponent<MobileInspectorOverlayPro
           onClick={onClose}
           aria-label="Close inspector"
           icon={X} iconClassName="h-5 w-5"
-          className="absolute right-3 top-3 z-10 h-9 w-9 p-0 rounded-full bg-surface-utility/30 hover:bg-surface-utility/50"
+          className="absolute right-3 top-3 z-10 p-0 rounded-full bg-surface-utility/30 hover:bg-surface-utility/50"
         />
         {children}
       </aside>

--- a/src/shared/ui/inspector/MobileInspectorOverlay.tsx
+++ b/src/shared/ui/inspector/MobileInspectorOverlay.tsx
@@ -1,6 +1,8 @@
 import type { ComponentChildren, FunctionComponent } from 'preact';
 import { createPortal } from 'preact/compat';
 import { useEffect, useId, useRef } from 'preact/hooks';
+import { X } from 'lucide-preact';
+import { Button } from '@/shared/ui/Button';
 import { THEME } from '@/shared/utils/constants';
 import { isTopmostModal, lockBodyScroll, registerModal, unlockBodyScroll, unregisterModal } from '@/shared/utils/modalStack';
 import { focusInitialElement, trapFocusWithin } from '@/shared/ui/dialog/focusUtils';
@@ -78,6 +80,18 @@ export const MobileInspectorOverlay: FunctionComponent<MobileInspectorOverlayPro
         tabIndex={-1}
         className="ui-surface-enter-right absolute inset-y-0 right-0 flex w-full max-w-2xl flex-col overflow-visible bg-surface-nav-secondary rounded-r-none rounded-l-2xl shadow-glass ring-1 ring-line-glass/20"
       >
+        {/* Visible close button — backdrop click + Escape are kept as fallback
+            paths, but a dedicated control matches the rest of our drawer chrome
+            and is reachable on touch screens where the backdrop area is small. */}
+        <Button
+          type="button"
+          variant="icon"
+          size="icon-sm"
+          onClick={onClose}
+          aria-label="Close inspector"
+          icon={X} iconClassName="h-5 w-5"
+          className="absolute right-3 top-3 z-10 h-9 w-9 p-0 rounded-full bg-surface-utility/30 hover:bg-surface-utility/50"
+        />
         {children}
       </aside>
     </div>,

--- a/src/shared/ui/layout/AppShell.tsx
+++ b/src/shared/ui/layout/AppShell.tsx
@@ -138,12 +138,30 @@ export const AppShell = ({
             // overflow-visible so the Sidebar's collapsed-state toggle button can stick
             // off the right edge. z-20 (vs z-10 on Main/List/Inspector) keeps the
             // overflow painted above neighboring grid items.
-            'relative z-20 row-start-2 min-h-0 overflow-visible hidden lg:block',
+            // On desktop the sidebar spans rows 1-2 so it sits flush against the
+            // header bar that lives in row 1 above listPanel/main/inspector.
+            'relative z-20 row-start-2 min-h-0 overflow-visible hidden lg:block lg:row-start-1 lg:row-span-2',
             sidebarClassName
           )}
         >
           {sidebar}
         </aside>
+      )}
+
+      {/* Header — on desktop sits in row 1 spanning listPanel/main/inspector
+          so it reads as "above the conversation list", not pushed to the right
+          of it. On mobile it lives in row 1 spanning the full width since
+          listPanel/inspector are drawers. */}
+      {hasHeader && (
+        <header
+          className={cn(
+            'relative z-10 col-span-full row-start-1',
+            hasSidebar ? 'lg:col-start-2 lg:col-end-[-1]' : 'lg:col-start-1 lg:col-end-[-1]',
+            headerClassName
+          )}
+        >
+          {header}
+        </header>
       )}
 
 
@@ -166,14 +184,6 @@ export const AppShell = ({
           mainClassName
         )}
       >
-        {/* Header is mounted once here. On mobile, sidebar/listPanel/inspector
-            are hidden, so this sits at the top of the viewport; on desktop it
-            sits inside main, right of the sidebar. */}
-        {hasHeader && (
-          <header className={cn('relative z-10', headerClassName)}>
-            {header}
-          </header>
-        )}
         {main}
       </main>
 

--- a/src/shared/ui/layout/DetailHeader.tsx
+++ b/src/shared/ui/layout/DetailHeader.tsx
@@ -17,7 +17,7 @@ export type DetailHeaderProps = {
   /** Optional badge rendered inline next to the title (e.g. "Unread" pill). */
   titleBadge?: ComponentChildren;
   /** Optional second row rendered below the main header row, sharing the bottom border.
-   *  Used by Pencil rxzde to surface the contact info strip (email · phone · linked matter). */
+   *  Used by Pencil to surface the contact info strip (email · phone · linked matter). */
   secondaryRow?: ComponentChildren;
 };
 
@@ -61,10 +61,14 @@ export const DetailHeader = ({
         </div>
       ) : null}
       <div className="workspace-header__identity">
-        <div className="flex min-w-0 items-center gap-2">
+        {titleBadge ? (
+          <div className="flex min-w-0 items-center gap-2">
+            <h1 className="workspace-header__title">{resolvedTitle}</h1>
+            {titleBadge}
+          </div>
+        ) : (
           <h1 className="workspace-header__title">{resolvedTitle}</h1>
-          {titleBadge}
-        </div>
+        )}
         {resolvedSubtitle ? <p className="workspace-header__subtitle">{resolvedSubtitle}</p> : null}
       </div>
       {(actions || onInspector) ? (

--- a/src/shared/ui/layout/DetailHeader.tsx
+++ b/src/shared/ui/layout/DetailHeader.tsx
@@ -14,6 +14,11 @@ export type DetailHeaderProps = {
   onInspector?: () => void;
   inspectorOpen?: boolean;
   className?: string;
+  /** Optional badge rendered inline next to the title (e.g. "Unread" pill). */
+  titleBadge?: ComponentChildren;
+  /** Optional second row rendered below the main header row, sharing the bottom border.
+   *  Used by Pencil rxzde to surface the contact info strip (email · phone · linked matter). */
+  secondaryRow?: ComponentChildren;
 };
 
 export const DetailHeader = ({
@@ -26,12 +31,20 @@ export const DetailHeader = ({
   onInspector,
   inspectorOpen = false,
   className,
+  titleBadge,
+  secondaryRow,
 }: DetailHeaderProps) => {
   const resolvedTitle = typeof title === 'string' ? title : '';
   const resolvedSubtitle = typeof subtitle === 'string' ? subtitle : undefined;
 
-  return (
-    <header className={cn('workspace-header', className)}>
+  const headerRow = (
+    <header
+      className={cn(
+        'workspace-header',
+        secondaryRow ? '!border-b-0 !min-h-0 !pb-1.5' : null,
+        secondaryRow ? null : className
+      )}
+    >
       {(leadingAction || showBack) ? (
         <div className="workspace-header__icon flex items-center gap-2">
           {leadingAction}
@@ -48,7 +61,10 @@ export const DetailHeader = ({
         </div>
       ) : null}
       <div className="workspace-header__identity">
-        <h1 className="workspace-header__title">{resolvedTitle}</h1>
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="workspace-header__title">{resolvedTitle}</h1>
+          {titleBadge}
+        </div>
         {resolvedSubtitle ? <p className="workspace-header__subtitle">{resolvedSubtitle}</p> : null}
       </div>
       {(actions || onInspector) ? (
@@ -67,6 +83,17 @@ export const DetailHeader = ({
         </div>
       ) : null}
     </header>
+  );
+
+  if (!secondaryRow) return headerRow;
+
+  return (
+    <div className={cn('flex flex-col border-b border-card-border bg-transparent', className)}>
+      {headerRow}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 px-4 pb-2 text-xs text-input-placeholder">
+        {secondaryRow}
+      </div>
+    </div>
   );
 };
 

--- a/src/shared/ui/profile/atoms/Avatar.tsx
+++ b/src/shared/ui/profile/atoms/Avatar.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'preact/hooks';
 import { Icon } from '@/shared/ui/Icon';
 import { sanitizeUserImageUrl } from '@/shared/utils/urlValidation';
 
+
 interface AvatarProps {
   src?: string | null;
   name: string;
@@ -20,9 +21,11 @@ interface AvatarProps {
    */
   bgClassName?: string;
   status?: 'active' | 'inactive' | 'offline';
+  /** Accessible label for status dot. Defaults to status value. */
+  statusLabel?: string;
 }
 
-export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, status }: AvatarProps) => {
+export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, status, statusLabel }: AvatarProps) => {
   const [hasImgError, setHasImgError] = useState(false);
 
   // Reset error state when src changes so new images can be attempted
@@ -74,7 +77,7 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
   const statusClasses = {
     active: 'bg-emerald-500',
     inactive: 'bg-amber-400',
-    offline: 'bg-input-placeholder/60'
+    offline: 'bg-input-placeholder ring-1 ring-white/80'
   } as const;
 
   const statusSizeClasses = {
@@ -104,10 +107,13 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
         )}
       </div>
       {status && (
-        <span
-          className={`absolute bottom-0 right-0 translate-x-1/4 translate-y-1/4 rounded-full ${statusClasses[status]} ${statusSizeClasses[size]}`}
-          aria-hidden="true"
-        />
+        <>
+          <span
+            className={`absolute bottom-0 right-0 translate-x-1/4 translate-y-1/4 rounded-full ${statusClasses[status]} ${statusSizeClasses[size]}`}
+            aria-hidden="true"
+          />
+          <span className="sr-only">{statusLabel || status}</span>
+        </>
       )}
     </div>
   );

--- a/src/shared/ui/profile/atoms/Avatar.tsx
+++ b/src/shared/ui/profile/atoms/Avatar.tsx
@@ -19,7 +19,7 @@ interface AvatarProps {
    *  rendering inside StackedAvatars to prevent backdrop-blur bleed-through.
    */
   bgClassName?: string;
-  status?: 'active' | 'inactive';
+  status?: 'active' | 'inactive' | 'offline';
 }
 
 export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, status }: AvatarProps) => {
@@ -73,7 +73,8 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
 
   const statusClasses = {
     active: 'bg-emerald-500',
-    inactive: 'bg-amber-400'
+    inactive: 'bg-amber-400',
+    offline: 'bg-input-placeholder/60'
   } as const;
 
   const statusSizeClasses = {
@@ -104,7 +105,7 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
       </div>
       {status && (
         <span
-          className={`absolute bottom-0 right-0 translate-x-1/4 translate-y-1/4 rounded-full ring-2 ring-accent-foreground ${statusClasses[status]} ${statusSizeClasses[size]}`}
+          className={`absolute bottom-0 right-0 translate-x-1/4 translate-y-1/4 rounded-full ${statusClasses[status]} ${statusSizeClasses[size]}`}
           aria-hidden="true"
         />
       )}

--- a/src/shared/utils/conversationDisplay.ts
+++ b/src/shared/utils/conversationDisplay.ts
@@ -153,13 +153,24 @@ export const resolveConversationPresence = (
   lastActivityAt: string | number | Date | null | undefined,
   isLive: boolean = false
 ): ConversationPresence => {
+  // Guard against null/undefined, but allow 0 (Unix epoch)
   const lastTs = (() => {
-    if (!lastActivityAt) return 0;
+    if (lastActivityAt == null) return 0;
     const date = lastActivityAt instanceof Date ? lastActivityAt : new Date(lastActivityAt);
     const ms = date.getTime();
     return Number.isFinite(ms) ? ms : 0;
   })();
-  const ageMs = lastTs > 0 ? Math.max(0, Date.now() - lastTs) : Number.POSITIVE_INFINITY;
+  // Compute age; if timestamp is in the future, treat as invalid (not active)
+  let ageMsRaw = Date.now() - lastTs;
+  let ageMs: number;
+  if (ageMsRaw < 0) {
+    // Future timestamp: treat as not active
+    ageMs = Number.POSITIVE_INFINITY;
+    // Optionally, could return a special label here
+  } else {
+    ageMs = lastTs > 0 ? ageMsRaw : Number.POSITIVE_INFINITY;
+  }
+  // If isLive, always active; otherwise, only if age is within threshold
   const isActive = isLive || ageMs <= ACTIVE_PRESENCE_THRESHOLD_MS;
   if (isActive) {
     return { status: 'active', label: 'Active now' };
@@ -181,7 +192,7 @@ const formatRelativePresence = (ageMs: number): string => {
   const weeks = Math.floor(days / 7);
   if (weeks < 5) return `${weeks} wk ago`;
   const months = Math.floor(days / 30);
-  if (months < 12) return `${months} mo ago`;
   const years = Math.floor(days / 365);
-  return `${years} yr ago`;
+  if (years >= 1) return `${years} yr ago`;
+  return `${months} mo ago`;
 };

--- a/src/shared/utils/conversationDisplay.ts
+++ b/src/shared/utils/conversationDisplay.ts
@@ -109,6 +109,10 @@ export const shouldShowConversationInPracticeInbox = (
   if (options.requireAcceptedIntakeRecord) {
     if (conversation.matter_id) return true;
     if (conversation.lead?.matter_id) return true;
+    // Staff-initiated conversations have no intake/matter yet but have been
+    // claimed via assignment. Treat assignment as acceptance so the thread
+    // appears in the inbox immediately after the picker creates it.
+    if (typeof conversation.assigned_to === 'string' && conversation.assigned_to.trim().length > 0) return true;
     return false;
   }
 
@@ -123,4 +127,61 @@ export const shouldShowConversationInPracticeInbox = (
   if (options.intakeLookupLoaded) return false;
 
   return true;
+};
+
+// Presence threshold: a conversation is "active" if its last activity was
+// within this window. Otherwise it's treated as offline. We don't have a real
+// presence signal yet so last_message_at + the live socket state are the
+// best proxies we can use today.
+const ACTIVE_PRESENCE_THRESHOLD_MS = 5 * 60 * 1000;
+
+export type ConversationPresence = {
+  status: 'active' | 'offline';
+  /** Subtitle label for the conversation header / inspector. */
+  label: string;
+};
+
+/**
+ * Resolve a "online | offline" presence indicator for a conversation header
+ * and the message-list avatar dot. Inputs:
+ * - `lastActivityAt`: ISO timestamp of the latest activity (typically
+ *   conversation.last_message_at). Newer than 5 min → active.
+ * - `isLive`: optional override — when the socket reports an active session
+ *   for the conversation we mark it active regardless of timestamps.
+ */
+export const resolveConversationPresence = (
+  lastActivityAt: string | number | Date | null | undefined,
+  isLive: boolean = false
+): ConversationPresence => {
+  const lastTs = (() => {
+    if (!lastActivityAt) return 0;
+    const date = lastActivityAt instanceof Date ? lastActivityAt : new Date(lastActivityAt);
+    const ms = date.getTime();
+    return Number.isFinite(ms) ? ms : 0;
+  })();
+  const ageMs = lastTs > 0 ? Math.max(0, Date.now() - lastTs) : Number.POSITIVE_INFINITY;
+  const isActive = isLive || ageMs <= ACTIVE_PRESENCE_THRESHOLD_MS;
+  if (isActive) {
+    return { status: 'active', label: 'Active now' };
+  }
+  if (lastTs === 0) {
+    return { status: 'offline', label: 'Offline' };
+  }
+  return { status: 'offline', label: `Last active ${formatRelativePresence(ageMs)}` };
+};
+
+const formatRelativePresence = (ageMs: number): string => {
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks} wk ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years} yr ago`;
 };

--- a/src/shared/utils/conversationDisplay.ts
+++ b/src/shared/utils/conversationDisplay.ts
@@ -160,16 +160,10 @@ export const resolveConversationPresence = (
     const ms = date.getTime();
     return Number.isFinite(ms) ? ms : 0;
   })();
-  // Compute age; if timestamp is in the future, treat as invalid (not active)
-  let ageMsRaw = Date.now() - lastTs;
-  let ageMs: number;
-  if (ageMsRaw < 0) {
-    // Future timestamp: treat as not active
-    ageMs = Number.POSITIVE_INFINITY;
-    // Optionally, could return a special label here
-  } else {
-    ageMs = lastTs > 0 ? ageMsRaw : Number.POSITIVE_INFINITY;
-  }
+  // Future timestamps and missing/invalid lastTs both fall through to
+  // POSITIVE_INFINITY so they're never treated as "active".
+  const ageMsRaw = Date.now() - lastTs;
+  const ageMs = ageMsRaw < 0 || lastTs <= 0 ? Number.POSITIVE_INFINITY : ageMsRaw;
   // If isLive, always active; otherwise, only if age is within threshold
   const isActive = isLive || ageMs <= ACTIVE_PRESENCE_THRESHOLD_MS;
   if (isActive) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,7 @@ const workerEndpoints = [
 	'matters',
 	'uploads',
 	'widget',
+	'presence',
 ];
 
 // Proxy configuration types from http-proxy-middleware

--- a/worker/durable-objects/ChatRoom.ts
+++ b/worker/durable-objects/ChatRoom.ts
@@ -367,8 +367,11 @@ export class ChatRoom {
       return;
     }
 
-    const content = this.readString(frame.data.content);
-    if (!content || content.length > MAX_CONTENT_LENGTH) {
+    // readString returns null when the field is missing or not a string;
+    // normalize to an empty string so the length check below is safe and the
+    // file-only path treats "no text" the same as "empty text".
+    const content = this.readString(frame.data.content) ?? '';
+    if (content.length > MAX_CONTENT_LENGTH) {
       this.rejectInvalidPayload(ws, frame.request_id, 'content invalid');
       return;
     }
@@ -380,6 +383,14 @@ export class ChatRoom {
     }
     if (attachments.length > MAX_ATTACHMENTS) {
       this.rejectInvalidPayload(ws, frame.request_id, 'attachments limit exceeded');
+      return;
+    }
+
+    // After attachments are validated: require non-empty content OR at least
+    // one attachment. File-only sends are valid (drop file, hit send without
+    // typing).
+    if (!content && attachments.length === 0) {
+      this.rejectInvalidPayload(ws, frame.request_id, 'content invalid');
       return;
     }
 
@@ -596,6 +607,10 @@ export class ChatRoom {
       return new Response('metadata invalid', { status: 400 });
     }
     const allowEmptyContent = (() => {
+      // File-only sends: when at least one attachment is present, the message
+      // can have empty content. Mirrors typical chat UX (drop a file, hit send
+      // without typing).
+      if (attachments.length > 0) return true;
       if (roleValue !== 'system') return false;
       if (!metadata || typeof metadata !== 'object') return false;
       const systemKey = (metadata as Record<string, unknown>).systemMessageKey;

--- a/worker/durable-objects/PresenceRoom.ts
+++ b/worker/durable-objects/PresenceRoom.ts
@@ -61,9 +61,6 @@ export class PresenceRoom {
     // `getTags(ws)` lookup tells us who hung up after a cold start.
     this.state.acceptWebSocket(server, [userId]);
     this.broadcastSnapshot();
-    // Also send the current snapshot directly to the new joiner so they
-    // populate state without waiting for the next delta.
-    this.sendFrameTo(server, this.buildSnapshotFrame());
 
     return new Response(null, { status: 101, webSocket: client });
   }

--- a/worker/durable-objects/PresenceRoom.ts
+++ b/worker/durable-objects/PresenceRoom.ts
@@ -1,0 +1,125 @@
+/**
+ * PresenceRoom — practice-scoped presence tracker.
+ *
+ * One DO instance per practice. Each authenticated client opens a single
+ * WebSocket to it (regardless of which conversation they're viewing). The DO
+ * holds a `Map<userId, Set<wsRef>>` so that a user with multiple tabs only
+ * goes offline when the *last* tab disconnects. State changes broadcast a
+ * compact `{ type: 'presence', online: string[] }` snapshot to every connected
+ * client. Subscribers also receive a snapshot immediately on join so the UI
+ * reflects current state without waiting for the next change.
+ *
+ * Wire format (server → client):
+ *   { type: 'presence', online: string[] }   // full snapshot
+ *
+ * Wire format (client → server):
+ *   { type: 'identify', userId: string }     // sent right after open
+ *   { type: 'ping' }                          // optional liveness keep-alive
+ *
+ * Hibernation-safe: connection state is reconstructed from
+ * `state.acceptWebSocket(ws, [userId])` tags so the user mapping survives DO
+ * eviction across cold starts.
+ */
+import type { DurableObjectState } from '@cloudflare/workers-types';
+import type { Env } from '../types.js';
+
+interface IdentifyFrame { type: 'identify'; userId: string }
+interface PingFrame { type: 'ping' }
+type ClientFrame = IdentifyFrame | PingFrame;
+
+export class PresenceRoom {
+  private readonly state: DurableObjectState;
+  private readonly env: Env;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const upgradeHeader = request.headers.get('Upgrade');
+    if (upgradeHeader?.toLowerCase() !== 'websocket') {
+      // Internal HTTP path: return current snapshot for debugging / fallback.
+      const url = new URL(request.url);
+      if (url.pathname.endsWith('/snapshot') && request.method === 'GET') {
+        return new Response(JSON.stringify({ online: this.collectOnlineUserIds() }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('expected websocket upgrade', { status: 426 });
+    }
+
+    const url = new URL(request.url);
+    const userId = (url.searchParams.get('userId') ?? '').trim();
+    if (!userId) {
+      return new Response('userId required', { status: 400 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    // Tag the server-side socket with the userId so the hibernation-safe
+    // `getTags(ws)` lookup tells us who hung up after a cold start.
+    this.state.acceptWebSocket(server, [userId]);
+    this.broadcastSnapshot();
+    // Also send the current snapshot directly to the new joiner so they
+    // populate state without waiting for the next delta.
+    this.sendFrameTo(server, this.buildSnapshotFrame());
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  webSocketMessage(ws: WebSocket, raw: string | ArrayBuffer): void {
+    if (typeof raw !== 'string') return;
+    let parsed: ClientFrame | null = null;
+    try { parsed = JSON.parse(raw) as ClientFrame; } catch { return; }
+    if (!parsed || typeof parsed !== 'object') return;
+    if (parsed.type === 'ping') {
+      // Echo a snapshot so latency-sensitive clients can measure rtt + refresh.
+      this.sendFrameTo(ws, this.buildSnapshotFrame());
+    }
+    // 'identify' is a no-op on the wire today — userId is locked at the URL
+    // query string and stored as a tag during accept. Reserved for future use.
+  }
+
+  webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+    // Closing the only socket for a userId removes them from `online`. The
+    // mapping is recomputed from the live socket set, not from a separate
+    // counter, so we never drift.
+    void ws;
+    this.broadcastSnapshot();
+  }
+
+  webSocketError(ws: WebSocket): void {
+    void ws;
+    this.broadcastSnapshot();
+  }
+
+  private collectOnlineUserIds(): string[] {
+    const ids = new Set<string>();
+    for (const ws of this.state.getWebSockets()) {
+      const tags = this.state.getTags(ws);
+      const userId = tags.find((tag) => typeof tag === 'string' && tag.length > 0);
+      if (userId) ids.add(userId);
+    }
+    return Array.from(ids);
+  }
+
+  private buildSnapshotFrame(): string {
+    return JSON.stringify({ type: 'presence', online: this.collectOnlineUserIds() });
+  }
+
+  private broadcastSnapshot(): void {
+    const payload = this.buildSnapshotFrame();
+    for (const ws of this.state.getWebSockets()) {
+      this.sendFrameTo(ws, payload);
+    }
+  }
+
+  private sendFrameTo(ws: WebSocket, payload: string): void {
+    try {
+      ws.send(payload);
+    } catch {
+      // Hibernated/dead sockets throw; safe to ignore — they'll be GC'd.
+    }
+  }
+}

--- a/worker/durable-objects/PresenceRoom.ts
+++ b/worker/durable-objects/PresenceRoom.ts
@@ -1,3 +1,4 @@
+/* global WebSocketPair, WebSocket */
 /**
  * PresenceRoom — practice-scoped presence tracker.
  *
@@ -79,21 +80,20 @@ export class PresenceRoom {
   }
 
   webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
-    // Closing the only socket for a userId removes them from `online`. The
-    // mapping is recomputed from the live socket set, not from a separate
-    // counter, so we never drift.
-    void ws;
-    this.broadcastSnapshot();
+    // The closing socket may still appear in state.getWebSockets() while the
+    // close is being processed; pass it through so collectOnlineUserIds can
+    // exclude it and remote tabs see the user drop offline immediately.
+    this.broadcastSnapshot(ws);
   }
 
   webSocketError(ws: WebSocket): void {
-    void ws;
-    this.broadcastSnapshot();
+    this.broadcastSnapshot(ws);
   }
 
-  private collectOnlineUserIds(): string[] {
+  private collectOnlineUserIds(exclude?: WebSocket): string[] {
     const ids = new Set<string>();
     for (const ws of this.state.getWebSockets()) {
+      if (exclude && ws === exclude) continue;
       const tags = this.state.getTags(ws);
       const userId = tags.find((tag) => typeof tag === 'string' && tag.length > 0);
       if (userId) ids.add(userId);
@@ -101,13 +101,14 @@ export class PresenceRoom {
     return Array.from(ids);
   }
 
-  private buildSnapshotFrame(): string {
-    return JSON.stringify({ type: 'presence', online: this.collectOnlineUserIds() });
+  private buildSnapshotFrame(exclude?: WebSocket): string {
+    return JSON.stringify({ type: 'presence', online: this.collectOnlineUserIds(exclude) });
   }
 
-  private broadcastSnapshot(): void {
-    const payload = this.buildSnapshotFrame();
+  private broadcastSnapshot(exclude?: WebSocket): void {
+    const payload = this.buildSnapshotFrame(exclude);
     for (const ws of this.state.getWebSockets()) {
+      if (exclude && ws === exclude) continue;
       this.sendFrameTo(ws, payload);
     }
   }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -21,6 +21,7 @@ import {
   handleMetricsVitals,
 } from './routes';
 import { handleConversations } from './routes/conversations.js';
+import { handlePresence } from './routes/presence.js';
 import { handleAiChat } from './routes/aiChat.js';
 import { handleAiIntent } from './routes/aiIntent.js';
 import { withAuth, withCache, withRateLimit } from './middleware/compose.js';
@@ -147,6 +148,11 @@ export const routes: RouteEntry[] = [
     // Anonymous and authenticated users are both admitted; downstream
     // operations gate via requirePracticeMember per-branch where needed.
     handler: withAuth((req, env) => handleConversations(req, env), { required: false }),
+  },
+  {
+    mode: 'owned',
+    match: prefix('/api/presence/'),
+    handler: (req, env) => handlePresence(req, env),
   },
   {
     mode: 'owned',
@@ -303,3 +309,4 @@ export async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionC
 export { ChatRoom } from './durable-objects/ChatRoom';
 export { ChatCounterObject } from './durable-objects/ChatCounterObject';
 export { MatterProgressRoom } from './durable-objects/MatterProgressRoom';
+export { PresenceRoom } from './durable-objects/PresenceRoom';

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -151,8 +151,8 @@ export const routes: RouteEntry[] = [
   },
   {
     mode: 'owned',
-    match: prefix('/api/presence/'),
-    handler: (req, env) => handlePresence(req, env),
+    match: prefix('/api/presence'),
+    handler: withAuth((req, env) => handlePresence(req, env), { required: false }),
   },
   {
     mode: 'owned',

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -276,13 +276,19 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     };
 
     const content = typeof body.content === 'string' ? body.content.trim() : '';
-    if (!content) {
-      throw HttpErrors.badRequest('content is required');
-    }
 
     const metadata = (body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata))
       ? body.metadata as Record<string, unknown>
       : undefined;
+
+    // Allow file-only messages: empty content is OK as long as the metadata
+    // carries attachments. Mirrors the WebSocket sendMessageOverWs path
+    // which accepts attachment-only sends.
+    const hasAttachments = Array.isArray(metadata?.attachments)
+      && (metadata?.attachments as unknown[]).length > 0;
+    if (!content && !hasAttachments) {
+      throw HttpErrors.badRequest('content is required');
+    }
 
     const storedMessage = await conversationService.sendMessage({
       conversationId,
@@ -623,6 +629,27 @@ export async function handleConversations(request: Request, env: Env): Promise<R
 
     const conversation = await conversationService.getConversation(conversationId, practiceId);
     return createJsonResponse(conversation);
+  }
+
+  // DELETE /api/conversations/:id - Hard-delete a conversation and its dependents
+  if (segments.length === 3 && request.method === 'DELETE') {
+    const requestWithContext = await withPracticeContext(request, env, {
+      requirePractice: true,
+      authContext,
+    });
+    const conversationId = segments[2];
+    const practiceId = getPracticeId(requestWithContext);
+
+    if (authContext.isAnonymous) {
+      throw HttpErrors.unauthorized('Authentication required');
+    }
+    // Only practice staff can hard-delete; clients should not be able to wipe
+    // a thread out from under the practice. Paralegal+ matches other write
+    // ops on this resource.
+    await requirePracticeMemberRole(request, env, practiceId, 'paralegal', { authContext });
+
+    await conversationService.deleteConversation(conversationId, practiceId);
+    return createJsonResponse({ deleted: true, conversationId });
   }
 
   // PATCH /api/conversations/:id/matter - Link or unlink a conversation to a matter

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -1091,12 +1091,22 @@ export async function handleConversations(request: Request, env: Env): Promise<R
   if (segments.length === 4 && segments[3] === 'read' && request.method === 'POST') {
     const requestWithContext = await withPracticeContext(request, env, {
       requirePractice: true,
-      authContext
+      authContext,
+      allowAuthenticatedUrlPracticeId: true,
     });
     const conversationId = segments[2];
     const practiceId = getPracticeId(requestWithContext);
 
-    await conversationService.validateParticipantAccess(conversationId, practiceId, userId, { previousAnonUserId: prevAnonId });
+    // Mirror the staff-bypass on GET /messages: practice staff can mark any
+    // thread in their practice as read without being explicit participants.
+    if (authContext.isAnonymous) {
+      await conversationService.validateParticipantAccess(conversationId, practiceId, userId, { previousAnonUserId: prevAnonId });
+    } else {
+      const membership = await checkPracticeMembership(request, env, practiceId, { authContext });
+      if (!isStaffMemberRole(membership.memberRole)) {
+        await conversationService.validateParticipantAccess(conversationId, practiceId, userId, { previousAnonUserId: prevAnonId });
+      }
+    }
 
     // Get the current latest_seq for the conversation to update read state
     const conversation = await conversationService.getConversation(conversationId, practiceId);

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -287,7 +287,7 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     const hasAttachments = Array.isArray(metadata?.attachments)
       && (metadata?.attachments as unknown[]).length > 0;
     if (!content && !hasAttachments) {
-      throw HttpErrors.badRequest('content is required');
+      throw HttpErrors.badRequest('content or valid attachments are required');
     }
 
     const storedMessage = await conversationService.sendMessage({
@@ -1085,6 +1085,33 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     });
 
     return createJsonResponse({ logged: true });
+  }
+
+  // POST /api/conversations/:id/read - Mark conversation as read for the current user
+  if (segments.length === 4 && segments[3] === 'read' && request.method === 'POST') {
+    const requestWithContext = await withPracticeContext(request, env, {
+      requirePractice: true,
+      authContext
+    });
+    const conversationId = segments[2];
+    const practiceId = getPracticeId(requestWithContext);
+
+    await conversationService.validateParticipantAccess(conversationId, practiceId, userId, { previousAnonUserId: prevAnonId });
+
+    // Get the current latest_seq for the conversation to update read state
+    const conversation = await conversationService.getConversation(conversationId, practiceId);
+    const latestSeq = conversation.latest_seq ?? 0;
+
+    // Update or insert conversation_read_state
+    await env.DB.prepare(`
+      INSERT INTO conversation_read_state (conversation_id, user_id, last_read_seq, updated_at)
+      VALUES (?, ?, ?, datetime('now'))
+      ON CONFLICT(conversation_id, user_id) DO UPDATE SET
+        last_read_seq = excluded.last_read_seq,
+        updated_at = datetime('now')
+    `).bind(conversationId, userId, latestSeq).run();
+
+    return createJsonResponse({ markedAsRead: true, lastReadSeq: latestSeq });
   }
 
   // GET /api/conversations/:id/participants - Get participant profiles for a conversation

--- a/worker/routes/presence.ts
+++ b/worker/routes/presence.ts
@@ -1,0 +1,56 @@
+import type { Request as WorkerRequest } from '@cloudflare/workers-types';
+import type { Env } from '../types.js';
+import { HttpErrors } from '../errorHandler.js';
+import { optionalAuth } from '../middleware/auth.js';
+
+/**
+ * GET /api/presence/:practiceId/ws
+ *
+ * Upgrades to a WebSocket connection on the practice's PresenceRoom DO. The
+ * caller's authenticated userId is forwarded as a query string parameter so
+ * the DO can tag the socket without re-running auth on the inside.
+ *
+ * Anonymous users get rejected — only authenticated members track presence.
+ * The DO itself is hibernation-safe and broadcasts a `{type:'presence',
+ * online:string[]}` snapshot on every connect/disconnect.
+ *
+ * Note: lives under /api/presence/, not /api/practice/presence/, because
+ * /api/practice/* is owned by the backend proxy (matchesBackendProxy in
+ * worker/index.ts).
+ */
+export async function handlePresence(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const segments = url.pathname.split('/').filter(Boolean);
+  // Expected: ['api', 'presence', ':practiceId', 'ws']
+  if (segments.length !== 4 || segments[0] !== 'api' || segments[1] !== 'presence' || segments[3] !== 'ws') {
+    throw HttpErrors.notFound('Presence route not found');
+  }
+  const practiceId = segments[2];
+  if (!practiceId) {
+    throw HttpErrors.badRequest('practiceId is required');
+  }
+
+  if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket') {
+    throw HttpErrors.badRequest('expected websocket upgrade');
+  }
+
+  const auth = await optionalAuth(request, env);
+  if (!auth || auth.isAnonymous) {
+    throw HttpErrors.unauthorized('Authentication required for presence');
+  }
+  const userId = auth.user.id;
+
+  const id = env.PRESENCE_ROOM.idFromName(practiceId);
+  const stub = env.PRESENCE_ROOM.get(id);
+
+  // Forward to the DO with userId as a query param so it can tag the socket
+  // and survive hibernation lookups.
+  const presenceUrl = new URL(request.url);
+  presenceUrl.searchParams.set('userId', userId);
+  const forwarded = new Request(presenceUrl.toString(), {
+    method: request.method,
+    headers: request.headers,
+    cf: request.cf,
+  });
+  return stub.fetch(forwarded as unknown as WorkerRequest) as unknown as Response;
+}

--- a/worker/routes/presence.ts
+++ b/worker/routes/presence.ts
@@ -25,10 +25,7 @@ export async function handlePresence(request: Request, env: Env): Promise<Respon
   if (segments.length !== 4 || segments[0] !== 'api' || segments[1] !== 'presence' || segments[3] !== 'ws') {
     throw HttpErrors.notFound('Presence route not found');
   }
-  const practiceId = segments[2];
-  if (!practiceId) {
-    throw HttpErrors.badRequest('practiceId is required');
-  }
+  const practiceId = segments[2]; // segments.length !== 4 guard above ensures this is always present
 
   if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket') {
     throw HttpErrors.badRequest('expected websocket upgrade');
@@ -39,6 +36,13 @@ export async function handlePresence(request: Request, env: Env): Promise<Respon
     throw HttpErrors.unauthorized('Authentication required for presence');
   }
   const userId = auth.user.id;
+
+  // Membership/authorization check: user must be a member of the practice
+  const members = await env.RemoteApiService.getPracticeMembers(env, practiceId, request);
+  const isMember = Array.isArray(members) && members.some(m => m.user_id === userId);
+  if (!isMember) {
+    throw HttpErrors.forbidden('Not authorized for this practice');
+  }
 
   const id = env.PRESENCE_ROOM.idFromName(practiceId);
   const stub = env.PRESENCE_ROOM.get(id);

--- a/worker/routes/presence.ts
+++ b/worker/routes/presence.ts
@@ -2,6 +2,7 @@ import type { Request as WorkerRequest } from '@cloudflare/workers-types';
 import type { Env } from '../types.js';
 import { HttpErrors } from '../errorHandler.js';
 import { optionalAuth } from '../middleware/auth.js';
+import { RemoteApiService } from '../services/RemoteApiService.js';
 
 /**
  * GET /api/presence/:practiceId/ws
@@ -37,9 +38,10 @@ export async function handlePresence(request: Request, env: Env): Promise<Respon
   }
   const userId = auth.user.id;
 
-  // Membership/authorization check: user must be a member of the practice
-  const members = await env.RemoteApiService.getPracticeMembers(env, practiceId, request);
-  const isMember = Array.isArray(members) && members.some(m => m.user_id === userId);
+  // Membership/authorization check: user must be a member of the practice.
+  // RemoteApiService is a class with static methods, not an env binding.
+  const members = await RemoteApiService.getPracticeMembers(env, practiceId, request);
+  const isMember = Array.isArray(members) && members.some((m) => m.user_id === userId);
   if (!isMember) {
     throw HttpErrors.forbidden('Not authorized for this practice');
   }

--- a/worker/services/ConversationService.ts
+++ b/worker/services/ConversationService.ts
@@ -463,6 +463,39 @@ export class ConversationService {
     return await this.getConversation(conversationId, options.practiceId);
   }
 
+  /**
+   * Hard-delete a conversation and every row that references it. Confirms the
+   * row exists and belongs to the given practice before deleting (so a
+   * mistargeted call returns 404 instead of silently no-op'ing).
+   *
+   * Cascade: chat_message_reactions (via message_id) → chat_messages →
+   * session_audit_events → conversation_participants → conversation_read_state
+   * → conversations. files / contact_forms / matter_events keep their
+   * conversation_id reference set (they survive the conversation, since they
+   * may be linked to matters or other entities).
+   */
+  async deleteConversation(conversationId: string, practiceId: string): Promise<void> {
+    const existing = await this.env.DB.prepare(
+      'SELECT id FROM conversations WHERE id = ? AND practice_id = ?'
+    ).bind(conversationId, practiceId).first<{ id: string } | null>();
+
+    if (!existing) {
+      throw HttpErrors.notFound('Conversation not found');
+    }
+
+    await this.env.DB.batch([
+      this.env.DB.prepare(`
+        DELETE FROM chat_message_reactions
+        WHERE message_id IN (SELECT id FROM chat_messages WHERE conversation_id = ?)
+      `).bind(conversationId),
+      this.env.DB.prepare('DELETE FROM chat_messages WHERE conversation_id = ?').bind(conversationId),
+      this.env.DB.prepare('DELETE FROM session_audit_events WHERE conversation_id = ?').bind(conversationId),
+      this.env.DB.prepare('DELETE FROM conversation_participants WHERE conversation_id = ?').bind(conversationId),
+      this.env.DB.prepare('DELETE FROM conversation_read_state WHERE conversation_id = ?').bind(conversationId),
+      this.env.DB.prepare('DELETE FROM conversations WHERE id = ? AND practice_id = ?').bind(conversationId, practiceId),
+    ]);
+  }
+
   private mapRecordToConversation(record: Record<string, unknown> | null): Conversation {
     if (!record) {
       throw new Error('[ConversationService] Cannot map null record to conversation');
@@ -1567,6 +1600,16 @@ export class ConversationService {
   }): Promise<{ messageId: string; seq: number; serverTs: string }> {
     const stub = this.env.CHAT_ROOM.get(this.env.CHAT_ROOM.idFromName(options.conversationId));
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    // Pull attachments out of metadata so the ChatRoom DO sees them at the top
+    // level (matches the WS frame shape). Without this, file-only sends sent
+    // through the HTTP route fail validation because the DO checks
+    // `payload.attachments`, not `payload.metadata.attachments`.
+    const metadataObj = options.metadata && typeof options.metadata === 'object'
+      ? (options.metadata as Record<string, unknown>)
+      : null;
+    const metadataAttachments = metadataObj && Array.isArray(metadataObj.attachments)
+      ? metadataObj.attachments
+      : null;
     const payload: Record<string, unknown> = {
       conversation_id: options.conversationId,
       user_id: options.userId,
@@ -1575,6 +1618,9 @@ export class ConversationService {
       metadata: options.metadata ?? null,
       client_id: options.clientId
     };
+    if (metadataAttachments) {
+      payload.attachments = metadataAttachments;
+    }
     if (options.replyToMessageId) {
       payload.reply_to_message_id = options.replyToMessageId;
     }

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -128,6 +128,7 @@ export interface Env {
   CHAT_ROOM: DurableObjectNamespace;
   MATTER_PROGRESS: DurableObjectNamespace;
   CHAT_COUNTER: DurableObjectNamespace;
+  PRESENCE_ROOM: DurableObjectNamespace;
   FILES_BUCKET?: R2Bucket;
   ADOBE_CLIENT_ID?: string;
   ADOBE_CLIENT_SECRET?: string;

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -46,9 +46,17 @@ deleted_classes = ["NotificationHub"]
 name = "MATTER_PROGRESS"
 class_name = "MatterProgressRoom"
 
+[[durable_objects.bindings]]
+name = "PRESENCE_ROOM"
+class_name = "PresenceRoom"
+
 [[migrations]]
 tag = "v4"
 new_classes = ["MatterProgressRoom"]
+
+[[migrations]]
+tag = "v5"
+new_classes = ["PresenceRoom"]
 
 
 [env.dev]
@@ -82,6 +90,10 @@ class_name = "ChatRoom"
 name = "MATTER_PROGRESS"
 class_name = "MatterProgressRoom"
 
+[[env.dev.durable_objects.bindings]]
+name = "PRESENCE_ROOM"
+class_name = "PresenceRoom"
+
 [[env.dev.migrations]]
 tag = "v2"
 new_classes = ["ChatRoom"]
@@ -89,6 +101,10 @@ new_classes = ["ChatRoom"]
 [[env.dev.migrations]]
 tag = "v4"
 new_classes = ["MatterProgressRoom"]
+
+[[env.dev.migrations]]
+tag = "v5"
+new_classes = ["PresenceRoom"]
 
 [env.dev.vars]
 NODE_ENV = "development"
@@ -143,6 +159,10 @@ class_name = "ChatRoom"
 name = "MATTER_PROGRESS"
 class_name = "MatterProgressRoom"
 
+[[env.staging.durable_objects.bindings]]
+name = "PRESENCE_ROOM"
+class_name = "PresenceRoom"
+
 [[env.staging.migrations]]
 tag = "v6"
 new_classes = ["MatterDiffStore"]
@@ -150,6 +170,10 @@ new_classes = ["MatterDiffStore"]
 [[env.staging.migrations]]
 tag = "v7"
 deleted_classes = ["MatterDiffStore"]
+
+[[env.staging.migrations]]
+tag = "v8"
+new_classes = ["PresenceRoom"]
 
 [env.staging.vars]
 NODE_ENV = "staging"
@@ -192,6 +216,9 @@ deleted_classes = ["NotificationHub"]
 [[env.production.migrations]]
 tag = "v5"
 new_classes = ["MatterProgressRoom"]
+[[env.production.migrations]]
+tag = "v6"
+new_classes = ["PresenceRoom"]
 [[env.production.r2_buckets]]
 binding = "FILES_BUCKET"
 bucket_name = "blawby-ai-files"
@@ -214,6 +241,10 @@ class_name = "ChatRoom"
 [[env.production.durable_objects.bindings]]
 name = "MATTER_PROGRESS"
 class_name = "MatterProgressRoom"
+
+[[env.production.durable_objects.bindings]]
+name = "PRESENCE_ROOM"
+class_name = "PresenceRoom"
 
 [env.production.vars]
 NODE_ENV = "production"


### PR DESCRIPTION
## Summary

- **Draft conversation pattern** — compose button enters draft mode (no DB write until first send), pinned "Draft" entry in the messages list, dedicated `DraftConversationView` with inline contact picker via the existing `Combobox`. Picking a contact who already has a conversation jumps to that thread instead of duplicating.
- **Real user presence** via a new practice-scoped `PresenceRoom` Durable Object on `/api/presence/:practiceId/ws` + a `PresenceProvider` that drives green/gray dots on every avatar in the list and draft picker.
- **File-only message sends** end-to-end (client guards, HTTP route, `ConversationService.postChatRoomMessage` forwarding attachments at top level, `ChatRoom` DO on both WS and HTTP paths).
- **Conversation header** always shows the contact name (no metadata.title or practice-org fallback) with an avatar leading and a presence dot.
- **DragDropOverlay** swapped for a light "Add anything / Drop any file here" prompt with pointer-events disabled, driven by real window-level drag tracking.
- **Hard-delete conversation** route + cascade (`chat_messages`, `chat_message_reactions`, `session_audit_events`, `conversation_participants`, `conversation_read_state`) + confirmation dialog.
- **AppShell layout** — header now spans listPanel + main + inspector on desktop; sidebar stays full-height alongside.
- **Polish** — `Avatar` gets an offline (gray) status without the ring; `useWorkspaceConversations` caches 404s from orphaned accepted-intake → conversation lookups so the worker log isn't 404-stormed on every refresh.

## Notable backend changes

- New DO: `worker/durable-objects/PresenceRoom.ts` — hibernation-safe via `state.acceptWebSocket(server, [userId])` tags.
- New route: `worker/routes/presence.ts` (mounted at `/api/presence/` to avoid the `/api/practice/*` backend-proxy prefix).
- `wrangler.toml` — bindings + migrations for `PresenceRoom` across dev/staging/production envs.
- `worker/services/ConversationService.ts` — `deleteConversation()` cascade + `postChatRoomMessage` extracts attachments from metadata so the DO sees them at the top level (matches WS frame shape).
- `worker/durable-objects/ChatRoom.ts` — both `handleSendMessage` (WS) and `handleInternalMessage` (HTTP) allow empty content when `attachments.length > 0`.
- `worker/routes/conversations.ts` — relaxed `content is required` for file-only sends; new `DELETE /api/conversations/:id` (paralegal+).

## Test plan

- [x] `npm run test:e2e` (public chromium): 9/9 passed
- [x] `npm run test:unit`: 313/313 passed
- [x] `npm run test:component`: 86/86 passed
- [ ] `npm run test:e2e:auth` — needs `E2E_*` credentials, skipped locally
- [ ] Manually verify presence dots flip green/gray with two authenticated tabs (different users)
- [ ] Manually verify file-only send: drop file, leave text empty, hit send → message lands with attachment
- [ ] Manually verify draft → existing conversation jump (pick a contact who already has a conversation)
- [ ] Manually verify hard-delete with confirmation dialog
- [ ] Manually verify desktop header layout (above conversation list, sidebar full-height)
- [ ] Manually verify mobile draft view full-screen takeover + cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presence indicators (active/offline) and updated unread badge
  * Conversation details panel (contact, source, recent activity, linked matter)
  * Draft message composition flow and forced conversation creation
  * Page-wide drag-and-drop for adding files
  * Conversation delete action

* **Improvements**
  * Audio recording enabled by default
  * Riched conversation header with primary action and metadata strip
  * Message layout, avatar sizing, and composer UI refinements

* **Style**
  * Sidebar label changed from "Inbox" to "Messages"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->