### PR TITLE
feat(intake): match Pencil designs + wire client portal intake status

### DIFF
--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -38,6 +38,7 @@ const ClientInvoicesPage = lazy(() => import('@/features/invoices/pages/ClientIn
 const ClientInvoiceDetailPage = lazy(() => import('@/features/invoices/pages/ClientInvoiceDetailPage').then(m => ({ default: m.ClientInvoiceDetailPage })));
 const PracticeReportsPage = lazy(() => import('@/features/reports/pages/PracticeReportsPage').then(m => ({ default: m.PracticeReportsPage })));
 const IntakesPage = lazy(() => import('@/features/intake/pages/IntakesPage').then(m => ({ default: m.IntakesPage })));
+const ClientIntakesView = lazy(() => import('@/features/intake/pages/ClientIntakesView').then(m => ({ default: m.ClientIntakesView })));
 const EngagementsPage = lazy(() => import('@/features/engagements/pages/EngagementsPage').then(m => ({ default: m.EngagementsPage })));
 import { useConversationSystemMessages } from '@/shared/hooks/useConversationSystemMessages';
 import { initializeAccentColor } from '@/shared/utils/accentColors';
@@ -80,7 +81,7 @@ export function MainApp({
   chatContent,
   routeConversationId,
   routeInvoiceId,
-  routeIntakeId: _routeIntakeId,
+  routeIntakeId,
   routeSettingsView,
   routeSettingsAppId,
   routeSettingsIntakeTemplateSlug,
@@ -213,6 +214,12 @@ export function MainApp({
     if (!slug) return null;
     return `/practice/${encodeURIComponent(slug)}/intakes`;
   }, [isPracticeWorkspace, resolvedPracticeSlug]);
+  const clientIntakesPath = useMemo(() => {
+    if (!isClientWorkspace) return null;
+    const slug = clientPracticeSlug ?? resolvedClientPracticeSlug;
+    if (!slug) return null;
+    return `/client/${encodeURIComponent(slug)}/intakes`;
+  }, [clientPracticeSlug, isClientWorkspace, resolvedClientPracticeSlug]);
 
   const practiceEngagementsPath = useMemo(() => {
     if (!isPracticeWorkspace) return null;
@@ -1090,7 +1097,16 @@ export function MainApp({
               />
             </LazyRouteBoundary>
           )
-          : undefined
+          : isClientWorkspace
+            ? () => (
+              <LazyRouteBoundary>
+                <ClientIntakesView
+                  basePath={clientIntakesPath ?? '/client/intakes'}
+                  practiceName={resolvedPracticeName}
+                />
+              </LazyRouteBoundary>
+            )
+            : undefined
       }
       engagementsView={
         isPracticeWorkspace

--- a/src/features/engagements/pages/EngagementDetailPage.tsx
+++ b/src/features/engagements/pages/EngagementDetailPage.tsx
@@ -376,13 +376,17 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
     if (!conversationId || !targetPracticeId) return;
     if (!previewCursor || !hasMorePreview || isLoadingMorePreview) return;
 
+    const controller = new AbortController();
     setIsLoadingMorePreview(true);
     try {
       const page = await fetchConversationMessages(conversationId, targetPracticeId, {
         limit: PREVIEW_PAGE_SIZE,
         cursor: previewCursor,
+        signal: controller.signal,
       });
-      if (!isMountedRef.current) return;
+      if (!isMountedRef.current || controller.signal.aborted) return;
+      if (engagement?.conversation_id !== conversationId) return;
+      
       setPreviewMessages((current) => {
         const existing = new Set(current.map((m) => m.id));
         const olderMapped = page.messages.map(mapMessage).filter((m) => !existing.has(m.id));
@@ -391,9 +395,12 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
       setPreviewCursor(page.cursor);
       setHasMorePreview(page.hasMore);
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
       console.warn('[EngagementDetailPage] Failed to load older messages', err);
     } finally {
-      if (isMountedRef.current) setIsLoadingMorePreview(false);
+      if (isMountedRef.current && engagement?.conversation_id === conversationId && !controller.signal.aborted) {
+        setIsLoadingMorePreview(false);
+      }
     }
   }, [engagement?.conversation_id, engagement?.organization_id, previewCursor, hasMorePreview, isLoadingMorePreview, mapMessage]);
 

--- a/src/features/engagements/pages/EngagementDetailPage.tsx
+++ b/src/features/engagements/pages/EngagementDetailPage.tsx
@@ -15,6 +15,7 @@ import { useNavigation } from '@/shared/utils/navigation';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { fetchConversationMessages } from '@/shared/lib/conversationApi';
+import type { ConversationMessage } from '@/shared/types/conversation';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
 import VirtualMessageList from '@/features/chat/components/VirtualMessageList';
 import type { ChatMessageUI } from '../../../../worker/types';
@@ -305,6 +306,21 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
   const [previewMessages, setPreviewMessages] = useState<ChatMessageUI[]>([]);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewCursor, setPreviewCursor] = useState<string | null>(null);
+  const [hasMorePreview, setHasMorePreview] = useState(false);
+  const [isLoadingMorePreview, setIsLoadingMorePreview] = useState(false);
+
+  const PREVIEW_PAGE_SIZE = 50;
+  const mapMessage = useCallback((m: ConversationMessage): ChatMessageUI => ({
+    id: m.id,
+    role: m.role,
+    content: m.content,
+    timestamp: new Date(m.created_at ?? m.server_ts).getTime(),
+    reply_to_message_id: m.reply_to_message_id ?? null,
+    metadata: m.metadata ?? undefined,
+    isUser: m.user_id === session?.user?.id,
+    seq: m.seq,
+  } satisfies ChatMessageUI), [session?.user?.id]);
   const [localStatus, setLocalStatus] = useState<string | null>(null);
   const isMountedRef = useRef(true);
 
@@ -313,33 +329,34 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
     return () => { isMountedRef.current = false; };
   }, []);
 
-  // Load conversation preview
+  // Load the most-recent page of messages. Older pages are fetched on-demand
+  // via loadOlderMessages (scroll-up trigger inside VirtualMessageList).
   useEffect(() => {
     const conversationId = engagement?.conversation_id;
     const targetPracticeId = engagement?.organization_id;
     if (!conversationId || !targetPracticeId) {
       setPreviewMessages([]);
       setPreviewLoading(false);
+      setPreviewCursor(null);
+      setHasMorePreview(false);
       return;
     }
     const controller = new AbortController();
     setPreviewMessages([]);
     setPreviewLoading(true);
     setPreviewError(null);
+    setPreviewCursor(null);
+    setHasMorePreview(false);
 
-    fetchConversationMessages(conversationId, targetPracticeId, { limit: 100, signal: controller.signal })
-      .then((messages) => {
+    fetchConversationMessages(conversationId, targetPracticeId, {
+      limit: PREVIEW_PAGE_SIZE,
+      signal: controller.signal,
+    })
+      .then((page) => {
         if (!isMountedRef.current || controller.signal.aborted) return;
-        setPreviewMessages(messages.map((m) => ({
-          id: m.id,
-          role: m.role,
-          content: m.content,
-          timestamp: new Date(m.created_at ?? m.server_ts).getTime(),
-          reply_to_message_id: m.reply_to_message_id ?? null,
-          metadata: m.metadata ?? undefined,
-          isUser: m.user_id === session?.user?.id,
-          seq: m.seq,
-        } satisfies ChatMessageUI)));
+        setPreviewMessages(page.messages.map(mapMessage));
+        setPreviewCursor(page.cursor);
+        setHasMorePreview(page.hasMore);
       })
       .catch((err) => {
         if (!isMountedRef.current || controller.signal.aborted) return;
@@ -351,7 +368,34 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
       });
 
     return () => controller.abort();
-  }, [engagement?.conversation_id, engagement?.organization_id, session?.user?.id]);
+  }, [engagement?.conversation_id, engagement?.organization_id, mapMessage]);
+
+  const loadOlderMessages = useCallback(async () => {
+    const conversationId = engagement?.conversation_id;
+    const targetPracticeId = engagement?.organization_id;
+    if (!conversationId || !targetPracticeId) return;
+    if (!previewCursor || !hasMorePreview || isLoadingMorePreview) return;
+
+    setIsLoadingMorePreview(true);
+    try {
+      const page = await fetchConversationMessages(conversationId, targetPracticeId, {
+        limit: PREVIEW_PAGE_SIZE,
+        cursor: previewCursor,
+      });
+      if (!isMountedRef.current) return;
+      setPreviewMessages((current) => {
+        const existing = new Set(current.map((m) => m.id));
+        const olderMapped = page.messages.map(mapMessage).filter((m) => !existing.has(m.id));
+        return [...olderMapped, ...current];
+      });
+      setPreviewCursor(page.cursor);
+      setHasMorePreview(page.hasMore);
+    } catch (err) {
+      console.warn('[EngagementDetailPage] Failed to load older messages', err);
+    } finally {
+      if (isMountedRef.current) setIsLoadingMorePreview(false);
+    }
+  }, [engagement?.conversation_id, engagement?.organization_id, previewCursor, hasMorePreview, isLoadingMorePreview, mapMessage]);
 
   const closeDialog = useCallback(() => {
     if (isSubmitting) return;
@@ -578,6 +622,9 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
                       practiceId: engagement.organization_id,
                     }}
                     practiceId={engagement.organization_id}
+                    hasMoreMessages={hasMorePreview}
+                    isLoadingMoreMessages={isLoadingMorePreview}
+                    onLoadMoreMessages={loadOlderMessages}
                   />
                 )}
               </div>

--- a/src/features/intake/components/IntakePreviewDialog.tsx
+++ b/src/features/intake/components/IntakePreviewDialog.tsx
@@ -7,6 +7,7 @@ import { getPublicFormUrl } from '@/features/intake/components/EmbedCodeBlock';
 import type { IntakeTemplate } from '@/shared/types/intake';
 import type { WidgetPreviewConfig } from '@/shared/types/widgetPreview';
 import type { MinorAmount } from '@/shared/utils/money';
+import { isMinorAmount, asMinor } from '@/shared/utils/money';
 
 type IntakePreviewDialogProps = {
   isOpen: boolean;
@@ -39,8 +40,8 @@ export const IntakePreviewDialog = ({
     accentColor: practiceAccentColor,
     introMessage: template.introMessage ?? null,
     legalDisclaimer: template.legalDisclaimer ?? null,
-    consultationFee: typeof template.consultationFee === 'number'
-      ? (template.consultationFee as MinorAmount)
+    consultationFee: isMinorAmount(template.consultationFee)
+      ? asMinor(template.consultationFee)
       : null,
     paymentLinkEnabled: template.paymentLinkEnabled,
     currency: currencyCode,
@@ -87,7 +88,11 @@ export const IntakePreviewDialog = ({
         ) : null}
         <Button
           onClick={async () => {
-            await onConfirm();
+            try {
+              await onConfirm();
+            } catch (err) {
+              console.error('[IntakePreviewDialog] Failed to confirm:', err);
+            }
           }}
           disabled={loading}
         >

--- a/src/features/intake/pages/ClientIntakeStatusPage.tsx
+++ b/src/features/intake/pages/ClientIntakeStatusPage.tsx
@@ -85,7 +85,7 @@ const TimelineRow: FunctionComponent<{ item: ClientIntakeTimelineItem; isLast: b
   const textClass = item.state === 'upcoming' ? 'text-input-placeholder' : 'text-input-text';
 
   return (
-    <div className="flex gap-3">
+    <li className="flex gap-3">
       <div className="flex flex-col items-center">
         <span className={cn('mt-1.5 h-2.5 w-2.5 rounded-full', dotClass)} aria-hidden="true" />
         {!isLast ? <span className="mt-1 h-full w-px flex-1 bg-card-border" aria-hidden="true" /> : null}
@@ -94,7 +94,7 @@ const TimelineRow: FunctionComponent<{ item: ClientIntakeTimelineItem; isLast: b
         <p className={cn('text-sm font-medium', textClass)}>{item.title}</p>
         <p className="text-xs text-input-placeholder">{item.timestamp}</p>
       </div>
-    </div>
+    </li>
   );
 };
 

--- a/src/features/intake/pages/ClientIntakeStatusPage.tsx
+++ b/src/features/intake/pages/ClientIntakeStatusPage.tsx
@@ -1,0 +1,192 @@
+import { FunctionComponent, type ComponentChildren } from 'preact';
+
+import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
+import { cn } from '@/shared/utils/cn';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ClientIntakeStatusKind = 'submitted' | 'in_review' | 'scheduled' | 'declined';
+
+export type ClientIntakeTimelineItem = {
+  id: string;
+  title: string;
+  timestamp: string;
+  state: 'complete' | 'current' | 'upcoming';
+};
+
+export type ClientIntakeResponse = {
+  id: string;
+  question: string;
+  answer: string;
+};
+
+export type ClientIntakeStatus = {
+  templateName: string;
+  submittedAt: string;
+  status: ClientIntakeStatusKind;
+  statusLabel: string;
+  nextStep: string | null;
+  timeline: ClientIntakeTimelineItem[];
+  responses: ClientIntakeResponse[];
+  notes: string | null;
+};
+
+type ClientIntakeStatusPageProps = {
+  intake: ClientIntakeStatus | null;
+  onBack?: () => void;
+};
+
+// ── Status pill ──────────────────────────────────────────────────────────────
+
+const statusPillClass = (kind: ClientIntakeStatusKind): string => {
+  switch (kind) {
+    case 'scheduled':
+      return 'bg-accent-success/15 text-accent-success ring-accent-success/30';
+    case 'declined':
+      return 'bg-accent-error/15 text-accent-error ring-accent-error/30';
+    case 'in_review':
+      return 'bg-accent-warning/15 text-accent-warning ring-accent-warning/30';
+    case 'submitted':
+    default:
+      return 'bg-surface-utility/40 text-input-text ring-line-subtle/30';
+  }
+};
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+const Card: FunctionComponent<{ children: ComponentChildren; className?: string }> = ({
+  children,
+  className,
+}) => (
+  <section
+    className={cn(
+      'rounded-xl border border-card-border bg-surface-card p-4 sm:p-5',
+      className,
+    )}
+  >
+    {children}
+  </section>
+);
+
+const SectionHeading: FunctionComponent<{ children: ComponentChildren }> = ({ children }) => (
+  <h2 className="text-sm font-semibold text-input-text">{children}</h2>
+);
+
+const TimelineRow: FunctionComponent<{ item: ClientIntakeTimelineItem; isLast: boolean }> = ({
+  item,
+  isLast,
+}) => {
+  const dotClass =
+    item.state === 'complete'
+      ? 'bg-accent-success'
+      : item.state === 'current'
+        ? 'bg-accent-warning'
+        : 'bg-input-placeholder/60';
+  const textClass = item.state === 'upcoming' ? 'text-input-placeholder' : 'text-input-text';
+
+  return (
+    <div className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <span className={cn('mt-1.5 h-2.5 w-2.5 rounded-full', dotClass)} aria-hidden="true" />
+        {!isLast ? <span className="mt-1 h-full w-px flex-1 bg-card-border" aria-hidden="true" /> : null}
+      </div>
+      <div className="flex-1 pb-3">
+        <p className={cn('text-sm font-medium', textClass)}>{item.title}</p>
+        <p className="text-xs text-input-placeholder">{item.timestamp}</p>
+      </div>
+    </div>
+  );
+};
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPageProps> = ({
+  intake,
+  onBack,
+}) => {
+  if (!intake) {
+    return (
+      <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+        <DetailHeader title="Intake Forms" showBack={Boolean(onBack)} onBack={onBack} />
+        <div className="p-6 text-sm text-input-placeholder">
+          You have not submitted any intakes yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+      <DetailHeader title="Intake Forms" showBack={Boolean(onBack)} onBack={onBack} />
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="mx-auto flex max-w-3xl flex-col gap-4 p-4 sm:p-6">
+          {/* Status card */}
+          <Card>
+            <div className="flex items-center justify-between gap-3">
+              <h1 className="text-base font-semibold text-input-text">{intake.templateName}</h1>
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ring-1 ring-inset',
+                  statusPillClass(intake.status),
+                )}
+              >
+                {intake.statusLabel}
+              </span>
+            </div>
+            <p className="mt-2 text-xs text-input-placeholder">Submitted {intake.submittedAt}</p>
+          </Card>
+
+          {/* Next step */}
+          {intake.nextStep ? (
+            <Card className="bg-surface-utility/30">
+              <SectionHeading>Next Step</SectionHeading>
+              <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-input-text/90">
+                {intake.nextStep}
+              </p>
+            </Card>
+          ) : null}
+
+          {/* Timeline */}
+          {intake.timeline.length > 0 ? (
+            <Card>
+              <SectionHeading>Timeline</SectionHeading>
+              <ol className="mt-3 space-y-0">
+                {intake.timeline.map((t, idx) => (
+                  <TimelineRow key={t.id} item={t} isLast={idx === intake.timeline.length - 1} />
+                ))}
+              </ol>
+            </Card>
+          ) : null}
+
+          {/* Your responses */}
+          {intake.responses.length > 0 ? (
+            <Card>
+              <SectionHeading>Your Responses</SectionHeading>
+              <dl className="mt-3 space-y-3">
+                {intake.responses.map((r) => (
+                  <div key={r.id} className="space-y-1">
+                    <dt className="text-xs text-input-placeholder">{r.question}</dt>
+                    <dd className="whitespace-pre-wrap text-sm text-input-text">{r.answer}</dd>
+                  </div>
+                ))}
+              </dl>
+            </Card>
+          ) : null}
+
+          {/* Notes */}
+          {intake.notes ? (
+            <Card>
+              <SectionHeading>Notes</SectionHeading>
+              <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-input-text/90">
+                {intake.notes}
+              </p>
+            </Card>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ClientIntakeStatusPage;

--- a/src/features/intake/pages/ClientIntakesView.tsx
+++ b/src/features/intake/pages/ClientIntakesView.tsx
@@ -1,0 +1,197 @@
+import { FunctionComponent } from 'preact';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useLocation } from 'preact-iso';
+
+import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { formatLongDate } from '@/shared/utils/dateFormatter';
+import { getIntakeStatus, type IntakeStatusResponse } from '../api/intakesApi';
+import {
+  ClientIntakeStatusPage,
+  type ClientIntakeStatus,
+  type ClientIntakeStatusKind,
+  type ClientIntakeTimelineItem,
+} from './ClientIntakeStatusPage';
+
+const safeDecode = (value: string | undefined | null): string | null => {
+  if (typeof value !== 'string') return null;
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const mapStatusKind = (raw: string): { kind: ClientIntakeStatusKind; label: string } => {
+  const normalized = raw.toLowerCase();
+  if (normalized.includes('schedule')) return { kind: 'scheduled', label: 'Consultation Scheduled' };
+  if (normalized.includes('accept')) return { kind: 'scheduled', label: 'Intake Accepted' };
+  if (normalized.includes('declin') || normalized.includes('reject')) return { kind: 'declined', label: 'Declined' };
+  if (normalized.includes('review') || normalized.includes('pending')) return { kind: 'in_review', label: 'Pending Review' };
+  return { kind: 'submitted', label: 'Submitted' };
+};
+
+const buildTimeline = (status: IntakeStatusResponse): ClientIntakeTimelineItem[] => {
+  const submittedAt = formatLongDate(status.metadata?.created_at as string | undefined ?? '') ?? 'Submitted';
+  const triageStatus = (status.metadata?.triage_status as string | undefined) ?? null;
+  const scheduledAt = (status.metadata?.consultation_scheduled_at as string | undefined) ?? null;
+
+  const items: ClientIntakeTimelineItem[] = [
+    {
+      id: 'submitted',
+      title: 'Intake Submitted',
+      timestamp: submittedAt,
+      state: 'complete',
+    },
+  ];
+
+  if (triageStatus === 'accepted' || scheduledAt) {
+    items.push({
+      id: 'accepted',
+      title: 'Intake Accepted',
+      timestamp: triageStatus === 'accepted' ? 'Accepted' : 'Pending',
+      state: scheduledAt ? 'complete' : 'current',
+    });
+  }
+
+  if (scheduledAt) {
+    const scheduledLabel = formatLongDate(scheduledAt) ?? scheduledAt;
+    items.push({
+      id: 'scheduled',
+      title: 'Consultation Scheduled',
+      timestamp: scheduledLabel,
+      state: 'current',
+    });
+  } else if (triageStatus === 'accepted') {
+    items.push({
+      id: 'awaiting',
+      title: 'Awaiting consultation scheduling',
+      timestamp: 'Upcoming',
+      state: 'upcoming',
+    });
+  }
+
+  return items;
+};
+
+const buildResponses = (status: IntakeStatusResponse) => {
+  const out: Array<{ id: string; question: string; answer: string }> = [];
+  if (status.description?.trim()) {
+    out.push({ id: 'description', question: 'Brief description', answer: status.description.trim() });
+  }
+  if (status.opposing_party?.trim()) {
+    out.push({ id: 'opposing-party', question: 'Opposing party', answer: status.opposing_party.trim() });
+  }
+  const meta = (status.metadata ?? {}) as Record<string, unknown>;
+  const customFields = meta.customFields ?? meta.custom_fields;
+  if (customFields && typeof customFields === 'object' && !Array.isArray(customFields)) {
+    for (const [key, value] of Object.entries(customFields as Record<string, unknown>)) {
+      if (key.startsWith('_') || value == null || value === '') continue;
+      const answer = typeof value === 'boolean' ? (value ? 'Yes' : 'No') : String(value);
+      const question = key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+      out.push({ id: key, question, answer });
+    }
+  }
+  return out;
+};
+
+const adaptStatus = (status: IntakeStatusResponse, templateName: string): ClientIntakeStatus => {
+  const submittedAt = (status.metadata?.created_at as string | undefined) ?? null;
+  const submittedLabel = submittedAt ? (formatLongDate(submittedAt) ?? submittedAt) : 'Recently';
+  const { kind, label } = mapStatusKind(status.status);
+  const scheduledAt = (status.metadata?.consultation_scheduled_at as string | undefined) ?? null;
+  const nextStep = scheduledAt
+    ? `Your consultation is scheduled for ${formatLongDate(scheduledAt) ?? scheduledAt}. You'll receive a meeting link via email.`
+    : kind === 'in_review' || kind === 'submitted'
+      ? "We've received your intake. The practice will review it and reach out about next steps."
+      : kind === 'declined'
+        ? 'The practice has reviewed your intake and could not take it on at this time.'
+        : null;
+
+  return {
+    templateName,
+    submittedAt: submittedLabel,
+    status: kind,
+    statusLabel: label,
+    nextStep,
+    timeline: buildTimeline(status),
+    responses: buildResponses(status),
+    notes: typeof status.metadata?.client_note === 'string' ? status.metadata.client_note : null,
+  };
+};
+
+type ClientIntakesViewProps = {
+  basePath: string;
+  practiceName: string;
+};
+
+export const ClientIntakesView: FunctionComponent<ClientIntakesViewProps> = ({
+  basePath,
+  practiceName,
+}) => {
+  const location = useLocation();
+
+  const intakeUuid = useMemo(() => {
+    const suffix = location.path.startsWith(basePath) ? location.path.slice(basePath.length) : '';
+    const segments = suffix.replace(/^\/+/, '').split('/').filter(Boolean);
+    return segments[0] ? safeDecode(segments[0]) : null;
+  }, [location.path, basePath]);
+
+  const [intake, setIntake] = useState<ClientIntakeStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!intakeUuid) {
+      setIntake(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    getIntakeStatus(intakeUuid)
+      .then((response) => {
+        if (cancelled) return;
+        setIntake(adaptStatus(response, `${practiceName} Intake`));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load intake');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [intakeUuid, practiceName]);
+
+  const onBack = useCallback(() => {
+    location.route(basePath);
+  }, [basePath, location]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center bg-surface-workspace">
+        <LoadingSpinner ariaLabel="Loading intake" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+        <DetailHeader title="Intake Forms" showBack={Boolean(intakeUuid)} onBack={intakeUuid ? onBack : undefined} />
+        <div className="p-6 text-sm text-error">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <ClientIntakeStatusPage intake={intake} onBack={intakeUuid ? onBack : undefined} />
+  );
+};
+
+export default ClientIntakesView;

--- a/src/features/intake/pages/ClientIntakesView.tsx
+++ b/src/features/intake/pages/ClientIntakesView.tsx
@@ -69,6 +69,13 @@ const buildTimeline = (status: IntakeStatusResponse): ClientIntakeTimelineItem[]
       timestamp: 'Upcoming',
       state: 'upcoming',
     });
+  } else if (triageStatus === 'pending_review' || triageStatus === 'declined' || triageStatus === 'rejected') {
+    items.push({
+      id: 'status',
+      title: triageStatus === 'pending_review' ? 'Pending review' : triageStatus === 'declined' ? 'Declined' : 'Rejected',
+      timestamp: triageStatus === 'pending_review' ? 'Pending' : triageStatus === 'declined' ? 'Declined' : 'Rejected',
+      state: 'current',
+    });
   }
 
   return items;

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -1,46 +1,55 @@
-import { FunctionComponent } from 'preact';
-import { useLocation } from 'preact-iso';
+import { FunctionComponent, type ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
-import { useMessageHandling } from '@/shared/hooks/useMessageHandling';
-import { apiClient, isHttpError } from '@/shared/lib/apiClient';
-import { CheckCircle2, CheckCircle2 as CheckCircleIconSolid, User, Scale, Clock, AlertTriangle, CreditCard, MapPin, ClipboardCheck } from 'lucide-preact';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ClipboardList,
+  Clock,
+  CreditCard,
+  Mail,
+  MessageSquare,
+  Phone,
+  Scale,
+  Sparkles,
+} from 'lucide-preact';
 
-
-import { Icon } from '@/shared/ui/Icon';
 import { Button } from '@/shared/ui/Button';
-import { UserCard } from '@/shared/ui/profile';
-import { EditorShell, DetailHeader } from '@/shared/ui/layout';
-import { Page } from '@/shared/ui/layout/Page';
-import { MessageRowSkeleton, SkeletonLoader } from '@/shared/ui/layout';
+import { Icon } from '@/shared/ui/Icon';
+import { Avatar } from '@/shared/ui/profile';
+import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
 import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { MessageRowSkeleton, SkeletonLoader } from '@/shared/ui/layout';
 import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
 import { Textarea } from '@/shared/ui/input';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
-import {
-  updateIntakeTriageStatus,
-  type PracticeIntakeDetail,
-} from '@/features/intake/api/intakesApi';
-import { useIntakeDetail } from '@/features/intake/hooks/useIntakeDetail';
+import { apiClient, isHttpError } from '@/shared/lib/apiClient';
+import { cn } from '@/shared/utils/cn';
 import {
   fetchConversationMessages,
   postConversationMessage,
   postSystemMessage,
   updateConversationMetadata,
 } from '@/shared/lib/conversationApi';
+import type { ConversationMessage } from '@/shared/types/conversation';
+import { useMessageHandling } from '@/shared/hooks/useMessageHandling';
+import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
+import { applyConsultationPatchToMetadata } from '@/shared/utils/consultationState';
 import { formatLongDate } from '@/shared/utils/dateFormatter';
+import { resolvePracticeServiceLabel } from '@/features/matters/utils/matterUtils';
+import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
+import {
+  updateIntakeTriageStatus,
+  type PracticeIntakeDetail,
+} from '@/features/intake/api/intakesApi';
+import { useIntakeDetail } from '@/features/intake/hooks/useIntakeDetail';
+import { DEFAULT_INTAKE_TEMPLATE } from '@/shared/constants/intakeTemplates';
+import type { IntakeTemplate, IntakeFieldDefinition } from '@/shared/types/intake';
 import VirtualMessageList from '@/features/chat/components/VirtualMessageList';
 import MessageComposer from '@/features/chat/components/MessageComposer';
 import type { ChatMessageUI } from '../../../../worker/types';
-import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
-import { resolvePracticeServiceLabel } from '@/features/matters/utils/matterUtils';
-import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
-import { applyConsultationPatchToMetadata } from '@/shared/utils/consultationState';
-import { DEFAULT_INTAKE_TEMPLATE } from '@/shared/constants/intakeTemplates';
-import type { IntakeTemplate, IntakeFieldDefinition } from '@/shared/types/intake';
-import EmbedCodeBlock from '@/features/intake/components/EmbedCodeBlock';
 
-// ── Template helpers ──────────────────────────────────────────────────────────
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 function parseTemplatesFromPracticeDetails(details: unknown): IntakeTemplate[] {
   if (!details || typeof details !== 'object') return [];
@@ -75,20 +84,17 @@ function resolveActiveTemplate(
   return templates.find((t) => t.slug === slug) ?? null;
 }
 
-/** Get the value for a given intake field from conversation state. */
 function resolveFieldValue(
   field: IntakeFieldDefinition,
   intakeState: Record<string, unknown> | null,
   intake?: PracticeIntakeDetail | null,
 ): string | null {
-  // Helper to normalize boolean/string/null handling
   const normalize = (v: unknown): string | null => {
     if (v === null || v === undefined || v === '') return null;
     if (typeof v === 'boolean') return v ? 'Yes' : 'No';
     return String(v);
   };
 
-  // Check the provided intakeState first (conversation-submitted answers)
   if (intakeState) {
     if (field.isStandard) {
       const v = intakeState[field.key];
@@ -102,11 +108,10 @@ function resolveFieldValue(
     }
   }
 
-  // Fallback: inspect intake.metadata (template-submitted answers or stored metadata)
   if (intake && typeof intake === 'object') {
     const meta = (intake.metadata ?? {}) as Record<string, unknown>;
     if (field.isStandard) {
-      const v = meta[field.key] ?? meta[field.key as string];
+      const v = meta[field.key];
       const nv = normalize(v);
       if (nv !== null) return nv;
     }
@@ -121,74 +126,150 @@ function resolveFieldValue(
   return null;
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-// Stat cell for use inside CSS grids — no border treatment
-type StatCellProps = { label: string; value?: string | null; icon?: typeof User };
-const StatCell: FunctionComponent<StatCellProps> = ({ label, value, icon: IconComp }) => {
-  const resolvedValue = value && value.trim().length > 0 ? value : null;
-  return (
-    <div className="flex items-start gap-2.5">
-      {IconComp && (
-        <div className="mt-0.5 flex-shrink-0 text-input-placeholder">
-          <Icon icon={IconComp} className="w-4 h-4" />
-        </div>
-      )}
-      <div className="min-w-0">
-        <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder mb-0.5">{label}</p>
-        <p className={`text-sm break-words ${resolvedValue ? 'text-input-text' : 'text-input-placeholder'}`}>
-          {resolvedValue ?? 'Not provided'}
-        </p>
-      </div>
-    </div>
-  );
-};
-
-type SummaryRowProps = { label: string; value?: string | number | null; icon: typeof User };
-const SummaryRow: FunctionComponent<SummaryRowProps> = ({ label, value, icon: IconComp }) => {
-  if (value === null || value === undefined || value === '') return null;
-  return (
-    <div className="grid grid-cols-[2rem_minmax(0,1fr)] gap-4 py-4 first:pt-0 last:pb-0">
-      <div className="pt-1 text-input-text">
-        <Icon icon={IconComp} className="h-4 w-4" />
-      </div>
-      <div className="min-w-0">
-        <dt className="mt-1 text-sm font-medium leading-tight text-input-placeholder">{label}</dt>
-        <dd className="break-words text-lg font-semibold leading-tight text-input-text">{value}</dd>
-      </div>
-    </div>
-  );
-};
-
-function formatAmount(amount?: number, currency?: string) {
-  if (typeof amount !== 'number' || !Number.isFinite(amount)) return null;
+function formatAmountCents(cents: number | null | undefined, currency = 'USD'): string | null {
+  if (typeof cents !== 'number' || !Number.isFinite(cents)) return null;
   try {
-    return new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency: currency || 'USD',
-    }).format(amount / 100);
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(cents / 100);
   } catch {
-    return `${amount / 100} ${currency || 'USD'}`;
+    return `$${(cents / 100).toFixed(2)}`;
   }
 }
 
-function urgencyLabel(u?: string | null) {
+function urgencyLabel(u?: string | null): string | null {
   if (u === 'emergency') return 'Emergency';
   if (u === 'time_sensitive') return 'Time Sensitive';
   if (u === 'routine') return 'Routine';
-  return u ?? null;
+  return null;
 }
 
-function triageLabel(status?: string) {
-  if (status === 'pending_review') return 'Pending Review';
-  if (status === 'accepted') return 'Accepted';
-  if (status === 'declined') return 'Declined';
-  if (status === 'rejected') return 'Rejected';
-  if (status === 'spam') return 'Spam';
-  return status ?? 'Unknown';
+function triageLabel(status?: string | null): string {
+  switch (status) {
+    case 'accepted': return 'Accepted';
+    case 'declined': return 'Declined';
+    case 'rejected': return 'Rejected';
+    case 'spam': return 'Spam';
+    case 'pending_review':
+    default: return 'Pending Review';
+  }
 }
 
-// ── Main component ────────────────────────────────────────────────────────────
+function triageBadgeClass(status?: string | null): string {
+  switch (status) {
+    case 'accepted':
+      return 'bg-success/10 text-success ring-success/20';
+    case 'declined':
+    case 'rejected':
+      return 'bg-error/10 text-error ring-error/20';
+    case 'spam':
+      return 'bg-surface-utility/40 text-input-placeholder ring-line-subtle/30';
+    case 'pending_review':
+    default:
+      return 'bg-warning/10 text-warning ring-warning/20';
+  }
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+const SectionLabel: FunctionComponent<{ children: ComponentChildren; className?: string }> = ({ children, className }) => (
+  <h2 className={cn('text-[10px] font-semibold uppercase tracking-[1px] text-input-placeholder', className)}>
+    {children}
+  </h2>
+);
+
+const Card: FunctionComponent<{ children: ComponentChildren; className?: string }> = ({ children, className }) => (
+  <section
+    className={cn(
+      'rounded-xl border border-card-border bg-surface-card p-4 sm:p-6',
+      className,
+    )}
+  >
+    {children}
+  </section>
+);
+
+type DetailFieldProps = { label: string; value: ComponentChildren; emptyText?: string };
+const DetailField: FunctionComponent<DetailFieldProps> = ({ label, value, emptyText = 'Not provided' }) => {
+  const isEmpty = value === null || value === undefined || value === '';
+  return (
+    <div className="space-y-1">
+      <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">{label}</dt>
+      <dd className={cn('text-sm break-words', isEmpty ? 'text-input-placeholder' : 'text-input-text')}>
+        {isEmpty ? emptyText : value}
+      </dd>
+    </div>
+  );
+};
+
+type InfoChipProps = { icon: typeof CheckCircle2; label: string; tone?: 'default' | 'warning' | 'success' | 'error' };
+const InfoChip: FunctionComponent<InfoChipProps> = ({ icon: IconComp, label, tone = 'default' }) => {
+  const toneClass = {
+    default: 'text-input-placeholder',
+    warning: 'text-warning',
+    success: 'text-success',
+    error: 'text-error',
+  }[tone];
+  return (
+    <span className={cn('inline-flex items-center gap-1.5 text-xs', toneClass)}>
+      <Icon icon={IconComp} className="h-3.5 w-3.5" />
+      <span>{label}</span>
+    </span>
+  );
+};
+
+// ── Skeleton ─────────────────────────────────────────────────────────────────
+
+const DetailSkeleton: FunctionComponent<{ onBack: () => void }> = ({ onBack }) => (
+  <div className="flex h-full flex-col min-h-0">
+    <DetailHeader title="Intake Details" showBack onBack={onBack} />
+    <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="grid h-full grid-cols-1 xl:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="space-y-4 p-6">
+          <div className="rounded-xl border border-card-border bg-surface-card p-6 space-y-3">
+            <SkeletonLoader variant="text" width="w-32" height="h-3" />
+            <SkeletonLoader variant="title" width="w-3/4" height="h-7" />
+            <SkeletonLoader variant="text" width="w-48" height="h-3" />
+            <div className="space-y-2 pt-3">
+              <SkeletonLoader variant="text" width="w-full" height="h-3" />
+              <SkeletonLoader variant="text" width="w-11/12" height="h-3" />
+              <SkeletonLoader variant="text" width="w-5/6" height="h-3" />
+            </div>
+          </div>
+          <div className="rounded-xl border border-card-border bg-surface-card p-6 space-y-4">
+            <SkeletonLoader variant="text" width="w-32" height="h-3" />
+            <div className="grid grid-cols-2 gap-4">
+              {[0, 1, 2, 3].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <SkeletonLoader variant="text" width="w-20" height="h-3" />
+                  <SkeletonLoader variant="text" width={i % 2 === 0 ? 'w-32' : 'w-40'} height="h-3.5" />
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-xl border border-card-border bg-surface-card p-6 space-y-3">
+            <SkeletonLoader variant="text" width="w-32" height="h-3" />
+            <MessageRowSkeleton lineWidths={['w-40', 'w-56']} />
+            <MessageRowSkeleton lineWidths={['w-64', 'w-44']} />
+          </div>
+        </div>
+        <aside className="hidden xl:block space-y-4 border-l border-card-border bg-surface-panel p-6">
+          <SkeletonLoader variant="button" width="w-full" />
+          <SkeletonLoader variant="button" width="w-full" />
+          <div className="rounded-xl border border-card-border bg-surface-card p-4 space-y-3">
+            <div className="flex items-center gap-3">
+              <SkeletonLoader variant="avatar" />
+              <div className="flex-1 space-y-1.5">
+                <SkeletonLoader variant="text" width="w-32" height="h-3.5" />
+                <SkeletonLoader variant="text" width="w-24" height="h-3" />
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </div>
+);
+
+// ── Main component ───────────────────────────────────────────────────────────
 
 type IntakeDetailPageProps = {
   practiceId: string | null;
@@ -208,7 +289,6 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   onBack,
   onTriageComplete,
 }) => {
-  const { route } = useLocation();
   const { showSuccess, showError } = useToastContext();
   const { session } = useSessionContext();
 
@@ -219,14 +299,29 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     refetch: refetchIntake,
   } = useIntakeDetail(practiceId, intakeId);
   const intake: PracticeIntakeDetail | null = intakeData ?? null;
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [localTriageStatus, setLocalTriageStatus] = useState<string | null>(null);
   const [triageDialogAction, setTriageDialogAction] = useState<'accepted' | 'declined' | null>(null);
   const [triageReason, setTriageReason] = useState('');
   const [previewMessages, setPreviewMessages] = useState<ChatMessageUI[]>([]);
   const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewCursor, setPreviewCursor] = useState<string | null>(null);
+  const [hasMorePreview, setHasMorePreview] = useState(false);
+  const [isLoadingMorePreview, setIsLoadingMorePreview] = useState(false);
 
-  // Use canonical conversation flow state
+  const PREVIEW_PAGE_SIZE = 50;
+  const mapMessage = useCallback((m: ConversationMessage): ChatMessageUI => ({
+    id: m.id,
+    role: m.role,
+    content: m.content,
+    timestamp: new Date(m.created_at).getTime(),
+    reply_to_message_id: m.reply_to_message_id ?? null,
+    metadata: m.metadata ?? undefined,
+    isUser: m.user_id === session?.user?.id,
+    seq: m.seq,
+  } satisfies ChatMessageUI), [session?.user?.id]);
+
   const {
     conversationMetadata,
     updateConversationMetadata: updateConversationMetadataPatch,
@@ -242,32 +337,32 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     return () => { isMountedRef.current = false; };
   }, []);
 
-  // Restore initial previewMessages loading
+  // Load the most-recent page of messages when an intake conversation exists.
+  // Older pages are fetched on-demand via loadOlderMessages (scroll-up trigger).
   useEffect(() => {
     const conversationId = intake?.conversation_id;
     const targetPracticeId = intake?.organization_id;
     if (!conversationId || !targetPracticeId) {
       setPreviewMessages([]);
       setPreviewLoading(false);
+      setPreviewCursor(null);
+      setHasMorePreview(false);
       return;
     }
     const controller = new AbortController();
     setPreviewMessages([]);
     setPreviewLoading(true);
-    fetchConversationMessages(conversationId, targetPracticeId, { limit: 100, signal: controller.signal })
-      .then((messages) => {
+    setPreviewCursor(null);
+    setHasMorePreview(false);
+    fetchConversationMessages(conversationId, targetPracticeId, {
+      limit: PREVIEW_PAGE_SIZE,
+      signal: controller.signal,
+    })
+      .then((page) => {
         if (!isMountedRef.current || controller.signal.aborted) return;
-        const mappedMessages = messages.map((message) => ({
-          id: message.id,
-          role: message.role,
-          content: message.content,
-          timestamp: new Date(message.created_at).getTime(),
-          reply_to_message_id: message.reply_to_message_id ?? null,
-          metadata: message.metadata ?? undefined,
-          isUser: message.user_id === session?.user?.id,
-          seq: message.seq,
-        } satisfies ChatMessageUI));
-        setPreviewMessages(mappedMessages);
+        setPreviewMessages(page.messages.map(mapMessage));
+        setPreviewCursor(page.cursor);
+        setHasMorePreview(page.hasMore);
       })
       .catch((err) => {
         if (!isMountedRef.current || controller.signal.aborted) return;
@@ -275,12 +370,39 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         setPreviewMessages([]);
       })
       .finally(() => {
-        if (isMountedRef.current && !controller.signal.aborted) {
-          setPreviewLoading(false);
-        }
+        if (isMountedRef.current && !controller.signal.aborted) setPreviewLoading(false);
       });
     return () => controller.abort();
-  }, [intake?.conversation_id, intake?.organization_id, session?.user?.id]);
+  }, [intake?.conversation_id, intake?.organization_id, mapMessage]);
+
+  const loadOlderMessages = useCallback(async () => {
+    const conversationId = intake?.conversation_id;
+    const targetPracticeId = intake?.organization_id;
+    if (!conversationId || !targetPracticeId) return;
+    if (!previewCursor || !hasMorePreview || isLoadingMorePreview) return;
+
+    setIsLoadingMorePreview(true);
+    try {
+      const page = await fetchConversationMessages(conversationId, targetPracticeId, {
+        limit: PREVIEW_PAGE_SIZE,
+        cursor: previewCursor,
+      });
+      if (!isMountedRef.current) return;
+      // Older messages are returned by the API; prepend them. De-dupe by id
+      // in case the cursor boundary overlaps.
+      setPreviewMessages((current) => {
+        const existing = new Set(current.map((m) => m.id));
+        const olderMapped = page.messages.map(mapMessage).filter((m) => !existing.has(m.id));
+        return [...olderMapped, ...current];
+      });
+      setPreviewCursor(page.cursor);
+      setHasMorePreview(page.hasMore);
+    } catch (err) {
+      console.warn('[IntakeDetailPage] Failed to load older messages', err);
+    } finally {
+      if (isMountedRef.current) setIsLoadingMorePreview(false);
+    }
+  }, [intake?.conversation_id, intake?.organization_id, previewCursor, hasMorePreview, isLoadingMorePreview, mapMessage]);
 
   const [composerValue, setComposerValue] = useState('');
   const [composerSubmitting, setComposerSubmitting] = useState(false);
@@ -319,20 +441,13 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
 
     setIsSubmitting(true);
     try {
-      const trimmedReason = typeof reason === 'string' && reason.trim().length > 0
-        ? reason.trim()
-        : undefined;
+      const trimmedReason = typeof reason === 'string' && reason.trim().length > 0 ? reason.trim() : undefined;
       let participantFailed = false;
-      const result = await updateIntakeTriageStatus(intakeId, {
-        status: action,
-        reason: trimmedReason,
-      });
+      const result = await updateIntakeTriageStatus(intakeId, { status: action, reason: trimmedReason });
 
-      const responseConversationId =
-        result?.conversation_id ?? result?.conversationId ?? intake.conversation_id;
+      const responseConversationId = result?.conversation_id ?? result?.conversationId ?? intake.conversation_id;
       const targetPracticeId = intake.organization_id;
 
-      // On accept: add practitioner as participant and post system message
       if (action === 'accepted' && session?.user?.id && responseConversationId && targetPracticeId) {
         try {
           await updateConversationMetadata(responseConversationId, targetPracticeId, {
@@ -342,8 +457,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             intakeTriageStatus: 'accepted',
             mode: 'CONVERSATION',
           });
-        } catch (conversationErr) {
-          console.warn('[IntakeDetailPage] Failed to mark conversation active', conversationErr);
+        } catch (e) {
+          console.warn('[IntakeDetailPage] Failed to mark conversation active', e);
         }
 
         try {
@@ -352,11 +467,9 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             { participantUserIds: [session.user.id] },
             { params: { practiceId: targetPracticeId } },
           );
-        } catch (participantErr) {
+        } catch (e) {
           participantFailed = true;
-          if (!isHttpError(participantErr)) {
-            console.warn('[IntakeDetailPage] Failed to add participant', participantErr);
-          }
+          if (!isHttpError(e)) console.warn('[IntakeDetailPage] Failed to add participant', e);
         }
 
         try {
@@ -371,8 +484,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
               triage_status: 'accepted',
             },
           });
-        } catch (msgErr) {
-          console.warn('[IntakeDetailPage] Failed to post join message', msgErr);
+        } catch (e) {
+          console.warn('[IntakeDetailPage] Failed to post join message', e);
         }
 
         if (trimmedReason) {
@@ -388,8 +501,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                 source: 'intake-triage',
               },
             });
-          } catch (msgErr) {
-            console.warn('[IntakeDetailPage] Failed to post intake triage note', msgErr);
+          } catch (e) {
+            console.warn('[IntakeDetailPage] Failed to post intake triage note', e);
           }
         }
       }
@@ -406,8 +519,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
               triage_status: action,
             },
           });
-        } catch (msgErr) {
-          console.warn('[IntakeDetailPage] Failed to post decline message', msgErr);
+        } catch (e) {
+          console.warn('[IntakeDetailPage] Failed to post decline message', e);
         }
         if (trimmedReason) {
           try {
@@ -422,16 +535,14 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                 source: 'intake-triage',
               },
             });
-          } catch (msgErr) {
-            console.warn('[IntakeDetailPage] Failed to post intake triage note (decline)', msgErr);
+          } catch (e) {
+            console.warn('[IntakeDetailPage] Failed to post intake triage note (decline)', e);
           }
         }
       }
 
       if (isMountedRef.current) {
         setLocalTriageStatus(action);
-        // Refresh from server in the background to pick up server-side state
-        // (conversation_id, etc.) without blocking the UI on the round-trip.
         void refetchIntake();
         setTriageDialogAction(null);
         setTriageReason('');
@@ -443,7 +554,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
               : (trimmedReason
                 ? 'The conversation is now active and your note was added.'
                 : 'The conversation is now active.'))
