### PR TITLE
fix: allow bodyless POST requests through worker validateRequest

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -43,12 +43,15 @@ function validateRequest(request: Request): boolean {
   }
 
   if (request.method === 'POST') {
-    const contentType = request.headers.get('content-type');
-    if (!contentType) {
-      return false;
-    }
-    if (!contentType.includes('application/json') && !contentType.includes('multipart/form-data')) {
-      return false;
+    const parsedLength = contentLength !== null ? parseInt(contentLength) : null;
+    if (parsedLength !== 0) {
+      const contentType = request.headers.get('content-type');
+      if (!contentType) {
+        return false;
+      }
+      if (!contentType.includes('application/json') && !contentType.includes('multipart/form-data')) {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
The /api/uploads/{id}/confirm and /restore endpoints are bodyless POSTs. The validateRequest guard was rejecting them with 400 because it required a Content-Type header on all POSTs, even those with content-length: 0.

Skip the Content-Type check when content-length is explicitly 0.

https://claude.ai/code/session_012H3xRdEZa4HfRW75x8YZj8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation handling for POST requests by making content-type checks conditional on the presence of request content, reducing unnecessary validation failures for empty POST requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/573)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->