### PR TITLE
fix(build): keep responsive @media rules in production CSS (#584)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+**Never merge without explicit human approval.** Do not run `git merge`, `gh pr merge`, or any equivalent that combines branches — including fast-forward merges and merges into your own working branch — unless the human has approved that specific merge in this conversation. Approval of one merge is not approval of the next. Rebases, cherry-picks, and pushes that would land merged history are covered by this rule.
+
 When an internal API returns errors, nulls, or malformed data, fix the API contract/source of truth first; do not add frontend fallbacks, guards, or workaround logic unless the API behavior is intentionally nullable and documented.
 
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
@@ -123,7 +125,52 @@ npx wrangler d1 execute DB --local --config worker/wrangler.toml --env dev --fil
 
 If a feature adds a new Worker-owned `/api/*` prefix, add it to `workerEndpoints` in `vite.config.ts`; otherwise Vite may proxy that path to the backend fallback and produce misleading local 404s.
 
-## 6. Browser-Agent And Playwright
+## 6. Compound Engineering Is The Default Workflow
+
+This project develops with the [Compound Engineering plugin](https://github.com/EveryInc/compound-engineering-plugin) (`ce-*` skills). Use it. Do not invent ad-hoc flows when a `ce-*` skill covers the task.
+
+**Routing is intent-based, not word-matching.** Trigger a `ce-*` skill only when the user is initiating a phase of work that the skill is designed for. A keyword appearing inside an unrelated sentence ("this doesn't work", "I plan to refactor later", "let me review the diff myself") is NOT a trigger.
+
+A request triggers a skill only when ALL three hold:
+
+1. The user is asking *you* to start a new phase of work (not narrating, complaining, or describing).
+2. The request is the imperative form of the skill's purpose (a request to brainstorm, a request to plan, a request to review, etc.) — not the word used in another grammatical role.
+3. No more-specific in-flight task is currently being executed that the skill would interrupt.
+
+If any of the three is in doubt, do not invoke the skill — answer normally and ask whether the user wants the formal workflow.
+
+| Trigger examples | Non-triggers (do NOT route) | Skill |
+|---|---|---|
+| "let's brainstorm X", "brainstorm a feature for…", "help me think through Y" | "I was brainstorming earlier", "we already brainstormed this" | `ce-brainstorm` |
+| "ideate on X", "give me ideas for Y", "what should I improve here", "surprise me" | "that's a good idea", "the idea is to…" | `ce-ideate` |
+| "plan this feature", "create a plan for X", "break this task down" | "I plan to look at this later", "the plan is already written", "what's the deployment plan" | `ce-plan` |
+| "implement the plan", "build this feature now", "execute the plan at docs/…" | "this doesn't work", "make it work", "the test isn't working", "work on it later" | `ce-work` |
+| "debug this", "why is /preferences 404ing", "investigate this stack trace", "fix this bug" (with reproducible failure) | "the debugger config is wrong", "debug output is noisy" | `ce-debug` |
+| "code review my changes", "review this branch / PR", "do a CE code review" | "let me review the diff myself", "I'll review later", "the reviewer said…" | `ce-code-review` |
+| "review the plan doc", "doc review this spec" | "the doc reviewer caught X" | `ce-doc-review` |
+| "commit this", "save my changes as a commit" | "the last commit was bad", "commit history is messy" | `ce-commit` |
+| "ship this", "commit and open a PR", "create a PR for this branch" | "ship date is tomorrow", "the PR description is wrong" | `ce-commit-push-pr` |
+| "resolve the PR feedback", "address the review comments" | "the feedback was useful" | `ce-resolve-pr-feedback` |
+| "compound this learning", "document this as a learning", "save what we learned" | "compound interest", "compound the bug count" | `ce-compound` |
+| "simplify the code I just wrote", "clean up this implementation" | "simple is better", "simplify the design later" | `ce-simplify-code` |
+| "lfg", "run the full pipeline autonomously", "ship it hands-off" | enthusiasm-only "lfg!!" in the middle of a different request | `lfg` |
+
+The canonical loop is **brainstorm → plan → work → code-review → compound**. Reach for `ce-debug` for bug investigation and `lfg` for autonomous end-to-end runs.
+
+**Already inside a skill?** Skill invocations don't recursively re-route. If a skill is in progress and the user says something that *would* be a trigger out of context, continue the current skill — don't switch mid-flight unless the user explicitly asks to (e.g., "stop, let's plan this instead").
+
+**Plugin install check.** Before invoking a `ce-*` skill, confirm `compound-engineering:*` skills appear in the available-skills list. If they don't, tell the user the plugin isn't installed and offer to install it. Install commands (Claude Code):
+
+```text
+/plugin marketplace add EveryInc/compound-engineering-plugin
+/plugin install compound-engineering
+```
+
+After they confirm, the plugin can be installed by running those slash commands in Claude Code. Don't try to install via `npm`, `bun`, or `git clone` — use the plugin marketplace.
+
+The first time the plugin is used in this repo, run `/ce-setup` once to bootstrap project config.
+
+## 7. Browser-Agent And Playwright
 
 Use browser-agent for exploratory smoke tests:
 

--- a/docs/engineering/responsive-audit.md
+++ b/docs/engineering/responsive-audit.md
@@ -12,6 +12,8 @@ Tracks responsive coverage of every page, layout shell, and significant primitiv
 
 Smoke specs assert no horizontal overflow at each tier (`tests/e2e/responsive-public.spec.ts`, `tests/e2e/responsive-auth.spec.ts`). Run with `npm run test:e2e:responsive` and `npm run test:e2e:responsive:auth`.
 
+> **Build-pipeline gotcha — Beasties `pruneSource` MUST stay `false`.** Beasties (`vite.config.ts` `criticalCssPlugin`) inlines critical CSS by walking the prerendered DOM. With `pruneSource: true`, it then deletes every rule whose selector didn't match that DOM — and prerender runs at zero viewport, so every `sm:`/`md:`/`lg:` rule looks unused and gets stripped from the external stylesheet, leaving empty `@media(min-width:Npx){}` blocks (issue #584). The overflow-based smoke specs above pass even in this state because mobile layouts also don't overflow, so the regression is invisible at the test layer. If you ever change the Beasties config, grep the built CSS for `@media(min-width:[0-9]+px)\{\}` — any match means responsive variants are being silently stripped.
+
 ## Conventions
 
 - **Shell + chrome** (`AppShell`, `Sidebar`, `MainApp`, routing): viewport queries (`sm:` / `md:` / `lg:`).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,10 +28,15 @@ const criticalCssPlugin = (): Plugin => ({
 		}
 		try {
 			const Beasties = (await import('beasties')).default;
+			// pruneSource MUST stay false. Beasties only "uses" a rule if a matching
+			// selector exists in the prerendered DOM — which renders at 0 viewport, so
+			// every `sm:`/`md:`/`lg:` rule looks unused and gets stripped, leaving
+			// empty `@media(min-width:Npx){}` blocks. That silently breaks every
+			// responsive breakpoint app-wide.
 			const beasties = new Beasties({
 				preload: 'media',
 				inlineFonts: true,
-				pruneSource: true,
+				pruneSource: false,
 				compress: true,
 				mergeStylesheets: true,
 				minimumExternalSize: 4096,


### PR DESCRIPTION
## Summary

Closes #584.

`Beasties` (the critical-CSS plugin in `vite.config.ts`) was running with `pruneSource: true`. After inlining critical CSS, that flag tells Beasties to **delete every rule from the external stylesheet whose selector didn't match the prerendered DOM**. Prerender renders the app at zero viewport, so every responsive rule (`sm:` / `md:` / `lg:` / `xl:` / `2xl:`) looked unused and got stripped — leaving 16 empty `@media(min-width:Npx){}` blocks in the production CSS bundle. End result: every page rendered with mobile-only styles, on every viewport (the auth form being full-width on desktop is one symptom of many).

## Diagnosis trail

1. Reproduced on staging at 1440px viewport: `sm:max-w-md` parent had `maxWidth: none`, `width: 1440px`.
2. Verified the variant wasn't in the stylesheet at all — but the `(min-width: 640px)` media query block *was* present and empty.
3. Confirmed in `dist/assets/prerenderEntry-*.css`:
   ```
   $ grep -oE "@media\(min-width:[0-9]+px\)\{\}" dist/assets/prerenderEntry-*.css | sort | uniq -c
        3 @media(min-width:1024px){}
        2 @media(min-width:1280px){}
        1 @media(min-width:1536px){}
        6 @media(min-width:640px){}
        4 @media(min-width:768px){}
   ```
   16 empty media-query blocks across every standard Tailwind breakpoint.
4. Source classes (`sm:max-w-md`, etc.) were correct in `AuthPage.tsx` and elsewhere — Tailwind's content scan picked them up, the bug was downstream in Beasties.

Why our existing smoke specs missed this: `tests/e2e/responsive-public.spec.ts` and `tests/e2e/responsive-auth.spec.ts` only assert *no horizontal overflow* at each tier — mobile layouts also satisfy that, so the regression-to-mobile was invisible at the test layer.

## Fix

- `vite.config.ts`: `pruneSource: true` → `pruneSource: false`. Critical CSS is still inlined into the HTML for fast first paint; the external stylesheet is now kept intact so media-query rules survive. Added a comment explaining why the flag matters.
- `docs/engineering/responsive-audit.md`: documented the gotcha and the grep check (`@media(min-width:[0-9]+px)\{\}`) to detect a recurrence.

## Verification

Rebuilt locally; ran `npm run preview` and inspected the auth page in headless Chromium:

| Viewport | Before fix              | After fix                                 |
| -------- | ----------------------- | ----------------------------------------- |
| 375px    | full-width (correct)    | full-width (correct, unchanged)           |
| 1440px   | full-width (bug)        | centered card, `x=496`, `w=448` (`max-w-md`) |

Built CSS after fix: zero empty `@media(min-width:Npx){}` blocks; `(min-width:640px)` now contains rules. Computed-style probes for `sm:max-w-md`, `md:grid-cols-2`, `lg:hidden` all return the expected values at the matching viewport.

## Test plan

- [ ] Pull this branch, `npm run build`, `npm run preview`.
- [ ] Open `/auth` at 1440px — expect centered card (~448px wide), not full-width.
- [ ] Resize to 375px — expect full-width form, no horizontal scroll.
- [ ] Sanity-check other pages with responsive grids (practice matters, dashboard widgets) at desktop width to confirm multi-column layouts now appear.
- [ ] Run `npm run test:e2e:responsive` and `npm run test:e2e:responsive:auth` — should still pass (these never caught the bug; doc note explains why).
- [ ] After deploy to staging, repeat the auth-page visual check on `ai-staging.blawby.com/auth`.

Note: visual-regression baselines under `tests/e2e/__screenshots__/` were captured against the broken build and will need regeneration via `npm run test:e2e:screenshots:update` after this lands.