-            : 'Your response has been recorded.'
+            : 'Your response has been recorded.',
         );
         onTriageComplete?.();
       }
@@ -466,11 +577,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     try {
       const message = await postConversationMessage(conversationId, targetPracticeId, {
         content,
-        metadata: {
-          source: 'intake-detail',
-          intakeUuid: intakeId,
-          senderType: 'team_member',
-        },
+        metadata: { source: 'intake-detail', intakeUuid: intakeId, senderType: 'team_member' },
       });
       setComposerValue('');
       if (composerTextareaRef.current) {
@@ -508,15 +615,14 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     const nextMetadata = applyConsultationPatchToMetadata(
       conversationMetadata,
       { case: { ...(currentCase ?? {}), enrichmentMode: true } },
-      { mirrorLegacyFields: true }
+      { mirrorLegacyFields: true },
     );
 
-    // Use the first unanswered enrichment field from the active template
-    // to build a targeted question instead of hardcoded prompts.
     const templateFields = (activeTemplate?.fields ?? DEFAULT_INTAKE_TEMPLATE.fields)
       .filter((f) => f.phase === 'enrichment');
+    const intakeStateRecord = intakeConversationState as unknown as Record<string, unknown> | null;
     const nextMissingField = templateFields.find(
-      (f) => !resolveFieldValue(f, intakeConversationState as unknown as Record<string, unknown> | null, intake)
+      (f) => !resolveFieldValue(f, intakeStateRecord, intake),
     );
     const prompt = nextMissingField
       ? `I can gather a little more detail for the attorney. ${nextMissingField.previewQuestion ?? `Can you tell me about your ${nextMissingField.label.toLowerCase()}?`}`
@@ -568,106 +674,15 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     updateConversationMetadataPatch,
   ]);
 
