### PR TITLE
fix(worker): unblock no-body POST to file confirm endpoints

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -52,7 +52,7 @@ function validateRequest(request: Request): boolean {
     const contentType = request.headers.get('content-type');
     const url = new URL(request.url);
     const isNoBodyEndpoint =
-      /\/files\/[^/]+\/confirm$/.test(url.pathname) ||
+      /^\/api\/practice-client-intakes\/[^/]+\/files\/[^/]+\/confirm$/.test(url.pathname) ||
       /^\/api\/uploads\/[^/]+\/confirm$/.test(url.pathname);
     if (!isNoBodyEndpoint && !contentType) {
       return false;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -50,10 +50,14 @@ function validateRequest(request: Request): boolean {
 
   if (request.method === 'POST') {
     const contentType = request.headers.get('content-type');
-    if (!contentType) {
+    const url = new URL(request.url);
+    const isNoBodyEndpoint =
+      /\/files\/[^/]+\/confirm$/.test(url.pathname) ||
+      /^\/api\/uploads\/[^/]+\/confirm$/.test(url.pathname);
+    if (!isNoBodyEndpoint && !contentType) {
       return false;
     }
-    if (!contentType.includes('application/json') && !contentType.includes('multipart/form-data')) {
+    if (contentType && !contentType.includes('application/json') && !contentType.includes('multipart/form-data')) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Intake file uploads now complete instead of failing at the confirm step. The worker's `validateRequest` rejected any POST without a `Content-Type` header, so the no-body confirm endpoints (`/api/practice-client-intakes/:uuid/files/:upload_id/confirm` and `/api/uploads/:upload_id/confirm`) returned `{ "errorCode": "INVALID_REQUEST" }` before the request ever reached the backend.

`validateRequest` now exempts those paths from the `Content-Type` requirement, and still rejects any other content type when one is provided.

Fixes Blawby/blawby-ai-chatbot#583.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation to allow file confirmation endpoints to process POST requests without requiring a content-type header, while maintaining validation standards for other requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->