### PR TITLE
feat(reports): legal firm reports — 9 reports, schedules, send-now, deliveries (#521)

### DIFF
--- a/config/vitest/vitest.config.ts
+++ b/config/vitest/vitest.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
             'src/__tests__/i18n.test.ts',
             'src/features/invoices/utils/__tests__/**/*.test.{ts,tsx}',
             'src/features/invoices/services/__tests__/**/*.test.{ts,tsx}',
+            'src/features/reports/**/__tests__/**/*.test.{ts,tsx}',
           ],
           exclude: [
             'node_modules/**',

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -81,6 +81,7 @@ export function MainApp({
   chatContent,
   routeConversationId,
   routeInvoiceId,
+  routeReportDeliveryId,
   routeIntakeId: _routeIntakeId,
   routeSettingsView,
   routeSettingsAppId,
@@ -98,6 +99,7 @@ export function MainApp({
   chatContent?: ComponentChildren;
   routeConversationId?: string;
   routeInvoiceId?: string;
+  routeReportDeliveryId?: string;
   routeIntakeId?: string;
   routeSettingsView?: SettingsView;
   routeSettingsAppId?: string;
@@ -859,6 +861,7 @@ export function MainApp({
             : resolvedPublicPracticeSlug
       }
       routeInvoiceId={routeInvoiceId ?? null}
+      routeReportDeliveryId={routeReportDeliveryId ?? null}
       practiceName={resolvedPracticeName}
       practiceLogo={resolvedPracticeLogo}
       messages={messages}

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -1065,9 +1065,15 @@ export function MainApp({
       }
       reportsView={
         isPracticeWorkspace
-          ? (reportTitle) => (
+          ? (reportTitle, reportType, deliveryId) => (
             <LazyRouteBoundary>
-              <PracticeReportsPage title={reportTitle} />
+              <PracticeReportsPage
+                title={reportTitle}
+                reportType={reportType}
+                deliveryId={deliveryId}
+                practiceId={effectivePracticeId ?? practiceId}
+                practiceSlug={resolvedPracticeSlug ?? practiceSlug ?? null}
+              />
             </LazyRouteBoundary>
           )
           : undefined

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -140,7 +140,7 @@ interface WorkspacePageProps {
   contactsListContent?: ComponentChildren | ((statusFilter: UserDetailStatus | null, prefetchData?: WorkspacePrefetchData) => ComponentChildren);
   invoicesView?: ComponentChildren | ((statusFilter: string[], onDetailInspector?: (() => void), detailInspectorOpen?: boolean, detailHeaderLeadingAction?: ComponentChildren) => ComponentChildren);
   invoicesListContent?: ComponentChildren | ((statusFilter: string[]) => ComponentChildren);
-  reportsView?: ComponentChildren | ((title: string) => ComponentChildren);
+  reportsView?: ComponentChildren | ((title: string, reportType: string, deliveryId: string | null) => ComponentChildren);
   intakesView?: ComponentChildren | ((activeFilter: string | null) => ComponentChildren);
   engagementsView?: ComponentChildren | ((activeFilter: string | null) => ComponentChildren);
   filesView?: ComponentChildren;
@@ -1262,7 +1262,15 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     </div>
   );
   const reportsTitle = WORKSPACE_REPORT_SECTION_TITLES[activeSecondaryFilter ?? 'all-reports'] ?? WORKSPACE_REPORT_SECTION_TITLES['all-reports'];
-  const reportsContent = resolveViewContent(reportsView, [reportsTitle] as const);
+  const reportsReportType = activeSecondaryFilter ?? 'all-reports';
+  const reportsDeliveryId = (() => {
+    if (reportsReportType !== 'deliveries') return null;
+    const marker = `${normalizedBase}/reports/deliveries/`;
+    if (!location.path.startsWith(marker)) return null;
+    const raw = location.path.slice(marker.length).split('/')[0] ?? '';
+    return raw.length > 0 ? decodeURIComponent(raw) : null;
+  })();
+  const reportsContent = resolveViewContent(reportsView, [reportsTitle, reportsReportType, reportsDeliveryId] as const);
   const filesContent = resolveViewContent(filesView, [] as const);
   const settingsContent = practiceSlug ? (
     <SettingsContent

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -105,6 +105,7 @@ interface WorkspacePageProps {
   settingsAppId?: string;
   settingsIntakeTemplateSlug?: string;
   routeInvoiceId?: string | null;
+  routeReportDeliveryId?: string | null;
   onStartNewConversation: (
     mode: ConversationMode,
     preferredConversationId?: string,
@@ -204,6 +205,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   settingsAppId,
   settingsIntakeTemplateSlug,
   routeInvoiceId: _,
+  routeReportDeliveryId,
   onStartNewConversation,
   activeConversationId = null,
   chatView,
@@ -1263,13 +1265,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   );
   const reportsTitle = WORKSPACE_REPORT_SECTION_TITLES[activeSecondaryFilter ?? 'all-reports'] ?? WORKSPACE_REPORT_SECTION_TITLES['all-reports'];
   const reportsReportType = activeSecondaryFilter ?? 'all-reports';
-  const reportsDeliveryId = (() => {
-    if (reportsReportType !== 'deliveries') return null;
-    const marker = `${normalizedBase}/reports/deliveries/`;
-    if (!location.path.startsWith(marker)) return null;
-    const raw = location.path.slice(marker.length).split('/')[0] ?? '';
-    return raw.length > 0 ? decodeURIComponent(raw) : null;
-  })();
+  const reportsDeliveryId = reportsReportType === 'deliveries' ? routeReportDeliveryId ?? null : null;
   const reportsContent = resolveViewContent(reportsView, [reportsTitle, reportsReportType, reportsDeliveryId] as const);
   const filesContent = resolveViewContent(filesView, [] as const);
   const settingsContent = practiceSlug ? (

--- a/src/features/chat/pages/hooks/useWorkspaceNavigation.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceNavigation.ts
@@ -13,6 +13,7 @@ import {
   getSettingsNavConfig,
 } from '@/shared/config/navConfig';
 import type { PracticeRole } from '@/shared/utils/practiceRoles';
+import { buildReportRouteMap } from '@/features/reports/config/reportCollection';
 
 
 export type UseWorkspaceNavigationInput = {
@@ -211,12 +212,7 @@ export function useWorkspaceNavigation({
       return;
     }
     if (workspaceSection === 'reports') {
-      const reportPathById: Record<string, string> = {
-        'all-reports': `${basePath}/reports`,
-        'payroll-matter-activity': `${basePath}/reports/payroll-matter-activity`,
-        'trust-reconciliation': `${basePath}/reports/trust-reconciliation`,
-        'stale-matters': `${basePath}/reports/stale-matters`,
-      };
+      const reportPathById = buildReportRouteMap(basePath);
       navigate(reportPathById[id] ?? `${basePath}/reports`);
       setSecondaryFilterBySection((prev) => ({ ...prev, [workspaceSection]: id }));
       return;

--- a/src/features/reports/components/BackendUnavailableState.tsx
+++ b/src/features/reports/components/BackendUnavailableState.tsx
@@ -1,0 +1,23 @@
+import type { FunctionComponent } from 'preact';
+import { Construction } from 'lucide-preact';
+
+import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import type { ReportDefinition } from '@/features/reports/config/reportCollection';
+
+interface BackendUnavailableStateProps {
+  definition: ReportDefinition;
+}
+
+export const BackendUnavailableState: FunctionComponent<BackendUnavailableStateProps> = ({ definition }) => (
+  <div className="flex min-h-0 flex-1 flex-col gap-2 p-4 sm:p-6">
+    <WorkspacePlaceholderState
+      icon={Construction}
+      title={`${definition.title} — coming soon`}
+      description={definition.description}
+      caption="This report depends on a backend endpoint that is not yet available. It will light up automatically once the backend ships."
+      className="h-full"
+    />
+  </div>
+);
+
+export default BackendUnavailableState;

--- a/src/features/reports/components/BackendUnavailableState.tsx
+++ b/src/features/reports/components/BackendUnavailableState.tsx
@@ -4,11 +4,11 @@ import { Construction } from 'lucide-preact';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import type { ReportDefinition } from '@/features/reports/config/reportCollection';
 
-interface BackendUnavailableStateProps {
+interface UnavailableStateProps {
   definition: ReportDefinition;
 }
 
-export const BackendUnavailableState: FunctionComponent<BackendUnavailableStateProps> = ({ definition }) => (
+export const BackendUnavailableState: FunctionComponent<UnavailableStateProps> = ({ definition }) => (
   <div className="flex min-h-0 flex-1 flex-col gap-2 p-4 sm:p-6">
     <WorkspacePlaceholderState
       icon={Construction}

--- a/src/features/reports/components/ReportCard.tsx
+++ b/src/features/reports/components/ReportCard.tsx
@@ -1,0 +1,63 @@
+import type { FunctionComponent } from 'preact';
+import {
+  BarChart3,
+  Briefcase,
+  Calendar,
+  Clock,
+  FileText,
+  TrendingUp,
+  Users,
+  Wallet,
+} from 'lucide-preact';
+
+import { cn } from '@/shared/utils/cn';
+import type {
+  ReportDefinition,
+  ReportIconName,
+} from '@/features/reports/config/reportCollection';
+
+const ICON_BY_NAME: Record<ReportIconName, typeof TrendingUp> = {
+  trending: TrendingUp,
+  file: FileText,
+  wallet: Wallet,
+  clock: Clock,
+  users: Users,
+  briefcase: Briefcase,
+  chart: BarChart3,
+  calendar: Calendar,
+};
+
+interface ReportCardProps {
+  definition: ReportDefinition;
+  onClick?: () => void;
+  className?: string;
+}
+
+export const ReportCard: FunctionComponent<ReportCardProps> = ({ definition, onClick, className }) => {
+  const Icon = ICON_BY_NAME[definition.icon] ?? TrendingUp;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full flex-col gap-2 rounded-2xl border border-line-glass/20 bg-surface-utility/5 p-4 text-left transition hover:bg-surface-utility/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line-glass/30 bg-surface-utility/10">
+          <Icon className="h-4 w-4 text-input-placeholder" aria-hidden="true" />
+        </div>
+        {definition.phase === 3 ? (
+          <span className="rounded-full bg-surface-utility/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-input-placeholder">
+            Coming soon
+          </span>
+        ) : null}
+      </div>
+      <h3 className="text-sm font-semibold text-input-text">{definition.title}</h3>
+      <p className="text-xs text-input-placeholder">{definition.description}</p>
+    </button>
+  );
+};
+
+export default ReportCard;

--- a/src/features/reports/components/ReportDataTable.tsx
+++ b/src/features/reports/components/ReportDataTable.tsx
@@ -1,0 +1,68 @@
+import type { FunctionComponent, ComponentChildren } from 'preact';
+import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import type { ColumnKind, ColumnSpec } from '@/features/reports/config/reportCollection';
+
+interface ReportDataTableProps {
+  columns: ColumnSpec[];
+  rows: Record<string, unknown>[];
+  loading?: boolean;
+  emptyState?: ComponentChildren;
+}
+
+const formatValue = (kind: ColumnKind, value: unknown): ComponentChildren => {
+  if (value == null || value === '') return '—';
+  switch (kind) {
+    case 'money':
+      return formatCurrency(typeof value === 'number' ? value / 100 : 0);
+    case 'percent':
+      return `${typeof value === 'number' ? value.toFixed(1) : value}%`;
+    case 'hours':
+      return `${typeof value === 'number' ? value.toFixed(2) : value}h`;
+    case 'days':
+      return `${value}`;
+    case 'date': {
+      const d = typeof value === 'string' ? new Date(value) : value instanceof Date ? value : null;
+      if (!d || Number.isNaN(d.getTime())) return String(value);
+      return d.toLocaleDateString();
+    }
+    case 'number':
+      return typeof value === 'number' ? value.toLocaleString() : String(value);
+    case 'text':
+    default:
+      return String(value);
+  }
+};
+
+const toDataTableColumns = (columns: ColumnSpec[]): DataTableColumn[] =>
+  columns.map((col) => ({
+    id: col.key,
+    label: col.label,
+    align: col.align,
+    hideAt: col.hideAt,
+    isPrimary: col.isPrimary,
+  }));
+
+const toDataTableRows = (rows: Record<string, unknown>[], columns: ColumnSpec[]): DataTableRow[] =>
+  rows.map((row, idx) => ({
+    id: typeof row.id === 'string' ? row.id : String(idx),
+    cells: Object.fromEntries(
+      columns.map((col) => [col.key, formatValue(col.kind, row[col.key])])
+    ),
+  }));
+
+export const ReportDataTable: FunctionComponent<ReportDataTableProps> = ({
+  columns,
+  rows,
+  loading,
+  emptyState,
+}) => (
+  <DataTable
+    columns={toDataTableColumns(columns)}
+    rows={toDataTableRows(rows, columns)}
+    loading={loading}
+    emptyState={emptyState ?? <span className="text-sm text-input-placeholder">No data</span>}
+  />
+);
+
+export default ReportDataTable;

--- a/src/features/reports/components/ReportFilters.tsx
+++ b/src/features/reports/components/ReportFilters.tsx
@@ -1,0 +1,115 @@
+import type { FunctionComponent } from 'preact';
+import { DatePicker } from '@/shared/ui/input/DatePicker';
+import { Input } from '@/shared/ui/input/Input';
+import { SegmentedToggle } from '@/shared/ui/input/SegmentedToggle';
+import { cn } from '@/shared/utils/cn';
+import type { FilterSpec } from '@/features/reports/config/reportCollection';
+
+export type ReportPeriod = 'month' | 'quarter' | 'year';
+
+export interface ReportFilterValues {
+  period?: ReportPeriod;
+  start?: string;
+  end?: string;
+  hourlyRate?: number;
+  [key: string]: string | number | undefined;
+}
+
+interface ReportFiltersProps {
+  filters: FilterSpec[];
+  values: ReportFilterValues;
+  onChange: (next: ReportFilterValues) => void;
+  className?: string;
+}
+
+const PERIOD_OPTIONS: ReadonlyArray<{ value: ReportPeriod; label: string }> = [
+  { value: 'month', label: 'Month' },
+  { value: 'quarter', label: 'Quarter' },
+  { value: 'year', label: 'Year' },
+];
+
+export const ReportFilters: FunctionComponent<ReportFiltersProps> = ({ filters, values, onChange, className }) => {
+  const set = (id: string, value: string | number | undefined) => {
+    onChange({ ...values, [id]: value });
+  };
+  return (
+    <div className={cn('flex flex-wrap items-end gap-3', className)}>
+      {filters.map((f) => {
+        if (f.kind === 'period') {
+          const current = (values.period ?? f.defaultValue ?? 'month') as ReportPeriod;
+          return (
+            <div key={f.id} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-input-text">{f.label}</label>
+              <SegmentedToggle<ReportPeriod>
+                value={current}
+                options={PERIOD_OPTIONS}
+                ariaLabel={f.label}
+                onChange={(value) => set('period', value)}
+              />
+            </div>
+          );
+        }
+        if (f.kind === 'date-range') {
+          return (
+            <div key={f.id} className="flex items-end gap-2">
+              <DatePicker
+                label="Start"
+                value={(values.start as string | undefined) ?? ''}
+                onChange={(v) => set('start', v || undefined)}
+                format="date"
+              />
+              <DatePicker
+                label="End"
+                value={(values.end as string | undefined) ?? ''}
+                onChange={(v) => set('end', v || undefined)}
+                format="date"
+              />
+            </div>
+          );
+        }
+        if (f.kind === 'select') {
+          const current = ((values[f.id] as string | undefined) ?? f.defaultValue ?? '');
+          return (
+            <div key={f.id} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-input-text">{f.label}</label>
+              <select
+                value={current}
+                onChange={(e) => set(f.id, (e.currentTarget as HTMLSelectElement).value)}
+                className="h-9 rounded-md border border-line-glass/30 bg-surface-utility/5 px-2 text-sm text-input-text"
+              >
+                {f.options.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+          );
+        }
+        if (f.kind === 'number') {
+          return (
+            <Input
+              key={f.id}
+              label={f.label}
+              type="number"
+              min={f.min}
+              max={f.max}
+              placeholder={f.placeholder}
+              value={(values[f.id] as number | undefined)?.toString() ?? ''}
+              onChange={(v) => set(f.id, v === '' ? undefined : Number(v))}
+            />
+          );
+        }
+        return (
+          <Input
+            key={f.id}
+            label={f.label}
+            placeholder={f.placeholder}
+            value={(values[f.id] as string | undefined) ?? ''}
+            onChange={(v) => set(f.id, v || undefined)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ReportFilters;

--- a/src/features/reports/components/ReportListKpiRow.tsx
+++ b/src/features/reports/components/ReportListKpiRow.tsx
@@ -1,0 +1,46 @@
+import type { FunctionComponent } from 'preact';
+import { StatCard } from '@/shared/ui/cards/StatCard';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import type {
+  ColumnKind,
+  SummaryCardSpec,
+} from '@/features/reports/config/reportCollection';
+
+interface ReportListKpiRowProps {
+  cards: SummaryCardSpec[];
+  meta: Record<string, unknown>;
+}
+
+const formatMetaValue = (kind: ColumnKind, value: unknown): string => {
+  if (value == null) return '—';
+  switch (kind) {
+    case 'money':
+      return formatCurrency(typeof value === 'number' ? value / 100 : 0);
+    case 'percent':
+      return `${typeof value === 'number' ? value.toFixed(1) : value}%`;
+    case 'hours':
+      return `${typeof value === 'number' ? value.toFixed(2) : value}h`;
+    case 'days':
+      return String(value);
+    case 'number':
+      return typeof value === 'number' ? value.toLocaleString() : String(value);
+    case 'date':
+    case 'text':
+    default:
+      return String(value);
+  }
+};
+
+export const ReportListKpiRow: FunctionComponent<ReportListKpiRowProps> = ({ cards, meta }) => (
+  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    {cards.map((card) => (
+      <StatCard
+        key={card.id}
+        label={card.label}
+        value={formatMetaValue(card.kind, meta[card.metaKey])}
+      />
+    ))}
+  </div>
+);
+
+export default ReportListKpiRow;

--- a/src/features/reports/components/ReportPageShell.tsx
+++ b/src/features/reports/components/ReportPageShell.tsx
@@ -1,9 +1,16 @@
+import { useMemo, useState } from 'preact/hooks';
 import type { FunctionComponent } from 'preact';
-import { BarChart3 } from 'lucide-preact';
+import { AlertTriangle } from 'lucide-preact';
 
-import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import { useToastContext } from '@/shared/contexts/ToastContext';
 import type { ReportDefinition } from '@/features/reports/config/reportCollection';
+import { useReportData } from '@/features/reports/hooks/useReportData';
+import { useReportExport } from '@/features/reports/hooks/useReportExport';
 import { BackendUnavailableState } from './BackendUnavailableState';
+import { ReportFilters, type ReportFilterValues } from './ReportFilters';
+import { ReportToolbar } from './ReportToolbar';
+import { ReportListKpiRow } from './ReportListKpiRow';
+import { ReportDataTable } from './ReportDataTable';
 
 interface ReportPageShellProps {
   definition: ReportDefinition;
@@ -11,21 +18,89 @@ interface ReportPageShellProps {
   practiceSlug: string | null;
 }
 
-export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ definition }) => {
-  if (definition.phase === 3) {
+const defaultFilterValues = (definition: ReportDefinition): ReportFilterValues => {
+  const values: ReportFilterValues = {};
+  for (const f of definition.filters) {
+    if (f.kind === 'period') values.period = f.defaultValue ?? 'month';
+  }
+  return values;
+};
+
+export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ definition, practiceId }) => {
+  const [filters, setFilters] = useState<ReportFilterValues>(() => defaultFilterValues(definition));
+  const { showError, showInfo } = useToastContext();
+  const { exportReport, exporting } = useReportExport();
+
+  const queryParams = useMemo(() => ({
+    period: filters.period,
+    start: filters.start,
+    end: filters.end,
+    hourlyRate: filters.hourlyRate,
+  }), [filters.period, filters.start, filters.end, filters.hourlyRate]);
+
+  const { data, loading, error, refetch } = useReportData(practiceId, definition.id, queryParams);
+
+  if (definition.phase === 3 && (!data || error)) {
     return <BackendUnavailableState definition={definition} />;
   }
+  if (error?.code === 'BACKEND_NOT_AVAILABLE') {
+    return <BackendUnavailableState definition={definition} />;
+  }
+
+  const handleExport = async () => {
+    try {
+      await exportReport(practiceId, definition.id, queryParams);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Export failed');
+    }
+  };
+  const handleSchedule = () => showInfo('Scheduling ships in the next milestone.');
+  const handleSendNow = () => showInfo('Send now ships in the next milestone.');
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
-      <div>
-        <h1 className="text-lg font-semibold text-input-text">{definition.title}</h1>
-        <p className="mt-1 text-sm text-input-placeholder">{definition.description}</p>
-      </div>
-      <WorkspacePlaceholderState
-        icon={BarChart3}
-        title="Report data not yet wired"
-        description="The data fetch for this report ships in the next milestone."
-        className="h-full"
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-input-text">{definition.title}</h1>
+          <p className="mt-1 text-sm text-input-placeholder">{definition.description}</p>
+        </div>
+        <ReportToolbar
+          definition={definition}
+          onExport={handleExport}
+          onSchedule={handleSchedule}
+          onSendNow={handleSendNow}
+          exporting={exporting}
+        />
+      </header>
+
+      {definition.filters.length > 0 ? (
+        <ReportFilters filters={definition.filters} values={filters} onChange={setFilters} />
+      ) : null}
+
+      {definition.summaryCards?.length && data?.meta ? (
+        <ReportListKpiRow cards={definition.summaryCards} meta={data.meta} />
+      ) : null}
+
+      {error ? (
+        <div className="flex items-center justify-between rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2">
+          <div className="flex items-center gap-2 text-sm text-red-400">
+            <AlertTriangle className="h-4 w-4" />
+            <span>{error.message}</span>
+          </div>
+          <button
+            type="button"
+            className="text-xs font-medium text-red-300 underline"
+            onClick={refetch}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      <ReportDataTable
+        columns={definition.columns}
+        rows={(data?.items as Record<string, unknown>[]) ?? []}
+        loading={loading && !data}
       />
     </div>
   );

--- a/src/features/reports/components/ReportPageShell.tsx
+++ b/src/features/reports/components/ReportPageShell.tsx
@@ -1,0 +1,34 @@
+import type { FunctionComponent } from 'preact';
+import { BarChart3 } from 'lucide-preact';
+
+import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import type { ReportDefinition } from '@/features/reports/config/reportCollection';
+import { BackendUnavailableState } from './BackendUnavailableState';
+
+interface ReportPageShellProps {
+  definition: ReportDefinition;
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ definition }) => {
+  if (definition.phase === 3) {
+    return <BackendUnavailableState definition={definition} />;
+  }
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-input-text">{definition.title}</h1>
+        <p className="mt-1 text-sm text-input-placeholder">{definition.description}</p>
+      </div>
+      <WorkspacePlaceholderState
+        icon={BarChart3}
+        title="Report data not yet wired"
+        description="The data fetch for this report ships in the next milestone."
+        className="h-full"
+      />
+    </div>
+  );
+};
+
+export default ReportPageShell;

--- a/src/features/reports/components/ReportPageShell.tsx
+++ b/src/features/reports/components/ReportPageShell.tsx
@@ -42,12 +42,14 @@ export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ defin
     hourlyRate: filters.hourlyRate,
   }), [filters.period, filters.start, filters.end, filters.hourlyRate]);
 
-  const { data, loading, error, refetch } = useReportData(practiceId, definition.id, queryParams);
+  const { data, loading, error, refetch } = useReportData(
+    practiceId,
+    definition.id,
+    queryParams,
+    { enabled: definition.phase !== 3 }
+  );
 
-  if (definition.phase === 3 && (!data || error)) {
-    return <BackendUnavailableState definition={definition} />;
-  }
-  if (error?.code === 'BACKEND_NOT_AVAILABLE') {
+  if (definition.phase === 3 || error?.code === 'BACKEND_NOT_AVAILABLE') {
     return <BackendUnavailableState definition={definition} />;
   }
 

--- a/src/features/reports/components/ReportPageShell.tsx
+++ b/src/features/reports/components/ReportPageShell.tsx
@@ -11,6 +11,8 @@ import { ReportFilters, type ReportFilterValues } from './ReportFilters';
 import { ReportToolbar } from './ReportToolbar';
 import { ReportListKpiRow } from './ReportListKpiRow';
 import { ReportDataTable } from './ReportDataTable';
+import { ScheduleModal } from './ScheduleModal';
+import { SendNowModal } from './SendNowModal';
 
 interface ReportPageShellProps {
   definition: ReportDefinition;
@@ -28,7 +30,9 @@ const defaultFilterValues = (definition: ReportDefinition): ReportFilterValues =
 
 export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ definition, practiceId }) => {
   const [filters, setFilters] = useState<ReportFilterValues>(() => defaultFilterValues(definition));
-  const { showError, showInfo } = useToastContext();
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [sendNowOpen, setSendNowOpen] = useState(false);
+  const { showError } = useToastContext();
   const { exportReport, exporting } = useReportExport();
 
   const queryParams = useMemo(() => ({
@@ -54,8 +58,13 @@ export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ defin
       showError(err instanceof Error ? err.message : 'Export failed');
     }
   };
-  const handleSchedule = () => showInfo('Scheduling ships in the next milestone.');
-  const handleSendNow = () => showInfo('Send now ships in the next milestone.');
+  const handleSchedule = () => setScheduleOpen(true);
+  const handleSendNow = () => setSendNowOpen(true);
+  const stringFilters: Record<string, string> = Object.fromEntries(
+    Object.entries(filters)
+      .filter(([, v]) => v != null && v !== '')
+      .map(([k, v]) => [k, String(v)])
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
@@ -101,6 +110,21 @@ export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ defin
         columns={definition.columns}
         rows={(data?.items as Record<string, unknown>[]) ?? []}
         loading={loading && !data}
+      />
+
+      <ScheduleModal
+        isOpen={scheduleOpen}
+        onClose={() => setScheduleOpen(false)}
+        practiceId={practiceId}
+        reportType={definition.id}
+        filters={stringFilters}
+      />
+      <SendNowModal
+        isOpen={sendNowOpen}
+        onClose={() => setSendNowOpen(false)}
+        practiceId={practiceId}
+        reportType={definition.id}
+        filters={stringFilters}
       />
     </div>
   );

--- a/src/features/reports/components/ReportToolbar.tsx
+++ b/src/features/reports/components/ReportToolbar.tsx
@@ -1,0 +1,55 @@
+import type { FunctionComponent } from 'preact';
+import { Download, CalendarClock, Send } from 'lucide-preact';
+import { Button } from '@/shared/ui/Button';
+import type { ReportDefinition } from '@/features/reports/config/reportCollection';
+
+interface ReportToolbarProps {
+  definition: ReportDefinition;
+  onExport?: () => void;
+  onSchedule?: () => void;
+  onSendNow?: () => void;
+  exporting?: boolean;
+}
+
+export const ReportToolbar: FunctionComponent<ReportToolbarProps> = ({
+  definition,
+  onExport,
+  onSchedule,
+  onSendNow,
+  exporting,
+}) => {
+  const disabled = definition.phase === 3;
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        size="sm"
+        variant="secondary"
+        icon={Download}
+        disabled={disabled || exporting}
+        onClick={onExport}
+      >
+        Export CSV
+      </Button>
+      <Button
+        size="sm"
+        variant="secondary"
+        icon={Send}
+        disabled={disabled}
+        onClick={onSendNow}
+      >
+        Send now
+      </Button>
+      <Button
+        size="sm"
+        variant="secondary"
+        icon={CalendarClock}
+        disabled={disabled}
+        onClick={onSchedule}
+      >
+        Schedule
+      </Button>
+    </div>
+  );
+};
+
+export default ReportToolbar;

--- a/src/features/reports/components/ScheduleModal.tsx
+++ b/src/features/reports/components/ScheduleModal.tsx
@@ -71,7 +71,7 @@ export const ScheduleModal: FunctionComponent<ScheduleModalProps> = ({
       <DialogBody>
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
-            <label className="text-xs font-medium text-input-text">Frequency</label>
+            <span className="text-xs font-medium text-input-text">Frequency</span>
             <SegmentedToggle<ReportFrequency>
               value={frequency}
               options={FREQ_OPTIONS}

--- a/src/features/reports/components/ScheduleModal.tsx
+++ b/src/features/reports/components/ScheduleModal.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'preact/hooks';
+import type { FunctionComponent } from 'preact';
+import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/Button';
+import { Input } from '@/shared/ui/input/Input';
+import { SegmentedToggle } from '@/shared/ui/input/SegmentedToggle';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { reportsApi } from '@/features/reports/services/reportsApi';
+import type { ReportFrequency } from '@/features/reports/services/reportsTypes';
+
+interface ScheduleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  practiceId: string;
+  reportType: string;
+  filters: Record<string, string>;
+  onCreated?: () => void;
+}
+
+const FREQ_OPTIONS: ReadonlyArray<{ value: ReportFrequency; label: string }> = [
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+];
+
+export const ScheduleModal: FunctionComponent<ScheduleModalProps> = ({
+  isOpen,
+  onClose,
+  practiceId,
+  reportType,
+  filters,
+  onCreated,
+}) => {
+  const [frequency, setFrequency] = useState<ReportFrequency>('weekly');
+  const [hourUtc, setHourUtc] = useState(9);
+  const [dayOfWeek, setDayOfWeek] = useState(1);
+  const [dayOfMonth, setDayOfMonth] = useState(1);
+  const [recipientsInput, setRecipientsInput] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const { showError, showSuccess } = useToastContext();
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const recipients = recipientsInput
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean);
+      await reportsApi.createSchedule(practiceId, {
+        reportType,
+        frequency,
+        dayOfWeek: frequency === 'weekly' ? dayOfWeek : undefined,
+        dayOfMonth: frequency === 'monthly' ? dayOfMonth : undefined,
+        hourUtc,
+        recipients,
+        filters,
+        active: true,
+      });
+      showSuccess('Schedule created');
+      onCreated?.();
+      onClose();
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to create schedule');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title="Schedule report">
+      <DialogBody>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-input-text">Frequency</label>
+            <SegmentedToggle<ReportFrequency>
+              value={frequency}
+              options={FREQ_OPTIONS}
+              ariaLabel="Frequency"
+              onChange={setFrequency}
+            />
+          </div>
+          <Input
+            label="Hour (UTC, 0-23)"
+            type="number"
+            min={0}
+            max={23}
+            value={String(hourUtc)}
+            onChange={(v) => setHourUtc(Number(v) || 0)}
+          />
+          {frequency === 'weekly' ? (
+            <Input
+              label="Day of week (0=Sun … 6=Sat)"
+              type="number"
+              min={0}
+              max={6}
+              value={String(dayOfWeek)}
+              onChange={(v) => setDayOfWeek(Number(v) || 0)}
+            />
+          ) : null}
+          {frequency === 'monthly' ? (
+            <Input
+              label="Day of month (1-28)"
+              type="number"
+              min={1}
+              max={28}
+              value={String(dayOfMonth)}
+              onChange={(v) => setDayOfMonth(Number(v) || 1)}
+            />
+          ) : null}
+          <Input
+            label="Recipients (user IDs, comma-separated)"
+            value={recipientsInput}
+            onChange={setRecipientsInput}
+            placeholder="user_123, user_456"
+          />
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="secondary" onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button onClick={handleSubmit} disabled={submitting}>{submitting ? 'Saving…' : 'Create schedule'}</Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+export default ScheduleModal;

--- a/src/features/reports/components/SendNowModal.tsx
+++ b/src/features/reports/components/SendNowModal.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent } from 'preact';
 import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/Button';
 import { Input } from '@/shared/ui/input/Input';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { reportsApi } from '@/features/reports/services/reportsApi';
 
@@ -62,7 +63,14 @@ export const SendNowModal: FunctionComponent<SendNowModalProps> = ({
       </DialogBody>
       <DialogFooter>
         <Button variant="secondary" onClick={onClose} disabled={submitting}>Cancel</Button>
-        <Button onClick={handleSubmit} disabled={submitting}>{submitting ? 'Sending…' : 'Send'}</Button>
+        <Button onClick={handleSubmit} disabled={submitting}>
+          {submitting ? (
+            <span className="mr-2 inline-flex">
+              <LoadingSpinner size="sm" ariaLabel="Sending report" announce={false} />
+            </span>
+          ) : null}
+          Send
+        </Button>
       </DialogFooter>
     </Dialog>
   );

--- a/src/features/reports/components/SendNowModal.tsx
+++ b/src/features/reports/components/SendNowModal.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'preact/hooks';
+import type { FunctionComponent } from 'preact';
+import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/Button';
+import { Input } from '@/shared/ui/input/Input';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { reportsApi } from '@/features/reports/services/reportsApi';
+
+interface SendNowModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  practiceId: string;
+  reportType: string;
+  filters: Record<string, string>;
+  onSent?: () => void;
+}
+
+export const SendNowModal: FunctionComponent<SendNowModalProps> = ({
+  isOpen,
+  onClose,
+  practiceId,
+  reportType,
+  filters,
+  onSent,
+}) => {
+  const [recipientsInput, setRecipientsInput] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const { showError, showSuccess } = useToastContext();
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const recipients = recipientsInput
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean);
+      await reportsApi.sendNow(practiceId, { reportType, recipients, filters });
+      showSuccess('Report sent', 'View it in Deliveries.');
+      onSent?.();
+      onClose();
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Send failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title="Send report now">
+      <DialogBody>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-input-placeholder">
+            Generate this report now and store it under Deliveries. Optionally notify recipients.
+          </p>
+          <Input
+            label="Recipients (user IDs, comma-separated, optional)"
+            value={recipientsInput}
+            onChange={setRecipientsInput}
+            placeholder="user_123, user_456"
+          />
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="secondary" onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button onClick={handleSubmit} disabled={submitting}>{submitting ? 'Sending…' : 'Send'}</Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+export default SendNowModal;

--- a/src/features/reports/config/__tests__/reportCollection.test.ts
+++ b/src/features/reports/config/__tests__/reportCollection.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  REPORT_DEFINITIONS,
+  ALL_REPORTS_HUB_ID,
+  DELIVERIES_SECTION_ID,
+  getReportDefinition,
+  tryGetReportDefinition,
+  buildReportRouteMap,
+  buildReportSectionTitles,
+} from '../reportCollection';
+
+describe('REPORT_DEFINITIONS', () => {
+  it('contains exactly nine reports', () => {
+    expect(REPORT_DEFINITIONS).toHaveLength(9);
+  });
+
+  it('every definition has at least one column', () => {
+    for (const def of REPORT_DEFINITIONS) {
+      expect(def.columns.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('column keys are unique within each definition', () => {
+    for (const def of REPORT_DEFINITIONS) {
+      const keys = def.columns.map((c) => c.key);
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+  });
+
+  it('ids are unique', () => {
+    const ids = REPORT_DEFINITIONS.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('getReportDefinition', () => {
+  it('returns the matching definition by id', () => {
+    expect(getReportDefinition('revenue').title).toBe('Revenue');
+  });
+
+  it('throws on unknown id', () => {
+    expect(() => getReportDefinition('does-not-exist')).toThrow();
+  });
+});
+
+describe('tryGetReportDefinition', () => {
+  it('returns null for unknown id', () => {
+    expect(tryGetReportDefinition('xxx')).toBeNull();
+  });
+});
+
+describe('buildReportRouteMap', () => {
+  it('includes hub, deliveries, and every report', () => {
+    const map = buildReportRouteMap('/practice/foo');
+    expect(map[ALL_REPORTS_HUB_ID]).toBe('/practice/foo/reports');
+    expect(map[DELIVERIES_SECTION_ID]).toBe('/practice/foo/reports/deliveries');
+    for (const def of REPORT_DEFINITIONS) {
+      expect(map[def.id]).toBe(`/practice/foo/reports/${def.id}`);
+    }
+  });
+});
+
+describe('buildReportSectionTitles', () => {
+  it('returns label entries for every report id plus hub and deliveries', () => {
+    const titles = buildReportSectionTitles();
+    expect(titles[ALL_REPORTS_HUB_ID]).toBe('All reports');
+    expect(titles[DELIVERIES_SECTION_ID]).toBe('Deliveries');
+    for (const def of REPORT_DEFINITIONS) {
+      expect(titles[def.id]).toBe(def.title);
+    }
+  });
+});

--- a/src/features/reports/config/reportCollection.ts
+++ b/src/features/reports/config/reportCollection.ts
@@ -1,0 +1,283 @@
+/**
+ * Single source of truth for the legal-firm reports system.
+ *
+ * Adding a new report = one entry in REPORT_DEFINITIONS.
+ * Nav, hub, page, CSV columns, filters, KPI cards all pick it up.
+ */
+
+export type ReportPhase = 1 | 2 | 3;
+
+export type ReportId =
+  | 'revenue'
+  | 'aging'
+  | 'profitability'
+  | 'utilization'
+  | 'trust-ledger'
+  | 'wip'
+  | 'originating-attorney'
+  | 'matters-by-attorney'
+  | 'task-productivity';
+
+export type ReportIconName =
+  | 'trending'
+  | 'file'
+  | 'wallet'
+  | 'clock'
+  | 'users'
+  | 'briefcase'
+  | 'chart'
+  | 'calendar';
+
+export type FilterSpec =
+  | { id: string; label: string; kind: 'period'; defaultValue?: 'month' | 'quarter' | 'year' }
+  | { id: string; label: string; kind: 'date-range' }
+  | { id: string; label: string; kind: 'text'; placeholder?: string }
+  | { id: string; label: string; kind: 'number'; placeholder?: string; min?: number; max?: number }
+  | { id: string; label: string; kind: 'select'; options: Array<{ value: string; label: string }>; defaultValue?: string };
+
+export type ColumnKind =
+  | 'text'
+  | 'money'
+  | 'percent'
+  | 'date'
+  | 'number'
+  | 'days'
+  | 'hours';
+
+export interface ColumnSpec {
+  key: string;
+  label: string;
+  kind: ColumnKind;
+  align?: 'left' | 'center' | 'right';
+  hideAt?: 'sm' | 'md' | 'lg';
+  isPrimary?: boolean;
+}
+
+export interface SummaryCardSpec {
+  id: string;
+  label: string;
+  kind: ColumnKind;
+  metaKey: string;
+}
+
+export interface ReportDefinition {
+  id: ReportId;
+  title: string;
+  description: string;
+  icon: ReportIconName;
+  phase: ReportPhase;
+  defaultPeriod?: 'month' | 'quarter' | 'year';
+  filters: FilterSpec[];
+  columns: ColumnSpec[];
+  summaryCards?: SummaryCardSpec[];
+}
+
+const PERIOD_FILTER: FilterSpec = {
+  id: 'period',
+  label: 'Period',
+  kind: 'period',
+  defaultValue: 'month',
+};
+
+const DATE_RANGE_FILTER: FilterSpec = {
+  id: 'dateRange',
+  label: 'Date range',
+  kind: 'date-range',
+};
+
+export const REPORT_DEFINITIONS: ReportDefinition[] = [
+  {
+    id: 'revenue',
+    title: 'Revenue',
+    description: 'Paid invoice revenue grouped by period.',
+    icon: 'trending',
+    phase: 1,
+    defaultPeriod: 'month',
+    filters: [PERIOD_FILTER, DATE_RANGE_FILTER],
+    columns: [
+      { key: 'periodLabel', label: 'Period', kind: 'text', isPrimary: true },
+      { key: 'invoiceCount', label: 'Invoices', kind: 'number', align: 'right' },
+      { key: 'paidAmountCents', label: 'Paid', kind: 'money', align: 'right' },
+      { key: 'outstandingAmountCents', label: 'Outstanding', kind: 'money', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalPaid', label: 'Paid (period)', kind: 'money', metaKey: 'totalPaidCents' },
+      { id: 'totalOutstanding', label: 'Outstanding (period)', kind: 'money', metaKey: 'totalOutstandingCents' },
+      { id: 'invoiceCount', label: 'Invoices (period)', kind: 'number', metaKey: 'totalInvoiceCount' },
+    ],
+  },
+  {
+    id: 'aging',
+    title: 'Accounts Receivable Aging',
+    description: 'Unpaid invoices grouped by days overdue.',
+    icon: 'wallet',
+    phase: 1,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'bucketLabel', label: 'Bucket', kind: 'text', isPrimary: true },
+      { key: 'invoiceCount', label: 'Invoices', kind: 'number', align: 'right' },
+      { key: 'totalAmountCents', label: 'Amount', kind: 'money', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalOutstanding', label: 'Total outstanding', kind: 'money', metaKey: 'totalOutstandingCents' },
+      { id: 'totalInvoices', label: 'Open invoices', kind: 'number', metaKey: 'totalInvoiceCount' },
+    ],
+  },
+  {
+    id: 'profitability',
+    title: 'Matter Profitability',
+    description: 'Revenue minus estimated cost per matter.',
+    icon: 'briefcase',
+    phase: 2,
+    filters: [
+      DATE_RANGE_FILTER,
+      { id: 'hourlyRate', label: 'Override hourly rate', kind: 'number', placeholder: 'e.g. 250', min: 0 },
+    ],
+    columns: [
+      { key: 'matterTitle', label: 'Matter', kind: 'text', isPrimary: true },
+      { key: 'revenueCents', label: 'Revenue', kind: 'money', align: 'right' },
+      { key: 'estimatedCostCents', label: 'Est. cost', kind: 'money', align: 'right' },
+      { key: 'marginCents', label: 'Margin', kind: 'money', align: 'right' },
+      { key: 'billableHours', label: 'Billable hrs', kind: 'hours', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalRevenue', label: 'Total revenue', kind: 'money', metaKey: 'totalRevenueCents' },
+      { id: 'totalCost', label: 'Total est. cost', kind: 'money', metaKey: 'totalCostCents' },
+      { id: 'totalMargin', label: 'Total margin', kind: 'money', metaKey: 'totalMarginCents' },
+    ],
+  },
+  {
+    id: 'utilization',
+    title: 'Attorney Utilization',
+    description: 'Billable share of tracked time, by user.',
+    icon: 'clock',
+    phase: 2,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'userId', label: 'User', kind: 'text', isPrimary: true },
+      { key: 'billableHours', label: 'Billable', kind: 'hours', align: 'right' },
+      { key: 'nonBillableHours', label: 'Non-billable', kind: 'hours', align: 'right' },
+      { key: 'totalHours', label: 'Total', kind: 'hours', align: 'right' },
+      { key: 'utilizationPercent', label: 'Utilization', kind: 'percent', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalBillable', label: 'Total billable hrs', kind: 'hours', metaKey: 'totalBillableHours' },
+      { id: 'avgUtilization', label: 'Avg utilization', kind: 'percent', metaKey: 'averageUtilizationPercent' },
+    ],
+  },
+  {
+    id: 'trust-ledger',
+    title: 'Trust Ledger',
+    description: 'Trust account transactions and balances.',
+    icon: 'wallet',
+    phase: 3,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'occurredAt', label: 'Date', kind: 'date', isPrimary: true },
+      { key: 'clientName', label: 'Client', kind: 'text' },
+      { key: 'description', label: 'Description', kind: 'text', hideAt: 'sm' },
+      { key: 'amountCents', label: 'Amount', kind: 'money', align: 'right' },
+      { key: 'balanceCents', label: 'Balance', kind: 'money', align: 'right' },
+    ],
+  },
+  {
+    id: 'wip',
+    title: 'Work in Progress',
+    description: 'Unbilled time and expenses by matter.',
+    icon: 'clock',
+    phase: 3,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'matterTitle', label: 'Matter', kind: 'text', isPrimary: true },
+      { key: 'unbilledHours', label: 'Unbilled hrs', kind: 'hours', align: 'right' },
+      { key: 'unbilledAmountCents', label: 'Unbilled amount', kind: 'money', align: 'right' },
+    ],
+  },
+  {
+    id: 'originating-attorney',
+    title: 'Originating Attorney',
+    description: 'Revenue and matters attributed to each originating attorney.',
+    icon: 'users',
+    phase: 3,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'attorneyName', label: 'Attorney', kind: 'text', isPrimary: true },
+      { key: 'matterCount', label: 'Matters', kind: 'number', align: 'right' },
+      { key: 'revenueCents', label: 'Revenue', kind: 'money', align: 'right' },
+    ],
+  },
+  {
+    id: 'matters-by-attorney',
+    title: 'Matters by Attorney',
+    description: 'Matter counts and status by responsible attorney.',
+    icon: 'users',
+    phase: 3,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'attorneyName', label: 'Attorney', kind: 'text', isPrimary: true },
+      { key: 'matterCount', label: 'Matters', kind: 'number', align: 'right' },
+      { key: 'openCount', label: 'Open', kind: 'number', align: 'right' },
+      { key: 'closedCount', label: 'Closed', kind: 'number', align: 'right' },
+    ],
+  },
+  {
+    id: 'task-productivity',
+    title: 'Task Productivity',
+    description: 'Completed task counts and cycle time.',
+    icon: 'chart',
+    phase: 3,
+    filters: [DATE_RANGE_FILTER],
+    columns: [
+      { key: 'assigneeName', label: 'Assignee', kind: 'text', isPrimary: true },
+      { key: 'completed', label: 'Completed', kind: 'number', align: 'right' },
+      { key: 'pending', label: 'Pending', kind: 'number', align: 'right' },
+      { key: 'avgCycleDays', label: 'Avg cycle (days)', kind: 'days', align: 'right' },
+    ],
+  },
+];
+
+const DEFINITIONS_BY_ID = new Map<string, ReportDefinition>(
+  REPORT_DEFINITIONS.map((def) => [def.id, def])
+);
+
+export const getReportDefinition = (id: string): ReportDefinition => {
+  const def = DEFINITIONS_BY_ID.get(id);
+  if (!def) {
+    throw new Error(`Unknown report id: ${id}`);
+  }
+  return def;
+};
+
+export const tryGetReportDefinition = (id: string): ReportDefinition | null =>
+  DEFINITIONS_BY_ID.get(id) ?? null;
+
+export const ALL_REPORTS_HUB_ID = 'all-reports';
+export const DELIVERIES_SECTION_ID = 'deliveries';
+
+export const REPORT_SECTION_IDS: string[] = [
+  ALL_REPORTS_HUB_ID,
+  ...REPORT_DEFINITIONS.map((d) => d.id),
+  DELIVERIES_SECTION_ID,
+];
+
+export const buildReportRouteMap = (basePath: string): Record<string, string> => {
+  const map: Record<string, string> = {
+    [ALL_REPORTS_HUB_ID]: `${basePath}/reports`,
+    [DELIVERIES_SECTION_ID]: `${basePath}/reports/deliveries`,
+  };
+  for (const def of REPORT_DEFINITIONS) {
+    map[def.id] = `${basePath}/reports/${def.id}`;
+  }
+  return map;
+};
+
+export const buildReportSectionTitles = (): Record<string, string> => {
+  const titles: Record<string, string> = {
+    [ALL_REPORTS_HUB_ID]: 'All reports',
+    [DELIVERIES_SECTION_ID]: 'Deliveries',
+  };
+  for (const def of REPORT_DEFINITIONS) {
+    titles[def.id] = def.title;
+  }
+  return titles;
+};

--- a/src/features/reports/config/reportCollection.ts
+++ b/src/features/reports/config/reportCollection.ts
@@ -170,7 +170,7 @@ export const REPORT_DEFINITIONS: ReportDefinition[] = [
     title: 'Trust Ledger',
     description: 'Trust account transactions and balances.',
     icon: 'wallet',
-    phase: 3,
+    phase: 2,
     filters: [DATE_RANGE_FILTER],
     columns: [
       { key: 'occurredAt', label: 'Date', kind: 'date', isPrimary: true },
@@ -179,18 +179,28 @@ export const REPORT_DEFINITIONS: ReportDefinition[] = [
       { key: 'amountCents', label: 'Amount', kind: 'money', align: 'right' },
       { key: 'balanceCents', label: 'Balance', kind: 'money', align: 'right' },
     ],
+    summaryCards: [
+      { id: 'totalCredits', label: 'Total credits', kind: 'money', metaKey: 'totalCreditsCents' },
+      { id: 'totalDebits', label: 'Total debits', kind: 'money', metaKey: 'totalDebitsCents' },
+      { id: 'endingBalance', label: 'Ending balance', kind: 'money', metaKey: 'endingBalanceCents' },
+    ],
   },
   {
     id: 'wip',
     title: 'Work in Progress',
     description: 'Unbilled time and expenses by matter.',
     icon: 'clock',
-    phase: 3,
+    phase: 2,
     filters: [DATE_RANGE_FILTER],
     columns: [
       { key: 'matterTitle', label: 'Matter', kind: 'text', isPrimary: true },
       { key: 'unbilledHours', label: 'Unbilled hrs', kind: 'hours', align: 'right' },
       { key: 'unbilledAmountCents', label: 'Unbilled amount', kind: 'money', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalUnbilledHours', label: 'Total unbilled hrs', kind: 'hours', metaKey: 'totalUnbilledHours' },
+      { id: 'totalUnbilledAmount', label: 'Total unbilled', kind: 'money', metaKey: 'totalUnbilledAmountCents' },
+      { id: 'matterCount', label: 'Matters with WIP', kind: 'number', metaKey: 'matterCount' },
     ],
   },
   {
@@ -198,12 +208,16 @@ export const REPORT_DEFINITIONS: ReportDefinition[] = [
     title: 'Originating Attorney',
     description: 'Revenue and matters attributed to each originating attorney.',
     icon: 'users',
-    phase: 3,
+    phase: 2,
     filters: [DATE_RANGE_FILTER],
     columns: [
       { key: 'attorneyName', label: 'Attorney', kind: 'text', isPrimary: true },
       { key: 'matterCount', label: 'Matters', kind: 'number', align: 'right' },
       { key: 'revenueCents', label: 'Revenue', kind: 'money', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalRevenue', label: 'Total revenue', kind: 'money', metaKey: 'totalRevenueCents' },
+      { id: 'totalMatters', label: 'Total matters', kind: 'number', metaKey: 'totalMatterCount' },
     ],
   },
   {
@@ -211,7 +225,7 @@ export const REPORT_DEFINITIONS: ReportDefinition[] = [
     title: 'Matters by Attorney',
     description: 'Matter counts and status by responsible attorney.',
     icon: 'users',
-    phase: 3,
+    phase: 2,
     filters: [DATE_RANGE_FILTER],
     columns: [
       { key: 'attorneyName', label: 'Attorney', kind: 'text', isPrimary: true },
@@ -219,19 +233,29 @@ export const REPORT_DEFINITIONS: ReportDefinition[] = [
       { key: 'openCount', label: 'Open', kind: 'number', align: 'right' },
       { key: 'closedCount', label: 'Closed', kind: 'number', align: 'right' },
     ],
+    summaryCards: [
+      { id: 'totalMatters', label: 'Total matters', kind: 'number', metaKey: 'totalMatterCount' },
+      { id: 'totalOpen', label: 'Open', kind: 'number', metaKey: 'totalOpenCount' },
+      { id: 'totalClosed', label: 'Closed', kind: 'number', metaKey: 'totalClosedCount' },
+    ],
   },
   {
     id: 'task-productivity',
     title: 'Task Productivity',
     description: 'Completed task counts and cycle time.',
     icon: 'chart',
-    phase: 3,
+    phase: 2,
     filters: [DATE_RANGE_FILTER],
     columns: [
       { key: 'assigneeName', label: 'Assignee', kind: 'text', isPrimary: true },
       { key: 'completed', label: 'Completed', kind: 'number', align: 'right' },
       { key: 'pending', label: 'Pending', kind: 'number', align: 'right' },
       { key: 'avgCycleDays', label: 'Avg cycle (days)', kind: 'days', align: 'right' },
+    ],
+    summaryCards: [
+      { id: 'totalCompleted', label: 'Completed', kind: 'number', metaKey: 'totalCompleted' },
+      { id: 'totalPending', label: 'Pending', kind: 'number', metaKey: 'totalPending' },
+      { id: 'avgCycle', label: 'Avg cycle (days)', kind: 'days', metaKey: 'averageCycleDays' },
     ],
   },
 ];

--- a/src/features/reports/hooks/useReportData.ts
+++ b/src/features/reports/hooks/useReportData.ts
@@ -29,10 +29,12 @@ const errorCodeFromHttp = (status: number, body: unknown): ReportErrorCode => {
 export const useReportData = <TRow = unknown, TMeta extends Record<string, unknown> = Record<string, unknown>>(
   practiceId: string,
   reportType: string,
-  params: ReportQueryParams = {}
+  params: ReportQueryParams = {},
+  options: { enabled?: boolean } = {}
 ): UseReportDataResult<TRow, TMeta> => {
+  const enabled = options.enabled ?? true;
   const [data, setData] = useState<ReportEnvelope<TRow, TMeta> | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<ReportError | null>(null);
   const [tick, setTick] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
@@ -48,7 +50,10 @@ export const useReportData = <TRow = unknown, TMeta extends Record<string, unkno
   });
 
   useEffect(() => {
-    if (!practiceId || !reportType) return undefined;
+    if (!enabled || !practiceId || !reportType) {
+      setLoading(false);
+      return undefined;
+    }
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -75,7 +80,7 @@ export const useReportData = <TRow = unknown, TMeta extends Record<string, unkno
 
     return () => controller.abort();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [practiceId, reportType, paramKey, tick]);
+  }, [enabled, practiceId, reportType, paramKey, tick]);
 
   return { data, loading, error, refetch };
 };

--- a/src/features/reports/hooks/useReportData.ts
+++ b/src/features/reports/hooks/useReportData.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { isHttpError, isAbortError } from '@/shared/lib/apiClient';
+import { reportsApi, type ReportQueryParams } from '@/features/reports/services/reportsApi';
+import type { ReportEnvelope } from '@/features/reports/services/reportsTypes';
+
+export type ReportErrorCode = 'BACKEND_NOT_AVAILABLE' | 'GENERIC';
+
+export interface ReportError {
+  code: ReportErrorCode;
+  message: string;
+}
+
+export interface UseReportDataResult<TRow, TMeta extends Record<string, unknown>> {
+  data: ReportEnvelope<TRow, TMeta> | null;
+  loading: boolean;
+  error: ReportError | null;
+  refetch: () => void;
+}
+
+const errorCodeFromHttp = (status: number, body: unknown): ReportErrorCode => {
+  if (status === 503) {
+    if (body && typeof body === 'object' && (body as { errorCode?: unknown }).errorCode === 'BACKEND_NOT_AVAILABLE') {
+      return 'BACKEND_NOT_AVAILABLE';
+    }
+  }
+  return 'GENERIC';
+};
+
+export const useReportData = <TRow = unknown, TMeta extends Record<string, unknown> = Record<string, unknown>>(
+  practiceId: string,
+  reportType: string,
+  params: ReportQueryParams = {}
+): UseReportDataResult<TRow, TMeta> => {
+  const [data, setData] = useState<ReportEnvelope<TRow, TMeta> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ReportError | null>(null);
+  const [tick, setTick] = useState(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  // Serialize params so React detects changes without referential equality games.
+  const paramKey = JSON.stringify({
+    period: params.period,
+    start: params.start,
+    end: params.end,
+    hourlyRate: params.hourlyRate,
+  });
+
+  useEffect(() => {
+    if (!practiceId || !reportType) return undefined;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+
+    reportsApi
+      .fetchReport<TRow, TMeta>(practiceId, reportType, { ...params, signal: controller.signal })
+      .then((env) => {
+        if (controller.signal.aborted) return;
+        setData(env);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (isAbortError(err) || controller.signal.aborted) return;
+        if (isHttpError(err)) {
+          const code = errorCodeFromHttp(err.response.status, err.response.data);
+          setError({ code, message: err.message });
+        } else {
+          setError({ code: 'GENERIC', message: err instanceof Error ? err.message : 'Request failed' });
+        }
+        setLoading(false);
+      });
+
+    return () => controller.abort();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [practiceId, reportType, paramKey, tick]);
+
+  return { data, loading, error, refetch };
+};

--- a/src/features/reports/hooks/useReportDeliveries.ts
+++ b/src/features/reports/hooks/useReportDeliveries.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import { reportsApi } from '@/features/reports/services/reportsApi';
 import type { ReportDelivery } from '@/features/reports/services/reportsTypes';
 
@@ -18,10 +18,13 @@ export const useReportDeliveries = (practiceId: string): UseReportDeliveriesResu
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tick, setTick] = useState(0);
+  const loadMoreRequestRef = useRef<{ key: string; controller: AbortController } | null>(null);
 
   useEffect(() => {
     if (!practiceId) return undefined;
     const controller = new AbortController();
+    loadMoreRequestRef.current?.controller.abort();
+    loadMoreRequestRef.current = null;
     setLoading(true);
     setError(null);
     reportsApi
@@ -38,23 +41,35 @@ export const useReportDeliveries = (practiceId: string): UseReportDeliveriesResu
         setError(err instanceof Error ? err.message : 'Failed to load deliveries');
         setLoading(false);
       });
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      loadMoreRequestRef.current?.controller.abort();
+      loadMoreRequestRef.current = null;
+    };
   }, [practiceId, tick]);
 
   const loadMore = useCallback(() => {
     if (!cursor || loading) return;
+    const controller = new AbortController();
+    const requestKey = `${practiceId}:${cursor}`;
+    loadMoreRequestRef.current?.controller.abort();
+    loadMoreRequestRef.current = { key: requestKey, controller };
     setLoading(true);
     reportsApi
-      .listDeliveries(practiceId, { cursor })
+      .listDeliveries(practiceId, { cursor, signal: controller.signal })
       .then((result) => {
+        if (controller.signal.aborted || loadMoreRequestRef.current?.key !== requestKey) return;
         setItems((prev) => [...prev, ...result.items]);
         setCursor(result.nextCursor);
         setHasMore(Boolean(result.nextCursor));
         setLoading(false);
+        loadMoreRequestRef.current = null;
       })
       .catch((err: unknown) => {
+        if (controller.signal.aborted || loadMoreRequestRef.current?.key !== requestKey) return;
         setError(err instanceof Error ? err.message : 'Failed to load deliveries');
         setLoading(false);
+        loadMoreRequestRef.current = null;
       });
   }, [practiceId, cursor, loading]);
 

--- a/src/features/reports/hooks/useReportDeliveries.ts
+++ b/src/features/reports/hooks/useReportDeliveries.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { reportsApi } from '@/features/reports/services/reportsApi';
+import type { ReportDelivery } from '@/features/reports/services/reportsTypes';
+
+interface UseReportDeliveriesResult {
+  items: ReportDelivery[];
+  loading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refetch: () => void;
+}
+
+export const useReportDeliveries = (practiceId: string): UseReportDeliveriesResult => {
+  const [items, setItems] = useState<ReportDelivery[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!practiceId) return undefined;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    reportsApi
+      .listDeliveries(practiceId, { signal: controller.signal })
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setItems(result.items);
+        setCursor(result.nextCursor);
+        setHasMore(Boolean(result.nextCursor));
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load deliveries');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [practiceId, tick]);
+
+  const loadMore = useCallback(() => {
+    if (!cursor || loading) return;
+    setLoading(true);
+    reportsApi
+      .listDeliveries(practiceId, { cursor })
+      .then((result) => {
+        setItems((prev) => [...prev, ...result.items]);
+        setCursor(result.nextCursor);
+        setHasMore(Boolean(result.nextCursor));
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load deliveries');
+        setLoading(false);
+      });
+  }, [practiceId, cursor, loading]);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { items, loading, error, hasMore, loadMore, refetch };
+};
+
+export const useReportDeliveryDetail = (practiceId: string, deliveryId: string) => {
+  const [delivery, setDelivery] = useState<ReportDelivery | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!practiceId || !deliveryId) return undefined;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    reportsApi
+      .getDelivery(practiceId, deliveryId, controller.signal)
+      .then((d) => {
+        if (controller.signal.aborted) return;
+        setDelivery(d);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load delivery');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [practiceId, deliveryId]);
+
+  return { delivery, loading, error };
+};

--- a/src/features/reports/hooks/useReportExport.ts
+++ b/src/features/reports/hooks/useReportExport.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'preact/hooks';
+import { reportsApi, type ReportQueryParams } from '@/features/reports/services/reportsApi';
+
+interface UseReportExportResult {
+  exporting: boolean;
+  error: string | null;
+  exportReport: (practiceId: string, reportType: string, params?: ReportQueryParams) => Promise<void>;
+}
+
+export const useReportExport = (): UseReportExportResult => {
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const exportReport = useCallback(
+    async (practiceId: string, reportType: string, params: ReportQueryParams = {}) => {
+      setExporting(true);
+      setError(null);
+      try {
+        const { blob, filename } = await reportsApi.exportReport(practiceId, reportType, params);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Export failed');
+        throw err;
+      } finally {
+        setExporting(false);
+      }
+    },
+    []
+  );
+
+  return { exporting, error, exportReport };
+};

--- a/src/features/reports/hooks/useReportSchedules.ts
+++ b/src/features/reports/hooks/useReportSchedules.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { reportsApi } from '@/features/reports/services/reportsApi';
+import type { ReportSchedule, ReportFrequency } from '@/features/reports/services/reportsTypes';
+
+interface UseReportSchedulesResult {
+  schedules: ReportSchedule[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+  create: (body: {
+    reportType: string;
+    frequency: ReportFrequency;
+    dayOfWeek?: number;
+    dayOfMonth?: number;
+    hourUtc: number;
+    recipients: string[];
+    filters: Record<string, string>;
+    active?: boolean;
+  }) => Promise<ReportSchedule>;
+  update: (id: string, patch: Partial<ReportSchedule>) => Promise<ReportSchedule>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const useReportSchedules = (practiceId: string): UseReportSchedulesResult => {
+  const [schedules, setSchedules] = useState<ReportSchedule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  useEffect(() => {
+    if (!practiceId) return undefined;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    reportsApi
+      .listSchedules(practiceId, controller.signal)
+      .then((items) => {
+        if (controller.signal.aborted) return;
+        setSchedules(items);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load schedules');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [practiceId, tick]);
+
+  const create: UseReportSchedulesResult['create'] = useCallback(async (body) => {
+    const created = await reportsApi.createSchedule(practiceId, body);
+    refetch();
+    return created;
+  }, [practiceId, refetch]);
+
+  const update: UseReportSchedulesResult['update'] = useCallback(async (id, patch) => {
+    const updated = await reportsApi.updateSchedule(practiceId, id, patch);
+    refetch();
+    return updated;
+  }, [practiceId, refetch]);
+
+  const remove = useCallback(async (id: string) => {
+    await reportsApi.deleteSchedule(practiceId, id);
+    refetch();
+  }, [practiceId, refetch]);
+
+  return { schedules, loading, error, refetch, create, update, remove };
+};

--- a/src/features/reports/pages/PracticeReportsPage.tsx
+++ b/src/features/reports/pages/PracticeReportsPage.tsx
@@ -2,22 +2,83 @@ import type { FunctionComponent } from 'preact';
 import { BarChart3 } from 'lucide-preact';
 
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import {
+  ALL_REPORTS_HUB_ID,
+  DELIVERIES_SECTION_ID,
+  tryGetReportDefinition,
+} from '@/features/reports/config/reportCollection';
+import { AllReportsHub } from './reports/AllReportsHub';
+import { RevenueReport } from './reports/RevenueReport';
+import { AgingReport } from './reports/AgingReport';
+import { ProfitabilityReport } from './reports/ProfitabilityReport';
+import { UtilizationReport } from './reports/UtilizationReport';
+import { TrustLedgerReport } from './reports/TrustLedgerReport';
+import { WipReport } from './reports/WipReport';
+import { OriginatingAttorneyReport } from './reports/OriginatingAttorneyReport';
+import { MattersByAttorneyReport } from './reports/MattersByAttorneyReport';
+import { TaskProductivityReport } from './reports/TaskProductivityReport';
+import { DeliveriesListView } from './reports/DeliveriesListView';
+import { DeliveryDetailView } from './reports/DeliveryDetailView';
 
 interface PracticeReportsPageProps {
   title: string;
+  reportType: string;
+  deliveryId: string | null;
+  practiceId: string;
+  practiceSlug: string | null;
 }
 
 export const PracticeReportsPage: FunctionComponent<PracticeReportsPageProps> = ({
   title,
-}) => (
-  <div className="flex min-h-0 flex-1 flex-col gap-2 p-4 sm:p-6">
-    <WorkspacePlaceholderState
-      icon={BarChart3}
-      title={title}
-      description="Report data and exports will appear here."
-      className="h-full"
-    />
-  </div>
-);
+  reportType,
+  deliveryId,
+  practiceId,
+  practiceSlug,
+}) => {
+  if (reportType === ALL_REPORTS_HUB_ID) {
+    return <AllReportsHub practiceSlug={practiceSlug} />;
+  }
+  if (reportType === DELIVERIES_SECTION_ID) {
+    return deliveryId
+      ? <DeliveryDetailView practiceId={practiceId} practiceSlug={practiceSlug} deliveryId={deliveryId} />
+      : <DeliveriesListView practiceId={practiceId} practiceSlug={practiceSlug} />;
+  }
+  const definition = tryGetReportDefinition(reportType);
+  if (!definition) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-2 p-4 sm:p-6">
+        <WorkspacePlaceholderState
+          icon={BarChart3}
+          title={title}
+          description="This report does not exist."
+          className="h-full"
+        />
+      </div>
+    );
+  }
+  const sharedProps = { practiceId, practiceSlug };
+  switch (definition.id) {
+    case 'revenue': return <RevenueReport {...sharedProps} />;
+    case 'aging': return <AgingReport {...sharedProps} />;
+    case 'profitability': return <ProfitabilityReport {...sharedProps} />;
+    case 'utilization': return <UtilizationReport {...sharedProps} />;
+    case 'trust-ledger': return <TrustLedgerReport {...sharedProps} />;
+    case 'wip': return <WipReport {...sharedProps} />;
+    case 'originating-attorney': return <OriginatingAttorneyReport {...sharedProps} />;
+    case 'matters-by-attorney': return <MattersByAttorneyReport {...sharedProps} />;
+    case 'task-productivity': return <TaskProductivityReport {...sharedProps} />;
+    default:
+      return (
+        <div className="flex min-h-0 flex-1 flex-col gap-2 p-4 sm:p-6">
+          <WorkspacePlaceholderState
+            icon={BarChart3}
+            title={title}
+            description="Report not yet implemented."
+            className="h-full"
+          />
+        </div>
+      );
+  }
+};
 
 export default PracticeReportsPage;

--- a/src/features/reports/pages/reports/AgingReport.tsx
+++ b/src/features/reports/pages/reports/AgingReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface AgingReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const AgingReport: FunctionComponent<AgingReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('aging')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default AgingReport;

--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -1,0 +1,36 @@
+import type { FunctionComponent } from 'preact';
+import { useNavigation } from '@/shared/utils/navigation';
+import {
+  REPORT_DEFINITIONS,
+  type ReportDefinition,
+} from '@/features/reports/config/reportCollection';
+import { ReportCard } from '@/features/reports/components/ReportCard';
+
+interface AllReportsHubProps {
+  practiceSlug: string | null;
+}
+
+export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceSlug }) => {
+  const { navigate } = useNavigation();
+
+  const handleSelect = (def: ReportDefinition) => {
+    if (!practiceSlug) return;
+    navigate(`/practice/${encodeURIComponent(practiceSlug)}/reports/${def.id}`);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-input-text">All reports</h1>
+        <p className="mt-1 text-sm text-input-placeholder">Browse the available reports for your practice.</p>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {REPORT_DEFINITIONS.map((def) => (
+          <ReportCard key={def.id} definition={def} onClick={() => handleSelect(def)} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AllReportsHub;

--- a/src/features/reports/pages/reports/DeliveriesListView.tsx
+++ b/src/features/reports/pages/reports/DeliveriesListView.tsx
@@ -1,0 +1,26 @@
+import type { FunctionComponent } from 'preact';
+import { Inbox } from 'lucide-preact';
+
+import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+
+interface DeliveriesListViewProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = () => (
+  <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+    <div>
+      <h1 className="text-lg font-semibold text-input-text">Deliveries</h1>
+      <p className="mt-1 text-sm text-input-placeholder">Past report deliveries from scheduled jobs and one-off sends.</p>
+    </div>
+    <WorkspacePlaceholderState
+      icon={Inbox}
+      title="No deliveries yet"
+      description="Schedule a report or use Send now to create your first delivery."
+      className="h-full"
+    />
+  </div>
+);
+
+export default DeliveriesListView;

--- a/src/features/reports/pages/reports/DeliveriesListView.tsx
+++ b/src/features/reports/pages/reports/DeliveriesListView.tsx
@@ -1,26 +1,91 @@
 import type { FunctionComponent } from 'preact';
 import { Inbox } from 'lucide-preact';
 
+import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import { useNavigation } from '@/shared/utils/navigation';
+import { useReportDeliveries } from '@/features/reports/hooks/useReportDeliveries';
+import {
+  REPORT_DEFINITIONS,
+  type ReportDefinition,
+} from '@/features/reports/config/reportCollection';
 
 interface DeliveriesListViewProps {
   practiceId: string;
   practiceSlug: string | null;
 }
 
-export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = () => (
-  <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
-    <div>
-      <h1 className="text-lg font-semibold text-input-text">Deliveries</h1>
-      <p className="mt-1 text-sm text-input-placeholder">Past report deliveries from scheduled jobs and one-off sends.</p>
+const DEFINITIONS_BY_ID = new Map<string, ReportDefinition>(REPORT_DEFINITIONS.map((d) => [d.id, d]));
+
+const COLUMNS: DataTableColumn[] = [
+  { id: 'createdAt', label: 'Created', isPrimary: true },
+  { id: 'reportType', label: 'Report' },
+  { id: 'status', label: 'Status' },
+  { id: 'recipients', label: 'Recipients' },
+];
+
+const STATUS_BADGE: Record<string, string> = {
+  pending: 'text-amber-400',
+  completed: 'text-emerald-400',
+  failed: 'text-red-400',
+};
+
+export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = ({ practiceId, practiceSlug }) => {
+  const { items, loading, error, hasMore, loadMore, refetch } = useReportDeliveries(practiceId);
+  const { navigate } = useNavigation();
+
+  const rows: DataTableRow[] = items.map((d) => ({
+    id: d.id,
+    onClick: () => {
+      if (!practiceSlug) return;
+      navigate(`/practice/${encodeURIComponent(practiceSlug)}/reports/deliveries/${encodeURIComponent(d.id)}`);
+    },
+    cells: {
+      createdAt: new Date(d.createdAt).toLocaleString(),
+      reportType: DEFINITIONS_BY_ID.get(d.reportType)?.title ?? d.reportType,
+      status: <span className={STATUS_BADGE[d.status] ?? ''}>{d.status}</span>,
+      recipients: d.recipients.length > 0 ? `${d.recipients.length} recipient${d.recipients.length === 1 ? '' : 's'}` : '—',
+    },
+  }));
+
+  if (!loading && items.length === 0 && !error) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+        <div>
+          <h1 className="text-lg font-semibold text-input-text">Deliveries</h1>
+          <p className="mt-1 text-sm text-input-placeholder">Past report deliveries from scheduled jobs and one-off sends.</p>
+        </div>
+        <WorkspacePlaceholderState
+          icon={Inbox}
+          title="No deliveries yet"
+          description="Schedule a report or use Send now to create your first delivery."
+          className="h-full"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-input-text">Deliveries</h1>
+        <p className="mt-1 text-sm text-input-placeholder">Past report deliveries from scheduled jobs and one-off sends.</p>
+      </div>
+      {error ? (
+        <div className="rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 text-sm text-red-400">
+          {error} <button type="button" className="ml-2 underline" onClick={refetch}>Retry</button>
+        </div>
+      ) : null}
+      <DataTable
+        columns={COLUMNS}
+        rows={rows}
+        loading={loading && items.length === 0}
+        hasMore={hasMore}
+        isLoadingMore={loading && items.length > 0}
+        onLoadMore={loadMore}
+      />
     </div>
-    <WorkspacePlaceholderState
-      icon={Inbox}
-      title="No deliveries yet"
-      description="Schedule a report or use Send now to create your first delivery."
-      className="h-full"
-    />
-  </div>
-);
+  );
+};
 
 export default DeliveriesListView;

--- a/src/features/reports/pages/reports/DeliveryDetailView.tsx
+++ b/src/features/reports/pages/reports/DeliveryDetailView.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from 'preact';
 import { ArrowLeft, Download, Inbox } from 'lucide-preact';
 
 import { Button } from '@/shared/ui/Button';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { useNavigation } from '@/shared/utils/navigation';
 import { reportsApi } from '@/features/reports/services/reportsApi';
@@ -36,8 +37,8 @@ export const DeliveryDetailView: FunctionComponent<DeliveryDetailViewProps> = ({
 
   if (loading) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
-        <p className="text-sm text-input-placeholder">Loading delivery…</p>
+      <div className="flex min-h-0 flex-1 items-center justify-center p-4 sm:p-6">
+        <LoadingSpinner size="md" ariaLabel="Loading delivery" />
       </div>
     );
   }

--- a/src/features/reports/pages/reports/DeliveryDetailView.tsx
+++ b/src/features/reports/pages/reports/DeliveryDetailView.tsx
@@ -1,0 +1,27 @@
+import type { FunctionComponent } from 'preact';
+import { Inbox } from 'lucide-preact';
+
+import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+
+interface DeliveryDetailViewProps {
+  practiceId: string;
+  practiceSlug: string | null;
+  deliveryId: string;
+}
+
+export const DeliveryDetailView: FunctionComponent<DeliveryDetailViewProps> = ({ deliveryId }) => (
+  <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+    <div>
+      <h1 className="text-lg font-semibold text-input-text">Delivery</h1>
+      <p className="mt-1 text-sm text-input-placeholder font-mono">{deliveryId}</p>
+    </div>
+    <WorkspacePlaceholderState
+      icon={Inbox}
+      title="Delivery details coming soon"
+      description="Detail view ships with the deliveries milestone."
+      className="h-full"
+    />
+  </div>
+);
+
+export default DeliveryDetailView;

--- a/src/features/reports/pages/reports/DeliveryDetailView.tsx
+++ b/src/features/reports/pages/reports/DeliveryDetailView.tsx
@@ -1,7 +1,15 @@
 import type { FunctionComponent } from 'preact';
-import { Inbox } from 'lucide-preact';
+import { ArrowLeft, Download, Inbox } from 'lucide-preact';
 
+import { Button } from '@/shared/ui/Button';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
+import { useNavigation } from '@/shared/utils/navigation';
+import { reportsApi } from '@/features/reports/services/reportsApi';
+import { useReportDeliveryDetail } from '@/features/reports/hooks/useReportDeliveries';
+import {
+  REPORT_DEFINITIONS,
+  type ReportDefinition,
+} from '@/features/reports/config/reportCollection';
 
 interface DeliveryDetailViewProps {
   practiceId: string;
@@ -9,19 +17,103 @@ interface DeliveryDetailViewProps {
   deliveryId: string;
 }
 
-export const DeliveryDetailView: FunctionComponent<DeliveryDetailViewProps> = ({ deliveryId }) => (
-  <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
-    <div>
-      <h1 className="text-lg font-semibold text-input-text">Delivery</h1>
-      <p className="mt-1 text-sm text-input-placeholder font-mono">{deliveryId}</p>
+const DEFINITIONS_BY_ID = new Map<string, ReportDefinition>(REPORT_DEFINITIONS.map((d) => [d.id, d]));
+
+const STATUS_COLOR: Record<string, string> = {
+  pending: 'text-amber-400',
+  completed: 'text-emerald-400',
+  failed: 'text-red-400',
+};
+
+export const DeliveryDetailView: FunctionComponent<DeliveryDetailViewProps> = ({ practiceId, practiceSlug, deliveryId }) => {
+  const { delivery, loading, error } = useReportDeliveryDetail(practiceId, deliveryId);
+  const { navigate } = useNavigation();
+
+  const backToList = () => {
+    if (!practiceSlug) return;
+    navigate(`/practice/${encodeURIComponent(practiceSlug)}/reports/deliveries`);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+        <p className="text-sm text-input-placeholder">Loading delivery…</p>
+      </div>
+    );
+  }
+
+  if (!delivery) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+        <Button size="sm" variant="ghost" icon={ArrowLeft} onClick={backToList}>Back to deliveries</Button>
+        <WorkspacePlaceholderState
+          icon={Inbox}
+          title="Delivery not found"
+          description={error ?? "We couldn't find this delivery."}
+          className="h-full"
+        />
+      </div>
+    );
+  }
+
+  const reportTitle = DEFINITIONS_BY_ID.get(delivery.reportType)?.title ?? delivery.reportType;
+  const downloadUrl = reportsApi.downloadDeliveryUrl(practiceId, deliveryId);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
+      <div className="flex items-center justify-between">
+        <Button size="sm" variant="ghost" icon={ArrowLeft} onClick={backToList}>Back to deliveries</Button>
+        {delivery.status === 'completed' ? (
+          <a
+            href={downloadUrl}
+            download
+            className="inline-flex items-center gap-2 rounded-md bg-accent-utility/10 px-3 py-1.5 text-sm font-medium text-accent-utility"
+          >
+            <Download className="h-4 w-4" />
+            Download CSV
+          </a>
+        ) : null}
+      </div>
+      <div>
+        <h1 className="text-lg font-semibold text-input-text">{reportTitle}</h1>
+        <p className="mt-1 text-sm font-mono text-input-placeholder">{delivery.id}</p>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-line-glass/20 p-3">
+          <p className="text-xs text-input-placeholder">Status</p>
+          <p className={`text-sm font-medium ${STATUS_COLOR[delivery.status] ?? ''}`}>{delivery.status}</p>
+        </div>
+        <div className="rounded-2xl border border-line-glass/20 p-3">
+          <p className="text-xs text-input-placeholder">Created</p>
+          <p className="text-sm text-input-text">{new Date(delivery.createdAt).toLocaleString()}</p>
+        </div>
+        {delivery.completedAt ? (
+          <div className="rounded-2xl border border-line-glass/20 p-3">
+            <p className="text-xs text-input-placeholder">Completed</p>
+            <p className="text-sm text-input-text">{new Date(delivery.completedAt).toLocaleString()}</p>
+          </div>
+        ) : null}
+        {typeof delivery.byteSize === 'number' ? (
+          <div className="rounded-2xl border border-line-glass/20 p-3">
+            <p className="text-xs text-input-placeholder">File size</p>
+            <p className="text-sm text-input-text">{delivery.byteSize.toLocaleString()} bytes</p>
+          </div>
+        ) : null}
+        <div className="rounded-2xl border border-line-glass/20 p-3 sm:col-span-2">
+          <p className="text-xs text-input-placeholder">Recipients</p>
+          <p className="text-sm text-input-text">
+            {delivery.recipients.length === 0 ? '—' : delivery.recipients.join(', ')}
+          </p>
+        </div>
+        {delivery.errorMessage ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-3 sm:col-span-2">
+            <p className="text-xs text-red-300">Error</p>
+            <p className="text-sm text-red-400">{delivery.errorMessage}</p>
+          </div>
+        ) : null}
+      </div>
     </div>
-    <WorkspacePlaceholderState
-      icon={Inbox}
-      title="Delivery details coming soon"
-      description="Detail view ships with the deliveries milestone."
-      className="h-full"
-    />
-  </div>
-);
+  );
+};
 
 export default DeliveryDetailView;

--- a/src/features/reports/pages/reports/MattersByAttorneyReport.tsx
+++ b/src/features/reports/pages/reports/MattersByAttorneyReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface MattersByAttorneyReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const MattersByAttorneyReport: FunctionComponent<MattersByAttorneyReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('matters-by-attorney')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default MattersByAttorneyReport;

--- a/src/features/reports/pages/reports/OriginatingAttorneyReport.tsx
+++ b/src/features/reports/pages/reports/OriginatingAttorneyReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface OriginatingAttorneyReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const OriginatingAttorneyReport: FunctionComponent<OriginatingAttorneyReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('originating-attorney')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default OriginatingAttorneyReport;

--- a/src/features/reports/pages/reports/ProfitabilityReport.tsx
+++ b/src/features/reports/pages/reports/ProfitabilityReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface ProfitabilityReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const ProfitabilityReport: FunctionComponent<ProfitabilityReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('profitability')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default ProfitabilityReport;

--- a/src/features/reports/pages/reports/RevenueReport.tsx
+++ b/src/features/reports/pages/reports/RevenueReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface RevenueReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const RevenueReport: FunctionComponent<RevenueReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('revenue')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default RevenueReport;

--- a/src/features/reports/pages/reports/TaskProductivityReport.tsx
+++ b/src/features/reports/pages/reports/TaskProductivityReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface TaskProductivityReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const TaskProductivityReport: FunctionComponent<TaskProductivityReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('task-productivity')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default TaskProductivityReport;

--- a/src/features/reports/pages/reports/TrustLedgerReport.tsx
+++ b/src/features/reports/pages/reports/TrustLedgerReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface TrustLedgerReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const TrustLedgerReport: FunctionComponent<TrustLedgerReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('trust-ledger')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default TrustLedgerReport;

--- a/src/features/reports/pages/reports/UtilizationReport.tsx
+++ b/src/features/reports/pages/reports/UtilizationReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface UtilizationReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const UtilizationReport: FunctionComponent<UtilizationReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('utilization')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default UtilizationReport;

--- a/src/features/reports/pages/reports/WipReport.tsx
+++ b/src/features/reports/pages/reports/WipReport.tsx
@@ -1,0 +1,18 @@
+import type { FunctionComponent } from 'preact';
+import { getReportDefinition } from '@/features/reports/config/reportCollection';
+import { ReportPageShell } from '@/features/reports/components/ReportPageShell';
+
+interface WipReportProps {
+  practiceId: string;
+  practiceSlug: string | null;
+}
+
+export const WipReport: FunctionComponent<WipReportProps> = ({ practiceId, practiceSlug }) => (
+  <ReportPageShell
+    definition={getReportDefinition('wip')}
+    practiceId={practiceId}
+    practiceSlug={practiceSlug}
+  />
+);
+
+export default WipReport;

--- a/src/features/reports/services/reportsApi.ts
+++ b/src/features/reports/services/reportsApi.ts
@@ -1,0 +1,154 @@
+import { apiClient, unwrapApiResponse } from '@/shared/lib/apiClient';
+import { getWorkerApiUrl } from '@/config/urls';
+import type {
+  AgingMeta,
+  AgingRow,
+  ProfitabilityMeta,
+  ProfitabilityRow,
+  ReportDelivery,
+  ReportEnvelope,
+  ReportFrequency,
+  ReportSchedule,
+  RevenueMeta,
+  RevenueRow,
+  UtilizationMeta,
+  UtilizationRow,
+} from './reportsTypes';
+
+const reportPath = (practiceId: string, segment: string) =>
+  `/api/reports/${encodeURIComponent(practiceId)}/${segment}`;
+
+const queryString = (params: Record<string, string | number | null | undefined>) => {
+  const search = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === null || v === undefined || v === '') continue;
+    search.set(k, String(v));
+  }
+  const out = search.toString();
+  return out ? `?${out}` : '';
+};
+
+export interface ReportQueryParams {
+  period?: 'month' | 'quarter' | 'year';
+  start?: string;
+  end?: string;
+  hourlyRate?: number;
+  signal?: AbortSignal;
+}
+
+const fetchReport = async <TRow, TMeta extends Record<string, unknown>>(
+  practiceId: string,
+  reportType: string,
+  params: ReportQueryParams = {}
+): Promise<ReportEnvelope<TRow, TMeta>> => {
+  const { signal, ...query } = params;
+  const url = reportPath(practiceId, reportType) + queryString(query);
+  const { data } = await apiClient.get<unknown>(url, { signal });
+  return unwrapApiResponse<ReportEnvelope<TRow, TMeta>>(data);
+};
+
+export const reportsApi = {
+  fetchRevenue: (practiceId: string, params?: ReportQueryParams) =>
+    fetchReport<RevenueRow, RevenueMeta>(practiceId, 'revenue', params),
+  fetchAging: (practiceId: string, params?: ReportQueryParams) =>
+    fetchReport<AgingRow, AgingMeta>(practiceId, 'aging', params),
+  fetchProfitability: (practiceId: string, params?: ReportQueryParams) =>
+    fetchReport<ProfitabilityRow, ProfitabilityMeta>(practiceId, 'profitability', params),
+  fetchUtilization: (practiceId: string, params?: ReportQueryParams) =>
+    fetchReport<UtilizationRow, UtilizationMeta>(practiceId, 'utilization', params),
+
+  /** Generic — used by useReportData for any report id. */
+  fetchReport: <TRow = unknown, TMeta extends Record<string, unknown> = Record<string, unknown>>(
+    practiceId: string,
+    reportType: string,
+    params?: ReportQueryParams
+  ): Promise<ReportEnvelope<TRow, TMeta>> =>
+    fetchReport<TRow, TMeta>(practiceId, reportType, params),
+
+  /** Returns the raw CSV blob URL ready for `<a download>` use. */
+  async exportReport(
+    practiceId: string,
+    reportType: string,
+    params: ReportQueryParams = {}
+  ): Promise<{ blob: Blob; filename: string }> {
+    const { signal, ...query } = params;
+    const relativeUrl = reportPath(practiceId, `export/${reportType}`) + queryString({ format: 'csv', ...query });
+    const fullUrl = /^https?:\/\//.test(relativeUrl) ? relativeUrl : `${getWorkerApiUrl()}${relativeUrl}`;
+    const response = await fetch(fullUrl, { credentials: 'include', signal });
+    if (!response.ok) {
+      throw new Error(`Export failed: ${response.status}`);
+    }
+    const disposition = response.headers.get('Content-Disposition') ?? '';
+    const fnameMatch = /filename="([^"]+)"/i.exec(disposition);
+    const filename = fnameMatch?.[1] ?? `${reportType}.csv`;
+    const blob = await response.blob();
+    return { blob, filename };
+  },
+
+  // ─── schedules (Phase 2) ──────────────────────────────────────────────
+  async listSchedules(practiceId: string, signal?: AbortSignal): Promise<ReportSchedule[]> {
+    const { data } = await apiClient.get<unknown>(reportPath(practiceId, 'schedules'), { signal });
+    return unwrapApiResponse<ReportSchedule[]>(data);
+  },
+  async createSchedule(
+    practiceId: string,
+    body: {
+      reportType: string;
+      frequency: ReportFrequency;
+      dayOfWeek?: number;
+      dayOfMonth?: number;
+      hourUtc: number;
+      recipients: string[];
+      filters: Record<string, string>;
+      active?: boolean;
+    }
+  ): Promise<ReportSchedule> {
+    const { data } = await apiClient.post<unknown>(reportPath(practiceId, 'schedules'), body);
+    return unwrapApiResponse<ReportSchedule>(data);
+  },
+  async updateSchedule(
+    practiceId: string,
+    scheduleId: string,
+    body: Partial<ReportSchedule>
+  ): Promise<ReportSchedule> {
+    const { data } = await apiClient.put<unknown>(reportPath(practiceId, `schedules/${encodeURIComponent(scheduleId)}`), body);
+    return unwrapApiResponse<ReportSchedule>(data);
+  },
+  async deleteSchedule(practiceId: string, scheduleId: string): Promise<void> {
+    await apiClient.delete(reportPath(practiceId, `schedules/${encodeURIComponent(scheduleId)}`));
+  },
+
+  // ─── send-now + deliveries (Phase 2) ──────────────────────────────────
+  async sendNow(
+    practiceId: string,
+    body: {
+      reportType: string;
+      recipients: string[];
+      filters: Record<string, string>;
+    }
+  ): Promise<ReportDelivery> {
+    const { data } = await apiClient.post<unknown>(reportPath(practiceId, 'send-now'), body);
+    return unwrapApiResponse<ReportDelivery>(data);
+  },
+  async listDeliveries(
+    practiceId: string,
+    params: { cursor?: string; limit?: number; signal?: AbortSignal } = {}
+  ): Promise<{ items: ReportDelivery[]; nextCursor: string | null }> {
+    const { signal, ...rest } = params;
+    const { data } = await apiClient.get<unknown>(
+      reportPath(practiceId, 'deliveries') + queryString(rest),
+      { signal }
+    );
+    return unwrapApiResponse<{ items: ReportDelivery[]; nextCursor: string | null }>(data);
+  },
+  async getDelivery(practiceId: string, deliveryId: string, signal?: AbortSignal): Promise<ReportDelivery> {
+    const { data } = await apiClient.get<unknown>(
+      reportPath(practiceId, `deliveries/${encodeURIComponent(deliveryId)}`),
+      { signal }
+    );
+    return unwrapApiResponse<ReportDelivery>(data);
+  },
+  downloadDeliveryUrl(practiceId: string, deliveryId: string): string {
+    return reportPath(practiceId, `deliveries/${encodeURIComponent(deliveryId)}/download`);
+  },
+};

--- a/src/features/reports/services/reportsTypes.ts
+++ b/src/features/reports/services/reportsTypes.ts
@@ -20,7 +20,7 @@ export interface RevenueRow {
   outstandingAmountCents: number;
 }
 
-export interface RevenueMeta {
+export interface RevenueMeta extends Record<string, unknown> {
   totalPaidCents: number;
   totalOutstandingCents: number;
   totalInvoiceCount: number;
@@ -34,7 +34,7 @@ export interface AgingRow {
   totalAmountCents: number;
 }
 
-export interface AgingMeta {
+export interface AgingMeta extends Record<string, unknown> {
   totalOutstandingCents: number;
   totalInvoiceCount: number;
 }
@@ -48,7 +48,7 @@ export interface ProfitabilityRow {
   billableHours: number;
 }
 
-export interface ProfitabilityMeta {
+export interface ProfitabilityMeta extends Record<string, unknown> {
   totalRevenueCents: number;
   totalCostCents: number;
   totalMarginCents: number;
@@ -63,7 +63,7 @@ export interface UtilizationRow {
   utilizationPercent: number;
 }
 
-export interface UtilizationMeta {
+export interface UtilizationMeta extends Record<string, unknown> {
   totalBillableHours: number;
   totalNonBillableHours: number;
   averageUtilizationPercent: number;

--- a/src/features/reports/services/reportsTypes.ts
+++ b/src/features/reports/services/reportsTypes.ts
@@ -1,0 +1,157 @@
+/**
+ * Wire types for report responses. Money fields are suffixed `*Cents`
+ * for invoice-derived amounts (integers) and `*Hours` for time totals.
+ */
+
+export interface ReportEnvelope<TRow, TMeta extends Record<string, unknown> = Record<string, unknown>> {
+  items: TRow[];
+  total: number;
+  generatedAt: string;
+  filters: Record<string, string | undefined>;
+  meta?: TMeta;
+}
+
+export interface RevenueRow {
+  periodLabel: string;
+  periodStart: string;
+  periodEnd: string;
+  invoiceCount: number;
+  paidAmountCents: number;
+  outstandingAmountCents: number;
+}
+
+export interface RevenueMeta {
+  totalPaidCents: number;
+  totalOutstandingCents: number;
+  totalInvoiceCount: number;
+}
+
+export interface AgingRow {
+  bucketLabel: string;
+  bucketMinDays: number;
+  bucketMaxDays: number | null;
+  invoiceCount: number;
+  totalAmountCents: number;
+}
+
+export interface AgingMeta {
+  totalOutstandingCents: number;
+  totalInvoiceCount: number;
+}
+
+export interface ProfitabilityRow {
+  matterId: string;
+  matterTitle: string;
+  revenueCents: number;
+  estimatedCostCents: number;
+  marginCents: number;
+  billableHours: number;
+}
+
+export interface ProfitabilityMeta {
+  totalRevenueCents: number;
+  totalCostCents: number;
+  totalMarginCents: number;
+  truncated?: boolean;
+}
+
+export interface UtilizationRow {
+  userId: string;
+  billableHours: number;
+  nonBillableHours: number;
+  totalHours: number;
+  utilizationPercent: number;
+}
+
+export interface UtilizationMeta {
+  totalBillableHours: number;
+  totalNonBillableHours: number;
+  averageUtilizationPercent: number;
+  truncated?: boolean;
+}
+
+export interface TrustLedgerRow {
+  id: string;
+  occurredAt: string;
+  clientName: string | null;
+  description: string | null;
+  amountCents: number;
+  balanceCents: number;
+}
+
+export interface WipRow {
+  matterId: string;
+  matterTitle: string;
+  unbilledHours: number;
+  unbilledAmountCents: number;
+}
+
+export interface OriginatingAttorneyRow {
+  attorneyId: string;
+  attorneyName: string;
+  matterCount: number;
+  revenueCents: number;
+}
+
+export interface MattersByAttorneyRow {
+  attorneyId: string;
+  attorneyName: string;
+  matterCount: number;
+  openCount: number;
+  closedCount: number;
+}
+
+export interface TaskProductivityRow {
+  assigneeId: string;
+  assigneeName: string;
+  completed: number;
+  pending: number;
+  avgCycleDays: number;
+}
+
+export type ReportRow =
+  | RevenueRow
+  | AgingRow
+  | ProfitabilityRow
+  | UtilizationRow
+  | TrustLedgerRow
+  | WipRow
+  | OriginatingAttorneyRow
+  | MattersByAttorneyRow
+  | TaskProductivityRow;
+
+export type ReportFrequency = 'daily' | 'weekly' | 'monthly';
+
+export interface ReportSchedule {
+  id: string;
+  practiceId: string;
+  reportType: string;
+  frequency: ReportFrequency;
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+  hourUtc: number;
+  recipients: string[];
+  filters: Record<string, string>;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  nextDeliveryAt?: string;
+}
+
+export type ReportDeliveryStatus = 'pending' | 'completed' | 'failed';
+
+export interface ReportDelivery {
+  id: string;
+  practiceId: string;
+  reportType: string;
+  filters: Record<string, string>;
+  recipients: string[];
+  status: ReportDeliveryStatus;
+  storageKey?: string;
+  byteSize?: number;
+  errorMessage?: string;
+  createdBy: string;
+  createdAt: string;
+  scheduledFor?: string;
+  completedAt?: string;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -472,6 +472,7 @@ function AppShell() {
           <Route path="/practice/:practiceSlug/engagements/:engagementId" component={PracticeAppRoute} workspaceView="engagements" />
           <Route path="/practice/:practiceSlug/files" component={PracticeAppRoute} workspaceView="files" />
           <Route path="/practice/:practiceSlug/reports" component={PracticeAppRoute} workspaceView="reports" />
+          <Route path="/practice/:practiceSlug/reports/deliveries/:reportDeliveryId" component={PracticeAppRoute} workspaceView="reports" />
           <Route path="/practice/:practiceSlug/reports/*" component={PracticeAppRoute} workspaceView="reports" />
           <Route path="/practice/:practiceSlug/invoices" component={PracticeAppRoute} workspaceView="invoices" />
           <Route path="/practice/:practiceSlug/invoices/new" component={PracticeAppRoute} workspaceView="invoices" />
@@ -704,6 +705,7 @@ function RootRoute() {
 function PracticeAppRoute({
   conversationId,
   invoiceId,
+  reportDeliveryId,
   appId,
   templateSlug,
   workspaceView = 'home',
@@ -712,6 +714,7 @@ function PracticeAppRoute({
 }: {
   conversationId?: string;
   invoiceId?: string;
+  reportDeliveryId?: string;
   appId?: string;
   templateSlug?: string;
   workspaceView?: WorkspaceView;
@@ -884,6 +887,7 @@ function PracticeAppRoute({
           workspace="practice"
           routeConversationId={conversationId}
           routeInvoiceId={invoiceId}
+          routeReportDeliveryId={reportDeliveryId}
           routeSettingsView={settingsView}
           routeSettingsAppId={appId}
           routeSettingsIntakeTemplateSlug={templateSlug}

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -22,6 +22,11 @@ import { SettingsNavIcon } from '@/shared/ui/nav/SettingsNavIcon';
 import { CONTACTS_DIRECTORY_LABEL } from '@/shared/domain/contacts';
 import type { PracticeRole } from '@/shared/utils/practiceRoles';
 import { getPreferencesCategory } from '@/shared/lib/preferencesApi';
+import {
+  REPORT_DEFINITIONS,
+  ALL_REPORTS_HUB_ID,
+  DELIVERIES_SECTION_ID,
+} from '@/features/reports/config/reportCollection';
 
 /**
  * Prefetch helpers for nav items. Fired on hover/focus so the route's code
@@ -105,6 +110,9 @@ export type SecondaryNavItem = {
   variant?: 'default' | 'danger';
   isAction?: boolean;
   icon?: ComponentType<unknown>;
+  /** Renders a small muted "Coming soon" pill next to the label. Used for
+   *  report entries that depend on a backend endpoint not yet shipped. */
+  comingSoon?: boolean;
   /** Fired on hover/focus — preload data for this sub-page. Idempotent. */
   prefetch?: () => void;
 };
@@ -381,13 +389,18 @@ const buildHomeSecondary = (basePath: string, workspace: 'practice' | 'client'):
 
 const buildReportsSecondary = (basePath: string, workspace: 'practice' | 'client'): NavSection[] | undefined => {
   if (workspace !== 'practice') return undefined;
+  const reportItems: SecondaryNavItem[] = REPORT_DEFINITIONS.map((def) => ({
+    id: def.id,
+    label: def.title,
+    href: `${basePath}/reports/${def.id}`,
+    comingSoon: def.phase === 3,
+  }));
   return [{
     label: 'Reports',
     items: [
-      { id: 'all-reports', label: 'All reports', href: `${basePath}/reports` },
-      { id: 'payroll-matter-activity', label: 'Payroll & Matter Activity', href: `${basePath}/reports/payroll-matter-activity` },
-      { id: 'trust-reconciliation', label: 'Trust Reconciliation', href: `${basePath}/reports/trust-reconciliation` },
-      { id: 'stale-matters', label: 'Stale Matters', href: `${basePath}/reports/stale-matters` },
+      { id: ALL_REPORTS_HUB_ID, label: 'All reports', href: `${basePath}/reports` },
+      ...reportItems,
+      { id: DELIVERIES_SECTION_ID, label: 'Deliveries', href: `${basePath}/reports/deliveries` },
     ],
   }];
 };
@@ -535,6 +548,8 @@ export type SidebarChild = {
   icon?: ComponentType<unknown>;
   /** Renders this child as a group heading + separator instead of a button. */
   isGroupLabel?: boolean;
+  /** Renders a small muted pill next to the label. */
+  comingSoon?: boolean;
 };
 
 export type SidebarItem = NavRailItem & {
@@ -583,6 +598,7 @@ function flattenSecondary(sections: NavSection[]): SidebarChild[] {
         variant: item.variant,
         isAction: item.isAction,
         icon: item.icon,
+        comingSoon: item.comingSoon,
       });
       if (item.children?.length) visit(item.children);
     }

--- a/src/shared/ui/nav/PracticeSidebar.tsx
+++ b/src/shared/ui/nav/PracticeSidebar.tsx
@@ -180,6 +180,7 @@ export const PracticeSidebar = ({
                         variant={child.variant}
                         isAction={child.isAction}
                         icon={child.icon}
+                        comingSoon={child.comingSoon}
                         onClick={
                           onSecondaryItemClick
                             ? () => {

--- a/src/shared/ui/nav/Sidebar.tsx
+++ b/src/shared/ui/nav/Sidebar.tsx
@@ -506,6 +506,8 @@ export interface SidebarSubItemProps {
   /** Optional 14px leading icon (Pencil GtRGH settings sub-items). */
   icon?: IconComponent;
   onClick?: () => void;
+  /** Renders a small muted pill next to the label. */
+  comingSoon?: boolean;
 }
 
 const SidebarSubItem: FunctionComponent<SidebarSubItemProps> = ({
@@ -517,6 +519,7 @@ const SidebarSubItem: FunctionComponent<SidebarSubItemProps> = ({
   isAction = false,
   icon,
   onClick,
+  comingSoon = false,
 }) => {
   const ctx = useContext(SidebarContext);
   const { navigate } = useNavigation();
@@ -557,6 +560,11 @@ const SidebarSubItem: FunctionComponent<SidebarSubItemProps> = ({
       <span className="flex min-w-0 items-center gap-2.5">
         {icon ? <Icon icon={icon} className="h-3.5 w-3.5 shrink-0" /> : null}
         <span className="truncate">{label}</span>
+        {comingSoon ? (
+          <span className="ml-1 shrink-0 rounded-full bg-[rgb(var(--sidebar-hover-bg))] px-1.5 py-px text-[10px] uppercase tracking-wide text-[rgb(var(--sidebar-text-secondary))]">
+            Soon
+          </span>
+        ) : null}
       </span>
       {(() => {
         const formattedCount = formatBadgeValue(count);

--- a/src/shared/utils/workspaceShell.ts
+++ b/src/shared/utils/workspaceShell.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceSection } from '@/shared/config/navConfig';
+import { buildReportSectionTitles } from '@/features/reports/config/reportCollection';
 
 export type WorkspaceView =
   | 'home'
@@ -30,12 +31,7 @@ type WorkspaceRouteState = {
   reportSectionFromPath: string;
 };
 
-const REPORT_SECTION_TITLES: Record<string, string> = {
-  'all-reports': 'All reports',
-  'payroll-matter-activity': 'Payroll & Matter Activity',
-  'trust-reconciliation': 'Trust Reconciliation',
-  'stale-matters': 'Stale Matters',
-};
+const REPORT_SECTION_TITLES: Record<string, string> = buildReportSectionTitles();
 
 const REPORT_SECTION_IDS = new Set(Object.keys(REPORT_SECTION_TITLES));
 

--- a/tests/unit/worker/services/ReportScheduleService.test.ts
+++ b/tests/unit/worker/services/ReportScheduleService.test.ts
@@ -40,6 +40,12 @@ describe('computeNextDelivery', () => {
     expect(iso).toBe('2026-05-18T09:00:00.000Z');
   });
 
+  it('rejects invalid weekly day of week values', () => {
+    const from = new Date('2026-05-14T12:00:00Z');
+    expect(() => computeNextDelivery('weekly', 9, { dayOfWeek: 7, from }))
+      .toThrow('dayOfWeek must be an integer from 0-6');
+  });
+
   it('targets the configured day of month for monthly', () => {
     const from = new Date('2026-05-14T12:00:00Z');
     const iso = computeNextDelivery('monthly', 9, { dayOfMonth: 5, from });

--- a/tests/unit/worker/services/ReportScheduleService.test.ts
+++ b/tests/unit/worker/services/ReportScheduleService.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ReportScheduleService,
+  computeNextDelivery,
+} from '../../../../worker/services/ReportScheduleService';
+import type { Env } from '../../../../worker/types';
+
+class FakeKV {
+  store = new Map<string, string>();
+  async get(key: string) { return this.store.get(key) ?? null; }
+  async put(key: string, value: string) { this.store.set(key, value); }
+  async delete(key: string) { this.store.delete(key); }
+  async list({ prefix }: { prefix: string }) {
+    const keys = Array.from(this.store.keys())
+      .filter((k) => k.startsWith(prefix))
+      .map((name) => ({ name }));
+    return { keys, list_complete: true as const };
+  }
+}
+
+const makeEnv = (kv: FakeKV) => ({ CHAT_SESSIONS: kv as unknown as KVNamespace } as unknown as Env);
+
+describe('computeNextDelivery', () => {
+  it('rolls daily forward to next-day occurrence if same-day hour has passed', () => {
+    const from = new Date('2026-05-14T12:00:00Z');
+    const iso = computeNextDelivery('daily', 8, { from });
+    expect(iso).toBe('2026-05-15T08:00:00.000Z');
+  });
+
+  it('keeps daily today if hour is in the future', () => {
+    const from = new Date('2026-05-14T06:00:00Z');
+    const iso = computeNextDelivery('daily', 8, { from });
+    expect(iso).toBe('2026-05-14T08:00:00.000Z');
+  });
+
+  it('targets the configured day of week (Mon=1) for weekly', () => {
+    const from = new Date('2026-05-14T12:00:00Z'); // Thursday
+    const iso = computeNextDelivery('weekly', 9, { dayOfWeek: 1, from });
+    // Next Monday from Thu = May 18
+    expect(iso).toBe('2026-05-18T09:00:00.000Z');
+  });
+
+  it('targets the configured day of month for monthly', () => {
+    const from = new Date('2026-05-14T12:00:00Z');
+    const iso = computeNextDelivery('monthly', 9, { dayOfMonth: 5, from });
+    // Today (14) > 5, roll to next month
+    expect(iso.startsWith('2026-06-05')).toBe(true);
+  });
+
+  it('clamps day of month to 28 to avoid Feb edge cases', () => {
+    const from = new Date('2026-05-14T12:00:00Z');
+    const iso = computeNextDelivery('monthly', 9, { dayOfMonth: 31, from });
+    expect(iso.endsWith('-28T09:00:00.000Z')).toBe(true);
+  });
+});
+
+describe('ReportScheduleService', () => {
+  let kv: FakeKV;
+  let service: ReportScheduleService;
+  beforeEach(() => {
+    kv = new FakeKV();
+    service = new ReportScheduleService(makeEnv(kv));
+  });
+
+  it('create -> get round-trip works and key is scoped to practice', async () => {
+    const created = await service.create('p1', {
+      reportType: 'revenue',
+      frequency: 'weekly',
+      hourUtc: 9,
+      dayOfWeek: 1,
+      recipients: ['u1'],
+      filters: { period: 'month' },
+    });
+    expect(created.practiceId).toBe('p1');
+    expect(created.id).toBeTruthy();
+    expect(kv.store.has(`report-schedule:p1:${created.id}`)).toBe(true);
+    const got = await service.get('p1', created.id);
+    expect(got?.recipients).toEqual(['u1']);
+  });
+
+  it('list returns only schedules for the requested practice', async () => {
+    await service.create('p1', { reportType: 'revenue', frequency: 'daily', hourUtc: 9, recipients: [], filters: {} });
+    await service.create('p2', { reportType: 'aging', frequency: 'daily', hourUtc: 9, recipients: [], filters: {} });
+    const p1 = await service.list('p1');
+    const p2 = await service.list('p2');
+    expect(p1).toHaveLength(1);
+    expect(p2).toHaveLength(1);
+    expect(p1[0].reportType).toBe('revenue');
+  });
+
+  it('update merges patch and recomputes nextDeliveryAt', async () => {
+    const created = await service.create('p1', {
+      reportType: 'revenue', frequency: 'daily', hourUtc: 9, recipients: [], filters: {},
+    });
+    const updated = await service.update('p1', created.id, { hourUtc: 14, recipients: ['u1', 'u2'] });
+    expect(updated?.hourUtc).toBe(14);
+    expect(updated?.recipients).toEqual(['u1', 'u2']);
+    expect(updated?.nextDeliveryAt).toMatch(/T14:00:00/);
+  });
+
+  it('delete removes the row and returns false on missing id', async () => {
+    const created = await service.create('p1', {
+      reportType: 'revenue', frequency: 'daily', hourUtc: 9, recipients: [], filters: {},
+    });
+    expect(await service.delete('p1', created.id)).toBe(true);
+    expect(await service.get('p1', created.id)).toBeNull();
+    expect(await service.delete('p1', 'missing')).toBe(false);
+  });
+});

--- a/tests/unit/worker/services/ReportService.aggregation.test.ts
+++ b/tests/unit/worker/services/ReportService.aggregation.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Pure-function aggregation tests for ReportService. The class itself
+ * touches Railway, but its helpers (groupRevenue / bucketAging /
+ * computeProfitability / groupUtilizationByUser / pLimit /
+ * resolveDateRange / sumBillableHours) are testable in isolation.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  groupRevenue,
+  bucketAging,
+  computeProfitability,
+  groupUtilizationByUser,
+  resolveDateRange,
+  sumBillableHours,
+  pLimit,
+} from '../../../../worker/services/ReportService';
+import type { BackendInvoice } from '../../../../worker/types/wire/invoice';
+import type {
+  BackendMatter,
+  BackendMatterTimeEntry,
+} from '../../../../worker/types/wire/matter';
+import { asMajor } from '../../../../src/shared/utils/money';
+
+const invoice = (overrides: Partial<BackendInvoice>): BackendInvoice => ({
+  id: overrides.id ?? `inv_${Math.random()}`,
+  organization_id: 'p1',
+  client_id: 'c1',
+  connected_account_id: 'acc1',
+  amount_paid: 0,
+  amount_due: 0,
+  status: 'open',
+  ...overrides,
+} as BackendInvoice);
+
+const matter = (overrides: Partial<BackendMatter>): BackendMatter => ({
+  id: overrides.id ?? `m_${Math.random()}`,
+  ...overrides,
+} as BackendMatter);
+
+const timeEntry = (overrides: Partial<BackendMatterTimeEntry>): BackendMatterTimeEntry => ({
+  id: overrides.id ?? `t_${Math.random()}`,
+  matter_id: overrides.matter_id ?? 'm1',
+  ...overrides,
+} as BackendMatterTimeEntry);
+
+describe('resolveDateRange', () => {
+  it('returns explicit range when both start and end provided', () => {
+    const r = resolveDateRange('2026-01-01T00:00:00Z', '2026-03-31T00:00:00Z', 'month');
+    expect(r.startIso).toBe('2026-01-01T00:00:00.000Z');
+    expect(r.endIso).toBe('2026-03-31T00:00:00.000Z');
+  });
+
+  it('falls back to last 12 months when period=month and no start/end', () => {
+    const now = new Date('2026-05-14T00:00:00Z');
+    const r = resolveDateRange(null, null, 'month', now);
+    expect(r.endMs).toBe(now.getTime());
+    // Start at month boundary 11 months back.
+    expect(new Date(r.startIso).getUTCMonth()).toBe(5);
+  });
+
+  it('throws when start is after end', () => {
+    expect(() => resolveDateRange('2026-05-01', '2026-01-01', 'month')).toThrow();
+  });
+});
+
+describe('pLimit', () => {
+  it('runs at most concurrency tasks at once', async () => {
+    let active = 0;
+    let peak = 0;
+    const result = await pLimit(3, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], async (item) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active -= 1;
+      return item * 2;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(result).toEqual([2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+  });
+
+  it('preserves order even with random durations', async () => {
+    const out = await pLimit(2, ['a', 'b', 'c', 'd'], async (s) => {
+      await new Promise((r) => setTimeout(r, Math.random() * 20));
+      return s.toUpperCase();
+    });
+    expect(out).toEqual(['A', 'B', 'C', 'D']);
+  });
+});
+
+describe('groupRevenue', () => {
+  const range = resolveDateRange('2026-01-01', '2026-12-31', 'month');
+
+  it('buckets paid invoices by paid_at month', () => {
+    const result = groupRevenue([
+      invoice({ paid_at: '2026-01-15T00:00:00Z', amount_paid: 50000, status: 'paid' }),
+      invoice({ paid_at: '2026-01-20T00:00:00Z', amount_paid: 25000, status: 'paid' }),
+      invoice({ paid_at: '2026-02-05T00:00:00Z', amount_paid: 80000, status: 'paid' }),
+    ], 'month', range);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].periodLabel).toMatch(/Jan 2026/);
+    expect(result.rows[0].paidAmountCents).toBe(75000);
+    expect(result.rows[0].invoiceCount).toBe(2);
+    expect(result.totalPaidCents).toBe(155000);
+    expect(result.totalInvoiceCount).toBe(3);
+  });
+
+  it('ignores invoices outside the range', () => {
+    const result = groupRevenue([
+      invoice({ paid_at: '2025-12-15T00:00:00Z', amount_paid: 99999, status: 'paid' }),
+      invoice({ paid_at: '2026-06-15T00:00:00Z', amount_paid: 100, status: 'paid' }),
+    ], 'month', range);
+    expect(result.rows).toHaveLength(1);
+    expect(result.totalPaidCents).toBe(100);
+  });
+
+  it('falls back to created_at when paid_at missing', () => {
+    const result = groupRevenue([
+      invoice({ paid_at: null, created_at: '2026-03-10T00:00:00Z', amount_paid: 12300, status: 'paid' }),
+    ], 'month', range);
+    expect(result.rows).toHaveLength(1);
+    expect(result.totalPaidCents).toBe(12300);
+  });
+
+  it('outstanding amounts add to the row but do not count toward invoiceCount', () => {
+    const result = groupRevenue([
+      invoice({ paid_at: '2026-04-01T00:00:00Z', amount_paid: 0, amount_due: 5000, status: 'open' }),
+    ], 'month', range);
+    expect(result.totalOutstandingCents).toBe(5000);
+    expect(result.totalInvoiceCount).toBe(0);
+  });
+});
+
+describe('bucketAging', () => {
+  const now = new Date('2026-05-14T00:00:00Z');
+
+  it('places overdue invoices in the correct bucket', () => {
+    const result = bucketAging([
+      invoice({ due_date: '2026-05-13', amount_due: 100, status: 'open' }), // 1d -> 1-30
+      invoice({ due_date: '2026-04-13', amount_due: 200, status: 'open' }), // ~31 -> 31-60
+      invoice({ due_date: '2026-03-13', amount_due: 300, status: 'overdue' }), // ~62 -> 61-90
+      invoice({ due_date: '2026-01-13', amount_due: 400, status: 'overdue' }), // ~120 -> 91+
+      invoice({ due_date: '2026-05-20', amount_due: 50, status: 'open' }), // -6 -> Current
+    ], now);
+    expect(result.rows.find((r) => r.bucketLabel.startsWith('1–30'))!.totalAmountCents).toBe(100);
+    expect(result.rows.find((r) => r.bucketLabel.startsWith('31–60'))!.totalAmountCents).toBe(200);
+    expect(result.rows.find((r) => r.bucketLabel.startsWith('61–90'))!.totalAmountCents).toBe(300);
+    expect(result.rows.find((r) => r.bucketLabel.startsWith('91+'))!.totalAmountCents).toBe(400);
+    expect(result.rows.find((r) => r.bucketLabel.startsWith('Current'))!.totalAmountCents).toBe(50);
+    expect(result.totalOutstandingCents).toBe(1050);
+    expect(result.totalInvoiceCount).toBe(5);
+  });
+
+  it('skips paid invoices', () => {
+    const result = bucketAging([
+      invoice({ due_date: '2026-04-13', amount_due: 0, status: 'paid' }),
+    ], now);
+    expect(result.totalInvoiceCount).toBe(0);
+  });
+
+  it('falls back to issue_date + 30d when due_date missing', () => {
+    const result = bucketAging([
+      invoice({ due_date: null, issue_date: '2026-04-01', amount_due: 99, status: 'open' }),
+    ], now);
+    // Effective due = 2026-05-01; 13 days overdue -> 1-30 bucket.
+    expect(result.rows.find((r) => r.bucketLabel.startsWith('1–30'))!.totalAmountCents).toBe(99);
+  });
+});
+
+describe('sumBillableHours', () => {
+  it('treats duration as seconds and converts to hours, skipping non-billable', () => {
+    const hours = sumBillableHours([
+      timeEntry({ duration: 3600, billable: true }),  // 1h
+      timeEntry({ duration: 1800, billable: true }),  // 0.5h
+      timeEntry({ duration: 7200, billable: false }), // skipped
+    ]);
+    expect(hours).toBe(1.5);
+  });
+});
+
+describe('computeProfitability', () => {
+  it('uses matter attorney_hourly_rate as default and overrides when provided', () => {
+    const matters = [
+      { ...matter({ id: 'm1', title: 'Smith', attorney_hourly_rate: asMajor(200) }), __revenueCents: 100_000 } as BackendMatter,
+      { ...matter({ id: 'm2', title: 'Jones', attorney_hourly_rate: null }),  __revenueCents: 50_000 } as BackendMatter,
+    ];
+    const entries = new Map<string, BackendMatterTimeEntry[]>([
+      ['m1', [timeEntry({ duration: 3600, billable: true })]],     // 1h
+      ['m2', [timeEntry({ duration: 7200, billable: true })]],     // 2h
+    ]);
+    const result = computeProfitability(matters, entries, null);
+    const smith = result.rows.find((r) => r.matterId === 'm1')!;
+    expect(smith.estimatedCostCents).toBe(200 * 1 * 100);
+    expect(smith.revenueCents).toBe(100_000);
+    expect(smith.marginCents).toBe(100_000 - 200 * 100);
+    const jones = result.rows.find((r) => r.matterId === 'm2')!;
+    // Falls back to DEFAULT_PROFITABILITY_RATE_DOLLARS = 250
+    expect(jones.estimatedCostCents).toBe(250 * 2 * 100);
+  });
+
+  it('honors override hourly rate', () => {
+    const matters = [
+      { ...matter({ id: 'm1', title: 'X', attorney_hourly_rate: asMajor(200) }), __revenueCents: 0 } as BackendMatter,
+    ];
+    const entries = new Map([['m1', [timeEntry({ duration: 3600, billable: true })]]]);
+    const result = computeProfitability(matters, entries, 500);
+    expect(result.rows[0].estimatedCostCents).toBe(500 * 1 * 100);
+  });
+});
+
+describe('groupUtilizationByUser', () => {
+  it('computes utilization% as billable / (billable + non-billable)', () => {
+    const result = groupUtilizationByUser([
+      timeEntry({ user_id: 'u1', duration: 3600, billable: true }),  // 1h
+      timeEntry({ user_id: 'u1', duration: 3600, billable: false }), // 1h non-bill
+      timeEntry({ user_id: 'u2', duration: 3600, billable: true }),  // 1h
+    ]);
+    const u1 = result.rows.find((r) => r.userId === 'u1')!;
+    expect(u1.billableHours).toBe(1);
+    expect(u1.nonBillableHours).toBe(1);
+    expect(u1.utilizationPercent).toBe(50);
+    const u2 = result.rows.find((r) => r.userId === 'u2')!;
+    expect(u2.utilizationPercent).toBe(100);
+    expect(result.totalBillableHours).toBe(2);
+    expect(result.averageUtilizationPercent).toBeCloseTo(66.67, 1);
+  });
+
+  it('handles empty user_id as "unassigned"', () => {
+    const result = groupUtilizationByUser([
+      timeEntry({ user_id: null, duration: 1800, billable: true }),
+    ]);
+    expect(result.rows[0].userId).toBe('unassigned');
+  });
+});

--- a/tests/unit/worker/services/ReportService.phase3.aggregation.test.ts
+++ b/tests/unit/worker/services/ReportService.phase3.aggregation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure-function aggregation tests for the Phase 3 reports (originally
+ * blocked on blawby-backend#233 — now wired through real Railway calls).
+ * The class-level Railway fetches are out of scope here; we exercise the
+ * exported helpers with fixtures.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateTrustLedger,
+  aggregateWip,
+  groupByOriginatingAttorney,
+  groupByResponsibleAttorney,
+  aggregateTaskProductivity,
+  resolveDateRange,
+} from '../../../../worker/services/ReportService';
+import type { BackendInvoice } from '../../../../worker/types/wire/invoice';
+import type { BackendMatter } from '../../../../worker/types/wire/matter';
+import type {
+  BackendTrustTransaction,
+  BackendWipMatter,
+  BackendPracticeTask,
+} from '../../../../worker/types/wire/reports';
+
+const trustTxn = (overrides: Partial<BackendTrustTransaction>): BackendTrustTransaction => ({
+  id: overrides.id ?? `t_${Math.random()}`,
+  ...overrides,
+} as BackendTrustTransaction);
+
+const wipMatter = (overrides: Partial<BackendWipMatter>): BackendWipMatter => ({
+  matter_id: overrides.matter_id ?? 'm1',
+  ...overrides,
+} as BackendWipMatter);
+
+const matter = (overrides: Partial<BackendMatter>): BackendMatter => ({
+  id: overrides.id ?? `m_${Math.random()}`,
+  ...overrides,
+} as BackendMatter);
+
+const invoice = (overrides: Partial<BackendInvoice>): BackendInvoice => ({
+  id: overrides.id ?? `inv_${Math.random()}`,
+  organization_id: 'p1',
+  client_id: 'c1',
+  connected_account_id: 'acc1',
+  amount_paid: 0,
+  amount_due: 0,
+  status: 'open',
+  ...overrides,
+} as BackendInvoice);
+
+const task = (overrides: Partial<BackendPracticeTask>): BackendPracticeTask => ({
+  id: overrides.id ?? `task_${Math.random()}`,
+  status: overrides.status ?? 'pending',
+  ...overrides,
+} as BackendPracticeTask);
+
+describe('aggregateTrustLedger', () => {
+  const range = resolveDateRange('2026-01-01', '2026-12-31', 'year');
+
+  it('partitions credits and debits, ignores out-of-range rows', () => {
+    const result = aggregateTrustLedger([
+      trustTxn({ id: 't1', occurred_at: '2026-03-15T00:00:00Z', amount: 50_000, balance_after: 50_000, type: 'deposit', description: 'Initial', client_name: 'Smith' }),
+      trustTxn({ id: 't2', occurred_at: '2026-04-01T00:00:00Z', amount: -20_000, balance_after: 30_000, type: 'fee_payment', client_name: 'Smith' }),
+      trustTxn({ id: 't3', occurred_at: '2025-12-15T00:00:00Z', amount: 99_000, balance_after: 0, type: 'deposit' }), // out of range
+    ], range);
+    expect(result.rows).toHaveLength(2);
+    // Newest first
+    expect(result.rows[0].id).toBe('t2');
+    expect(result.totalCreditsCents).toBe(50_000);
+    expect(result.totalDebitsCents).toBe(20_000);
+    expect(result.endingBalanceCents).toBe(30_000); // latest row's balance_after
+    expect(result.transactionCount).toBe(2);
+  });
+
+  it('resolves client name from join when client_name not present', () => {
+    const result = aggregateTrustLedger([
+      trustTxn({
+        id: 't1',
+        occurred_at: '2026-03-15T00:00:00Z',
+        amount: 50_000,
+        balance_after: 50_000,
+        client: { name: 'Jones' },
+      }),
+    ], range);
+    expect(result.rows[0].clientName).toBe('Jones');
+  });
+
+  it('returns empty aggregate when no rows', () => {
+    const result = aggregateTrustLedger([], range);
+    expect(result.rows).toEqual([]);
+    expect(result.endingBalanceCents).toBe(0);
+  });
+});
+
+describe('aggregateWip', () => {
+  it('converts seconds to hours and sorts by amount desc', () => {
+    const result = aggregateWip([
+      wipMatter({ matter_id: 'm1', matter_title: 'Smith', unbilled_seconds: 3600, unbilled_amount: 25_000 }),
+      wipMatter({ matter_id: 'm2', matter_title: 'Jones', unbilled_seconds: 7200, unbilled_amount: 100_000 }),
+    ]);
+    expect(result.rows[0].matterId).toBe('m2');
+    expect(result.rows[0].unbilledHours).toBe(2);
+    expect(result.rows[1].unbilledHours).toBe(1);
+    expect(result.totalUnbilledAmountCents).toBe(125_000);
+    expect(result.totalUnbilledHours).toBe(3);
+    expect(result.matterCount).toBe(2);
+  });
+
+  it('skips rows with no unbilled time or amount', () => {
+    const result = aggregateWip([
+      wipMatter({ matter_id: 'm1', unbilled_seconds: 0, unbilled_amount: 0 }),
+    ]);
+    expect(result.rows).toHaveLength(0);
+  });
+});
+
+describe('groupByOriginatingAttorney', () => {
+  const range = resolveDateRange('2026-01-01', '2026-12-31', 'year');
+
+  it('groups matters by originating attorney with paid invoice revenue', () => {
+    const matters = [
+      matter({ id: 'm1', title: 'Case A', originating_attorney_id: 'u1' }),
+      matter({ id: 'm2', title: 'Case B', originating_attorney_id: 'u1' }),
+      matter({ id: 'm3', title: 'Case C', originating_attorney_id: 'u2' }),
+      matter({ id: 'm4', title: 'Case D', originating_attorney_id: null }),
+    ];
+    const invoices = [
+      invoice({ matter_id: 'm1', paid_at: '2026-03-15T00:00:00Z', amount_paid: 100_000, status: 'paid' }),
+      invoice({ matter_id: 'm2', paid_at: '2026-04-01T00:00:00Z', amount_paid: 50_000, status: 'paid' }),
+      invoice({ matter_id: 'm3', paid_at: '2026-06-01T00:00:00Z', amount_paid: 200_000, status: 'paid' }),
+      // Out-of-range invoice should not count
+      invoice({ matter_id: 'm1', paid_at: '2025-06-01T00:00:00Z', amount_paid: 999, status: 'paid' }),
+    ];
+    const names = new Map([['u1', 'Alice'], ['u2', 'Bob']]);
+    const result = groupByOriginatingAttorney(matters, invoices, range, names);
+    // Sorted by revenue desc: Bob (200k), Alice (150k), Unassigned (0)
+    expect(result.rows[0]).toMatchObject({ attorneyId: 'u2', attorneyName: 'Bob', revenueCents: 200_000, matterCount: 1 });
+    expect(result.rows[1]).toMatchObject({ attorneyId: 'u1', attorneyName: 'Alice', revenueCents: 150_000, matterCount: 2 });
+    expect(result.rows[2]).toMatchObject({ attorneyName: 'Unassigned', matterCount: 1 });
+    expect(result.totalRevenueCents).toBe(350_000);
+    expect(result.totalMatterCount).toBe(4);
+  });
+
+  it('falls back to attorney id when no name in map', () => {
+    const result = groupByOriginatingAttorney(
+      [matter({ id: 'm1', originating_attorney_id: 'u999' })],
+      [],
+      range,
+      new Map()
+    );
+    expect(result.rows[0].attorneyName).toBe('u999');
+  });
+});
+
+describe('groupByResponsibleAttorney', () => {
+  it('counts open vs closed matters per attorney', () => {
+    const matters = [
+      matter({ id: 'm1', responsible_attorney_id: 'u1', status: 'active' }),
+      matter({ id: 'm2', responsible_attorney_id: 'u1', status: 'closed' }),
+      matter({ id: 'm3', responsible_attorney_id: 'u2', status: 'declined' }),
+      matter({ id: 'm4', responsible_attorney_id: 'u2', status: 'discovery' }),
+    ];
+    const names = new Map([['u1', 'Alice'], ['u2', 'Bob']]);
+    const result = groupByResponsibleAttorney(matters, names);
+    const alice = result.rows.find((r) => r.attorneyId === 'u1')!;
+    expect(alice).toMatchObject({ attorneyName: 'Alice', matterCount: 2, openCount: 1, closedCount: 1 });
+    const bob = result.rows.find((r) => r.attorneyId === 'u2')!;
+    expect(bob).toMatchObject({ attorneyName: 'Bob', matterCount: 2, openCount: 1, closedCount: 1 });
+    expect(result.totalMatterCount).toBe(4);
+    expect(result.totalOpenCount).toBe(2);
+    expect(result.totalClosedCount).toBe(2);
+  });
+
+  it('groups unassigned attorneys', () => {
+    const result = groupByResponsibleAttorney(
+      [matter({ id: 'm1', responsible_attorney_id: null, status: 'active' })],
+      new Map()
+    );
+    expect(result.rows[0]).toMatchObject({ attorneyName: 'Unassigned', matterCount: 1, openCount: 1 });
+  });
+});
+
+describe('aggregateTaskProductivity', () => {
+  const range = resolveDateRange('2026-01-01', '2026-12-31', 'year');
+
+  it('counts completed/pending per assignee and computes avg cycle days', () => {
+    const tasks = [
+      task({
+        id: 't1',
+        assignee_id: 'u1',
+        status: 'completed',
+        created_at: '2026-03-01T00:00:00Z',
+        completed_at: '2026-03-05T00:00:00Z', // 4 days
+      }),
+      task({
+        id: 't2',
+        assignee_id: 'u1',
+        status: 'completed',
+        created_at: '2026-04-01T00:00:00Z',
+        completed_at: '2026-04-07T00:00:00Z', // 6 days
+      }),
+      task({ id: 't3', assignee_id: 'u1', status: 'pending' }),
+      task({ id: 't4', assignee_id: 'u2', status: 'in_progress' }),
+    ];
+    const names = new Map([['u1', 'Alice'], ['u2', 'Bob']]);
+    const result = aggregateTaskProductivity(tasks, range, names);
+    const alice = result.rows.find((r) => r.assigneeId === 'u1')!;
+    expect(alice.completed).toBe(2);
+    expect(alice.pending).toBe(1);
+    expect(alice.avgCycleDays).toBe(5);
+    const bob = result.rows.find((r) => r.assigneeId === 'u2')!;
+    expect(bob.completed).toBe(0);
+    expect(bob.pending).toBe(1);
+    expect(result.totalCompleted).toBe(2);
+    expect(result.totalPending).toBe(2);
+    expect(result.averageCycleDays).toBe(5);
+  });
+
+  it('ignores completed tasks outside the date range', () => {
+    const result = aggregateTaskProductivity([
+      task({
+        id: 't1',
+        assignee_id: 'u1',
+        status: 'completed',
+        created_at: '2025-01-01T00:00:00Z',
+        completed_at: '2025-01-05T00:00:00Z',
+      }),
+    ], range, new Map());
+    expect(result.totalCompleted).toBe(0);
+  });
+
+  it('returns zero avg cycle days when no completed tasks have created_at', () => {
+    const result = aggregateTaskProductivity([
+      task({
+        id: 't1',
+        assignee_id: 'u1',
+        status: 'completed',
+        created_at: null,
+        completed_at: '2026-03-05T00:00:00Z',
+      }),
+    ], range, new Map());
+    expect(result.totalCompleted).toBe(1);
+    expect(result.averageCycleDays).toBe(0);
+  });
+
+});

--- a/tests/unit/worker/utils/csv.test.ts
+++ b/tests/unit/worker/utils/csv.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { toCsv } from '../../../../worker/utils/csv';
+
+describe('toCsv', () => {
+  it('emits header only when rows are empty', () => {
+    const out = toCsv<{ a: string; b: number }>([], [
+      { key: 'a', header: 'A' },
+      { key: 'b', header: 'B' },
+    ]);
+    expect(out).toBe('A,B');
+  });
+
+  it('escapes quotes, commas, and newlines per RFC 4180', () => {
+    const out = toCsv([
+      { name: 'Smith, Jones', notes: 'has "quotes"\nand newline' },
+    ], [
+      { key: 'name', header: 'Name' },
+      { key: 'notes', header: 'Notes' },
+    ]);
+    const lines = out.split('\r\n');
+    expect(lines[0]).toBe('Name,Notes');
+    expect(lines[1]).toBe('"Smith, Jones","has ""quotes""\nand newline"');
+  });
+
+  it('emits empty string for null/undefined', () => {
+    const out = toCsv([
+      { name: null, amount: undefined },
+    ] as unknown as Array<Record<string, unknown>>, [
+      { key: 'name', header: 'Name' },
+      { key: 'amount', header: 'Amount' },
+    ]);
+    expect(out).toBe('Name,Amount\r\n,');
+  });
+
+  it('applies the column format function before escaping', () => {
+    const out = toCsv([
+      { cents: 12345 },
+    ], [
+      {
+        key: 'cents',
+        header: 'Amount',
+        format: (v) => (Number(v) / 100).toFixed(2),
+      },
+    ]);
+    expect(out).toBe('Amount\r\n123.45');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,6 +67,7 @@ const workerEndpoints = [
 	'onboarding',
 	'practice',
 	'preferences',
+	'reports',
 	'subscriptions',
 	'subscription',
 	'matters',

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -19,6 +19,7 @@ import {
   handleBillingSummary,
   handleSidebarCounts,
   handleMetricsVitals,
+  handleReports,
 } from './routes';
 import { handleConversations } from './routes/conversations.js';
 import { handlePresence } from './routes/presence.js';
@@ -115,6 +116,11 @@ export const routes: RouteEntry[] = [
   { mode: 'proxy', match: prefix('/api/practices'), handler: (req, env) => handlePractices(req, env) },
   { mode: 'owned', match: prefix('/api/paralegal'), handler: (req, env) => handleParalegal(req, env) },
   { mode: 'owned', match: prefix('/api/activity'), handler: (req, env) => handleActivity(req, env) },
+  {
+    mode: 'owned',
+    match: prefix('/api/reports/'),
+    handler: withAuth((req, env) => handleReports(req, env), { required: true }),
+  },
   { mode: 'owned', match: prefix('/api/files'), handler: (req, env) => handleFiles(req, env) },
   { mode: 'owned', match: exact('/api/analyze'), handler: (req, env) => handleAnalyze(req, env) },
   { mode: 'owned', match: prefix('/api/pdf'), handler: (req, env) => handlePDF(req, env) },

--- a/worker/migrations/20260514_add_report_deliveries.sql
+++ b/worker/migrations/20260514_add_report_deliveries.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS report_deliveries (
   report_type TEXT NOT NULL,
   filters_json TEXT NOT NULL DEFAULT '{}',
   recipients_json TEXT NOT NULL DEFAULT '[]',
-  status TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending','completed','failed')),
   storage_key TEXT,
   byte_size INTEGER,
   error_message TEXT,
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS report_deliveries (
 );
 
 CREATE INDEX IF NOT EXISTS idx_report_deliveries_practice_created
-  ON report_deliveries(practice_id, created_at DESC);
+  ON report_deliveries(practice_id, created_at DESC, id DESC);
 
 CREATE INDEX IF NOT EXISTS idx_report_deliveries_practice_status
   ON report_deliveries(practice_id, status, created_at DESC);

--- a/worker/migrations/20260514_add_report_deliveries.sql
+++ b/worker/migrations/20260514_add_report_deliveries.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS report_deliveries (
+  id TEXT PRIMARY KEY,
+  practice_id TEXT NOT NULL,
+  report_type TEXT NOT NULL,
+  filters_json TEXT NOT NULL DEFAULT '{}',
+  recipients_json TEXT NOT NULL DEFAULT '[]',
+  status TEXT NOT NULL,
+  storage_key TEXT,
+  byte_size INTEGER,
+  error_message TEXT,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  scheduled_for TEXT,
+  completed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_report_deliveries_practice_created
+  ON report_deliveries(practice_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_report_deliveries_practice_status
+  ON report_deliveries(practice_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_report_deliveries_practice_type
+  ON report_deliveries(practice_id, report_type, created_at DESC);

--- a/worker/routes/index.ts
+++ b/worker/routes/index.ts
@@ -19,3 +19,4 @@ export { handlePracticeTeam } from './practiceTeam';
 export { handleBillingSummary } from './billingSummary';
 export { handleSidebarCounts } from './sidebarCounts';
 export { handleMetricsVitals } from './metrics';
+export { handleReports } from './reports';

--- a/worker/routes/reports.ts
+++ b/worker/routes/reports.ts
@@ -409,6 +409,18 @@ const handleExport = async (
 
 const FREQUENCIES = new Set<ReportFrequency>(['daily', 'weekly', 'monthly']);
 
+const requireIntegerInRange = (
+  value: unknown,
+  field: string,
+  min: number,
+  max: number
+): number => {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
+    throw HttpErrors.badRequest(`${field} must be an integer from ${min}-${max}`);
+  }
+  return value;
+};
+
 const handleSchedulesList = async (env: Env, practiceId: string): Promise<Response> => {
   const service = new ReportScheduleService(env);
   const schedules = await service.list(practiceId);
@@ -439,9 +451,17 @@ const handleScheduleCreate = async (
   if (!body.frequency || !FREQUENCIES.has(body.frequency as ReportFrequency)) {
     throw HttpErrors.badRequest('Invalid frequency');
   }
-  if (typeof body.hourUtc !== 'number' || body.hourUtc < 0 || body.hourUtc > 23) {
-    throw HttpErrors.badRequest('hourUtc must be 0-23');
-  }
+  const hourUtc = requireIntegerInRange(body.hourUtc, 'hourUtc', 0, 23);
+  const dayOfWeek = body.frequency === 'weekly'
+    ? requireIntegerInRange(body.dayOfWeek, 'dayOfWeek', 0, 6)
+    : body.dayOfWeek === undefined
+      ? undefined
+      : requireIntegerInRange(body.dayOfWeek, 'dayOfWeek', 0, 6);
+  const dayOfMonth = body.frequency === 'monthly'
+    ? requireIntegerInRange(body.dayOfMonth, 'dayOfMonth', 1, 31)
+    : body.dayOfMonth === undefined
+      ? undefined
+      : requireIntegerInRange(body.dayOfMonth, 'dayOfMonth', 1, 31);
   const recipients = Array.isArray(body.recipients)
     ? (body.recipients as unknown[]).filter((r): r is string => typeof r === 'string')
     : [];
@@ -455,9 +475,9 @@ const handleScheduleCreate = async (
   const created = await service.create(practiceId, {
     reportType: body.reportType,
     frequency: body.frequency as ReportFrequency,
-    dayOfWeek: body.dayOfWeek,
-    dayOfMonth: body.dayOfMonth,
-    hourUtc: body.hourUtc,
+    dayOfWeek,
+    dayOfMonth,
+    hourUtc,
     recipients,
     filters,
     active: body.active ?? true,
@@ -476,12 +496,15 @@ const handleScheduleUpdate = async (
 ): Promise<Response> => {
   const body = await parseJsonBody(request) as Record<string, unknown>;
   const patch: Record<string, unknown> = {};
-  if (typeof body.frequency === 'string' && FREQUENCIES.has(body.frequency as ReportFrequency)) {
+  if (body.frequency !== undefined) {
+    if (typeof body.frequency !== 'string' || !FREQUENCIES.has(body.frequency as ReportFrequency)) {
+      throw HttpErrors.badRequest('Invalid frequency');
+    }
     patch.frequency = body.frequency;
   }
-  if (typeof body.hourUtc === 'number') patch.hourUtc = body.hourUtc;
-  if (typeof body.dayOfWeek === 'number') patch.dayOfWeek = body.dayOfWeek;
-  if (typeof body.dayOfMonth === 'number') patch.dayOfMonth = body.dayOfMonth;
+  if (body.hourUtc !== undefined) patch.hourUtc = requireIntegerInRange(body.hourUtc, 'hourUtc', 0, 23);
+  if (body.dayOfWeek !== undefined) patch.dayOfWeek = requireIntegerInRange(body.dayOfWeek, 'dayOfWeek', 0, 6);
+  if (body.dayOfMonth !== undefined) patch.dayOfMonth = requireIntegerInRange(body.dayOfMonth, 'dayOfMonth', 1, 31);
   if (Array.isArray(body.recipients)) {
     patch.recipients = (body.recipients as unknown[]).filter((r): r is string => typeof r === 'string');
   }

--- a/worker/routes/reports.ts
+++ b/worker/routes/reports.ts
@@ -1,0 +1,336 @@
+/**
+ * /api/reports/:practiceId/* — legal-firm reports.
+ *
+ * Phase 1: revenue, aging + CSV export
+ * Phase 2: profitability, utilization, schedules, send-now, deliveries
+ * Phase 3: stubbed to 503 BACKEND_NOT_AVAILABLE until #233 ships.
+ */
+
+import type { Env } from '../types.js';
+import { HttpErrors, handleError } from '../errorHandler.js';
+import { getAttachedAuthContext } from '../middleware/compose.js';
+import { requirePracticeMember } from '../middleware/auth.js';
+import { buildForwardHeaders } from '../utils/intakeVisibility.js';
+import {
+  BackendUnavailableError,
+  ReportService,
+  resolveDateRange,
+  type ResolvedDateRange,
+} from '../services/ReportService.js';
+import { toCsv, type CsvColumn } from '../utils/csv.js';
+
+const PRACTICE_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
+const VALID_REPORT_TYPES = new Set<string>([
+  'revenue',
+  'aging',
+  'profitability',
+  'utilization',
+  'trust-ledger',
+  'wip',
+  'originating-attorney',
+  'matters-by-attorney',
+  'task-productivity',
+]);
+
+const PHASE_3_REPORTS = new Set<string>([
+  'trust-ledger',
+  'wip',
+  'originating-attorney',
+  'matters-by-attorney',
+  'task-productivity',
+]);
+
+const VALID_PERIODS = new Set(['month', 'quarter', 'year']);
+
+interface ReportEnvelope<T> {
+  items: T[];
+  total: number;
+  generatedAt: string;
+  filters: Record<string, string | undefined>;
+  meta?: Record<string, unknown>;
+}
+
+const envelope = <T>(payload: ReportEnvelope<T>): Response =>
+  new Response(JSON.stringify({ success: true, data: payload }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const csvResponse = (filename: string, body: string): Response =>
+  new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  });
+
+const backendUnavailable = (reportType: string): Response =>
+  new Response(
+    JSON.stringify({
+      success: false,
+      error: `Report '${reportType}' depends on a backend endpoint that is not yet available.`,
+      errorCode: 'BACKEND_NOT_AVAILABLE',
+    }),
+    { status: 503, headers: { 'Content-Type': 'application/json' } }
+  );
+
+const parsePeriod = (raw: string | null): 'month' | 'quarter' | 'year' => {
+  if (raw && VALID_PERIODS.has(raw)) return raw as 'month' | 'quarter' | 'year';
+  return 'month';
+};
+
+const parseRange = (url: URL, period: 'month' | 'quarter' | 'year'): ResolvedDateRange => {
+  return resolveDateRange(
+    url.searchParams.get('start'),
+    url.searchParams.get('end'),
+    period
+  );
+};
+
+const parsePracticeId = (raw: string | undefined): string => {
+  if (!raw) throw HttpErrors.badRequest('Practice ID required');
+  let practiceId: string;
+  try {
+    practiceId = decodeURIComponent(raw);
+  } catch {
+    throw HttpErrors.badRequest('Invalid practice ID');
+  }
+  if (!PRACTICE_ID_RE.test(practiceId)) throw HttpErrors.badRequest('Invalid practice ID');
+  return practiceId;
+};
+
+const filenameFor = (reportType: string, practiceId: string): string => {
+  const date = new Date().toISOString().slice(0, 10);
+  return `${reportType}-${practiceId}-${date}.csv`;
+};
+
+// ─── CSV column maps (mirror the report column specs) ───────────────────
+
+const REVENUE_CSV_COLUMNS: CsvColumn<{
+  periodLabel: string;
+  invoiceCount: number;
+  paidAmountCents: number;
+  outstandingAmountCents: number;
+}>[] = [
+  { key: 'periodLabel', header: 'Period' },
+  { key: 'invoiceCount', header: 'Invoices' },
+  { key: 'paidAmountCents', header: 'Paid (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+  { key: 'outstandingAmountCents', header: 'Outstanding (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+];
+
+const AGING_CSV_COLUMNS: CsvColumn<{
+  bucketLabel: string;
+  invoiceCount: number;
+  totalAmountCents: number;
+}>[] = [
+  { key: 'bucketLabel', header: 'Bucket' },
+  { key: 'invoiceCount', header: 'Invoices' },
+  { key: 'totalAmountCents', header: 'Amount (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+];
+
+const PROFITABILITY_CSV_COLUMNS: CsvColumn<{
+  matterTitle: string;
+  revenueCents: number;
+  estimatedCostCents: number;
+  marginCents: number;
+  billableHours: number;
+}>[] = [
+  { key: 'matterTitle', header: 'Matter' },
+  { key: 'revenueCents', header: 'Revenue (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+  { key: 'estimatedCostCents', header: 'Est. cost (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+  { key: 'marginCents', header: 'Margin (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+  { key: 'billableHours', header: 'Billable hours' },
+];
+
+const UTILIZATION_CSV_COLUMNS: CsvColumn<{
+  userId: string;
+  billableHours: number;
+  nonBillableHours: number;
+  totalHours: number;
+  utilizationPercent: number;
+}>[] = [
+  { key: 'userId', header: 'User' },
+  { key: 'billableHours', header: 'Billable hours' },
+  { key: 'nonBillableHours', header: 'Non-billable hours' },
+  { key: 'totalHours', header: 'Total hours' },
+  { key: 'utilizationPercent', header: 'Utilization (%)' },
+];
+
+// ─── per-report handlers ─────────────────────────────────────────────────
+
+const runReport = async (
+  reportType: string,
+  request: Request,
+  env: Env,
+  practiceId: string
+): Promise<{ rows: Record<string, unknown>[]; meta: Record<string, unknown>; filters: Record<string, string | undefined> }> => {
+  const url = new URL(request.url);
+  const headers = buildForwardHeaders(request);
+  const service = new ReportService(env);
+
+  if (reportType === 'revenue') {
+    const period = parsePeriod(url.searchParams.get('period'));
+    const range = parseRange(url, period);
+    const result = await service.revenue(practiceId, headers, { period, range });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalPaidCents: result.totalPaidCents,
+        totalOutstandingCents: result.totalOutstandingCents,
+        totalInvoiceCount: result.totalInvoiceCount,
+      },
+      filters: { period, start: range.startIso, end: range.endIso },
+    };
+  }
+  if (reportType === 'aging') {
+    const range = parseRange(url, 'month');
+    const result = await service.aging(practiceId, headers, { now: new Date() });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalOutstandingCents: result.totalOutstandingCents,
+        totalInvoiceCount: result.totalInvoiceCount,
+      },
+      filters: { start: range.startIso, end: range.endIso },
+    };
+  }
+  if (reportType === 'profitability') {
+    const range = parseRange(url, 'month');
+    const rateRaw = url.searchParams.get('hourlyRate');
+    const rate = rateRaw ? Number(rateRaw) : null;
+    const result = await service.profitability(practiceId, headers, {
+      range,
+      overrideHourlyRateDollars: rate != null && Number.isFinite(rate) && rate > 0 ? rate : null,
+    });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalRevenueCents: result.totalRevenueCents,
+        totalCostCents: result.totalCostCents,
+        totalMarginCents: result.totalMarginCents,
+        truncated: result.truncated,
+      },
+      filters: {
+        start: range.startIso,
+        end: range.endIso,
+        hourlyRate: rate != null ? String(rate) : undefined,
+      },
+    };
+  }
+  if (reportType === 'utilization') {
+    const range = parseRange(url, 'month');
+    const result = await service.utilization(practiceId, headers, { range });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalBillableHours: result.totalBillableHours,
+        totalNonBillableHours: result.totalNonBillableHours,
+        averageUtilizationPercent: result.averageUtilizationPercent,
+        truncated: result.truncated,
+      },
+      filters: { start: range.startIso, end: range.endIso },
+    };
+  }
+  if (PHASE_3_REPORTS.has(reportType)) {
+    await service.forwardPhase3(reportType);
+  }
+  throw HttpErrors.notFound(`Unknown report type: ${reportType}`);
+};
+
+const handleGetReport = async (
+  reportType: string,
+  request: Request,
+  env: Env,
+  practiceId: string
+): Promise<Response> => {
+  const result = await runReport(reportType, request, env, practiceId);
+  return envelope({
+    items: result.rows,
+    total: result.rows.length,
+    generatedAt: new Date().toISOString(),
+    filters: result.filters,
+    meta: result.meta,
+  });
+};
+
+const csvColumnsFor = (reportType: string): CsvColumn<Record<string, unknown>>[] | null => {
+  switch (reportType) {
+    case 'revenue': return REVENUE_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'aging': return AGING_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'profitability': return PROFITABILITY_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'utilization': return UTILIZATION_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    default: return null;
+  }
+};
+
+const handleExport = async (
+  reportType: string,
+  request: Request,
+  env: Env,
+  practiceId: string
+): Promise<Response> => {
+  const url = new URL(request.url);
+  const format = (url.searchParams.get('format') ?? 'csv').toLowerCase();
+  if (format !== 'csv') throw HttpErrors.unprocessableEntity('Only CSV format is supported');
+  const columns = csvColumnsFor(reportType);
+  if (!columns) {
+    throw HttpErrors.unprocessableEntity(`CSV export not supported for '${reportType}'`);
+  }
+  const result = await runReport(reportType, request, env, practiceId);
+  const body = toCsv(result.rows, columns);
+  return csvResponse(filenameFor(reportType, practiceId), body);
+};
+
+// ─── route dispatch ──────────────────────────────────────────────────────
+
+export async function handleReports(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const match = url.pathname.match(/^\/api\/reports\/([^/]+)(?:\/(.+))?$/);
+  if (!match) throw HttpErrors.notFound('Route not found');
+
+  const practiceId = parsePracticeId(match[1]);
+  const remainder = match[2] ?? '';
+
+  // Auth + practice membership before any data access.
+  const authContext = getAttachedAuthContext(request);
+  if (!authContext) throw HttpErrors.unauthorized('Authentication required');
+  if (authContext.isAnonymous) throw HttpErrors.forbidden('Access denied');
+  await requirePracticeMember(request, env, practiceId, 'paralegal');
+
+  if (!env.BACKEND_API_URL) {
+    throw HttpErrors.internalServerError('BACKEND_API_URL not configured');
+  }
+
+  try {
+    // Phase 2 endpoints (schedules / send-now / deliveries) — wired in milestone 4.
+    if (remainder.startsWith('schedules')) {
+      throw HttpErrors.notFound('Schedules ships in milestone 4');
+    }
+    if (remainder === 'send-now') {
+      throw HttpErrors.notFound('Send-now ships in milestone 4');
+    }
+    if (remainder.startsWith('deliveries')) {
+      throw HttpErrors.notFound('Deliveries ships in milestone 4');
+    }
+
+    if (remainder.startsWith('export/')) {
+      const reportType = remainder.slice('export/'.length);
+      if (!VALID_REPORT_TYPES.has(reportType)) throw HttpErrors.notFound(`Unknown report: ${reportType}`);
+      if (request.method !== 'GET') throw HttpErrors.methodNotAllowed('Only GET allowed for export');
+      return await handleExport(reportType, request, env, practiceId);
+    }
+
+    if (VALID_REPORT_TYPES.has(remainder)) {
+      if (request.method !== 'GET') throw HttpErrors.methodNotAllowed('Only GET allowed');
+      return await handleGetReport(remainder, request, env, practiceId);
+    }
+
+    throw HttpErrors.notFound(`Unknown reports path: /${remainder}`);
+  } catch (err) {
+    if (err instanceof BackendUnavailableError) {
+      return backendUnavailable(err.reportType);
+    }
+    return handleError(err);
+  }
+}

--- a/worker/routes/reports.ts
+++ b/worker/routes/reports.ts
@@ -17,7 +17,13 @@ import {
   resolveDateRange,
   type ResolvedDateRange,
 } from '../services/ReportService.js';
+import {
+  ReportScheduleService,
+  type ReportFrequency,
+} from '../services/ReportScheduleService.js';
+import { ReportDeliveryService } from '../services/ReportDeliveryService.js';
 import { toCsv, type CsvColumn } from '../utils/csv.js';
+import { parseJsonBody } from '../utils.js';
 
 const PRACTICE_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
 const VALID_REPORT_TYPES = new Set<string>([
@@ -282,7 +288,254 @@ const handleExport = async (
   return csvResponse(filenameFor(reportType, practiceId), body);
 };
 
+// ─── schedules ───────────────────────────────────────────────────────────
+
+const FREQUENCIES = new Set<ReportFrequency>(['daily', 'weekly', 'monthly']);
+
+const handleSchedulesList = async (env: Env, practiceId: string): Promise<Response> => {
+  const service = new ReportScheduleService(env);
+  const schedules = await service.list(practiceId);
+  return new Response(JSON.stringify({ success: true, data: schedules }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+const handleScheduleCreate = async (
+  request: Request,
+  env: Env,
+  practiceId: string
+): Promise<Response> => {
+  const body = await parseJsonBody(request) as {
+    reportType?: string;
+    frequency?: string;
+    dayOfWeek?: number;
+    dayOfMonth?: number;
+    hourUtc?: number;
+    recipients?: unknown;
+    filters?: unknown;
+    active?: boolean;
+  };
+  if (!body.reportType || !VALID_REPORT_TYPES.has(body.reportType)) {
+    throw HttpErrors.badRequest('Invalid reportType');
+  }
+  if (!body.frequency || !FREQUENCIES.has(body.frequency as ReportFrequency)) {
+    throw HttpErrors.badRequest('Invalid frequency');
+  }
+  if (typeof body.hourUtc !== 'number' || body.hourUtc < 0 || body.hourUtc > 23) {
+    throw HttpErrors.badRequest('hourUtc must be 0-23');
+  }
+  const recipients = Array.isArray(body.recipients)
+    ? (body.recipients as unknown[]).filter((r): r is string => typeof r === 'string')
+    : [];
+  const filters: Record<string, string> = {};
+  if (body.filters && typeof body.filters === 'object' && !Array.isArray(body.filters)) {
+    for (const [k, v] of Object.entries(body.filters as Record<string, unknown>)) {
+      if (typeof v === 'string') filters[k] = v;
+    }
+  }
+  const service = new ReportScheduleService(env);
+  const created = await service.create(practiceId, {
+    reportType: body.reportType,
+    frequency: body.frequency as ReportFrequency,
+    dayOfWeek: body.dayOfWeek,
+    dayOfMonth: body.dayOfMonth,
+    hourUtc: body.hourUtc,
+    recipients,
+    filters,
+    active: body.active ?? true,
+  });
+  return new Response(JSON.stringify({ success: true, data: created }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+const handleScheduleUpdate = async (
+  request: Request,
+  env: Env,
+  practiceId: string,
+  scheduleId: string
+): Promise<Response> => {
+  const body = await parseJsonBody(request) as Record<string, unknown>;
+  const patch: Record<string, unknown> = {};
+  if (typeof body.frequency === 'string' && FREQUENCIES.has(body.frequency as ReportFrequency)) {
+    patch.frequency = body.frequency;
+  }
+  if (typeof body.hourUtc === 'number') patch.hourUtc = body.hourUtc;
+  if (typeof body.dayOfWeek === 'number') patch.dayOfWeek = body.dayOfWeek;
+  if (typeof body.dayOfMonth === 'number') patch.dayOfMonth = body.dayOfMonth;
+  if (Array.isArray(body.recipients)) {
+    patch.recipients = (body.recipients as unknown[]).filter((r): r is string => typeof r === 'string');
+  }
+  if (body.filters && typeof body.filters === 'object' && !Array.isArray(body.filters)) {
+    const filters: Record<string, string> = {};
+    for (const [k, v] of Object.entries(body.filters as Record<string, unknown>)) {
+      if (typeof v === 'string') filters[k] = v;
+    }
+    patch.filters = filters;
+  }
+  if (typeof body.active === 'boolean') patch.active = body.active;
+
+  const service = new ReportScheduleService(env);
+  const updated = await service.update(practiceId, scheduleId, patch);
+  if (!updated) throw HttpErrors.notFound('Schedule not found');
+  return new Response(JSON.stringify({ success: true, data: updated }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+const handleScheduleDelete = async (
+  env: Env,
+  practiceId: string,
+  scheduleId: string
+): Promise<Response> => {
+  const service = new ReportScheduleService(env);
+  const ok = await service.delete(practiceId, scheduleId);
+  if (!ok) throw HttpErrors.notFound('Schedule not found');
+  return new Response(null, { status: 204 });
+};
+
+// ─── send-now + deliveries ───────────────────────────────────────────────
+
+const handleSendNow = async (
+  request: Request,
+  env: Env,
+  practiceId: string,
+  authUserId: string,
+  practiceSlug: string | null
+): Promise<Response> => {
+  const body = await parseJsonBody(request) as {
+    reportType?: string;
+    recipients?: unknown;
+    filters?: unknown;
+  };
+  if (!body.reportType || !VALID_REPORT_TYPES.has(body.reportType)) {
+    throw HttpErrors.badRequest('Invalid reportType');
+  }
+  if (PHASE_3_REPORTS.has(body.reportType)) {
+    throw new BackendUnavailableError(body.reportType);
+  }
+  const columns = csvColumnsFor(body.reportType);
+  if (!columns) {
+    throw HttpErrors.unprocessableEntity(`CSV export not supported for '${body.reportType}'`);
+  }
+  const recipients = Array.isArray(body.recipients)
+    ? (body.recipients as unknown[]).filter((r): r is string => typeof r === 'string')
+    : [];
+  const filters: Record<string, string> = {};
+  if (body.filters && typeof body.filters === 'object' && !Array.isArray(body.filters)) {
+    for (const [k, v] of Object.entries(body.filters as Record<string, unknown>)) {
+      if (typeof v === 'string') filters[k] = v;
+    }
+  }
+
+  // Synthesize the same query string our GET endpoint accepts so we reuse
+  // the runReport pipeline 1:1 (period, start, end, hourlyRate).
+  const synthUrl = new URL(request.url);
+  const synthSearch = new URLSearchParams();
+  for (const [k, v] of Object.entries(filters)) synthSearch.set(k, v);
+  synthUrl.search = synthSearch.toString();
+  const synthRequest = new Request(synthUrl.toString(), { method: 'GET', headers: request.headers });
+
+  const deliveryService = new ReportDeliveryService(env);
+  const delivery = await deliveryService.create({
+    practiceId,
+    reportType: body.reportType,
+    filters,
+    recipients,
+    createdBy: authUserId,
+  });
+
+  try {
+    const result = await runReport(body.reportType, synthRequest, env, practiceId);
+    const csv = toCsv(result.rows, columns);
+    const stored = await deliveryService.storeCsv(practiceId, delivery.id, body.reportType, csv);
+    await deliveryService.markCompleted(delivery.id, stored);
+    const completed = { ...delivery, status: 'completed' as const, ...stored, completedAt: new Date().toISOString() };
+    if (recipients.length > 0) {
+      await deliveryService.notifyRecipients({ practiceId, delivery: completed, practiceSlug });
+    }
+    return new Response(JSON.stringify({ success: true, data: completed }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Send failed';
+    await deliveryService.markFailed(delivery.id, message);
+    throw err;
+  }
+};
+
+const handleDeliveriesList = async (
+  request: Request,
+  env: Env,
+  practiceId: string
+): Promise<Response> => {
+  const url = new URL(request.url);
+  const limit = Number(url.searchParams.get('limit')) || undefined;
+  const cursor = url.searchParams.get('cursor') ?? undefined;
+  const service = new ReportDeliveryService(env);
+  const result = await service.list(practiceId, { limit, cursor });
+  return new Response(JSON.stringify({ success: true, data: result }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+const handleDeliveryGet = async (
+  env: Env,
+  practiceId: string,
+  deliveryId: string
+): Promise<Response> => {
+  const service = new ReportDeliveryService(env);
+  const delivery = await service.get(practiceId, deliveryId);
+  if (!delivery) throw HttpErrors.notFound('Delivery not found');
+  return new Response(JSON.stringify({ success: true, data: delivery }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+const handleDeliveryDownload = async (
+  env: Env,
+  practiceId: string,
+  deliveryId: string
+): Promise<Response> => {
+  const service = new ReportDeliveryService(env);
+  const delivery = await service.get(practiceId, deliveryId);
+  if (!delivery) throw HttpErrors.notFound('Delivery not found');
+  if (delivery.status !== 'completed') {
+    throw HttpErrors.conflict(`Delivery is ${delivery.status}, not completed`);
+  }
+  const { body, contentType, size } = await service.downloadBody(delivery);
+  if (!body) throw HttpErrors.notFound('Delivery file not found in storage');
+  const headers: Record<string, string> = {
+    'Content-Type': contentType,
+    'Content-Disposition': `attachment; filename="${filenameFor(delivery.reportType, practiceId)}"`,
+  };
+  if (size != null) headers['Content-Length'] = String(size);
+  return new Response(body, { status: 200, headers });
+};
+
 // ─── route dispatch ──────────────────────────────────────────────────────
+
+const resolvePracticeSlug = async (
+  env: Env,
+  practiceId: string,
+  forwardHeaders: Record<string, string>
+): Promise<string | null> => {
+  try {
+    const url = `${env.BACKEND_API_URL}/api/practice/details/${encodeURIComponent(practiceId)}`;
+    const resp = await fetch(url, { headers: forwardHeaders });
+    if (!resp.ok) return null;
+    const json = await resp.json() as { slug?: string; data?: { slug?: string } };
+    return json?.data?.slug ?? json?.slug ?? null;
+  } catch {
+    return null;
+  }
+};
 
 export async function handleReports(request: Request, env: Env): Promise<Response> {
   const url = new URL(request.url);
@@ -303,15 +556,51 @@ export async function handleReports(request: Request, env: Env): Promise<Respons
   }
 
   try {
-    // Phase 2 endpoints (schedules / send-now / deliveries) — wired in milestone 4.
-    if (remainder.startsWith('schedules')) {
-      throw HttpErrors.notFound('Schedules ships in milestone 4');
+    if (remainder === 'schedules') {
+      if (request.method === 'GET') return await handleSchedulesList(env, practiceId);
+      if (request.method === 'POST') return await handleScheduleCreate(request, env, practiceId);
+      throw HttpErrors.methodNotAllowed('GET or POST');
     }
+    const schedMatch = /^schedules\/([^/]+)$/.exec(remainder);
+    if (schedMatch) {
+      const scheduleId = decodeURIComponent(schedMatch[1]);
+      if (request.method === 'PUT' || request.method === 'PATCH') {
+        return await handleScheduleUpdate(request, env, practiceId, scheduleId);
+      }
+      if (request.method === 'DELETE') {
+        return await handleScheduleDelete(env, practiceId, scheduleId);
+      }
+      if (request.method === 'GET') {
+        const service = new ReportScheduleService(env);
+        const schedule = await service.get(practiceId, scheduleId);
+        if (!schedule) throw HttpErrors.notFound('Schedule not found');
+        return new Response(JSON.stringify({ success: true, data: schedule }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      throw HttpErrors.methodNotAllowed('GET/PUT/PATCH/DELETE');
+    }
+
     if (remainder === 'send-now') {
-      throw HttpErrors.notFound('Send-now ships in milestone 4');
+      if (request.method !== 'POST') throw HttpErrors.methodNotAllowed('POST');
+      const forwardHeaders = buildForwardHeaders(request);
+      const practiceSlug = await resolvePracticeSlug(env, practiceId, forwardHeaders);
+      return await handleSendNow(request, env, practiceId, authContext.user.id, practiceSlug);
     }
-    if (remainder.startsWith('deliveries')) {
-      throw HttpErrors.notFound('Deliveries ships in milestone 4');
+
+    if (remainder === 'deliveries') {
+      if (request.method !== 'GET') throw HttpErrors.methodNotAllowed('GET');
+      return await handleDeliveriesList(request, env, practiceId);
+    }
+    const downloadMatch = /^deliveries\/([^/]+)\/download$/.exec(remainder);
+    if (downloadMatch) {
+      if (request.method !== 'GET') throw HttpErrors.methodNotAllowed('GET');
+      return await handleDeliveryDownload(env, practiceId, decodeURIComponent(downloadMatch[1]));
+    }
+    const deliveryMatch = /^deliveries\/([^/]+)$/.exec(remainder);
+    if (deliveryMatch) {
+      if (request.method !== 'GET') throw HttpErrors.methodNotAllowed('GET');
+      return await handleDeliveryGet(env, practiceId, decodeURIComponent(deliveryMatch[1]));
     }
 
     if (remainder.startsWith('export/')) {

--- a/worker/routes/reports.ts
+++ b/worker/routes/reports.ts
@@ -38,14 +38,6 @@ const VALID_REPORT_TYPES = new Set<string>([
   'task-productivity',
 ]);
 
-const PHASE_3_REPORTS = new Set<string>([
-  'trust-ledger',
-  'wip',
-  'originating-attorney',
-  'matters-by-attorney',
-  'task-productivity',
-]);
-
 const VALID_PERIODS = new Set(['month', 'quarter', 'year']);
 
 interface ReportEnvelope<T> {
@@ -163,6 +155,66 @@ const UTILIZATION_CSV_COLUMNS: CsvColumn<{
   { key: 'utilizationPercent', header: 'Utilization (%)' },
 ];
 
+const TRUST_LEDGER_CSV_COLUMNS: CsvColumn<{
+  occurredAt: string;
+  clientName: string | null;
+  description: string | null;
+  type: string | null;
+  amountCents: number;
+  balanceCents: number;
+}>[] = [
+  { key: 'occurredAt', header: 'Date' },
+  { key: 'clientName', header: 'Client' },
+  { key: 'type', header: 'Type' },
+  { key: 'description', header: 'Description' },
+  { key: 'amountCents', header: 'Amount (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+  { key: 'balanceCents', header: 'Balance (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+];
+
+const WIP_CSV_COLUMNS: CsvColumn<{
+  matterTitle: string;
+  unbilledHours: number;
+  unbilledAmountCents: number;
+}>[] = [
+  { key: 'matterTitle', header: 'Matter' },
+  { key: 'unbilledHours', header: 'Unbilled hours' },
+  { key: 'unbilledAmountCents', header: 'Unbilled amount (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+];
+
+const ORIGINATING_ATTORNEY_CSV_COLUMNS: CsvColumn<{
+  attorneyName: string;
+  matterCount: number;
+  revenueCents: number;
+}>[] = [
+  { key: 'attorneyName', header: 'Attorney' },
+  { key: 'matterCount', header: 'Matters' },
+  { key: 'revenueCents', header: 'Revenue (USD)', format: (v) => (Number(v) / 100).toFixed(2) },
+];
+
+const MATTERS_BY_ATTORNEY_CSV_COLUMNS: CsvColumn<{
+  attorneyName: string;
+  matterCount: number;
+  openCount: number;
+  closedCount: number;
+}>[] = [
+  { key: 'attorneyName', header: 'Attorney' },
+  { key: 'matterCount', header: 'Matters' },
+  { key: 'openCount', header: 'Open' },
+  { key: 'closedCount', header: 'Closed' },
+];
+
+const TASK_PRODUCTIVITY_CSV_COLUMNS: CsvColumn<{
+  assigneeName: string;
+  completed: number;
+  pending: number;
+  avgCycleDays: number;
+}>[] = [
+  { key: 'assigneeName', header: 'Assignee' },
+  { key: 'completed', header: 'Completed' },
+  { key: 'pending', header: 'Pending' },
+  { key: 'avgCycleDays', header: 'Avg cycle (days)' },
+];
+
 // ─── per-report handlers ─────────────────────────────────────────────────
 
 const runReport = async (
@@ -238,8 +290,68 @@ const runReport = async (
       filters: { start: range.startIso, end: range.endIso },
     };
   }
-  if (PHASE_3_REPORTS.has(reportType)) {
-    await service.forwardPhase3(reportType);
+  if (reportType === 'trust-ledger') {
+    const range = parseRange(url, 'month');
+    const result = await service.trustLedger(practiceId, headers, { range });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalCreditsCents: result.totalCreditsCents,
+        totalDebitsCents: result.totalDebitsCents,
+        endingBalanceCents: result.endingBalanceCents,
+        transactionCount: result.transactionCount,
+      },
+      filters: { start: range.startIso, end: range.endIso },
+    };
+  }
+  if (reportType === 'wip') {
+    const result = await service.wip(practiceId, headers);
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalUnbilledHours: result.totalUnbilledHours,
+        totalUnbilledAmountCents: result.totalUnbilledAmountCents,
+        matterCount: result.matterCount,
+      },
+      filters: {},
+    };
+  }
+  if (reportType === 'originating-attorney') {
+    const range = parseRange(url, 'month');
+    const result = await service.originatingAttorney(practiceId, headers, request, { range });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalRevenueCents: result.totalRevenueCents,
+        totalMatterCount: result.totalMatterCount,
+      },
+      filters: { start: range.startIso, end: range.endIso },
+    };
+  }
+  if (reportType === 'matters-by-attorney') {
+    const result = await service.mattersByAttorney(practiceId, headers, request);
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalMatterCount: result.totalMatterCount,
+        totalOpenCount: result.totalOpenCount,
+        totalClosedCount: result.totalClosedCount,
+      },
+      filters: {},
+    };
+  }
+  if (reportType === 'task-productivity') {
+    const range = parseRange(url, 'month');
+    const result = await service.taskProductivity(practiceId, headers, request, { range });
+    return {
+      rows: result.rows as unknown as Record<string, unknown>[],
+      meta: {
+        totalCompleted: result.totalCompleted,
+        totalPending: result.totalPending,
+        averageCycleDays: result.averageCycleDays,
+      },
+      filters: { start: range.startIso, end: range.endIso },
+    };
   }
   throw HttpErrors.notFound(`Unknown report type: ${reportType}`);
 };
@@ -266,6 +378,11 @@ const csvColumnsFor = (reportType: string): CsvColumn<Record<string, unknown>>[]
     case 'aging': return AGING_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
     case 'profitability': return PROFITABILITY_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
     case 'utilization': return UTILIZATION_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'trust-ledger': return TRUST_LEDGER_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'wip': return WIP_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'originating-attorney': return ORIGINATING_ATTORNEY_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'matters-by-attorney': return MATTERS_BY_ATTORNEY_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
+    case 'task-productivity': return TASK_PRODUCTIVITY_CSV_COLUMNS as unknown as CsvColumn<Record<string, unknown>>[];
     default: return null;
   }
 };
@@ -413,9 +530,6 @@ const handleSendNow = async (
   };
   if (!body.reportType || !VALID_REPORT_TYPES.has(body.reportType)) {
     throw HttpErrors.badRequest('Invalid reportType');
-  }
-  if (PHASE_3_REPORTS.has(body.reportType)) {
-    throw new BackendUnavailableError(body.reportType);
   }
   const columns = csvColumnsFor(body.reportType);
   if (!columns) {

--- a/worker/services/ReportDeliveryService.ts
+++ b/worker/services/ReportDeliveryService.ts
@@ -1,0 +1,229 @@
+/**
+ * Persists report deliveries in D1, stores the CSV bytes in R2, and
+ * enqueues an in-app notification. Reads downstream by the deliveries
+ * list/detail UI.
+ *
+ * R2 key shape: `report-exports/{practiceId}/{deliveryId}/{reportType}.csv`
+ * D1 table:    `report_deliveries` (see migration 20260514).
+ */
+
+import type { Env, NotificationQueueMessage } from '../types.js';
+import { enqueueNotification } from './NotificationPublisher.js';
+
+export type ReportDeliveryStatus = 'pending' | 'completed' | 'failed';
+
+export interface ReportDelivery {
+  id: string;
+  practiceId: string;
+  reportType: string;
+  filters: Record<string, string>;
+  recipients: string[];
+  status: ReportDeliveryStatus;
+  storageKey?: string;
+  byteSize?: number;
+  errorMessage?: string;
+  createdBy: string;
+  createdAt: string;
+  scheduledFor?: string;
+  completedAt?: string;
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const buildStorageKey = (practiceId: string, deliveryId: string, reportType: string) =>
+  `report-exports/${practiceId}/${deliveryId}/${reportType}.csv`;
+
+const rowToDelivery = (row: Record<string, unknown>): ReportDelivery => ({
+  id: String(row.id),
+  practiceId: String(row.practice_id),
+  reportType: String(row.report_type),
+  filters: row.filters_json ? safeJsonParse(String(row.filters_json), {} as Record<string, string>) : {},
+  recipients: row.recipients_json ? safeJsonParse(String(row.recipients_json), [] as string[]) : [],
+  status: (row.status as ReportDeliveryStatus) ?? 'pending',
+  storageKey: row.storage_key ? String(row.storage_key) : undefined,
+  byteSize: typeof row.byte_size === 'number' ? row.byte_size : undefined,
+  errorMessage: row.error_message ? String(row.error_message) : undefined,
+  createdBy: String(row.created_by),
+  createdAt: String(row.created_at),
+  scheduledFor: row.scheduled_for ? String(row.scheduled_for) : undefined,
+  completedAt: row.completed_at ? String(row.completed_at) : undefined,
+});
+
+function safeJsonParse<T>(raw: string, fallback: T): T {
+  try { return JSON.parse(raw) as T; } catch { return fallback; }
+}
+
+export class ReportDeliveryService {
+  constructor(private readonly env: Env) {}
+
+  async create(input: {
+    practiceId: string;
+    reportType: string;
+    filters: Record<string, string>;
+    recipients: string[];
+    createdBy: string;
+    scheduledFor?: string;
+  }): Promise<ReportDelivery> {
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    await this.env.DB.prepare(`
+      INSERT INTO report_deliveries
+        (id, practice_id, report_type, filters_json, recipients_json, status, created_by, created_at, scheduled_for)
+      VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+    `).bind(
+      id,
+      input.practiceId,
+      input.reportType,
+      JSON.stringify(input.filters),
+      JSON.stringify(input.recipients),
+      input.createdBy,
+      createdAt,
+      input.scheduledFor ?? null,
+    ).run();
+
+    return {
+      id,
+      practiceId: input.practiceId,
+      reportType: input.reportType,
+      filters: input.filters,
+      recipients: input.recipients,
+      status: 'pending',
+      createdBy: input.createdBy,
+      createdAt,
+      scheduledFor: input.scheduledFor,
+    };
+  }
+
+  async storeCsv(
+    practiceId: string,
+    deliveryId: string,
+    reportType: string,
+    body: string
+  ): Promise<{ storageKey: string; byteSize: number }> {
+    if (!this.env.FILES_BUCKET) {
+      throw new Error('FILES_BUCKET binding not configured');
+    }
+    const key = buildStorageKey(practiceId, deliveryId, reportType);
+    const bytes = new TextEncoder().encode(body);
+    await this.env.FILES_BUCKET.put(key, bytes, {
+      httpMetadata: { contentType: 'text/csv; charset=utf-8' },
+    });
+    return { storageKey: key, byteSize: bytes.byteLength };
+  }
+
+  async markCompleted(
+    deliveryId: string,
+    update: { storageKey: string; byteSize: number }
+  ): Promise<void> {
+    await this.env.DB.prepare(`
+      UPDATE report_deliveries
+      SET status = 'completed',
+          storage_key = ?,
+          byte_size = ?,
+          completed_at = ?
+      WHERE id = ?
+    `).bind(
+      update.storageKey,
+      update.byteSize,
+      new Date().toISOString(),
+      deliveryId,
+    ).run();
+  }
+
+  async markFailed(deliveryId: string, errorMessage: string): Promise<void> {
+    await this.env.DB.prepare(`
+      UPDATE report_deliveries
+      SET status = 'failed',
+          error_message = ?,
+          completed_at = ?
+      WHERE id = ?
+    `).bind(
+      errorMessage,
+      new Date().toISOString(),
+      deliveryId,
+    ).run();
+  }
+
+  async list(
+    practiceId: string,
+    options: { limit?: number; cursor?: string } = {}
+  ): Promise<{ items: ReportDelivery[]; nextCursor: string | null }> {
+    const limit = Math.min(Math.max(1, options.limit ?? DEFAULT_LIMIT), MAX_LIMIT);
+    const cursor = options.cursor ?? null;
+    const query = cursor
+      ? `SELECT * FROM report_deliveries
+         WHERE practice_id = ? AND created_at < ?
+         ORDER BY created_at DESC LIMIT ?`
+      : `SELECT * FROM report_deliveries
+         WHERE practice_id = ?
+         ORDER BY created_at DESC LIMIT ?`;
+    const stmt = cursor
+      ? this.env.DB.prepare(query).bind(practiceId, cursor, limit + 1)
+      : this.env.DB.prepare(query).bind(practiceId, limit + 1);
+    const result = await stmt.all<Record<string, unknown>>();
+    const rows = result.results ?? [];
+    const hasMore = rows.length > limit;
+    const slice = hasMore ? rows.slice(0, limit) : rows;
+    const items = slice.map(rowToDelivery);
+    const nextCursor = hasMore && slice.length > 0
+      ? String(slice[slice.length - 1].created_at)
+      : null;
+    return { items, nextCursor };
+  }
+
+  async get(practiceId: string, deliveryId: string): Promise<ReportDelivery | null> {
+    const row = await this.env.DB.prepare(`
+      SELECT * FROM report_deliveries WHERE practice_id = ? AND id = ?
+    `).bind(practiceId, deliveryId).first<Record<string, unknown>>();
+    return row ? rowToDelivery(row) : null;
+  }
+
+  async downloadBody(delivery: ReportDelivery): Promise<{ body: ReadableStream | null; contentType: string; size: number | null }> {
+    if (!delivery.storageKey || !this.env.FILES_BUCKET) {
+      return { body: null, contentType: 'text/csv; charset=utf-8', size: null };
+    }
+    const obj = await this.env.FILES_BUCKET.get(delivery.storageKey);
+    if (!obj) return { body: null, contentType: 'text/csv; charset=utf-8', size: null };
+    return {
+      body: obj.body as unknown as ReadableStream,
+      contentType: obj.httpMetadata?.contentType ?? 'text/csv; charset=utf-8',
+      size: typeof obj.size === 'number' ? obj.size : null,
+    };
+  }
+
+  async notifyRecipients(input: {
+    practiceId: string;
+    delivery: ReportDelivery;
+    practiceSlug: string | null;
+  }): Promise<void> {
+    const link = input.practiceSlug
+      ? `/practice/${encodeURIComponent(input.practiceSlug)}/reports/deliveries/${input.delivery.id}`
+      : `/reports/deliveries/${input.delivery.id}`;
+    const message: NotificationQueueMessage = {
+      eventId: crypto.randomUUID(),
+      practiceId: input.practiceId,
+      category: 'system',
+      entityType: 'report_delivery',
+      entityId: input.delivery.id,
+      title: `Report ready: ${input.delivery.reportType}`,
+      body: 'Your report is ready to download.',
+      link,
+      severity: 'info',
+      recipients: input.delivery.recipients.map((userId) => ({
+        userId,
+        email: null,
+        preferences: {
+          pushEnabled: true,
+          emailEnabled: true,
+          desktopPushEnabled: true,
+          mentionsOnly: false,
+          inAppEnabled: true,
+          inAppFrequency: 'all',
+        },
+      })),
+      createdAt: new Date().toISOString(),
+    };
+    await enqueueNotification(this.env, message);
+  }
+}

--- a/worker/services/ReportDeliveryService.ts
+++ b/worker/services/ReportDeliveryService.ts
@@ -34,6 +34,18 @@ const MAX_LIMIT = 100;
 const buildStorageKey = (practiceId: string, deliveryId: string, reportType: string) =>
   `report-exports/${practiceId}/${deliveryId}/${reportType}.csv`;
 
+const parseDeliveryCursor = (cursor: string | null): { createdAt: string; id: string } | null => {
+  if (!cursor) return null;
+  const separator = cursor.lastIndexOf('|');
+  if (separator <= 0 || separator === cursor.length - 1) {
+    throw new Error('Invalid delivery cursor');
+  }
+  return {
+    createdAt: cursor.slice(0, separator),
+    id: cursor.slice(separator + 1),
+  };
+};
+
 const rowToDelivery = (row: Record<string, unknown>): ReportDelivery => ({
   id: String(row.id),
   practiceId: String(row.practice_id),
@@ -150,16 +162,17 @@ export class ReportDeliveryService {
     options: { limit?: number; cursor?: string } = {}
   ): Promise<{ items: ReportDelivery[]; nextCursor: string | null }> {
     const limit = Math.min(Math.max(1, options.limit ?? DEFAULT_LIMIT), MAX_LIMIT);
-    const cursor = options.cursor ?? null;
+    const cursor = parseDeliveryCursor(options.cursor ?? null);
     const query = cursor
       ? `SELECT * FROM report_deliveries
-         WHERE practice_id = ? AND created_at < ?
-         ORDER BY created_at DESC LIMIT ?`
+         WHERE practice_id = ?
+           AND (created_at < ? OR (created_at = ? AND id < ?))
+         ORDER BY created_at DESC, id DESC LIMIT ?`
       : `SELECT * FROM report_deliveries
          WHERE practice_id = ?
-         ORDER BY created_at DESC LIMIT ?`;
+         ORDER BY created_at DESC, id DESC LIMIT ?`;
     const stmt = cursor
-      ? this.env.DB.prepare(query).bind(practiceId, cursor, limit + 1)
+      ? this.env.DB.prepare(query).bind(practiceId, cursor.createdAt, cursor.createdAt, cursor.id, limit + 1)
       : this.env.DB.prepare(query).bind(practiceId, limit + 1);
     const result = await stmt.all<Record<string, unknown>>();
     const rows = result.results ?? [];
@@ -167,7 +180,7 @@ export class ReportDeliveryService {
     const slice = hasMore ? rows.slice(0, limit) : rows;
     const items = slice.map(rowToDelivery);
     const nextCursor = hasMore && slice.length > 0
-      ? String(slice[slice.length - 1].created_at)
+      ? `${String(slice[slice.length - 1].created_at)}|${String(slice[slice.length - 1].id)}`
       : null;
     return { items, nextCursor };
   }

--- a/worker/services/ReportScheduleService.ts
+++ b/worker/services/ReportScheduleService.ts
@@ -33,6 +33,14 @@ const buildKey = (practiceId: string, scheduleId: string) =>
 
 const listPrefix = (practiceId: string) => `${KEY_PREFIX}${practiceId}:`;
 
+const requireDayOfWeek = (value: number | undefined): number => {
+  const target = value ?? 1; // Monday default
+  if (!Number.isInteger(target) || target < 0 || target > 6) {
+    throw new Error('dayOfWeek must be an integer from 0-6');
+  }
+  return target;
+};
+
 export const computeNextDelivery = (
   frequency: ReportFrequency,
   hourUtc: number,
@@ -54,7 +62,7 @@ export const computeNextDelivery = (
     return candidate.toISOString();
   }
   if (frequency === 'weekly') {
-    const target = options.dayOfWeek ?? 1; // Monday default
+    const target = requireDayOfWeek(options.dayOfWeek);
     while (candidate.getUTCDay() !== target) {
       candidate.setUTCDate(candidate.getUTCDate() + 1);
     }

--- a/worker/services/ReportScheduleService.ts
+++ b/worker/services/ReportScheduleService.ts
@@ -1,0 +1,160 @@
+/**
+ * KV-backed CRUD for report schedules. Keys live under
+ * `report-schedule:${practiceId}:${id}`.
+ *
+ * `computeNextDelivery` is exported separately so unit tests can exercise
+ * the cron math without the KV layer.
+ */
+
+import type { Env } from '../types.js';
+
+export type ReportFrequency = 'daily' | 'weekly' | 'monthly';
+
+export interface ReportSchedule {
+  id: string;
+  practiceId: string;
+  reportType: string;
+  frequency: ReportFrequency;
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+  hourUtc: number;
+  recipients: string[];
+  filters: Record<string, string>;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  nextDeliveryAt?: string;
+}
+
+const KEY_PREFIX = 'report-schedule:';
+
+const buildKey = (practiceId: string, scheduleId: string) =>
+  `${KEY_PREFIX}${practiceId}:${scheduleId}`;
+
+const listPrefix = (practiceId: string) => `${KEY_PREFIX}${practiceId}:`;
+
+export const computeNextDelivery = (
+  frequency: ReportFrequency,
+  hourUtc: number,
+  options: { dayOfWeek?: number; dayOfMonth?: number; from?: Date } = {}
+): string => {
+  const from = options.from ?? new Date();
+  const candidate = new Date(Date.UTC(
+    from.getUTCFullYear(),
+    from.getUTCMonth(),
+    from.getUTCDate(),
+    hourUtc,
+    0,
+    0,
+    0
+  ));
+  if (candidate <= from) candidate.setUTCDate(candidate.getUTCDate() + 1);
+
+  if (frequency === 'daily') {
+    return candidate.toISOString();
+  }
+  if (frequency === 'weekly') {
+    const target = options.dayOfWeek ?? 1; // Monday default
+    while (candidate.getUTCDay() !== target) {
+      candidate.setUTCDate(candidate.getUTCDate() + 1);
+    }
+    return candidate.toISOString();
+  }
+  // monthly
+  const targetDay = Math.max(1, Math.min(28, options.dayOfMonth ?? 1));
+  if (candidate.getUTCDate() > targetDay) {
+    candidate.setUTCMonth(candidate.getUTCMonth() + 1);
+  }
+  candidate.setUTCDate(targetDay);
+  return candidate.toISOString();
+};
+
+export class ReportScheduleService {
+  constructor(private readonly env: Env) {}
+
+  async list(practiceId: string): Promise<ReportSchedule[]> {
+    const prefix = listPrefix(practiceId);
+    const out: ReportSchedule[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await this.env.CHAT_SESSIONS.list({ prefix, cursor });
+      for (const key of page.keys) {
+        const raw = await this.env.CHAT_SESSIONS.get(key.name);
+        if (!raw) continue;
+        try {
+          out.push(JSON.parse(raw) as ReportSchedule);
+        } catch {
+          /* skip corrupt rows */
+        }
+      }
+      cursor = page.list_complete
+        ? undefined
+        : (page as { cursor?: string }).cursor;
+    } while (cursor);
+    return out;
+  }
+
+  async get(practiceId: string, scheduleId: string): Promise<ReportSchedule | null> {
+    const raw = await this.env.CHAT_SESSIONS.get(buildKey(practiceId, scheduleId));
+    if (!raw) return null;
+    try { return JSON.parse(raw) as ReportSchedule; } catch { return null; }
+  }
+
+  async create(
+    practiceId: string,
+    input: Omit<ReportSchedule, 'id' | 'practiceId' | 'createdAt' | 'updatedAt' | 'nextDeliveryAt' | 'active'> & { active?: boolean }
+  ): Promise<ReportSchedule> {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const record: ReportSchedule = {
+      id,
+      practiceId,
+      reportType: input.reportType,
+      frequency: input.frequency,
+      dayOfWeek: input.dayOfWeek,
+      dayOfMonth: input.dayOfMonth,
+      hourUtc: input.hourUtc,
+      recipients: input.recipients,
+      filters: input.filters,
+      active: input.active ?? true,
+      createdAt: now,
+      updatedAt: now,
+      nextDeliveryAt: computeNextDelivery(input.frequency, input.hourUtc, {
+        dayOfWeek: input.dayOfWeek,
+        dayOfMonth: input.dayOfMonth,
+      }),
+    };
+    await this.env.CHAT_SESSIONS.put(buildKey(practiceId, id), JSON.stringify(record));
+    return record;
+  }
+
+  async update(
+    practiceId: string,
+    scheduleId: string,
+    patch: Partial<Omit<ReportSchedule, 'id' | 'practiceId' | 'createdAt'>>
+  ): Promise<ReportSchedule | null> {
+    const existing = await this.get(practiceId, scheduleId);
+    if (!existing) return null;
+    const merged: ReportSchedule = {
+      ...existing,
+      ...patch,
+      id: existing.id,
+      practiceId: existing.practiceId,
+      createdAt: existing.createdAt,
+      updatedAt: new Date().toISOString(),
+    };
+    merged.nextDeliveryAt = computeNextDelivery(merged.frequency, merged.hourUtc, {
+      dayOfWeek: merged.dayOfWeek,
+      dayOfMonth: merged.dayOfMonth,
+    });
+    await this.env.CHAT_SESSIONS.put(buildKey(practiceId, scheduleId), JSON.stringify(merged));
+    return merged;
+  }
+
+  async delete(practiceId: string, scheduleId: string): Promise<boolean> {
+    const existing = await this.get(practiceId, scheduleId);
+    if (!existing) return false;
+    await this.env.CHAT_SESSIONS.delete(buildKey(practiceId, scheduleId));
+    return true;
+  }
+}

--- a/worker/services/ReportService.ts
+++ b/worker/services/ReportService.ts
@@ -23,6 +23,26 @@ import {
   type BackendMatter,
   type BackendMatterTimeEntry,
 } from '../types/wire/matter.js';
+import {
+  BackendTrustTransactionSchema,
+  BackendWipMatterSchema,
+  BackendPracticeTaskSchema,
+  type BackendTrustTransaction,
+  type BackendWipMatter,
+  type BackendPracticeTask,
+} from '../types/wire/reports.js';
+import { RemoteApiService } from './RemoteApiService.js';
+
+/**
+ * Railway paths for the endpoints introduced in blawby-backend#233.
+ * Keep the URLs here so they can be updated in one place when backend
+ * confirms the final shape.
+ */
+export const RAILWAY_REPORT_PATHS = {
+  trustLedger: (practiceId: string) => `/api/trust-ledger/${encodeURIComponent(practiceId)}`,
+  wip: (practiceId: string) => `/api/matters/${encodeURIComponent(practiceId)}/wip`,
+  tasks: (practiceId: string) => `/api/tasks/${encodeURIComponent(practiceId)}`,
+} as const;
 
 export const MAX_LIST_PAGES = 20;
 export const MAX_LIST_PAGE_SIZE = 100;
@@ -466,6 +486,319 @@ export const groupUtilizationByUser = (
   };
 };
 
+// ─── trust ledger ─────────────────────────────────────────────────────────
+
+export interface TrustLedgerAggregateRow {
+  id: string;
+  occurredAt: string;
+  clientName: string | null;
+  description: string | null;
+  amountCents: number;
+  balanceCents: number;
+  type: string | null;
+}
+
+export interface TrustLedgerAggregate {
+  rows: TrustLedgerAggregateRow[];
+  totalCreditsCents: number;
+  totalDebitsCents: number;
+  endingBalanceCents: number;
+  transactionCount: number;
+}
+
+const resolveClientName = (raw: BackendTrustTransaction): string | null => {
+  if (raw.client_name) return raw.client_name;
+  if (raw.client && typeof raw.client === 'object') {
+    const c = raw.client as Record<string, unknown>;
+    if (typeof c.name === 'string') return c.name;
+    if (typeof c.full_name === 'string') return c.full_name;
+  }
+  return null;
+};
+
+export const aggregateTrustLedger = (
+  transactions: readonly BackendTrustTransaction[],
+  range: ResolvedDateRange
+): TrustLedgerAggregate => {
+  const filtered: TrustLedgerAggregateRow[] = [];
+  let credits = 0;
+  let debits = 0;
+  for (const txn of transactions) {
+    const ms = parseDateMs(txn.occurred_at);
+    if (ms == null || ms < range.startMs || ms > range.endMs) continue;
+    const amount = toCents(txn.amount);
+    const balance = toCents(txn.balance_after);
+    filtered.push({
+      id: txn.id,
+      occurredAt: new Date(ms).toISOString(),
+      clientName: resolveClientName(txn),
+      description: txn.description ?? null,
+      amountCents: amount,
+      balanceCents: balance,
+      type: txn.type ?? null,
+    });
+    if (amount >= 0) credits += amount;
+    else debits += Math.abs(amount);
+  }
+  // Newest first for display; ending balance reads the latest row.
+  filtered.sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+  const endingBalanceCents = filtered.length > 0 ? filtered[0].balanceCents : 0;
+  return {
+    rows: filtered,
+    totalCreditsCents: credits,
+    totalDebitsCents: debits,
+    endingBalanceCents,
+    transactionCount: filtered.length,
+  };
+};
+
+// ─── work in progress ─────────────────────────────────────────────────────
+
+export interface WipAggregateRow {
+  matterId: string;
+  matterTitle: string;
+  unbilledHours: number;
+  unbilledAmountCents: number;
+}
+
+export interface WipAggregate {
+  rows: WipAggregateRow[];
+  totalUnbilledHours: number;
+  totalUnbilledAmountCents: number;
+  matterCount: number;
+}
+
+export const aggregateWip = (rows: readonly BackendWipMatter[]): WipAggregate => {
+  const out: WipAggregateRow[] = [];
+  let totalHours = 0;
+  let totalAmount = 0;
+  for (const r of rows) {
+    const seconds = typeof r.unbilled_seconds === 'number' ? r.unbilled_seconds : 0;
+    const hours = Number((seconds / 3600).toFixed(2));
+    const amount = toCents(r.unbilled_amount);
+    if (hours <= 0 && amount <= 0) continue;
+    out.push({
+      matterId: r.matter_id,
+      matterTitle: r.matter_title ?? r.matter_id,
+      unbilledHours: hours,
+      unbilledAmountCents: amount,
+    });
+    totalHours += hours;
+    totalAmount += amount;
+  }
+  out.sort((a, b) => b.unbilledAmountCents - a.unbilledAmountCents);
+  return {
+    rows: out,
+    totalUnbilledHours: Number(totalHours.toFixed(2)),
+    totalUnbilledAmountCents: totalAmount,
+    matterCount: out.length,
+  };
+};
+
+// ─── originating attorney ────────────────────────────────────────────────
+
+export interface OriginatingAttorneyAggregateRow {
+  attorneyId: string;
+  attorneyName: string;
+  matterCount: number;
+  revenueCents: number;
+}
+
+export interface OriginatingAttorneyAggregate {
+  rows: OriginatingAttorneyAggregateRow[];
+  totalRevenueCents: number;
+  totalMatterCount: number;
+}
+
+const UNASSIGNED_ATTORNEY_ID = 'unassigned';
+const UNASSIGNED_ATTORNEY_LABEL = 'Unassigned';
+
+export const groupByOriginatingAttorney = (
+  matters: readonly BackendMatter[],
+  invoices: readonly BackendInvoice[],
+  range: ResolvedDateRange,
+  attorneyNamesById: ReadonlyMap<string, string>
+): OriginatingAttorneyAggregate => {
+  const revenueByMatter = new Map<string, number>();
+  for (const inv of invoices) {
+    if (!inv.matter_id) continue;
+    const eventMs = parseDateMs(inv.paid_at) ?? parseDateMs(inv.created_at);
+    if (eventMs == null || eventMs < range.startMs || eventMs > range.endMs) continue;
+    const paid = toCents(inv.amount_paid);
+    if (paid <= 0) continue;
+    revenueByMatter.set(inv.matter_id, (revenueByMatter.get(inv.matter_id) ?? 0) + paid);
+  }
+
+  const byAttorney = new Map<string, OriginatingAttorneyAggregateRow>();
+  let totalRevenue = 0;
+  for (const m of matters) {
+    const attorneyId = m.originating_attorney_id ?? UNASSIGNED_ATTORNEY_ID;
+    const matterRevenue = revenueByMatter.get(m.id) ?? 0;
+    let row = byAttorney.get(attorneyId);
+    if (!row) {
+      row = {
+        attorneyId,
+        attorneyName: attorneyId === UNASSIGNED_ATTORNEY_ID
+          ? UNASSIGNED_ATTORNEY_LABEL
+          : attorneyNamesById.get(attorneyId) ?? attorneyId,
+        matterCount: 0,
+        revenueCents: 0,
+      };
+      byAttorney.set(attorneyId, row);
+    }
+    row.matterCount += 1;
+    row.revenueCents += matterRevenue;
+    totalRevenue += matterRevenue;
+  }
+  const rows = Array.from(byAttorney.values()).sort((a, b) => b.revenueCents - a.revenueCents);
+  return {
+    rows,
+    totalRevenueCents: totalRevenue,
+    totalMatterCount: matters.length,
+  };
+};
+
+// ─── matters by attorney ─────────────────────────────────────────────────
+
+export interface MattersByAttorneyAggregateRow {
+  attorneyId: string;
+  attorneyName: string;
+  matterCount: number;
+  openCount: number;
+  closedCount: number;
+}
+
+export interface MattersByAttorneyAggregate {
+  rows: MattersByAttorneyAggregateRow[];
+  totalMatterCount: number;
+  totalOpenCount: number;
+  totalClosedCount: number;
+}
+
+const CLOSED_MATTER_STATUSES = new Set(['closed', 'declined', 'conflicted', 'referred']);
+
+export const groupByResponsibleAttorney = (
+  matters: readonly BackendMatter[],
+  attorneyNamesById: ReadonlyMap<string, string>
+): MattersByAttorneyAggregate => {
+  const byAttorney = new Map<string, MattersByAttorneyAggregateRow>();
+  let totalOpen = 0;
+  let totalClosed = 0;
+  for (const m of matters) {
+    const attorneyId = m.responsible_attorney_id ?? UNASSIGNED_ATTORNEY_ID;
+    let row = byAttorney.get(attorneyId);
+    if (!row) {
+      row = {
+        attorneyId,
+        attorneyName: attorneyId === UNASSIGNED_ATTORNEY_ID
+          ? UNASSIGNED_ATTORNEY_LABEL
+          : attorneyNamesById.get(attorneyId) ?? attorneyId,
+        matterCount: 0,
+        openCount: 0,
+        closedCount: 0,
+      };
+      byAttorney.set(attorneyId, row);
+    }
+    row.matterCount += 1;
+    const status = (m.status ?? '').toLowerCase();
+    if (CLOSED_MATTER_STATUSES.has(status)) {
+      row.closedCount += 1;
+      totalClosed += 1;
+    } else {
+      row.openCount += 1;
+      totalOpen += 1;
+    }
+  }
+  const rows = Array.from(byAttorney.values()).sort((a, b) => b.matterCount - a.matterCount);
+  return {
+    rows,
+    totalMatterCount: matters.length,
+    totalOpenCount: totalOpen,
+    totalClosedCount: totalClosed,
+  };
+};
+
+// ─── task productivity ──────────────────────────────────────────────────
+
+export interface TaskProductivityAggregateRow {
+  assigneeId: string;
+  assigneeName: string;
+  completed: number;
+  pending: number;
+  avgCycleDays: number;
+}
+
+export interface TaskProductivityAggregate {
+  rows: TaskProductivityAggregateRow[];
+  totalCompleted: number;
+  totalPending: number;
+  averageCycleDays: number;
+}
+
+const COMPLETED_TASK_STATUS = 'completed';
+
+export const aggregateTaskProductivity = (
+  tasks: readonly BackendPracticeTask[],
+  range: ResolvedDateRange,
+  assigneeNamesById: ReadonlyMap<string, string>
+): TaskProductivityAggregate => {
+  type Bucket = { completed: number; pending: number; cycleDaysSum: number; cycleDaysCount: number };
+  const byAssignee = new Map<string, Bucket>();
+  let totalCompleted = 0;
+  let totalPending = 0;
+  let cycleDaysSum = 0;
+  let cycleDaysCount = 0;
+
+  for (const t of tasks) {
+    const assigneeId = t.assignee_id ?? UNASSIGNED_ATTORNEY_ID;
+    let bucket = byAssignee.get(assigneeId);
+    if (!bucket) {
+      bucket = { completed: 0, pending: 0, cycleDaysSum: 0, cycleDaysCount: 0 };
+      byAssignee.set(assigneeId, bucket);
+    }
+    const status = (t.status ?? '').toLowerCase();
+    if (status === COMPLETED_TASK_STATUS) {
+      const createdMs = parseDateMs(t.created_at);
+      const completedMs = parseDateMs(t.completed_at) ?? parseDateMs(t.updated_at);
+      if (completedMs == null) continue;
+      if (completedMs < range.startMs || completedMs > range.endMs) continue;
+      bucket.completed += 1;
+      totalCompleted += 1;
+      if (createdMs != null && completedMs >= createdMs) {
+        const days = (completedMs - createdMs) / 86_400_000;
+        bucket.cycleDaysSum += days;
+        bucket.cycleDaysCount += 1;
+        cycleDaysSum += days;
+        cycleDaysCount += 1;
+      }
+    } else if (status !== '') {
+      bucket.pending += 1;
+      totalPending += 1;
+    }
+  }
+
+  const rows: TaskProductivityAggregateRow[] = [];
+  for (const [assigneeId, b] of byAssignee) {
+    if (b.completed === 0 && b.pending === 0) continue;
+    rows.push({
+      assigneeId,
+      assigneeName: assigneeId === UNASSIGNED_ATTORNEY_ID
+        ? UNASSIGNED_ATTORNEY_LABEL
+        : assigneeNamesById.get(assigneeId) ?? assigneeId,
+      completed: b.completed,
+      pending: b.pending,
+      avgCycleDays: b.cycleDaysCount > 0 ? Number((b.cycleDaysSum / b.cycleDaysCount).toFixed(2)) : 0,
+    });
+  }
+  rows.sort((a, b) => b.completed - a.completed);
+  return {
+    rows,
+    totalCompleted,
+    totalPending,
+    averageCycleDays: cycleDaysCount > 0 ? Number((cycleDaysSum / cycleDaysCount).toFixed(2)) : 0,
+  };
+};
+
 // ─── service class ────────────────────────────────────────────────────────
 
 export interface ListResult<T> {
@@ -666,9 +999,158 @@ export class ReportService {
     return groupUtilizationByUser(allEntries, truncated);
   }
 
-  // Phase 3 forwarders. Real Railway paths are TBD; we throw
-  // BackendUnavailableError so the route handler can return 503.
-  async forwardPhase3(reportType: string): Promise<never> {
-    throw new BackendUnavailableError(reportType);
+  // ─── Phase 3 (blawby-backend#233) ──────────────────────────────────────
+
+  /**
+   * Returns a `Map<userId, displayName>` for the practice's team. Used to
+   * resolve `originating_attorney_id` / `responsible_attorney_id` /
+   * `assignee_id` to human-readable names. Falls back to an empty map if
+   * the team endpoint is unavailable — display will fall back to the id.
+   */
+  private async fetchAttorneyNames(
+    practiceId: string,
+    request: Request
+  ): Promise<Map<string, string>> {
+    try {
+      const team = await RemoteApiService.getPracticeTeam(this.env, practiceId, request);
+      const map = new Map<string, string>();
+      for (const m of team.members) {
+        if (m.userId && m.name) map.set(m.userId, m.name);
+        else if (m.userId) map.set(m.userId, m.email || m.userId);
+      }
+      return map;
+    } catch (err) {
+      Logger.warn('reports: practice team fetch failed', {
+        practiceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new Map();
+    }
+  }
+
+  async trustLedger(
+    practiceId: string,
+    headers: Record<string, string>,
+    options: { range: ResolvedDateRange }
+  ): Promise<TrustLedgerAggregate> {
+    const path = RAILWAY_REPORT_PATHS.trustLedger(practiceId);
+    const params = new URLSearchParams({
+      start: options.range.startIso,
+      end: options.range.endIso,
+    });
+    const url = `${this.backendUrl}${path}?${params.toString()}`;
+    let resp: Response;
+    try {
+      resp = await fetch(url, { headers });
+    } catch (err) {
+      throw new BackendUnavailableError('trust-ledger', err instanceof Error ? err.message : 'network error');
+    }
+    if (resp.status === 404 || resp.status === 501) {
+      throw new BackendUnavailableError('trust-ledger');
+    }
+    if (!resp.ok) {
+      throw new Error(`trust-ledger upstream returned ${resp.status}`);
+    }
+    const json = await resp.json();
+    const rawItems = extractListArray(json, ['transactions', 'items', 'data']);
+    const parsed: BackendTrustTransaction[] = [];
+    for (const raw of rawItems) {
+      const result = BackendTrustTransactionSchema.safeParse(raw);
+      if (result.success) parsed.push(result.data);
+    }
+    return aggregateTrustLedger(parsed, options.range);
+  }
+
+  async wip(
+    practiceId: string,
+    headers: Record<string, string>
+  ): Promise<WipAggregate> {
+    const path = RAILWAY_REPORT_PATHS.wip(practiceId);
+    const url = `${this.backendUrl}${path}`;
+    let resp: Response;
+    try {
+      resp = await fetch(url, { headers });
+    } catch (err) {
+      throw new BackendUnavailableError('wip', err instanceof Error ? err.message : 'network error');
+    }
+    if (resp.status === 404 || resp.status === 501) {
+      throw new BackendUnavailableError('wip');
+    }
+    if (!resp.ok) {
+      throw new Error(`wip upstream returned ${resp.status}`);
+    }
+    const json = await resp.json();
+    const rawItems = extractListArray(json, ['matters', 'items', 'data']);
+    const parsed: BackendWipMatter[] = [];
+    for (const raw of rawItems) {
+      const result = BackendWipMatterSchema.safeParse(raw);
+      if (result.success) parsed.push(result.data);
+    }
+    return aggregateWip(parsed);
+  }
+
+  async originatingAttorney(
+    practiceId: string,
+    headers: Record<string, string>,
+    request: Request,
+    options: { range: ResolvedDateRange }
+  ): Promise<OriginatingAttorneyAggregate> {
+    const [invoices, mattersResult, attorneyNames] = await Promise.all([
+      this.fetchInvoices(practiceId, headers),
+      this.fetchMatters(practiceId, headers),
+      this.fetchAttorneyNames(practiceId, request),
+    ]);
+    return groupByOriginatingAttorney(mattersResult.items, invoices, options.range, attorneyNames);
+  }
+
+  async mattersByAttorney(
+    practiceId: string,
+    headers: Record<string, string>,
+    request: Request
+  ): Promise<MattersByAttorneyAggregate> {
+    const [mattersResult, attorneyNames] = await Promise.all([
+      this.fetchMatters(practiceId, headers),
+      this.fetchAttorneyNames(practiceId, request),
+    ]);
+    return groupByResponsibleAttorney(mattersResult.items, attorneyNames);
+  }
+
+  async taskProductivity(
+    practiceId: string,
+    headers: Record<string, string>,
+    request: Request,
+    options: { range: ResolvedDateRange }
+  ): Promise<TaskProductivityAggregate> {
+    const path = RAILWAY_REPORT_PATHS.tasks(practiceId);
+    const all: BackendPracticeTask[] = [];
+    for (let page = 1; page <= MAX_LIST_PAGES; page += 1) {
+      const url = `${this.backendUrl}${path}?page=${page}&limit=${MAX_LIST_PAGE_SIZE}`;
+      let resp: Response;
+      try {
+        resp = await fetch(url, { headers });
+      } catch (err) {
+        if (page === 1) {
+          throw new BackendUnavailableError('task-productivity', err instanceof Error ? err.message : 'network error');
+        }
+        break;
+      }
+      if (resp.status === 404 || resp.status === 501) {
+        if (page === 1) throw new BackendUnavailableError('task-productivity');
+        break;
+      }
+      if (!resp.ok) {
+        if (page === 1) throw new Error(`task-productivity upstream returned ${resp.status}`);
+        break;
+      }
+      const json = await resp.json();
+      const items = extractListArray(json, ['tasks', 'items', 'data']);
+      for (const raw of items) {
+        const result = BackendPracticeTaskSchema.safeParse(raw);
+        if (result.success) all.push(result.data);
+      }
+      if (items.length < MAX_LIST_PAGE_SIZE) break;
+    }
+    const attorneyNames = await this.fetchAttorneyNames(practiceId, request);
+    return aggregateTaskProductivity(all, options.range, attorneyNames);
   }
 }

--- a/worker/services/ReportService.ts
+++ b/worker/services/ReportService.ts
@@ -1,0 +1,674 @@
+/**
+ * ReportService — Phase 1 + 2 report aggregation.
+ *
+ * Aggregation helpers are exported as pure functions so unit tests can
+ * exercise them with fixture invoices/matters/time entries (no Railway
+ * round-trips). The class wires those helpers into Railway fetches.
+ *
+ * Money convention:
+ *   - Invoice fields are in cents (integers). Field names suffixed `*Cents`.
+ *   - Matter hourly rates are in dollars (MajorAmount). Suffixed `*Dollars`.
+ *   - Time totals are in hours (number). Suffixed `*Hours`.
+ *
+ * Pagination cap: invoices/matters paginate at MAX_LIST_PAGE_SIZE/page;
+ * we cap at MAX_LIST_PAGES (set to 20) to keep worker time bounded.
+ */
+
+import type { Env } from '../types.js';
+import { Logger } from '../utils/logger.js';
+import { BackendInvoiceSchema, type BackendInvoice } from '../types/wire/invoice.js';
+import {
+  BackendMatterSchema,
+  BackendMatterTimeEntrySchema,
+  type BackendMatter,
+  type BackendMatterTimeEntry,
+} from '../types/wire/matter.js';
+
+export const MAX_LIST_PAGES = 20;
+export const MAX_LIST_PAGE_SIZE = 100;
+export const DEFAULT_PROFITABILITY_RATE_DOLLARS = 250;
+export const TIME_ENTRY_CONCURRENCY = 5;
+
+export class BackendUnavailableError extends Error {
+  constructor(public reportType: string, message?: string) {
+    super(message ?? `Report '${reportType}' depends on a backend endpoint that is not yet available.`);
+    this.name = 'BackendUnavailableError';
+  }
+}
+
+// ─── shared utilities ─────────────────────────────────────────────────────
+
+export const unwrapRecord = (raw: unknown): Record<string, unknown> => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const record = raw as Record<string, unknown>;
+  if (record.data && typeof record.data === 'object' && !Array.isArray(record.data)) {
+    return unwrapRecord(record.data);
+  }
+  return record;
+};
+
+const extractListArray = (raw: unknown, candidateKeys: readonly string[]): unknown[] => {
+  if (Array.isArray(raw)) return raw;
+  if (!raw || typeof raw !== 'object') return [];
+  const record = raw as Record<string, unknown>;
+  for (const key of candidateKeys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value;
+  }
+  if (record.data) return extractListArray(record.data, candidateKeys);
+  return [];
+};
+
+/**
+ * Bounded-concurrency promise runner. Runs `task` over `items` at most
+ * `concurrency` at a time. Resolves with results in input order.
+ */
+export const pLimit = async <T, R>(
+  concurrency: number,
+  items: readonly T[],
+  task: (item: T, index: number) => Promise<R>
+): Promise<R[]> => {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers: Promise<void>[] = [];
+  const width = Math.max(1, Math.min(concurrency, items.length));
+  for (let w = 0; w < width; w += 1) {
+    workers.push((async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= items.length) return;
+        out[i] = await task(items[i], i);
+      }
+    })());
+  }
+  await Promise.all(workers);
+  return out;
+};
+
+export interface ResolvedDateRange {
+  startMs: number;
+  endMs: number;
+  startIso: string;
+  endIso: string;
+}
+
+const startOfMonth = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+const startOfQuarter = (d: Date) => {
+  const q = Math.floor(d.getUTCMonth() / 3) * 3;
+  return new Date(Date.UTC(d.getUTCFullYear(), q, 1));
+};
+const startOfYear = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+
+/**
+ * Resolve `start`/`end` ISO inputs into a date range. Falls back to a
+ * `period`-derived range when start/end aren't provided.
+ */
+export const resolveDateRange = (
+  start: string | null | undefined,
+  end: string | null | undefined,
+  period: 'month' | 'quarter' | 'year' | undefined,
+  now: Date = new Date()
+): ResolvedDateRange => {
+  let startMs: number;
+  let endMs: number;
+  if (start && end) {
+    const s = Date.parse(start);
+    const e = Date.parse(end);
+    if (!Number.isFinite(s) || !Number.isFinite(e) || s > e) {
+      throw new Error('Invalid date range');
+    }
+    startMs = s;
+    endMs = e;
+  } else {
+    endMs = now.getTime();
+    const yearsBack = period === 'year' ? 1 : period === 'quarter' ? 0 : 0;
+    const monthsBack = period === 'month' ? 11 : 0;
+    const baseStart = period === 'year'
+      ? startOfYear(new Date(now.getTime() - yearsBack * 365 * 24 * 60 * 60 * 1000))
+      : period === 'quarter'
+        ? startOfQuarter(now)
+        : startOfMonth(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - monthsBack, 1)));
+    startMs = baseStart.getTime();
+  }
+  return {
+    startMs,
+    endMs,
+    startIso: new Date(startMs).toISOString(),
+    endIso: new Date(endMs).toISOString(),
+  };
+};
+
+const formatPeriodLabel = (
+  bucketStartMs: number,
+  granularity: 'month' | 'quarter' | 'year'
+): string => {
+  const d = new Date(bucketStartMs);
+  const year = d.getUTCFullYear();
+  if (granularity === 'year') return String(year);
+  if (granularity === 'quarter') {
+    const q = Math.floor(d.getUTCMonth() / 3) + 1;
+    return `${year} Q${q}`;
+  }
+  const month = d.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' });
+  return `${month} ${year}`;
+};
+
+const bucketStartFor = (
+  d: Date,
+  granularity: 'month' | 'quarter' | 'year'
+): number => {
+  if (granularity === 'year') return startOfYear(d).getTime();
+  if (granularity === 'quarter') return startOfQuarter(d).getTime();
+  return startOfMonth(d).getTime();
+};
+
+// ─── revenue ──────────────────────────────────────────────────────────────
+
+export interface RevenueAggregateRow {
+  periodLabel: string;
+  periodStart: string;
+  periodEnd: string;
+  invoiceCount: number;
+  paidAmountCents: number;
+  outstandingAmountCents: number;
+}
+
+export interface RevenueAggregate {
+  rows: RevenueAggregateRow[];
+  totalPaidCents: number;
+  totalOutstandingCents: number;
+  totalInvoiceCount: number;
+}
+
+const toCents = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.round(value);
+};
+
+const parseDateMs = (raw: unknown): number | null => {
+  if (raw instanceof Date) return raw.getTime();
+  if (typeof raw === 'string') {
+    const t = Date.parse(raw);
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
+};
+
+/**
+ * Group invoices by period (month/quarter/year). An invoice is bucketed by
+ * `paid_at` when present (falling back to `created_at`). Unpaid invoices
+ * contribute to `outstandingAmountCents` but not `invoiceCount`.
+ */
+export const groupRevenue = (
+  invoices: readonly BackendInvoice[],
+  granularity: 'month' | 'quarter' | 'year',
+  range: ResolvedDateRange
+): RevenueAggregate => {
+  const buckets = new Map<number, RevenueAggregateRow>();
+  let totalPaid = 0;
+  let totalOutstanding = 0;
+  let totalInvoiceCount = 0;
+
+  for (const inv of invoices) {
+    const eventMs = parseDateMs(inv.paid_at) ?? parseDateMs(inv.created_at);
+    if (eventMs == null) continue;
+    if (eventMs < range.startMs || eventMs > range.endMs) continue;
+    const bucketKey = bucketStartFor(new Date(eventMs), granularity);
+    let row = buckets.get(bucketKey);
+    if (!row) {
+      row = {
+        periodLabel: formatPeriodLabel(bucketKey, granularity),
+        periodStart: new Date(bucketKey).toISOString(),
+        periodEnd: new Date(bucketKey).toISOString(),
+        invoiceCount: 0,
+        paidAmountCents: 0,
+        outstandingAmountCents: 0,
+      };
+      buckets.set(bucketKey, row);
+    }
+    const paid = toCents(inv.amount_paid);
+    const due = toCents(inv.amount_due);
+    row.paidAmountCents += paid;
+    row.outstandingAmountCents += due;
+    if (paid > 0) {
+      row.invoiceCount += 1;
+      totalInvoiceCount += 1;
+    }
+    totalPaid += paid;
+    totalOutstanding += due;
+  }
+
+  const rows = Array.from(buckets.values()).sort((a, b) => a.periodStart.localeCompare(b.periodStart));
+  return {
+    rows,
+    totalPaidCents: totalPaid,
+    totalOutstandingCents: totalOutstanding,
+    totalInvoiceCount,
+  };
+};
+
+// ─── aging ────────────────────────────────────────────────────────────────
+
+export interface AgingAggregateRow {
+  bucketLabel: string;
+  bucketMinDays: number;
+  bucketMaxDays: number | null;
+  invoiceCount: number;
+  totalAmountCents: number;
+}
+
+export interface AgingAggregate {
+  rows: AgingAggregateRow[];
+  totalOutstandingCents: number;
+  totalInvoiceCount: number;
+}
+
+const AGING_BUCKETS: Array<{ label: string; min: number; max: number | null }> = [
+  { label: 'Current (≤ 0 days)', min: -Infinity, max: 0 },
+  { label: '1–30 days', min: 1, max: 30 },
+  { label: '31–60 days', min: 31, max: 60 },
+  { label: '61–90 days', min: 61, max: 90 },
+  { label: '91+ days', min: 91, max: null },
+];
+
+const isUnpaidStatus = (status: string | null | undefined): boolean => {
+  if (!status) return true;
+  const s = status.toLowerCase();
+  return s === 'sent' || s === 'open' || s === 'overdue' || s === 'draft';
+};
+
+/**
+ * Bucket unpaid invoices by daysOverdue from `due_date` (fallback
+ * `issue_date + 30d`). `now` defaults to current time; tests pass a fixed
+ * value.
+ */
+export const bucketAging = (
+  invoices: readonly BackendInvoice[],
+  now: Date = new Date()
+): AgingAggregate => {
+  const rows: AgingAggregateRow[] = AGING_BUCKETS.map((b) => ({
+    bucketLabel: b.label,
+    bucketMinDays: Number.isFinite(b.min) ? b.min : 0,
+    bucketMaxDays: b.max,
+    invoiceCount: 0,
+    totalAmountCents: 0,
+  }));
+  let totalOutstandingCents = 0;
+  let totalInvoiceCount = 0;
+  const nowMs = now.getTime();
+
+  for (const inv of invoices) {
+    if (!isUnpaidStatus(inv.status)) continue;
+    const due = toCents(inv.amount_due);
+    if (due <= 0) continue;
+
+    const dueMs = parseDateMs(inv.due_date) ?? (() => {
+      const issued = parseDateMs(inv.issue_date);
+      return issued != null ? issued + 30 * 86400000 : null;
+    })();
+    if (dueMs == null) continue;
+
+    const daysOverdue = Math.floor((nowMs - dueMs) / 86400000);
+    const idx = AGING_BUCKETS.findIndex((b) => daysOverdue >= b.min && (b.max == null || daysOverdue <= b.max));
+    if (idx === -1) continue;
+    rows[idx].invoiceCount += 1;
+    rows[idx].totalAmountCents += due;
+    totalOutstandingCents += due;
+    totalInvoiceCount += 1;
+  }
+
+  return { rows, totalOutstandingCents, totalInvoiceCount };
+};
+
+// ─── profitability ────────────────────────────────────────────────────────
+
+export interface ProfitabilityAggregateRow {
+  matterId: string;
+  matterTitle: string;
+  revenueCents: number;
+  estimatedCostCents: number;
+  marginCents: number;
+  billableHours: number;
+}
+
+export interface ProfitabilityAggregate {
+  rows: ProfitabilityAggregateRow[];
+  totalRevenueCents: number;
+  totalCostCents: number;
+  totalMarginCents: number;
+  truncated: boolean;
+}
+
+const matterRateDollars = (matter: BackendMatter): number | null => {
+  const rate = matter.attorney_hourly_rate;
+  return typeof rate === 'number' && Number.isFinite(rate) ? rate : null;
+};
+
+/**
+ * Sum billable seconds from `BackendMatterTimeEntry[]` and convert to hours.
+ * Assumes `duration` is seconds (matches `totalBillableSeconds` naming in
+ * wire schema). If backend later confirms minutes/hours, swap the divisor.
+ */
+export const sumBillableHours = (entries: readonly BackendMatterTimeEntry[]): number => {
+  let totalSeconds = 0;
+  for (const e of entries) {
+    if (e.billable === false) continue;
+    const d = e.duration;
+    if (typeof d === 'number' && Number.isFinite(d)) totalSeconds += d;
+  }
+  return totalSeconds / 3600;
+};
+
+export const computeProfitability = (
+  matters: readonly BackendMatter[],
+  timeEntriesByMatter: Map<string, BackendMatterTimeEntry[]>,
+  overrideHourlyRateDollars: number | null,
+  truncated = false
+): ProfitabilityAggregate => {
+  const rows: ProfitabilityAggregateRow[] = [];
+  let totalRevenue = 0;
+  let totalCost = 0;
+  let totalMargin = 0;
+  for (const m of matters) {
+    const entries = timeEntriesByMatter.get(m.id) ?? [];
+    const hours = sumBillableHours(entries);
+    const rate = overrideHourlyRateDollars ?? matterRateDollars(m) ?? DEFAULT_PROFITABILITY_RATE_DOLLARS;
+    const estimatedCostCents = Math.round(hours * rate * 100);
+    // Revenue per matter is the running paid-invoice subtotal injected by
+    // the caller via m.metadata; computed in `ReportService.profitability`.
+    const meta = (m as unknown as { __revenueCents?: number }).__revenueCents;
+    const revenueCents = typeof meta === 'number' ? meta : 0;
+    const marginCents = revenueCents - estimatedCostCents;
+    rows.push({
+      matterId: m.id,
+      matterTitle: m.title ?? m.id,
+      revenueCents,
+      estimatedCostCents,
+      marginCents,
+      billableHours: Number(hours.toFixed(2)),
+    });
+    totalRevenue += revenueCents;
+    totalCost += estimatedCostCents;
+    totalMargin += marginCents;
+  }
+  rows.sort((a, b) => b.marginCents - a.marginCents);
+  return {
+    rows,
+    totalRevenueCents: totalRevenue,
+    totalCostCents: totalCost,
+    totalMarginCents: totalMargin,
+    truncated,
+  };
+};
+
+// ─── utilization ──────────────────────────────────────────────────────────
+
+export interface UtilizationAggregateRow {
+  userId: string;
+  billableHours: number;
+  nonBillableHours: number;
+  totalHours: number;
+  utilizationPercent: number;
+}
+
+export interface UtilizationAggregate {
+  rows: UtilizationAggregateRow[];
+  totalBillableHours: number;
+  totalNonBillableHours: number;
+  averageUtilizationPercent: number;
+  truncated: boolean;
+}
+
+export const groupUtilizationByUser = (
+  entries: readonly BackendMatterTimeEntry[],
+  truncated = false
+): UtilizationAggregate => {
+  const byUser = new Map<string, { billableSec: number; nonBillableSec: number }>();
+  for (const e of entries) {
+    const userId = e.user_id ?? 'unassigned';
+    const d = typeof e.duration === 'number' && Number.isFinite(e.duration) ? e.duration : 0;
+    let bucket = byUser.get(userId);
+    if (!bucket) {
+      bucket = { billableSec: 0, nonBillableSec: 0 };
+      byUser.set(userId, bucket);
+    }
+    if (e.billable === false) bucket.nonBillableSec += d;
+    else bucket.billableSec += d;
+  }
+  const rows: UtilizationAggregateRow[] = [];
+  let totalBillable = 0;
+  let totalNonBillable = 0;
+  for (const [userId, b] of byUser) {
+    const billable = b.billableSec / 3600;
+    const nonBillable = b.nonBillableSec / 3600;
+    const total = billable + nonBillable;
+    const utilization = total > 0 ? (billable / total) * 100 : 0;
+    rows.push({
+      userId,
+      billableHours: Number(billable.toFixed(2)),
+      nonBillableHours: Number(nonBillable.toFixed(2)),
+      totalHours: Number(total.toFixed(2)),
+      utilizationPercent: Number(utilization.toFixed(2)),
+    });
+    totalBillable += billable;
+    totalNonBillable += nonBillable;
+  }
+  rows.sort((a, b) => b.utilizationPercent - a.utilizationPercent);
+  const grandTotal = totalBillable + totalNonBillable;
+  return {
+    rows,
+    totalBillableHours: Number(totalBillable.toFixed(2)),
+    totalNonBillableHours: Number(totalNonBillable.toFixed(2)),
+    averageUtilizationPercent: Number(
+      (grandTotal > 0 ? (totalBillable / grandTotal) * 100 : 0).toFixed(2)
+    ),
+    truncated,
+  };
+};
+
+// ─── service class ────────────────────────────────────────────────────────
+
+export interface ListResult<T> {
+  items: T[];
+  truncated: boolean;
+}
+
+export class ReportService {
+  constructor(private readonly env: Env) {}
+
+  private get backendUrl(): string {
+    const url = this.env.BACKEND_API_URL;
+    if (!url) throw new Error('BACKEND_API_URL not configured');
+    return url;
+  }
+
+  private async fetchAllPages<T>(
+    path: string,
+    headers: Record<string, string>,
+    candidateKeys: readonly string[],
+    label: string
+  ): Promise<ListResult<T>> {
+    const all: T[] = [];
+    let truncated = false;
+    for (let page = 1; page <= MAX_LIST_PAGES; page += 1) {
+      try {
+        const url = `${this.backendUrl}${path}?page=${page}&limit=${MAX_LIST_PAGE_SIZE}`;
+        const resp = await fetch(url, { headers });
+        if (!resp.ok) {
+          Logger.warn(`reports: ${label} page ${page} returned ${resp.status}`);
+          break;
+        }
+        const json = await resp.json();
+        const items = extractListArray(json, candidateKeys);
+        all.push(...(items as T[]));
+        if (items.length < MAX_LIST_PAGE_SIZE) {
+          return { items: all, truncated: false };
+        }
+      } catch (err) {
+        Logger.warn(`reports: ${label} page ${page} failed`, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        break;
+      }
+    }
+    truncated = all.length >= MAX_LIST_PAGES * MAX_LIST_PAGE_SIZE;
+    return { items: all, truncated };
+  }
+
+  async fetchInvoices(practiceId: string, headers: Record<string, string>): Promise<BackendInvoice[]> {
+    const { items } = await this.fetchAllPages<unknown>(
+      `/api/invoices/${encodeURIComponent(practiceId)}`,
+      headers,
+      ['invoices', 'items'],
+      'invoices'
+    );
+    const parsed: BackendInvoice[] = [];
+    for (const raw of items) {
+      const result = BackendInvoiceSchema.safeParse(raw);
+      if (result.success) parsed.push(result.data);
+    }
+    return parsed;
+  }
+
+  async fetchMatters(practiceId: string, headers: Record<string, string>): Promise<ListResult<BackendMatter>> {
+    const { items, truncated } = await this.fetchAllPages<unknown>(
+      `/api/matters/${encodeURIComponent(practiceId)}`,
+      headers,
+      ['matters', 'items'],
+      'matters'
+    );
+    const parsed: BackendMatter[] = [];
+    for (const raw of items) {
+      const result = BackendMatterSchema.safeParse(raw);
+      if (result.success) parsed.push(result.data);
+    }
+    return { items: parsed, truncated };
+  }
+
+  async fetchTimeEntriesForMatter(
+    practiceId: string,
+    matterId: string,
+    headers: Record<string, string>
+  ): Promise<BackendMatterTimeEntry[]> {
+    try {
+      const url = `${this.backendUrl}/api/matters/${encodeURIComponent(practiceId)}/${encodeURIComponent(matterId)}/time-entries`;
+      const resp = await fetch(url, { headers });
+      if (!resp.ok) return [];
+      const json = await resp.json();
+      const items = extractListArray(json, ['time_entries', 'timeEntries', 'items']);
+      const out: BackendMatterTimeEntry[] = [];
+      for (const raw of items) {
+        const result = BackendMatterTimeEntrySchema.safeParse(raw);
+        if (result.success) out.push(result.data);
+      }
+      return out;
+    } catch (err) {
+      Logger.warn(`reports: time entries for ${matterId} failed`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }
+
+  async revenue(
+    practiceId: string,
+    headers: Record<string, string>,
+    options: { period: 'month' | 'quarter' | 'year'; range: ResolvedDateRange }
+  ): Promise<RevenueAggregate> {
+    const invoices = await this.fetchInvoices(practiceId, headers);
+    return groupRevenue(invoices, options.period, options.range);
+  }
+
+  async aging(
+    practiceId: string,
+    headers: Record<string, string>,
+    options: { now?: Date }
+  ): Promise<AgingAggregate> {
+    const invoices = await this.fetchInvoices(practiceId, headers);
+    return bucketAging(invoices, options.now ?? new Date());
+  }
+
+  async profitability(
+    practiceId: string,
+    headers: Record<string, string>,
+    options: {
+      range: ResolvedDateRange;
+      overrideHourlyRateDollars: number | null;
+    }
+  ): Promise<ProfitabilityAggregate> {
+    const [invoices, mattersResult] = await Promise.all([
+      this.fetchInvoices(practiceId, headers),
+      this.fetchMatters(practiceId, headers),
+    ]);
+    const matters = mattersResult.items;
+
+    // Per-matter paid revenue restricted to the date range.
+    const revenueByMatter = new Map<string, number>();
+    for (const inv of invoices) {
+      const matterId = inv.matter_id;
+      if (!matterId) continue;
+      const eventMs = parseDateMs(inv.paid_at) ?? parseDateMs(inv.created_at);
+      if (eventMs == null) continue;
+      if (eventMs < options.range.startMs || eventMs > options.range.endMs) continue;
+      const paid = toCents(inv.amount_paid);
+      if (paid <= 0) continue;
+      revenueByMatter.set(matterId, (revenueByMatter.get(matterId) ?? 0) + paid);
+    }
+
+    // Fetch time entries with bounded concurrency.
+    const timeEntriesByMatter = new Map<string, BackendMatterTimeEntry[]>();
+    const entriesList = await pLimit(
+      TIME_ENTRY_CONCURRENCY,
+      matters,
+      (m) => this.fetchTimeEntriesForMatter(practiceId, m.id, headers)
+    );
+    matters.forEach((m, i) => {
+      const inRange = entriesList[i].filter((e) => {
+        const ms = parseDateMs(e.start_time) ?? parseDateMs(e.end_time) ?? parseDateMs(e.created_at);
+        if (ms == null) return true;
+        return ms >= options.range.startMs && ms <= options.range.endMs;
+      });
+      timeEntriesByMatter.set(m.id, inRange);
+    });
+
+    const decoratedMatters = matters.map((m) => ({
+      ...m,
+      __revenueCents: revenueByMatter.get(m.id) ?? 0,
+    })) as BackendMatter[];
+
+    return computeProfitability(
+      decoratedMatters,
+      timeEntriesByMatter,
+      options.overrideHourlyRateDollars,
+      mattersResult.truncated
+    );
+  }
+
+  async utilization(
+    practiceId: string,
+    headers: Record<string, string>,
+    options: { range: ResolvedDateRange }
+  ): Promise<UtilizationAggregate> {
+    const { items: matters, truncated } = await this.fetchMatters(practiceId, headers);
+    const entriesList = await pLimit(
+      TIME_ENTRY_CONCURRENCY,
+      matters,
+      (m) => this.fetchTimeEntriesForMatter(practiceId, m.id, headers)
+    );
+    const allEntries: BackendMatterTimeEntry[] = [];
+    for (const list of entriesList) {
+      for (const e of list) {
+        const ms = parseDateMs(e.start_time) ?? parseDateMs(e.end_time) ?? parseDateMs(e.created_at);
+        if (ms != null && (ms < options.range.startMs || ms > options.range.endMs)) continue;
+        allEntries.push(e);
+      }
+    }
+    return groupUtilizationByUser(allEntries, truncated);
+  }
+
+  // Phase 3 forwarders. Real Railway paths are TBD; we throw
+  // BackendUnavailableError so the route handler can return 503.
+  async forwardPhase3(reportType: string): Promise<never> {
+    throw new BackendUnavailableError(reportType);
+  }
+}

--- a/worker/types/wire/reports.ts
+++ b/worker/types/wire/reports.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 
 const nullableString = () => z.string().nullable().optional();
 const nullableNumber = () => z.number().nullable().optional();
-const isoDate = () => z.string().nullable().optional();
+const isoDate = () => z.union([z.iso.datetime(), z.iso.date()]).nullable().optional();
 
 export const BackendTrustTransactionSchema = z.object({
   id: z.string(),

--- a/worker/types/wire/reports.ts
+++ b/worker/types/wire/reports.ts
@@ -1,0 +1,64 @@
+/**
+ * Wire types for the new Railway endpoints introduced by blawby-backend#233.
+ *
+ * Trust transactions (`/api/trust-ledger/:practiceId`), WIP aggregates
+ * (`/api/matters/:practiceId/wip`), and the per-practice tasks list
+ * (`/api/tasks/:practiceId`) are not yet shipped in the existing wire/
+ * schemas — defining them here keeps the worker code typed today and
+ * gives one place to update when backend confirms the final shape.
+ *
+ * snake_case fields per the rest of the wire/ contract. All money in
+ * cents (integers) following the invoice convention.
+ */
+
+import { z } from 'zod';
+
+const nullableString = () => z.string().nullable().optional();
+const nullableNumber = () => z.number().nullable().optional();
+const isoDate = () => z.string().nullable().optional();
+
+export const BackendTrustTransactionSchema = z.object({
+  id: z.string(),
+  practice_id: nullableString(),
+  client_id: nullableString(),
+  matter_id: nullableString(),
+  type: nullableString(), // 'deposit' | 'withdrawal' | 'fee_payment' | …
+  amount: nullableNumber(), // cents, signed (negative = withdrawal)
+  balance_after: nullableNumber(), // cents, running balance
+  description: nullableString(),
+  occurred_at: isoDate(),
+  client_name: nullableString(),
+  client: z.record(z.string(), z.unknown()).nullable().optional(),
+}).passthrough();
+export type BackendTrustTransaction = z.infer<typeof BackendTrustTransactionSchema>;
+
+export const BackendWipMatterSchema = z.object({
+  matter_id: z.string(),
+  matter_title: nullableString(),
+  unbilled_seconds: nullableNumber(),
+  unbilled_amount: nullableNumber(), // cents
+}).passthrough();
+export type BackendWipMatter = z.infer<typeof BackendWipMatterSchema>;
+
+/**
+ * Practice-wide tasks endpoint. Differs from `BackendMatterTask` only in
+ * that it tolerates a missing `matter_id` (e.g. ad-hoc tasks not yet
+ * attached to a matter) and includes assignee name when joined backend-
+ * side.
+ */
+export const BackendPracticeTaskSchema = z.object({
+  id: z.string(),
+  matter_id: nullableString(),
+  name: nullableString(),
+  description: nullableString(),
+  assignee_id: nullableString(),
+  assignee_name: nullableString(),
+  due_date: isoDate(),
+  status: z.string(), // 'pending' | 'in_progress' | 'completed' | 'blocked' or backend-defined
+  priority: nullableString(),
+  stage: nullableString(),
+  completed_at: isoDate(),
+  created_at: isoDate(),
+  updated_at: isoDate(),
+}).passthrough();
+export type BackendPracticeTask = z.infer<typeof BackendPracticeTaskSchema>;

--- a/worker/utils/csv.ts
+++ b/worker/utils/csv.ts
@@ -1,0 +1,31 @@
+export interface CsvColumn<TRow> {
+  key: keyof TRow & string;
+  header: string;
+  format?: (value: TRow[keyof TRow], row: TRow) => string | number | null | undefined;
+}
+
+const escapeCell = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  const str = typeof value === 'string' ? value : String(value);
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+export const toCsv = <TRow extends Record<string, unknown>>(
+  rows: TRow[],
+  columns: CsvColumn<TRow>[]
+): string => {
+  const headerRow = columns.map((col) => escapeCell(col.header)).join(',');
+  const dataRows = rows.map((row) =>
+    columns
+      .map((col) => {
+        const raw = row[col.key];
+        const formatted = col.format ? col.format(raw, row) : raw;
+        return escapeCell(formatted);
+      })
+      .join(',')
+  );
+  return [headerRow, ...dataRows].join('\r\n');
+};


### PR DESCRIPTION
## Summary

Implements the Clio-parity legal firm reports system from #521. Cloudflare Worker owns `/api/reports/*`, aggregates from existing Railway APIs, computes report results, and serves a Preact frontend at `/practice/:slug/reports/<report-id>`. All 9 reports are wired end-to-end including the 5 that were originally blocked on `blawby-backend#233` (now implemented as if backend shipped, with `BackendUnavailableError` as the defensive fallback if the Railway endpoints aren't yet live).

- **9 reports**: revenue, AR aging, profitability, utilization, trust ledger, WIP, originating attorney, matters by attorney, task productivity
- **Single source of truth**: `src/features/reports/config/reportCollection.ts` — adding a 10th report = one entry
- **Worker**: `ReportService` (Railway fetches + pure-function aggregation helpers), `ReportScheduleService` (KV CRUD), `ReportDeliveryService` (D1 + R2 + queue), CSV export, send-now, deliveries list/detail/download
- **Frontend**: dispatcher page, shared `ReportPageShell`, hub, schedule/send-now modals, real deliveries views
- **39 new unit tests** (aggregation, schedule math, CSV, collection, Phase 3 aggregation)
- **No backend changes** — all aggregation runs in the worker over existing Railway endpoints
- **No new bindings** — reuses existing D1, KV (CHAT_SESSIONS), R2 (FILES_BUCKET), Queue (NOTIFICATION_EVENTS)
- **1 D1 migration** (`20260514_add_report_deliveries.sql`): `report_deliveries` table + 3 indexes

Resolves #521.

## Architecture

```
Browser
   │
   ▼
Cloudflare Worker  /api/reports/*  (this branch)
   │
   ├─ ReportService          — Railway fetches + aggregation + CSV
   ├─ ReportScheduleService  — KV CRUD (CHAT_SESSIONS, prefix `report-schedule:`)
   └─ ReportDeliveryService  — D1 (report_deliveries) + R2 (FILES_BUCKET)
                                + NOTIFICATION_EVENTS queue
   │
   ▼
Railway (BACKEND_API_URL)
   /api/invoices/:practiceId
   /api/matters/:practiceId
   /api/matters/:practiceId/:id/time-entries
```

Response envelope (every JSON endpoint):

```ts
interface ReportEnvelope<T> {
  items: T[];
  total: number;
  generatedAt: string;
  filters: Record<string, string | undefined>;
  meta?: Record<string, unknown>;
}
```

## Commits

Each milestone is its own commit, green and shippable on its own:

1. `feat(reports): foundation` — `reportCollection.ts`, types, csv util, D1 migration, nav refactor, 9 report page stubs + delivery views
2. `feat(reports): Phase 1 worker` — revenue + aging + profitability + utilization + CSV export
3. `feat(reports): Phase 1 frontend` — `reportsApi`, `useReportData`, `ReportPageShell`, filters, KPI, DataTable adapter, export modal
4. `feat(reports): Phase 2 worker` — `ReportScheduleService` (KV), `ReportDeliveryService` (D1 + R2), send-now, deliveries list/detail/download
5. `feat(reports): Phase 2 frontend` — schedule + send-now modals, real `DeliveriesListView` + `DeliveryDetailView`
6. `feat(reports): Phase 3 — skip fetch for not-yet-shipped reports` — `useReportData({ enabled })` + Phase-3 short-circuit to `BackendUnavailableState`
7. `test(reports): aggregation, schedule math, csv, reportCollection coverage` — 39 tests, 4 files
8. `feat(reports): implement Phase 3 reports as if backend #233 shipped` — promotes Phase 3 reports to phase 2, real Railway-backed aggregation, +12 tests

## File summary

- **New worker files**: `worker/routes/reports.ts`, `worker/services/Report{Service,ScheduleService,DeliveryService}.ts`, `worker/utils/csv.ts`, `worker/types/wire/reports.ts`, `worker/migrations/20260514_add_report_deliveries.sql`
- **Modified worker files**: `worker/index.ts` (route registration), `worker/routes/index.ts` (re-export)
- **New frontend files (29)**: full `src/features/reports/` subtree — `config/reportCollection.ts`, `services/{reportsApi,reportsTypes}.ts`, hooks (`useReportData`, `useReportExport`, `useReportSchedules`, `useReportDeliveries`), components (`ReportPageShell`, `ReportCard`, `ReportFilters`, `ReportToolbar`, `ReportListKpiRow`, `ReportDataTable`, `ExportModal`, `ScheduleModal`, `SendNowModal`, `BackendUnavailableState`), pages (`AllReportsHub`, 9 report pages, `DeliveriesListView`, `DeliveryDetailView`)
- **Modified frontend files (6)**: `PracticeReportsPage.tsx` (dispatcher), `workspaceShell.ts`, `useWorkspaceNavigation.ts`, `navConfig.ts`, `WorkspacePage.tsx`, `MainApp.tsx`, `Sidebar.tsx` (comingSoon prop)
- **New test files (5)**: `tests/unit/worker/services/Report{Service.aggregation,ScheduleService,Service.phase3.aggregation}.test.ts`, `tests/unit/worker/utils/csv.test.ts`, `src/features/reports/config/__tests__/reportCollection.test.ts`

## Critical decisions (reconciled in commits)

| Topic | Decision | Why |
|---|---|---|
| CSV URL shape | `GET /api/reports/:practiceId/export/:reportType?format=csv` | Matches #521 spec verbatim |
| Send-now URL | `POST /api/reports/:practiceId/send-now` (single endpoint; `reportType` in body) | Matches #521 spec |
| Money in response | Cents (integers) for invoice-derived fields; dollars for matter rates; field names suffixed `*Cents`/`*Dollars`/`*Hours` | Avoids float drift; frontend formats via `formatCurrency(toMajorUnits(cents))` |
| `REPORT_SECTION_TITLES` source | Derived from `REPORT_DEFINITIONS` | Single source of truth |
| Phase 3 fallback | Catch Railway 404/501/network → 503 with `errorCode='BACKEND_NOT_AVAILABLE'` → frontend renders `BackendUnavailableState` | Graceful degradation if real Railway endpoints aren't live |
| Schedule execution | KV CRUD only this branch; cron-trigger execution is follow-up | Acceptance criteria says schedules can be created/listed/updated/deleted — doesn't require automatic execution |

## Test plan

- [x] `npm run type-check` clean across app + worker + test configs
- [x] 51 reports unit tests passing (`npm test -- ReportService ReportSchedule csv reportCollection`)
- [ ] `npm run dev:full`, open https://local.blawby.com, navigate to `/practice/<slug>/reports`
  - [ ] Nav rail Reports expands; secondary nav shows 9 reports + Deliveries + All reports
  - [ ] Hub renders 11 cards (9 reports + All reports + Deliveries)
  - [ ] Revenue: period filter (month/quarter/year), date range narrows results, summary cards show totals, table renders with formatted USD
  - [ ] Aging: 5 buckets render, sum equals `meta.totalOutstanding`
  - [ ] Export → modal → Download → CSV downloads with filename `revenue-<practiceId>-<date>.csv`; quoted client names with commas open correctly in Excel/Numbers
  - [ ] Profitability: per-matter revenue/cost/margin; `pLimit(5)` keeps worker under 30s timeout on large practices
  - [ ] Utilization: per-user billable percentages
  - [ ] Schedule modal: create → save; verify KV row under `report-schedule:<practiceId>:<id>`
  - [ ] Send Now modal: create → toast confirms → navigate to `/reports/deliveries`; row appears with `status='completed'`; click → detail view; Download → CSV
  - [ ] In-app notification fires and links to `/reports/deliveries/<id>`
  - [ ] Phase 3 reports (trust-ledger, wip, originating-attorney, matters-by-attorney, task-productivity) render with real data if Railway endpoints are live; fall back to `BackendUnavailableState` ("Coming soon" empty state) if Railway returns 404/501
  - [ ] Auth: log out → reload → 401/redirect; anonymous user → 403

## Open items / known gaps (not blocking ship)

- **Schedule cron execution**: this branch ships KV CRUD only. Future PR adds `[triggers] crons = ["*/15 * * * *"]` block + extends `scheduled()` handler in `worker/index.ts`. Acceptance criteria for #521 doesn't require cron-driven execution.
- **Pagination caps**: profitability/utilization cap at 20 pages × 100 entries per matter. Larger practices need streaming aggregation in Railway or paginated UI. Cap-hit signalled via `meta.truncated: true`.
- **Time entry `duration` unit**: assumed seconds (consistent with `totalBillableSeconds` naming elsewhere). Locked with fixture test in `ReportService.aggregation.test.ts`. If backend confirms minutes/hours, swap divisor in `sumBillableHours` + `groupUtilizationByUser`.
- **Phase 3 Railway paths**: assumed in `RAILWAY_REPORT_PATHS` config at top of `ReportService.ts`. Real paths from `blawby-backend#233` may differ — single point to update.
- **Trust ledger money unit**: assumed cents (matches invoice convention). Confirm with backend when #233 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive reports system with nine report types including revenue, aging, profitability, utilization, trust ledger, and others.
  * Added report filtering, CSV export, and scheduling capabilities.
  * Added ability to send reports immediately to recipients or schedule for future delivery.
  * Added delivery history view with status tracking and download options.
  * Added centralized reports navigation hub.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/572)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->