-  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
-
-  if (isLoading) {
-    return (
-      <div className="flex h-full flex-col min-h-0">
-        <DetailHeader title="Consultation Request" showBack onBack={onBack} />
-        <div className="flex-1 min-h-0 overflow-y-auto p-6">
-          <div className="mx-auto grid w-full max-w-7xl grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
-            {/* Main column */}
-            <div className="min-w-0 space-y-6">
-              {/* Header card: title + posted-date + 9 summary rows */}
-              <section className="glass-card overflow-hidden p-6 sm:p-10">
-                <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
-                  <div className="min-w-0 space-y-4">
-                    <SkeletonLoader variant="text" width="w-32" height="h-3" />
-                    <SkeletonLoader variant="title" width="w-3/4" height="h-9" />
-                    <SkeletonLoader variant="text" width="w-56" height="h-3" />
-                    <div className="space-y-2 pt-4">
-                      <SkeletonLoader variant="text" width="w-full" height="h-3" />
-                      <SkeletonLoader variant="text" width="w-11/12" height="h-3" />
-                      <SkeletonLoader variant="text" width="w-5/6" height="h-3" />
-                    </div>
-                  </div>
-                  <aside className="lg:border-l lg:border-line-glass/10 lg:pl-6 space-y-4">
-                    {[0, 1, 2, 3, 4].map((i) => (
-                      <div key={i} className="flex justify-between gap-4">
-                        <SkeletonLoader variant="text" width="w-24" height="h-3" />
-                        <SkeletonLoader variant="text" width="w-20" height="h-4" />
-                      </div>
-                    ))}
-                  </aside>
-                </div>
-              </section>
-
-              {/* Form details grid (3 columns × 2 rows of stat cells) */}
-              <section className="glass-card p-6 sm:p-8 space-y-6">
-                <SkeletonLoader variant="text" width="w-32" height="h-3" />
-                <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
-                  {[0, 1, 2, 3, 4, 5].map((i) => (
-                    <div key={i} className="space-y-1.5">
-                      <SkeletonLoader variant="text" width="w-20" height="h-3" />
-                      <SkeletonLoader variant="text" width={i % 2 === 0 ? 'w-32' : 'w-40'} height="h-3.5" />
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              {/* Conversation preview */}
-              <section className="glass-card flex min-h-[420px] flex-col overflow-hidden">
-                <header className="shrink-0 border-b border-line-glass/10 p-5 space-y-2">
-                  <SkeletonLoader variant="text" width="w-32" height="h-3" />
-                  <SkeletonLoader variant="text" width="w-64" height="h-3" />
-                </header>
-                <div className="space-y-3 px-4 py-4">
-                  <MessageRowSkeleton lineWidths={['w-40', 'w-56']} />
-                  <MessageRowSkeleton lineWidths={['w-64', 'w-44', 'w-52']} />
-                  <MessageRowSkeleton lineWidths={['w-36', 'w-48']} />
-                </div>
-              </section>
-            </div>
-
-            {/* Sidebar */}
-            <aside className="min-w-0 space-y-6 xl:sticky xl:top-6 xl:self-start">
-              <section className="glass-card p-5 sm:p-6 space-y-3">
-                <SkeletonLoader variant="button" width="w-full" />
-                <SkeletonLoader variant="button" width="w-full" />
-              </section>
-              <section className="glass-card space-y-6 p-5 sm:p-6">
-                <div className="flex items-center gap-3">
-                  <SkeletonLoader variant="avatar" />
-                  <div className="space-y-1.5 min-w-0 flex-1">
-                    <SkeletonLoader variant="text" width="w-32" height="h-3.5" />
-                    <SkeletonLoader variant="text" width="w-24" height="h-3" />
-                  </div>
-                </div>
-                <div className="space-y-3">
-                  {[0, 1, 2].map((i) => (
-                    <div key={i} className="space-y-1.5">
-                      <SkeletonLoader variant="text" width="w-16" height="h-3" />
-                      <SkeletonLoader variant="text" width={['w-40', 'w-32', 'w-44'][i]} height="h-3.5" />
-                    </div>
-                  ))}
-                </div>
-              </section>
-            </aside>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  if (isLoading) return <DetailSkeleton onBack={onBack} />;
 
   if (loadError || !intake) {
     return (
       <div className="flex h-full flex-col min-h-0">
-        <DetailHeader title="Consultation Request" showBack onBack={onBack} />
-        <Page>
-          <div className="glass-card p-6 text-sm text-rose-400">
-            {loadError ?? 'Intake not found.'}
-          </div>
-        </Page>
+        <DetailHeader title="Intake Details" showBack onBack={onBack} />
+        <div className="p-6 text-sm text-error">
+          {loadError ?? 'Intake not found.'}
+        </div>
       </div>
     );
   }
@@ -677,95 +692,167 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   const email = typeof meta.email === 'string' ? meta.email : null;
   const phone = typeof meta.phone === 'string' ? meta.phone : null;
   const description = typeof meta.description === 'string' ? meta.description : null;
-  const practiceServiceUuid = typeof meta.practice_service_uuid === 'string' ? meta.practice_service_uuid : null;
-  const onBehalfOf = typeof meta.on_behalf_of === 'string' ? (meta.on_behalf_of.trim() || null) : null;
   const opposingParty = typeof meta.opposing_party === 'string' ? (meta.opposing_party.trim() || null) : null;
+  const onBehalfOf = typeof meta.on_behalf_of === 'string' ? (meta.on_behalf_of.trim() || null) : null;
+  const practiceServiceUuid = typeof meta.practice_service_uuid === 'string' ? meta.practice_service_uuid : null;
   const services = Array.isArray(practiceDetails?.services) ? practiceDetails.services : [];
-  const matchingService = services.find((service) => (
-    service
-      && typeof service === 'object'
-      && service.id === practiceServiceUuid
-      && typeof service.name === 'string'
-  ));
+  const matchingService = services.find((s) => s && typeof s === 'object' && s.id === practiceServiceUuid && typeof s.name === 'string');
   const matchingServiceName = typeof matchingService?.name === 'string' ? matchingService.name : undefined;
-  const practiceServiceName = practiceServiceUuid
-    ? resolvePracticeServiceLabel(practiceServiceUuid, matchingServiceName)
-    : null;
-  const address = meta.address && typeof meta.address === 'object' && !Array.isArray(meta.address)
-    ? meta.address as Record<string, unknown>
-    : null;
-  const city = typeof address?.city === 'string' ? address.city : null;
-  const state = typeof address?.state === 'string' ? address.state : null;
+  const practiceServiceName = practiceServiceUuid ? resolvePracticeServiceLabel(practiceServiceUuid, matchingServiceName) : null;
+
   const dateLabel = formatLongDate(intake.created_at);
   const caseStrength = typeof intake.case_strength === 'number' ? `${intake.case_strength}%` : null;
-  const feeAmount = formatAmount(intake.amount, intake.currency);
-  const householdSize = typeof intake.household_size === 'number' ? intake.household_size : (typeof meta.household_size === 'number' ? meta.household_size : null);
-  const income = typeof intake.income === 'number' ? formatAmount(intake.income, intake.currency) : (typeof meta.income === 'number' ? formatAmount(meta.income, intake.currency) : null);
-  const hasDocs = intake.has_documents === true || meta.has_documents === true ? 'Yes' : 'No';
-  const effectiveTriageStatus = localTriageStatus ?? intake.triage_status;
-  const isPendingReview = effectiveTriageStatus === 'pending_review' || !effectiveTriageStatus;
+  const feeAmount = formatAmountCents(intake.amount, intake.currency);
+  const householdSize = typeof intake.household_size === 'number'
+    ? intake.household_size
+    : (typeof meta.household_size === 'number' ? meta.household_size : null);
+  const income = typeof intake.income === 'number'
+    ? formatAmountCents(intake.income, intake.currency)
+    : (typeof meta.income === 'number' ? formatAmountCents(meta.income, intake.currency) : null);
+  const hasDocs = intake.has_documents === true || meta.has_documents === true;
+  const courtDate = intake.court_date ? (formatLongDate(intake.court_date) ?? intake.court_date) : null;
+  const urgencyLbl = urgencyLabel(intake.urgency);
+  const desiredOutcome = intake.desired_outcome ?? null;
+
+  const effectiveTriageStatus = localTriageStatus ?? intake.triage_status ?? 'pending_review';
+  const isPending = effectiveTriageStatus === 'pending_review' || !effectiveTriageStatus;
   const intakeTitle = resolveIntakeTitle(
     {
       ...meta,
       title: conversationMetadata?.title ?? meta.title,
       intake_title: conversationMetadata?.intake_title ?? meta.intake_title,
     },
-    name ? `${name} intake` : 'Untitled intake'
+    name ? `${name} intake` : 'Untitled intake',
   );
-  const locationLabel = [city, state].filter(Boolean).join(', ') || null;
-  const paymentLabel = feeAmount ? `${feeAmount} ${intake.stripe_charge_id ? 'paid' : 'consultation'}` : null;
   const canReplyInIntake = Boolean(intake.conversation_id && effectiveTriageStatus === 'accepted');
-  const templateName = activeTemplate?.name
-    ?? (() => {
-      // Fall back to the stored name from custom_fields if template not found in practice data
-      const cf = (meta.custom_fields ?? meta.customFields) as Record<string, unknown> | undefined;
-      const storedName = cf?._intake_template_name;
-      return typeof storedName === 'string' && storedName.trim() ? storedName.trim() : null;
-    })();
-
-  // Enrichment fields from the matched template (or fallback to defaults)
   const enrichmentFields: IntakeFieldDefinition[] = (
     activeTemplate?.fields ?? DEFAULT_INTAKE_TEMPLATE.fields
   ).filter((f) => f.phase === 'enrichment');
-
-  // Cast intakeConversationState to a plain record for resolveFieldValue
   const intakeStateRecord = intakeConversationState as unknown as Record<string, unknown> | null;
+  const unansweredEnrichment = enrichmentFields.filter((f) => !resolveFieldValue(f, intakeStateRecord, intake));
+  const showGatherDetails = unansweredEnrichment.length > 0 && Boolean(intake.conversation_id);
 
-  // hasMissingLegalDetails: true if any enrichment field is unanswered
-  const unansweredEnrichmentFields = enrichmentFields.filter(
-    (f) => !resolveFieldValue(f, intakeStateRecord, intake),
+  const customFields = (() => {
+    const cf = (meta.customFields ?? meta.custom_fields) as Record<string, unknown> | undefined;
+    if (!cf || typeof cf !== 'object') return [] as Array<{ key: string; value: string }>;
+    return Object.entries(cf)
+      .filter(([key]) => !key.startsWith('_'))
+      .map(([key, value]) => ({
+        key,
+        value: value === null || value === undefined ? '' : (typeof value === 'boolean' ? (value ? 'Yes' : 'No') : String(value)),
+      }))
+      .filter((entry) => entry.value.trim().length > 0);
+  })();
+
+  const statusBadge = (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium ring-1 ring-inset',
+        triageBadgeClass(effectiveTriageStatus),
+      )}
+    >
+      {triageLabel(effectiveTriageStatus)}
+    </span>
   );
-  const hasMissingLegalDetails = unansweredEnrichmentFields.length > 0 && Boolean(intake.conversation_id);
 
-  const statusChipClass = (status: string) => {
-    if (status === 'accepted') return 'bg-emerald-500/10 text-emerald-500 ring-emerald-500/20';
-    if (status === 'declined' || status === 'rejected') return 'bg-rose-500/10 text-rose-500 ring-rose-500/20';
-    if (status === 'spam') return 'bg-gray-500/10 text-input-placeholder ring-gray-500/20';
-    return 'bg-accent/10 text-accent ring-accent/20';
-  };
-
-  const conversationSection = intake.conversation_id ? (
-    <section className="glass-card flex min-h-[620px] flex-col overflow-hidden">
-      <header className="shrink-0 border-b border-line-glass/10 p-5">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
-          Conversation
-        </h2>
-        <p className="mt-2 text-sm text-input-placeholder">
-          Continue the client thread from this intake.
+  const intakeDetailsCard = (
+    <Card>
+      <div className="space-y-2">
+        <SectionLabel>Intake Details</SectionLabel>
+        <h3 className="text-lg font-bold leading-tight text-input-text sm:text-xl">{intakeTitle}</h3>
+        <p className="text-xs text-input-placeholder">
+          Posted {dateLabel}{practiceServiceName ? ` · ${practiceServiceName}` : ''}
         </p>
-      </header>
+      </div>
+      {description ? (
+        <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-input-text/90">{description}</p>
+      ) : null}
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <InfoChip
+          icon={CheckCircle2}
+          label={triageLabel(effectiveTriageStatus)}
+          tone={effectiveTriageStatus === 'accepted' ? 'success' : effectiveTriageStatus === 'declined' || effectiveTriageStatus === 'rejected' ? 'error' : 'warning'}
+        />
+        {feeAmount ? <InfoChip icon={CreditCard} label={`${feeAmount}${intake.stripe_charge_id ? ' paid' : ' consultation'}`} /> : null}
+        {courtDate ? <InfoChip icon={Clock} label={courtDate} /> : null}
+        {caseStrength ? <InfoChip icon={Scale} label={`Case strength ${caseStrength}`} /> : null}
+        <InfoChip icon={ClipboardList} label={hasDocs ? 'Documents shared' : 'No documents'} />
+        {urgencyLbl ? (
+          <InfoChip
+            icon={AlertTriangle}
+            label={urgencyLbl}
+            tone={intake.urgency === 'emergency' ? 'error' : intake.urgency === 'time_sensitive' ? 'warning' : 'default'}
+          />
+        ) : null}
+      </div>
+    </Card>
+  );
+
+  const formDetailsCard = (
+    <Card>
+      <div className="mb-4 flex items-center gap-2">
+        <Icon icon={ClipboardList} className="h-4 w-4 text-input-placeholder" />
+        <h3 className="text-sm font-semibold text-input-text">Form Details</h3>
+      </div>
+      <dl className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
+        <DetailField label="Case Type" value={intakeTitle} />
+        <DetailField label="Urgency" value={urgencyLbl} />
+        <DetailField label="Court Date" value={courtDate} />
+        <DetailField label="Has Documents" value={hasDocs ? 'Yes' : 'No'} />
+        <DetailField label="Desired Outcome" value={desiredOutcome} />
+        <DetailField label="Opposing Party" value={opposingParty} />
+        <DetailField label="On Behalf Of" value={onBehalfOf} />
+        <DetailField label="Income" value={income} />
+        <DetailField label="Household Size" value={householdSize === null ? null : String(householdSize)} />
+        {customFields.map((cf) => (
+          <DetailField key={cf.key} label={cf.key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())} value={cf.value} />
+        ))}
+      </dl>
+    </Card>
+  );
+
+  const blawbyCard = showGatherDetails ? (
+    <Card>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-lg bg-accent/10 p-2 text-accent">
+            <Icon icon={Sparkles} className="h-4 w-4" />
+          </div>
+          <p className="text-sm leading-relaxed text-input-text/90">
+            Blawby can ask the client for the missing legal details and add them to this thread.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          onClick={() => void startGatherDetailsFlow()}
+          disabled={gatherDetailsSubmitting}
+          className="shrink-0"
+        >
+          {gatherDetailsSubmitting ? 'Starting…' : 'Use Blawby to gather details'}
+        </Button>
+      </div>
+    </Card>
+  ) : null;
+
+  const conversationCard = intake.conversation_id ? (
+    <Card className="flex min-h-[420px] flex-col p-0 overflow-hidden">
+      <div className="border-b border-card-border p-4 sm:px-6 sm:py-5">
+        <SectionLabel>Conversation</SectionLabel>
+        <p className="mt-1 text-xs text-input-placeholder">Continue the client thread from this intake.</p>
+      </div>
       <div className="min-h-0 flex-1 overflow-hidden bg-surface-overlay/20 touch-pan-y">
         {previewLoading && previewMessages.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center p-6 text-center">
-            <div className="w-full space-y-3 px-4 py-4">
-              <MessageRowSkeleton lineWidths={['w-40', 'w-56']} />
-              <MessageRowSkeleton lineWidths={['w-64', 'w-44', 'w-52']} />
-              <MessageRowSkeleton lineWidths={['w-36', 'w-48']} />
-            </div>
+          <div className="space-y-3 px-4 py-4">
+            <MessageRowSkeleton lineWidths={['w-40', 'w-56']} />
+            <MessageRowSkeleton lineWidths={['w-64', 'w-44', 'w-52']} />
+            <MessageRowSkeleton lineWidths={['w-36', 'w-48']} />
           </div>
         ) : previewMessages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center p-6 text-center">
-            <p className="text-sm text-input-placeholder">No conversation history found for this intake.</p>
+            <Icon icon={MessageSquare} className="mb-2 h-6 w-6 text-input-placeholder" />
+            <p className="text-sm text-input-placeholder">No conversation history yet.</p>
           </div>
         ) : (
           <VirtualMessageList
@@ -779,12 +866,14 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
               practiceId: intake.organization_id,
             }}
             practiceId={intake.organization_id}
+            hasMoreMessages={hasMorePreview}
+            isLoadingMoreMessages={isLoadingMorePreview}
+            onLoadMoreMessages={loadOlderMessages}
           />
         )}
       </div>
-
       {canReplyInIntake ? (
-        <div className="shrink-0 border-t border-line-glass/10 px-4 py-5">
+        <div className="border-t border-card-border px-4 py-4">
           <MessageComposer
             inputValue={composerValue}
             setInputValue={setComposerValue}
@@ -815,236 +904,140 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           />
         </div>
       ) : null}
-    </section>
+    </Card>
   ) : null;
 
-  const intakeSidebar = (
-    <aside className="min-w-0 space-y-6 xl:sticky xl:top-6 xl:self-start">
-      {isPendingReview && (
-        <section className="glass-card p-5 sm:p-6">
-          <div className="space-y-3">
-            <Button
-              id="intake-accept-btn"
-              variant="primary"
-              className="w-full"
-              disabled={isSubmitting}
-              onClick={() => openTriageDialog('accepted')}
-            >
-              {isSubmitting ? (
-                <span className="inline-flex items-center">
-                  <LoadingSpinner size="sm" className="mr-2" ariaLabel="Accepting consultation" />
-                  Accepting...
-                </span>
-              ) : 'Approve consultation'}
-            </Button>
-            <Button
-              id="intake-reject-btn"
-              variant="secondary"
-              className="w-full"
-              disabled={isSubmitting}
-              onClick={() => openTriageDialog('declined')}
-            >
-              Reject
-            </Button>
+  const contactCard = (email || phone) ? (
+    <Card>
+      <SectionLabel className="mb-3">Contact Information</SectionLabel>
+      <dl className="space-y-3 text-sm">
+        {email ? (
+          <div className="flex items-start gap-3">
+            <Icon icon={Mail} className="mt-0.5 h-4 w-4 shrink-0 text-input-placeholder" />
+            <div className="min-w-0 flex-1">
+              <dt className="text-xs text-input-placeholder">Email</dt>
+              <dd className="truncate">
+                <a href={`mailto:${email}`} className="text-input-text hover:text-accent">{email}</a>
+              </dd>
+            </div>
           </div>
-        </section>
-      )}
+        ) : null}
+        {phone ? (
+          <div className="flex items-start gap-3">
+            <Icon icon={Phone} className="mt-0.5 h-4 w-4 shrink-0 text-input-placeholder" />
+            <div className="min-w-0 flex-1">
+              <dt className="text-xs text-input-placeholder">Phone</dt>
+              <dd>
+                <a href={`tel:${phone}`} className="text-input-text hover:text-accent">{phone}</a>
+              </dd>
+            </div>
+          </div>
+        ) : null}
+      </dl>
+    </Card>
+  ) : null;
 
-      <section className="glass-card space-y-6 p-5 sm:p-6">
-        <div>
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-input-placeholder">About</h3>
-          <div className="space-y-4">
-            {intake.payment_verified && (
-              <div className="flex items-center gap-2 text-xs font-bold text-emerald-600 dark:text-emerald-400">
-                <Icon icon={CheckCircle2} className="h-4 w-4" />
-                Payment method verified
-              </div>
-            )}
-            <UserCard
-              name={name == null ? '' : name}
-              secondary={null}
-              className="px-0 py-0"
-              size="md"
-            />
-          </div>
+  const triageActions = (
+    <>
+      <Button
+        variant="primary"
+        className="btn-primary btn-md w-full !bg-accent-success !text-white hover:!bg-accent-success/90"
+        disabled={isSubmitting}
+        onClick={() => openTriageDialog('accepted')}
+      >
+        {isSubmitting ? (
+          <span className="inline-flex items-center">
+            <LoadingSpinner size="sm" className="mr-2" ariaLabel="Accepting consultation" />
+            Accepting…
+          </span>
+        ) : 'Approve consultation'}
+      </Button>
+      <Button
+        variant="primary"
+        className="btn-primary btn-md w-full !bg-accent-error !text-white hover:!bg-accent-error/90"
+        disabled={isSubmitting}
+        onClick={() => openTriageDialog('declined')}
+      >
+        Reject
+      </Button>
+    </>
+  );
+
+  const aboutCard = (
+    <Card className="p-4">
+      <div className="flex items-center gap-3">
+        <Avatar
+          name={name ?? ''}
+          size="md"
+          className="bg-surface-utility/40 text-input-text ring-1 ring-line-glass/20"
+        />
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-input-text">{name ?? 'Unnamed lead'}</p>
+          {intake.payment_verified ? (
+            <p className="mt-0.5 inline-flex items-center gap-1 text-xs text-success">
+              <Icon icon={CheckCircle2} className="h-3 w-3" />
+              Payment verified
+            </p>
+          ) : null}
         </div>
-
-        {(email || phone || locationLabel) && (
-          <div>
-            <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-input-placeholder">Contact Information</h3>
-            <dl className="space-y-3 text-sm">
-              {email && (
-                <div className="flex flex-col">
-                  <dt className="mb-0.5 text-xs text-input-placeholder">Email</dt>
-                  <dd className="truncate font-medium text-input-text">{email}</dd>
-                </div>
-              )}
-              {phone && (
-                <div className="flex flex-col">
-                  <dt className="mb-0.5 text-xs text-input-placeholder">Phone</dt>
-                  <dd className="font-medium text-input-text">{phone}</dd>
-                </div>
-              )}
-              {locationLabel && (
-                <div className="flex flex-col">
-                  <dt className="mb-0.5 text-xs text-input-placeholder">Location</dt>
-                  <dd className="truncate font-medium capitalize text-input-text">{locationLabel}</dd>
-                </div>
-              )}
-            </dl>
-          </div>
-        )}
-      </section>
-    </aside>
+      </div>
+      {(email || phone) ? (
+        <dl className="mt-4 space-y-2 text-sm">
+          {email ? (
+            <div>
+              <dt className="text-xs text-input-placeholder">Email</dt>
+              <dd className="truncate">
+                <a href={`mailto:${email}`} className="text-input-text hover:text-accent">{email}</a>
+              </dd>
+            </div>
+          ) : null}
+          {phone ? (
+            <div>
+              <dt className="text-xs text-input-placeholder">Phone</dt>
+              <dd>
+                <a href={`tel:${phone}`} className="text-input-text hover:text-accent">{phone}</a>
+              </dd>
+            </div>
+          ) : null}
+        </dl>
+      ) : null}
+    </Card>
   );
 
   return (
-    <EditorShell
-      title={intake.client_name ?? name ?? 'Intake Details'}
-      subtitle={intake.practice_area ?? practiceServiceName ?? undefined}
-      showBack
-      onBack={onBack}
-      actions={
-        <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ring-1 ring-inset ${statusChipClass(effectiveTriageStatus || 'pending_review')}`}>
-            {triageLabel(effectiveTriageStatus || 'pending_review')}
-        </span>
-      }
-      contentMaxWidth={null}
-      contentClassName="px-4 py-6 sm:px-6 lg:px-8"
-    >
-      <div className="mx-auto grid w-full max-w-7xl grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <div className="min-w-0 space-y-6">
-          {/* Main header card */}
-          <section className="glass-card overflow-hidden p-6 sm:p-10">
-          <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
-            <header className="min-w-0">
-              <h2 className="mb-2 text-xs font-semibold uppercase tracking-widest text-input-placeholder">
-                Intake details
-              </h2>
-              <h1 className="break-words text-2xl font-bold leading-tight text-input-text sm:text-4xl">
-                {intakeTitle}
-              </h1>
-              <p className="mt-3 text-sm text-input-placeholder">
-                Posted {dateLabel}{practiceServiceName ? ` · ${practiceServiceName}` : ''}
-              </p>
+    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+      <DetailHeader
+        title={name ?? intakeTitle}
+        showBack
+        onBack={onBack}
+        actions={statusBadge}
+      />
 
-              {description ? (
-                <div className="mt-8">
-                  <p className={`whitespace-pre-wrap text-base leading-relaxed text-input-text ${descriptionExpanded ? '' : 'line-clamp-6'}`}>
-                    {description}
-                  </p>
-                  {description.length > 350 ? (
-                    <Button
-                      variant="link"
-                      size="sm"
-                      type="button"
-                      onClick={() => setDescriptionExpanded(!descriptionExpanded)}
-                      className="mt-3 px-0"
-                    >
-                      {descriptionExpanded ? 'Show less' : 'Read more'}
-                    </Button>
-                  ) : null}
-                </div>
-              ) : (
-                <p className="mt-8 text-sm text-input-placeholder">No description yet.</p>
-              )}
-            </header>
-
-            <aside className="lg:border-l lg:border-line-glass/10 lg:pl-6">
-              <dl className="divide-y divide-line-glass/10 text-sm">
-                <SummaryRow label="Status" value={triageLabel(effectiveTriageStatus)} icon={CheckCircle2} />
-                <SummaryRow label="Consultation" value={paymentLabel} icon={CreditCard} />
-                <SummaryRow label="Location" value={locationLabel} icon={MapPin} />
-                <SummaryRow label="Urgency" value={intake.urgency ? urgencyLabel(intake.urgency) : null} icon={AlertTriangle} />
-                <SummaryRow label="Court date" value={intake.court_date ? (formatLongDate(intake.court_date) ?? intake.court_date) : null} icon={Clock} />
-                <SummaryRow label="Documents" value={hasDocs} icon={ClipboardCheck} />
-                <SummaryRow label="AI case strength" value={caseStrength} icon={Scale} />
-                <SummaryRow label="Household income" value={income} icon={CreditCard} />
-                <SummaryRow label="Household size" value={householdSize} icon={User} />
-              </dl>
-            </aside>
-          </div>
-        </section>
-
-        <section className="glass-card p-6 sm:p-8">
-          <div className="mb-6 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
-                Form details
-              </h2>
-              {templateName ? (
-                <span className="inline-flex items-center rounded-full bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent ring-1 ring-inset ring-accent/20">
-                  {templateName}
-                </span>
-              ) : null}
-            </div>
-
-            {activeTemplate && (practiceDetails as { slug?: string })?.slug ? (
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                onClick={() => {
-                  const slug = (practiceDetails as { slug?: string }).slug;
-                  if (typeof slug === 'string' && slug && activeTemplate?.slug) {
-                    route(`/practice/${encodeURIComponent(slug)}/intakes/${encodeURIComponent(activeTemplate.slug)}/edit`);
-                  }
-                }}
-                className="h-auto p-0 text-xs text-accent hover:text-accent-hover"
-              >
-                View form setup
-              </Button>
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_280px]">
+          {/* Main content */}
+          <div className="flex flex-col gap-4 p-4 sm:p-6">
+            {/* Mobile-only triage actions at top */}
+            {isPending ? (
+              <div className="flex flex-col gap-3 xl:hidden">
+                {triageActions}
+              </div>
             ) : null}
+
+            {intakeDetailsCard}
+            {formDetailsCard}
+            {/* Mobile-only contact info */}
+            <div className="xl:hidden">{contactCard}</div>
+            {blawbyCard}
+            {conversationCard}
           </div>
-          {activeTemplate && (practiceDetails as { slug?: string })?.slug && (
-            <div className="mt-4">
-              <EmbedCodeBlock
-                practiceSlug={((practiceDetails as { slug?: string }).slug || '') as string}
-                templateSlug={activeTemplate.slug}
-              />
-            </div>
-          )}
-          {enrichmentFields.length > 0 ? (
-            <dl className="grid grid-cols-1 gap-5 md:grid-cols-3">
-              {enrichmentFields.map((field) => (
-                <StatCell
-                  key={field.key}
-                  label={field.label}
-                  value={resolveFieldValue(field, intakeStateRecord, intake)}
-                  icon={ClipboardCheck}
-                />
-              ))}
-            </dl>
-          ) : (
-            <dl className="grid grid-cols-1 gap-5 md:grid-cols-3">
-              <StatCell label="On behalf of" value={onBehalfOf} icon={User} />
-              <StatCell label="Opposing party" value={opposingParty} icon={Scale} />
-              <StatCell label="Desired outcome" value={intake.desired_outcome} icon={CheckCircle2} />
-            </dl>
-          )}
-          {hasMissingLegalDetails ? (
-            <div className="mt-6 flex flex-col gap-3 border-t border-line-glass/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm leading-relaxed text-input-placeholder">
-                Blawby can ask the client for the missing legal details and add them to this thread.
-              </p>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => void startGatherDetailsFlow()}
-                disabled={gatherDetailsSubmitting}
-                className="shrink-0"
-              >
-                {gatherDetailsSubmitting ? 'Starting...' : 'Ask Blawby to gather details'}
-              </Button>
-            </div>
-          ) : null}
-        </section>
 
-          {conversationSection}
+          {/* Desktop right panel */}
+          <aside className="hidden xl:flex flex-col gap-4 border-l border-card-border bg-surface-panel p-6">
+            {isPending ? <div className="flex flex-col gap-3">{triageActions}</div> : null}
+            {aboutCard}
+          </aside>
         </div>
-
-        {intakeSidebar}
       </div>
 
       <Dialog
@@ -1053,8 +1046,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         title={triageDialogAction === 'accepted' ? 'Approve consultation' : 'Reject consultation'}
         description={
           triageDialogAction === 'accepted'
-            ? "This will approve the lead and prepare for onboarding."
-            : "This will mark the intake as rejected."
+            ? 'This will approve the lead and prepare for onboarding.'
+            : 'This will mark the intake as rejected.'
         }
         disableBackdropClick={isSubmitting}
       >
@@ -1072,17 +1065,23 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             Cancel
           </Button>
           <Button
-            variant={triageDialogAction === 'accepted' ? 'primary' : 'danger'}
+            variant="primary"
             disabled={isSubmitting}
+            className={cn(
+              'btn-primary btn-md !text-white',
+              triageDialogAction === 'accepted'
+                ? '!bg-accent-success hover:!bg-accent-success/90'
+                : '!bg-accent-error hover:!bg-accent-error/90',
+            )}
             onClick={() => {
               if (triageDialogAction) void runTriage(triageDialogAction, triageReason);
             }}
           >
-            {isSubmitting ? 'Updating...' : (triageDialogAction === 'accepted' ? 'Confirm approval' : 'Confirm')}
+            {isSubmitting ? 'Updating…' : (triageDialogAction === 'accepted' ? 'Confirm approval' : 'Confirm rejection')}
           </Button>
         </DialogFooter>
       </Dialog>
-    </EditorShell>
+    </div>
   );
 };
 

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -131,7 +131,7 @@ function formatAmountCents(cents: number | null | undefined, currency = 'USD'): 
   try {
     return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(cents / 100);
   } catch {
-    return `$${(cents / 100).toFixed(2)}`;
+    return `${currency}${(cents / 100).toFixed(2)}`;
   }
 }
 
@@ -332,6 +332,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   });
 
   const isMountedRef = useRef(true);
+  const isLoadingMorePreviewRef = useRef(false);
   useEffect(() => {
     isMountedRef.current = true;
     return () => { isMountedRef.current = false; };
@@ -379,8 +380,9 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     const conversationId = intake?.conversation_id;
     const targetPracticeId = intake?.organization_id;
     if (!conversationId || !targetPracticeId) return;
-    if (!previewCursor || !hasMorePreview || isLoadingMorePreview) return;
+    if (!previewCursor || !hasMorePreview || isLoadingMorePreviewRef.current) return;
 
+    isLoadingMorePreviewRef.current = true;
     setIsLoadingMorePreview(true);
     try {
       const page = await fetchConversationMessages(conversationId, targetPracticeId, {
@@ -400,9 +402,12 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     } catch (err) {
       console.warn('[IntakeDetailPage] Failed to load older messages', err);
     } finally {
-      if (isMountedRef.current) setIsLoadingMorePreview(false);
+      if (isMountedRef.current) {
+        isLoadingMorePreviewRef.current = false;
+        setIsLoadingMorePreview(false);
+      }
     }
-  }, [intake?.conversation_id, intake?.organization_id, previewCursor, hasMorePreview, isLoadingMorePreview, mapMessage]);
+  }, [intake?.conversation_id, intake?.organization_id, previewCursor, hasMorePreview, mapMessage]);
 
   const [composerValue, setComposerValue] = useState('');
   const [composerSubmitting, setComposerSubmitting] = useState(false);

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -869,6 +869,10 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             hasMoreMessages={hasMorePreview}
             isLoadingMoreMessages={isLoadingMorePreview}
             onLoadMoreMessages={loadOlderMessages}
+            compactLayout={false}
+            bottomInsetPx={0}
+            hideMessageActions={false}
+            showSkeleton={false}
           />
         )}
       </div>
@@ -941,7 +945,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     <>
       <Button
         variant="primary"
-        className="btn-primary btn-md w-full !bg-accent-success !text-white hover:!bg-accent-success/90"
+        className="btn-primary btn-md w-full !bg-accent-500 text-[rgb(var(--accent-foreground))]"
         disabled={isSubmitting}
         onClick={() => openTriageDialog('accepted')}
       >
@@ -950,11 +954,11 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
             <LoadingSpinner size="sm" className="mr-2" ariaLabel="Accepting consultation" />
             Accepting…
           </span>
-        ) : 'Approve consultation'}
+        ) : 'Accept'}
       </Button>
       <Button
-        variant="primary"
-        className="btn-primary btn-md w-full !bg-accent-error !text-white hover:!bg-accent-error/90"
+        variant="secondary"
+        className="btn-secondary btn-md w-full"
         disabled={isSubmitting}
         onClick={() => openTriageDialog('declined')}
       >
@@ -1043,7 +1047,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
       <Dialog
         isOpen={triageDialogAction !== null}
         onClose={closeTriageDialog}
-        title={triageDialogAction === 'accepted' ? 'Approve consultation' : 'Reject consultation'}
+        title={triageDialogAction === 'accepted' ? 'Accept' : 'Reject'}
         description={
           triageDialogAction === 'accepted'
             ? 'This will approve the lead and prepare for onboarding.'
@@ -1067,12 +1071,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           <Button
             variant="primary"
             disabled={isSubmitting}
-            className={cn(
-              'btn-primary btn-md !text-white',
-              triageDialogAction === 'accepted'
-                ? '!bg-accent-success hover:!bg-accent-success/90'
-                : '!bg-accent-error hover:!bg-accent-error/90',
-            )}
+            className="btn-primary btn-md"
             onClick={() => {
               if (triageDialogAction) void runTriage(triageDialogAction, triageReason);
             }}

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -126,6 +126,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
 
   const fetchPage = useCallback(async (targetPage: number, signal: AbortSignal): Promise<void> => {
     if (!practiceId) return;
+    const localSeq = ++requestSeqRef.current;
     const triageFilter = mobileFilter !== 'all' ? mobileFilter : undefined;
     try {
       const result = await listIntakes(
@@ -133,13 +134,13 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
         { page: targetPage, limit: PAGE_SIZE, triage_status: triageFilter },
         { signal },
       );
-      if (signal.aborted) return;
+      if (signal.aborted || requestSeqRef.current !== localSeq) return;
       setItems((prev) => (targetPage === 1 ? result.intakes : [...prev, ...result.intakes]));
       setPage(targetPage);
       setHasMore(targetPage < result.total_pages);
       setError(null);
     } catch (err) {
-      if (signal.aborted) return;
+      if (signal.aborted || requestSeqRef.current !== localSeq) return;
       setError(err instanceof Error ? err.message : 'Failed to load intakes');
     }
   }, [practiceId, mobileFilter]);
@@ -256,9 +257,11 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
     };
   });
 
-  const showEmpty = !isLoading && !error && filteredItems.length === 0;
+  const showEmpty = !isLoading && !error && filteredItems.length === 0 && !hasMore;
   const emptyMessage = searchQuery
-    ? `No responses match “${searchQuery}”.`
+    ? hasMore
+      ? `No matches in loaded items. Load more to search additional pages.`
+      : `No responses match “${searchQuery}”.`
     : mobileFilter === 'pending_review'
       ? "You've caught up on all pending reviews! New consultation inquiries will appear here."
       : mobileFilter === 'accepted'

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -1,39 +1,67 @@
-import { FunctionComponent } from 'preact';
-import { useCallback, useEffect, useState, useRef } from 'preact/hooks';
+import { FunctionComponent, type ComponentChildren } from 'preact';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
-import { Inbox } from 'lucide-preact';
+import { Inbox, Search } from 'lucide-preact';
 
+import { Input } from '@/shared/ui/input';
+import { Tabs, type TabItem } from '@/shared/ui/tabs/Tabs';
+import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
+import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import { InfiniteScroll } from '@/shared/ui/layout/InfiniteScroll';
 import type { IconComponent } from '@/shared/ui/Icon';
+import { cn } from '@/shared/utils/cn';
+import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
+import { listIntakes, type IntakeListItem } from '../api/intakesApi';
+import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
+import IntakeDetailPage from './IntakeDetailPage';
 
 const InboxIcon: IconComponent = (props) => (
-  // Heroicons types are incompatible with our IconComponent; forced cast is required
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   <Inbox {...(props as any)} />
 );
-import { Panel } from '@/shared/ui/layout/Panel';
-import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
-import { Avatar } from '@/shared/ui/profile';
-import { cn } from '@/shared/utils/cn';
-import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
-import { EntityList } from '@/shared/ui/list/EntityList';
-import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
-import { listIntakes, type IntakeListItem } from '../api/intakesApi';
-import IntakeDetailPage from './IntakeDetailPage';
-import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
-import { DEFAULT_INTAKE_TEMPLATE } from '@/shared/constants/intakeTemplates';
-import { SELECTED_ACCENT_SURFACE_CLASS } from '@/shared/ui/layout/selectionStyles';
 
 const PAGE_SIZE = 20;
-// Limit additional backend pages fetched in client-side template filtering to avoid unbounded sequential fetches
-const MAX_ADDITIONAL_PAGES = 10;
-const normalizeTriageStatus = (value: unknown): string => (
-  typeof value === 'string' ? value.trim().toLowerCase() : ''
-);
 
-// Internal type that satisfies usePaginatedList's { id: string } constraint
-interface PaginatedIntake extends IntakeListItem {
-  id: string;
-}
+type TriageFilter = 'all' | 'pending_review' | 'accepted' | 'declined';
+
+const TRIAGE_FILTERS: ReadonlyArray<{ id: TriageFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'pending_review', label: 'Pending' },
+  { id: 'accepted', label: 'Accepted' },
+  { id: 'declined', label: 'Declined' },
+];
+
+const normalizeFilter = (value: string | null | undefined): TriageFilter => {
+  if (value === 'pending_review' || value === 'accepted' || value === 'declined') return value;
+  return 'all';
+};
+
+const triageStatusVariant = (status: string | null | undefined): {
+  label: string;
+  className: string;
+} => {
+  switch (status) {
+    case 'accepted':
+      return { label: 'Accepted', className: 'text-success' };
+    case 'declined':
+    case 'rejected':
+      return { label: status === 'rejected' ? 'Rejected' : 'Declined', className: 'text-error' };
+    case 'spam':
+      return { label: 'Spam', className: 'text-input-placeholder' };
+    case 'pending_review':
+    default:
+      return { label: 'Pending Review', className: 'text-warning' };
+  }
+};
+
+const matchesSearch = (item: IntakeListItem, query: string): boolean => {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  const name = (item.metadata?.name || '').toLowerCase();
+  const email = (item.metadata?.email || '').toLowerCase();
+  const subject = resolveIntakeTitle(item.metadata, '').toLowerCase();
+  return name.includes(q) || email.includes(q) || subject.includes(q);
+};
 
 type IntakesPageProps = {
   practiceId: string | null;
@@ -41,56 +69,7 @@ type IntakesPageProps = {
   conversationsBasePath?: string | null;
   practiceName: string;
   practiceLogo: string | null;
-  renderMode?: 'full' | 'listOnly' | 'detailOnly';
   activeTriageFilter?: string | null;
-  prefetchedItems?: IntakeListItem[];
-  prefetchedLoading?: boolean;
-  prefetchedError?: string | null;
-  onRefetchList?: (signal?: AbortSignal) => Promise<void>;
-};
-
-const IntakeListItemRow = ({
-  intake,
-  isSelected,
-}: {
-  intake: PaginatedIntake;
-  isSelected: boolean;
-}) => {
-  const name = intake.metadata?.name || 'Anonymous Lead';
-  const title = resolveIntakeTitle(intake.metadata, name);
-  const email = intake.metadata?.email || 'No email';
-  const timeLabel = formatRelativeTime(intake.created_at);
-  const status = intake.triage_status?.replace(/_/g, ' ') || 'pending';
-
-  return (
-    <div className={cn(
-      'w-full px-4 py-3.5 text-left flex items-center gap-3 transition-colors duration-150',
-      isSelected ? SELECTED_ACCENT_SURFACE_CLASS : 'hover:bg-surface-utility/40'
-    )}>
-      <Avatar
-        name={name}
-        size="sm"
-        className="bg-surface-utility/40 text-input-text ring-1 ring-line-glass/20"
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <h2 className="min-w-0 truncate text-sm font-semibold leading-6 text-input-text">
-              {title}
-            </h2>
-            <div className="mt-1 flex items-center gap-2 text-xs text-input-placeholder">
-              <span className="truncate">{email}</span>
-              <span>•</span>
-              <span className="capitalize">{status}</span>
-            </div>
-          </div>
-          <div className="flex flex-col items-end gap-1">
-            <span className="text-xs text-input-placeholder">{timeLabel}</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
 };
 
 export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
@@ -99,17 +78,10 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
   conversationsBasePath,
   practiceName,
   practiceLogo,
-  renderMode = 'full',
   activeTriageFilter = 'all',
-  prefetchedItems = [],
-  prefetchedLoading = false,
-  prefetchedError = null,
-  onRefetchList,
 }) => {
   const location = useLocation();
-  const [refreshCounter, setRefreshCounter] = useState(0);
 
-  // ── Routing ──────────────────────────────────────────────────────────────
   const pathSuffix = location.path.startsWith(basePath) ? location.path.slice(basePath.length) : '';
   const pathSegments = pathSuffix.replace(/^\/+/, '').split('/').filter(Boolean);
   const isResponsesRoute = pathSegments[0] === 'responses';
@@ -117,186 +89,115 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
     if (typeof value !== 'string') return null;
     try { return decodeURIComponent(value); } catch { return value; }
   };
+  const selectedIntakeId = isResponsesRoute && pathSegments[1] ? safeDecode(pathSegments[1]) : null;
 
-  const selectedIntakeId = isResponsesRoute && pathSegments[1]
-    ? safeDecode(pathSegments[1])
-    : null;
-  const templateFilter = typeof location.query?.template === 'string' && location.query.template.trim()
-    ? safeDecode(location.query.template)
-    : null;
-
-  // Template editing has moved to /settings/intake-forms. Map any legacy
-  // /intakes/* URL to its equivalent under the new settings path so deep links
-  // (bookmarks, old emails) keep working instead of silently flattening to
-  // responses. /intakes itself goes to the responses list (the rail target).
+  // Redirect any non-responses sub-route to /responses (greenfield: legacy
+  // /intakes/:slug paths now belong to /settings/intake-forms).
   useEffect(() => {
     if (isResponsesRoute) return;
-    const settingsBase = basePath.replace(/\/intakes$/, '/settings/intake-forms');
-    const first = pathSegments[0];
-    let target: string;
-    if (!first) {
-      target = `${basePath}/responses`;
-    } else if (first === 'new') {
-      target = `${settingsBase}/new`;
-    } else {
-      const slug = safeDecode(first);
-      const isEdit = pathSegments[1] === 'edit';
-      target = slug
-        ? `${settingsBase}/${encodeURIComponent(slug)}${isEdit ? '/edit' : ''}`
-        : `${basePath}/responses`;
-    }
-    location.route(target, true);
-    // safeDecode is defined inside this component but stable for the lifetime
-    // of a render — including pathSegments captures the exact URL we're
-    // redirecting from.
+    location.route(`${basePath}/responses`, true);
+    // pathSegments[0] captures the segment we redirect from.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [basePath, isResponsesRoute, pathSegments[0], pathSegments[1]]);
+  }, [basePath, isResponsesRoute, pathSegments[0]]);
 
-  const paginationSessionIdRef = useRef(0);
-  // Recompute a numeric session id when routing/filter inputs change so
-  // downstream hooks can reset their state. Use state so updates trigger
-  // a re-render (refs alone would not).
-  const [paginationSessionId, setPaginationSessionId] = useState(() => {
-    paginationSessionIdRef.current = 0;
-    return paginationSessionIdRef.current;
-  });
+  const desktopFilter: TriageFilter = normalizeFilter(activeTriageFilter ?? 'all');
+  const [mobileFilter, setMobileFilter] = useState<TriageFilter>(desktopFilter);
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Keep mobile tab in sync when desktop sidebar updates the activeTriageFilter prop.
   useEffect(() => {
-    paginationSessionIdRef.current++;
-    setPaginationSessionId(paginationSessionIdRef.current);
-  }, [practiceId, isResponsesRoute, activeTriageFilter, templateFilter, refreshCounter]);
+    setMobileFilter(desktopFilter);
+  }, [desktopFilter]);
 
-  const accumulatedFilteredRef = useRef<PaginatedIntake[]>([]);
-  const lastBackendPageRef = useRef(0);
-  const totalBackendPagesRef = useRef(1);
+  // Debounce search input → committed query.
+  useEffect(() => {
+    const timer = setTimeout(() => setSearchQuery(searchInput.trim()), 200);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
-  const fetchIntakePage = useCallback(async (page: number, signal: AbortSignal) => {
-    const currentSessionId = paginationSessionId;
-    if (!practiceId || !isResponsesRoute) return { items: [], hasMore: false };
+  const [items, setItems] = useState<IntakeListItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestSeqRef = useRef(0);
 
-    const validTriageFilters = ['pending_review', 'accepted', 'declined'] as const;
-    type ValidTriageFilter = typeof validTriageFilters[number];
-    const triageFilter: ValidTriageFilter | undefined =
-      validTriageFilters.includes(activeTriageFilter as ValidTriageFilter)
-        ? (activeTriageFilter as ValidTriageFilter)
-        : undefined;
-
-    // When page is 1, reset our local accumulator and backend progress.
-    if (page === 1) {
-      accumulatedFilteredRef.current = [];
-      lastBackendPageRef.current = 0;
-      totalBackendPagesRef.current = 1;
-    }
-
-    const itemsNeeded = page * PAGE_SIZE;
-
-    // Keep fetching backend pages until we have enough filtered items for the
-    // requested page or we've exhausted all backend results. Guard with
-    // MAX_ADDITIONAL_PAGES to avoid unbounded sequential fetches when
-    // client-side filtering (templateFilter) is enabled.
-    let pagesFetched = 0;
-    while (
-      accumulatedFilteredRef.current.length < itemsNeeded &&
-      lastBackendPageRef.current < totalBackendPagesRef.current
-    ) {
-      if (pagesFetched >= MAX_ADDITIONAL_PAGES) {
-        // stop fetching more pages to avoid long blocking loops; backend
-        // should handle templateFilter server-side (TODO: move filter to API)
-        break;
-      }
-      lastBackendPageRef.current++;
-      const limit = templateFilter || triageFilter ? 100 : PAGE_SIZE;
-      const result = await listIntakes(practiceId, {
-        page: lastBackendPageRef.current,
-        limit,
-        triage_status: triageFilter,
-      }, { signal });
-
-      if (currentSessionId !== paginationSessionIdRef.current) {
-        return { items: [], hasMore: false };
-      }
-
-      totalBackendPagesRef.current = result.total_pages;
-
-      pagesFetched++;
-      const triageFiltered = triageFilter
-        ? result.intakes.filter((item) => normalizeTriageStatus(item.triage_status) === triageFilter)
-        : result.intakes;
-      const filtered = templateFilter
-        ? triageFiltered.filter((item) => {
-          const metadata = item.metadata as Record<string, unknown> | null | undefined;
-          const directSlug = metadata?.intake_template_slug ?? metadata?.template_slug;
-          if (typeof directSlug === 'string' && directSlug.trim()) return directSlug.trim() === templateFilter;
-          const customFields = metadata?.custom_fields ?? metadata?.customFields;
-          if (customFields && typeof customFields === 'object' && !Array.isArray(customFields)) {
-            const storedSlug = (customFields as Record<string, unknown>)._intake_template_slug;
-            if (typeof storedSlug === 'string' && storedSlug.trim()) return storedSlug.trim() === templateFilter;
-          }
-          return templateFilter === DEFAULT_INTAKE_TEMPLATE.slug;
-        })
-        : triageFiltered;
-
-      accumulatedFilteredRef.current.push(
-        ...filtered.map(item => ({ ...item, id: item.uuid }))
+  const fetchPage = useCallback(async (targetPage: number, signal: AbortSignal): Promise<void> => {
+    if (!practiceId) return;
+    const triageFilter = mobileFilter !== 'all' ? mobileFilter : undefined;
+    try {
+      const result = await listIntakes(
+        practiceId,
+        { page: targetPage, limit: PAGE_SIZE, triage_status: triageFilter },
+        { signal },
       );
-
-      // If we got fewer results than requested, we've hit the end of the backend.
-      if (result.intakes.length < limit) {
-        totalBackendPagesRef.current = lastBackendPageRef.current;
-        break;
-      }
+      if (signal.aborted) return;
+      setItems((prev) => (targetPage === 1 ? result.intakes : [...prev, ...result.intakes]));
+      setPage(targetPage);
+      setHasMore(targetPage < result.total_pages);
+      setError(null);
+    } catch (err) {
+      if (signal.aborted) return;
+      setError(err instanceof Error ? err.message : 'Failed to load intakes');
     }
+  }, [practiceId, mobileFilter]);
 
-    const start = (page - 1) * PAGE_SIZE;
-    const pageItems = accumulatedFilteredRef.current.slice(start, start + PAGE_SIZE);
+  // Reset & fetch when filter or practice changes.
+  useEffect(() => {
+    if (!practiceId || !isResponsesRoute) {
+      setItems([]);
+      setIsLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    const seq = ++requestSeqRef.current;
+    setIsLoading(true);
+    setItems([]);
+    setPage(1);
+    setHasMore(false);
+    fetchPage(1, controller.signal).finally(() => {
+      if (seq === requestSeqRef.current && !controller.signal.aborted) setIsLoading(false);
+    });
+    return () => controller.abort();
+  }, [practiceId, mobileFilter, isResponsesRoute, fetchPage]);
 
-    return {
-      items: pageItems,
-      // hasMore is true if we either already have more items cached or there are 
-      // more pages left in the backend.
-      hasMore: 
-        accumulatedFilteredRef.current.length > itemsNeeded || 
-        lastBackendPageRef.current < totalBackendPagesRef.current,
-    };
-  }, [paginationSessionId, practiceId, isResponsesRoute, activeTriageFilter, templateFilter]);
+  const loadMore = useCallback(() => {
+    if (!hasMore || isLoading || isLoadingMore) return;
+    const controller = new AbortController();
+    setIsLoadingMore(true);
+    void fetchPage(page + 1, controller.signal).finally(() => setIsLoadingMore(false));
+  }, [hasMore, isLoading, isLoadingMore, fetchPage, page]);
 
-  const {
-    items: intakes,
-    isLoading,
-    isLoadingMore,
-    error,
-    hasMore,
-    loadMore,
-  } = usePaginatedList<PaginatedIntake>({
-    fetchPage: fetchIntakePage,
-    deps: [paginationSessionId],
-  });
+  const filteredItems = useMemo(
+    () => items.filter((item) => matchesSearch(item, searchQuery)),
+    [items, searchQuery],
+  );
 
-  const handleSelectIntake = useCallback((intake: PaginatedIntake) => {
+  const handleSelectIntake = useCallback((intake: IntakeListItem) => {
     location.route(`${basePath}/responses/${encodeURIComponent(intake.uuid)}`);
   }, [basePath, location]);
 
   const handleBack = useCallback(() => {
-    const target = templateFilter
-      ? `${basePath}/responses?template=${encodeURIComponent(templateFilter)}`
-      : `${basePath}/responses`;
-    location.route(target);
-  }, [basePath, location, templateFilter]);
+    location.route(`${basePath}/responses`);
+  }, [basePath, location]);
 
   const handleTriageComplete = useCallback(() => {
-    setRefreshCounter(c => c + 1);
-    if (onRefetchList) void onRefetchList();
+    if (!practiceId || !isResponsesRoute) return;
+    const controller = new AbortController();
+    setIsLoading(true);
+    void fetchPage(1, controller.signal).finally(() => setIsLoading(false));
     handleBack();
-  }, [handleBack, onRefetchList]);
+  }, [practiceId, isResponsesRoute, fetchPage, handleBack]);
 
-  // ── Rendering ────────────────────────────────────────────────────────────
+  const handleMobileFilterChange = useCallback((id: string) => {
+    setMobileFilter(normalizeFilter(id));
+  }, []);
 
-  if (!isResponsesRoute) {
-    // Effect above redirects to /responses. Show nothing during the brief tick
-    // before navigation lands.
-    return null;
-  }
+  if (!isResponsesRoute) return null;
 
-  if (selectedIntakeId && renderMode !== 'listOnly') {
+  if (selectedIntakeId) {
     return (
       <IntakeDetailPage
         practiceId={practiceId}
@@ -310,51 +211,195 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
     );
   }
 
-  if (renderMode === 'detailOnly') return null;
+  const headerCellClass = 'text-xs font-semibold uppercase tracking-wide text-input-placeholder';
+  const columns: DataTableColumn[] = [
+    {
+      id: 'subject',
+      label: 'Subject',
+      isPrimary: true,
+      headerClassName: headerCellClass,
+    },
+    {
+      id: 'contact',
+      label: 'Contact',
+      hideAt: 'sm',
+      headerClassName: headerCellClass,
+      mobileClassName: 'text-input-placeholder',
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      headerClassName: headerCellClass,
+    },
+    {
+      id: 'date',
+      label: 'Date',
+      align: 'right',
+      hideAt: 'sm',
+      headerClassName: headerCellClass,
+    },
+  ];
 
-  const displayLoading = isLoading || prefetchedLoading;
-  const displayError = error || prefetchedError;
-  const localLoaded = !isLoading;
-  const displayItems = localLoaded ? intakes : prefetchedItems.map(item => ({ ...item, id: item.uuid }));
+  const rows: DataTableRow[] = filteredItems.map((item) => {
+    const triage = triageStatusVariant(item.triage_status);
+    const subject = resolveIntakeTitle(item.metadata, item.metadata?.name?.trim() || 'Anonymous Lead');
+    const contact = item.metadata?.email?.trim() || item.metadata?.name?.trim() || '—';
+    return {
+      id: item.uuid,
+      onClick: () => handleSelectIntake(item),
+      cells: {
+        subject: <span className="truncate font-medium text-input-text">{subject}</span>,
+        contact: <span className="truncate text-input-placeholder">{contact}</span>,
+        status: <span className={cn('font-medium', triage.className)}>{triage.label}</span>,
+        date: <span className="tabular-nums text-input-placeholder">{formatRelativeTime(item.created_at)}</span>,
+      },
+    };
+  });
 
-  if (renderMode === 'listOnly' && !displayLoading && !displayError && displayItems.length === 0) {
-    return null;
-  }
+  const showEmpty = !isLoading && !error && filteredItems.length === 0;
+  const emptyMessage = searchQuery
+    ? `No responses match “${searchQuery}”.`
+    : mobileFilter === 'pending_review'
+      ? "You've caught up on all pending reviews! New consultation inquiries will appear here."
+      : mobileFilter === 'accepted'
+        ? 'No accepted responses yet.'
+        : mobileFilter === 'declined'
+          ? 'No declined responses.'
+          : 'No leads have come in yet. New consultation inquiries will appear here.';
+
+  const tabItems: TabItem[] = TRIAGE_FILTERS.map((f) => ({ id: f.id, label: f.label }));
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
-      <Panel className="list-panel-card-gradient min-h-0 flex-1 overflow-hidden">
-        <EntityList
-          items={displayItems}
-          renderItem={(intake, isSelected) => (
-            <IntakeListItemRow
-              intake={intake}
-              isSelected={isSelected}
-            />
-          )}
-          onSelect={handleSelectIntake}
-          selectedId={selectedIntakeId ?? undefined}
-          isLoading={displayLoading}
-          isLoadingMore={isLoadingMore}
-          error={displayError}
-          onLoadMore={hasMore ? loadMore : undefined}
-          minMountSkeletonMs={250}
-          emptyState={
-            <WorkspacePlaceholderState
-              icon={InboxIcon}
-              title="No leads yet"
-              description={templateFilter
-                ? `No responses have been submitted for ?template=${templateFilter} yet.`
-                : activeTriageFilter === 'pending_review'
-                  ? "You've caught up on all pending reviews! New consultation inquiries will appear here."
-                  : "No leads match this filter."
-              }
-              className="p-8"
-            />
-          }
+    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+      {/* Header (desktop only — mobile hides because the workspace shell already
+          renders its own mobile header with the section title). */}
+      <header className="hidden md:flex items-center justify-between gap-4 border-b border-card-border px-6 py-5">
+        <h1 className="text-xl font-semibold text-input-text">All Responses</h1>
+        <div className="w-72">
+          <Input
+            type="search"
+            placeholder="Search by name or email"
+            value={searchInput}
+            onChange={setSearchInput}
+            icon={Search}
+            iconClassName="h-4 w-4"
+          />
+        </div>
+      </header>
+
+      {/* Mobile filter tabs */}
+      <div className="md:hidden border-b border-card-border bg-surface-workspace">
+        <Tabs
+          items={tabItems}
+          activeId={mobileFilter}
+          onChange={handleMobileFilterChange}
+          className="px-2"
         />
-      </Panel>
+      </div>
+
+      {/* Mobile search */}
+      <div className="md:hidden px-4 py-3 border-b border-card-border">
+        <Input
+          type="search"
+          placeholder="Search responses…"
+          value={searchInput}
+          onChange={setSearchInput}
+          icon={Search}
+          iconClassName="h-4 w-4"
+        />
+      </div>
+
+      {/* List body */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {error ? (
+          <div className="p-6 text-sm text-error">{error}</div>
+        ) : showEmpty ? (
+          <WorkspacePlaceholderState
+            icon={InboxIcon}
+            title="No responses"
+            description={emptyMessage}
+            className="p-8"
+          />
+        ) : (
+          <>
+            {/* Desktop table */}
+            <div className="hidden md:block px-6 py-4">
+              <DataTable
+                columns={columns}
+                rows={rows}
+                loading={isLoading && rows.length === 0}
+                density="compact"
+                stickyHeader
+                rowClassName="transition-colors duration-150 hover:!bg-surface-card-hover"
+                hasMore={hasMore}
+                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMore}
+              />
+            </div>
+
+            {/* Mobile cards */}
+            <div className="md:hidden">
+              {isLoading && rows.length === 0 ? (
+                <div className="flex flex-col gap-3 px-4 py-3">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <div key={`skeleton-${i}`} className="h-32 rounded-xl bg-surface-card animate-pulse" />
+                  ))}
+                </div>
+              ) : (
+                <InfiniteScroll
+                  className="gap-3 px-4 py-3"
+                  hasMore={hasMore}
+                  loading={isLoadingMore}
+                  onLoadMore={loadMore}
+                >
+                  {filteredItems.map((item) => (
+                    <IntakeMobileCard
+                      key={item.uuid}
+                      item={item}
+                      onClick={() => handleSelectIntake(item)}
+                    />
+                  ))}
+                </InfiniteScroll>
+              )}
+            </div>
+          </>
+        )}
+      </div>
     </div>
+  );
+};
+
+type IntakeMobileCardProps = {
+  item: IntakeListItem;
+  onClick: () => void;
+};
+
+const IntakeMobileCard: FunctionComponent<IntakeMobileCardProps> = ({ item, onClick }) => {
+  const triage = triageStatusVariant(item.triage_status);
+  const subject = resolveIntakeTitle(item.metadata, item.metadata?.name?.trim() || 'Anonymous Lead');
+  const email = item.metadata?.email?.trim() || '—';
+
+  const rows: ReadonlyArray<{ label: string; value: ComponentChildren }> = [
+    { label: 'Subject', value: <span className="font-medium text-input-text break-words">{subject}</span> },
+    { label: 'Email', value: <span className="text-input-placeholder break-all">{email}</span> },
+    { label: 'Status', value: <span className={cn('font-medium', triage.className)}>{triage.label}</span> },
+  ];
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full rounded-xl border border-card-border bg-surface-card px-4 py-3 text-left transition-colors hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+    >
+      <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm">
+        {rows.map(({ label, value }) => (
+          <div key={label} className="contents">
+            <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">{label}</dt>
+            <dd className="text-right">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </button>
   );
 };
 

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/features/invoices/config/invoiceCollection';
 import { DropdownMenuItem } from '@/shared/ui/dropdown';
 import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table';
-import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
 interface InvoicesTableProps {
   invoices: InvoiceSummary[];
@@ -27,6 +26,8 @@ interface InvoicesTableProps {
   onSyncInvoice?: (invoice: InvoiceSummary) => void;
   toolbar?: ComponentChildren;
   loadingMore?: boolean;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
   visibleOptionalColumns?: InvoiceColumnKey[];
   footer?: ComponentChildren;
 }
@@ -62,6 +63,8 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
   onSyncInvoice,
   toolbar,
   loadingMore = false,
+  hasMore = false,
+  onLoadMore,
   visibleOptionalColumns = [],
   footer,
 }) => {
@@ -285,12 +288,10 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         bodyClassName="bg-transparent"
         stickyHeader
         density="compact"
+        hasMore={hasMore}
+        isLoadingMore={loadingMore}
+        onLoadMore={onLoadMore}
       />
-      {loadingMore ? (
-        <div className="flex justify-center px-4 py-3">
-          <LoadingSpinner size="sm" ariaLabel="Loading more invoices" />
-        </div>
-      ) : null}
       {footer ? (
         <div className="border-t border-line-glass/30 px-4 py-3 text-sm text-input-placeholder">
           <div>{footer}</div>

--- a/src/features/invoices/pages/ClientInvoicesPage.tsx
+++ b/src/features/invoices/pages/ClientInvoicesPage.tsx
@@ -52,7 +52,6 @@ export function ClientInvoicesPage({
     error,
     hasMore,
     loadMore,
-    loadMoreRef,
   } = usePaginatedList<InvoiceSummary>({
     fetchPage: async (page, signal) => {
       if (!practiceId || renderMode === 'detailOnly') {
@@ -116,6 +115,8 @@ export function ClientInvoicesPage({
           invoices={invoices}
           loading={isLoading}
           loadingMore={isLoadingMore}
+          hasMore={hasMore}
+          onLoadMore={loadMore}
           error={error}
           emptyMessage={hasFilters ? 'No invoices match these filters.' : undefined}
           onRowClick={handleRowClick}
@@ -123,7 +124,6 @@ export function ClientInvoicesPage({
           footer={(
             <div className="flex w-full items-center justify-between gap-4">
               <span>{invoices.length} item{invoices.length === 1 ? '' : 's'}</span>
-              {hasMore ? <div ref={loadMoreRef} className="h-6 w-6" /> : null}
             </div>
           )}
         />

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -63,7 +63,6 @@ export function PracticeInvoicesPage({
     error,
     hasMore,
     loadMore,
-    loadMoreRef,
   } = usePaginatedList<InvoiceSummary>({
     fetchPage: async (page, signal) => {
       if (!practiceId || renderMode === 'detailOnly') {
@@ -141,6 +140,8 @@ export function PracticeInvoicesPage({
           invoices={invoices}
           loading={isLoading}
           loadingMore={isLoadingMore}
+          hasMore={hasMore}
+          onLoadMore={loadMore}
           error={error}
           emptyMessage={hasFilters ? 'No invoices match these filters.' : undefined}
           onRowClick={handleRowClick}
@@ -149,7 +150,6 @@ export function PracticeInvoicesPage({
           footer={(
             <div className="flex w-full items-center justify-between gap-4">
               <span>{invoices.length} item{invoices.length === 1 ? '' : 's'}</span>
-              {hasMore ? <div ref={loadMoreRef} className="h-6 w-6" /> : null}
             </div>
           )}
         />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -389,6 +389,8 @@ function AppShell() {
           <Route path="/client/:practiceSlug/engagements/:engagementId/review" component={ClientEngagementReviewRoute} />
           <Route path="/client/:practiceSlug/invoices" component={ClientPracticeRoute} workspaceView="invoices" />
           <Route path="/client/:practiceSlug/invoices/:invoiceId" component={ClientPracticeRoute} workspaceView="invoiceDetail" />
+          <Route path="/client/:practiceSlug/intakes" component={ClientPracticeRoute} workspaceView="intakes" />
+          <Route path="/client/:practiceSlug/intakes/:intakeId" component={ClientPracticeRoute} workspaceView="intakeDetail" />
           <Route path="/client/:practiceSlug/settings" component={ClientPracticeRoute} workspaceView="settings" settingsView="general" />
           <Route path="/client/:practiceSlug/settings/general" component={ClientPracticeRoute} workspaceView="settings" settingsView="general" />
           <Route path="/client/:practiceSlug/settings/notifications" component={ClientPracticeRoute} workspaceView="settings" settingsView="notifications" />
@@ -829,6 +831,7 @@ function ClientPracticeRoute({
   practiceSlug,
   conversationId,
   invoiceId,
+  intakeId,
   appId,
   workspaceView = 'home',
   settingsView = 'general',
@@ -836,8 +839,9 @@ function ClientPracticeRoute({
   practiceSlug?: string;
   conversationId?: string;
   invoiceId?: string;
+  intakeId?: string;
   appId?: string;
-  workspaceView?: 'home' | 'list' | 'conversation' | 'matters' | 'invoices' | 'invoiceDetail' | 'settings';
+  workspaceView?: 'home' | 'list' | 'conversation' | 'matters' | 'invoices' | 'invoiceDetail' | 'intakes' | 'intakeDetail' | 'settings';
   settingsView?: 'general' | 'notifications' | 'account' | 'practice' | 'practice-payouts' | 'practice-team' | 'apps' | 'app-detail' | 'intake-forms' | 'intake-forms-editor' | 'security' | 'help';
 }) {
   const location = useLocation();
@@ -941,6 +945,7 @@ function ClientPracticeRoute({
           clientPracticeSlug={slug || undefined}
           routeConversationId={conversationId}
           routeInvoiceId={invoiceId}
+          routeIntakeId={intakeId}
           routeSettingsView={settingsView}
           routeSettingsAppId={appId}
           workspaceView={workspaceView}

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -268,6 +268,14 @@ const buildClientRail = (basePath: string): NavRailItem[] => [
     expandable: true,
   },
   {
+    id: 'intakes',
+    label: 'Intake Forms',
+    icon: Contact,
+    href: `${basePath}/intakes`,
+    matchHrefs: [`${basePath}/intakes`],
+    prefetch: prefetchIntakesChunk,
+  },
+  {
     id: 'invoices',
     label: 'Payments',
     icon: CreditCard,

--- a/src/shared/lib/conversationApi.ts
+++ b/src/shared/lib/conversationApi.ts
@@ -264,22 +264,37 @@ export const postConversationMessage = async (
   }
 };
 
+export interface ConversationMessagesPage {
+  messages: ConversationMessage[];
+  /** Whether older messages are available beyond this page. */
+  hasMore: boolean;
+  /** Cursor to pass on the next call to fetch older messages. Null when exhausted. */
+  cursor: string | null;
+}
+
 export const fetchConversationMessages = async (
   conversationId: string,
   practiceId: string,
   options: { limit?: number; cursor?: string; signal?: AbortSignal } = {}
-): Promise<ConversationMessage[]> => {
+): Promise<ConversationMessagesPage> => {
   const params: Record<string, string> = { practiceId };
   if (options.limit != null) params.limit = String(options.limit);
   if (options.cursor) params.cursor = options.cursor;
 
   try {
-    const { data } = await apiClient.get<{ success?: boolean; data?: { messages?: ConversationMessage[] } }>(
+    const { data } = await apiClient.get<{
+      success?: boolean;
+      data?: { messages?: ConversationMessage[]; hasMore?: boolean; cursor?: string | null };
+    }>(
       `/api/conversations/${encodeURIComponent(conversationId)}/messages`,
       { params, signal: options.signal },
     );
     if (!data?.success) throw new Error('Failed to fetch messages');
-    return data.data?.messages ?? [];
+    return {
+      messages: data.data?.messages ?? [],
+      hasMore: Boolean(data.data?.hasMore),
+      cursor: data.data?.cursor ?? null,
+    };
   } catch (error) {
     throw toErrorMessage(error, 'Failed to fetch messages');
   }

--- a/src/shared/ui/layout/ContentWithBuilder.tsx
+++ b/src/shared/ui/layout/ContentWithBuilder.tsx
@@ -23,7 +23,7 @@ export function ContentWithBuilder({
   return (
     <div
       className={cn(
-        'grid min-h-0 flex-1 lg:grid-cols-[340px_minmax(0,1fr)_380px]',
+        'grid min-h-0 flex-1 md:grid-cols-[300px_minmax(0,1fr)] lg:grid-cols-[340px_minmax(0,1fr)_380px] xl:grid-cols-[360px_minmax(0,1fr)_400px]',
         className
       )}
     >

--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -1,6 +1,8 @@
 import type { ComponentChildren } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
 import { cn } from '@/shared/utils/cn';
 import { SkeletonLoader } from '@/shared/ui/layout/SkeletonLoader';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
 export type DataTableColumn = {
   id: string;
@@ -41,6 +43,14 @@ interface DataTableProps {
    *  longer surfaced. Kept for prop-API back-compat at call sites. */
   loadingLabel?: string;
   density?: 'regular' | 'compact';
+  /** Fires when the sentinel row scrolls into view. Pair with `hasMore`. */
+  onLoadMore?: () => void;
+  /** Whether more pages exist. When false, the sentinel is not rendered. */
+  hasMore?: boolean;
+  /** Show a spinner row at the bottom while the next page is fetching. */
+  isLoadingMore?: boolean;
+  /** Distance (px) below the viewport at which to trigger onLoadMore. */
+  loadMoreThreshold?: number;
 }
 
 const ALIGN_CLASS: Record<NonNullable<DataTableColumn['align']>, string> = {
@@ -83,6 +93,68 @@ const resolveStackedHideAt = (columns: DataTableColumn[]) => {
   );
 };
 
+type LoadMoreSentinelProps = {
+  colSpan: number;
+  onLoadMore: () => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  threshold: number;
+};
+
+/**
+ * A `<tr>` placed at the bottom of `<tbody>` that observes its own
+ * intersection with the viewport and fires `onLoadMore` when visible.
+ * Lives inside the table to inherit the same scroll context as the rows.
+ */
+const LoadMoreSentinel = ({
+  colSpan,
+  onLoadMore,
+  hasMore,
+  isLoadingMore,
+  threshold,
+}: LoadMoreSentinelProps) => {
+  const sentinelRef = useRef<HTMLTableRowElement>(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+
+  // Keep the latest callback in a ref so the observer effect can stay
+  // dependency-free (re-creating the observer on every render would race
+  // with the next page's data arriving).
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore || isLoadingMore) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          observer.disconnect();
+          onLoadMoreRef.current();
+        }
+      },
+      { rootMargin: `${threshold}px` },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, isLoadingMore, threshold]);
+
+  return (
+    <tr ref={sentinelRef} aria-hidden="true">
+      <td colSpan={colSpan} className="p-0">
+        {isLoadingMore ? (
+          <div className="flex items-center justify-center py-4">
+            <LoadingSpinner size="sm" ariaLabel="Loading more results" />
+          </div>
+        ) : (
+          <div className="h-px" />
+        )}
+      </td>
+    </tr>
+  );
+};
+
 export const DataTable = ({
   columns,
   rows,
@@ -99,6 +171,10 @@ export const DataTable = ({
   loading = false,
   loadingLabel: _loadingLabel,
   density = 'regular',
+  onLoadMore,
+  hasMore = false,
+  isLoadingMore = false,
+  loadMoreThreshold = 200,
 }: DataTableProps) => {
   const primaryColumn = columns.find((column) => column.isPrimary) ?? columns[0];
   const mobileColumns = columns.filter((column) => column.id !== primaryColumn?.id && column.hideAt);
@@ -143,7 +219,11 @@ export const DataTable = ({
     );
   };
 
-  const renderDesktopTable = (tableWrapperClassName: string, rowsOverride?: DataTableRow[]) => (
+  const renderDesktopTable = (
+    tableWrapperClassName: string,
+    rowsOverride?: DataTableRow[],
+    options: { showSentinel?: boolean } = {},
+  ) => (
     <div className={tableWrapperClassName}>
       <table className={cn('min-w-full', tableClassName)}>
         {caption ? <caption className="sr-only">{caption}</caption> : null}
@@ -191,7 +271,7 @@ export const DataTable = ({
                 </tr>
               );
             }
-            return renderRows.map((row) => {
+            const mappedRows = renderRows.map((row) => {
               const isClickable = Boolean(row.onClick) && !row.isPlaceholder;
 
               return (
@@ -248,6 +328,22 @@ export const DataTable = ({
                 </tr>
               );
             });
+
+            if (!options.showSentinel || !onLoadMore || (!hasMore && !isLoadingMore)) {
+              return mappedRows;
+            }
+            return (
+              <>
+                {mappedRows}
+                <LoadMoreSentinel
+                  colSpan={columns.length}
+                  onLoadMore={onLoadMore}
+                  hasMore={hasMore}
+                  isLoadingMore={isLoadingMore}
+                  threshold={loadMoreThreshold}
+                />
+              </>
+            );
           })()}
         </tbody>
       </table>
@@ -314,7 +410,7 @@ export const DataTable = ({
       ) : errorState ? (
         <div>{errorState}</div>
       ) : (
-        renderDesktopTable('overflow-x-auto')
+        renderDesktopTable('overflow-x-auto', undefined, { showSentinel: true })
       )}
     </div>
   );

--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -134,7 +134,7 @@ const LoadMoreSentinel = ({
           onLoadMoreRef.current();
         }
       },
-      { rootMargin: `${threshold}px` },
+      { rootMargin: `0px 0px ${threshold}px 0px` },
     );
     observer.observe(sentinel);
     return () => observer.disconnect();

--- a/src/shared/utils/money.ts
+++ b/src/shared/utils/money.ts
@@ -10,6 +10,10 @@ export const asMinor = (amount: number): MinorAmount => amount as MinorAmount;
  */
 export const isFiniteNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
 
+export const isMinorAmount = (value: unknown): value is MinorAmount => {
+  return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+};
+
 const isDev =
   typeof import.meta !== 'undefined' &&
   typeof import.meta.env !== 'undefined' &&


### PR DESCRIPTION
Practice surfaces:
- IntakeDetailPage: solid green Approve / red Reject (Pencil LA4ZS), matching confirm buttons in triage dialogs, drop duplicate ids on the dual-rendered (mobile + desktop) action buttons.
- IntakesPage: simplify columns to Subject / Contact / Status / Date (Pencil NHPoS), mobile cards collapse to those three fields.

Client portal:
- New ClientIntakeStatusPage (Pencil F6PAa / j9BBv4): status card, next-step callout, vertical timeline with complete/current/upcoming dot states, Your Responses, optional notes.
- New ClientIntakesView wraps it, parses :intakeId from the URL, fetches via getIntakeStatus, adapts the response shape.
- Routes /client/:slug/intakes and /client/:slug/intakes/:intakeId added to index.tsx; ClientPracticeRoute typed for the new views.
- "Intake Forms" rail item added to buildClientRail.
- MainApp wires intakesView for client workspace and forwards routeIntakeId through.

Carries forward already-uncommitted shared changes the intake views depend on:
- DataTable: sentinel-based infinite-scroll wiring.
- conversationApi.fetchConversationMessages: cursor-based pagination.
- EngagementDetailPage / Practice & Client InvoicesPage / InvoicesTable consume the new pagination shape.

Memory: project_intake_flow updated to clarify the client portal does have a read-only Intake Status page (only submission stays in the widget/URL, not the portal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client intake pages and status viewer with timeline, responses, and detail view.
  * Conversation previews now load older messages incrementally ("load more").

* **Improvements**
  * Routing and navigation updated to surface client intakes in workspaces.
  * Unified "load more" pagination for lists (intakes, invoices, tables) and refined list/search/triage UX.
  * Responsive layout tweaks and safer money handling; publish action failures are now caught and logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->