### PR TITLE
fix(auth): preserve email/password across signin↔signup toggle (#585)

### DIFF
--- a/config/vitest/vitest.config.ts
+++ b/config/vitest/vitest.config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
             'src/__tests__/RTLSupport.test.tsx',
             'src/components/settings/**/__tests__/**/*.{test,spec}.{js,ts,jsx,tsx}',
             'src/shared/ui/**/__tests__/**/*.{test,spec}.{js,ts,jsx,tsx}',
+            'src/shared/components/**/__tests__/**/*.{test,spec}.{js,ts,jsx,tsx}',
             'src/features/invoices/components/**/__tests__/**/*.{test,spec}.{js,ts,jsx,tsx}',
             'tests/component/**/*.{test,spec}.{js,ts,jsx,tsx}',
           ],

--- a/docs/solutions/conventions/form-reset-pattern-2026-05-18.md
+++ b/docs/solutions/conventions/form-reset-pattern-2026-05-18.md
@@ -1,0 +1,80 @@
+---
+title: "Form reset is allowed on close/submit, never on tab/mode/step change"
+date: 2026-05-18
+category: conventions
+module: ui
+problem_type: convention
+component: forms
+severity: medium
+applies_when:
+  - Adding a multi-mode form (signin/signup toggle, tabbed form, multi-step wizard)
+  - Writing reset logic in `handleToggleMode`, `onTabChange`, `onStepChange`, or similar UI control handlers
+  - Adding `useEffect` resets driven by tab/mode/step state
+  - Forcing a remount with `key={mode}` or `key={activeTab}` to clear inputs
+  - Reviewing a dialog form for input-loss UX bugs
+related_components: ["auth", "engagements", "files", "invoices", "matters"]
+tags: ["forms", "reset", "ux", "auth", "tabs", "modes", "dialogs", "preact"]
+---
+
+# Form reset is allowed on close/submit, never on tab/mode/step change
+
+## Context
+
+[Issue #585](https://github.com/Blawby/blawby-ai-chatbot/issues/585): users entering credentials in `AuthForm` lost their input when toggling between sign-in and sign-up. Root cause was a `setFormData({...})` call in `handleToggleMode` that ran on every mode toggle. Fixed in [PR #592](https://github.com/Blawby/blawby-ai-chatbot/pull/592).
+
+The codebase-wide audit triggered by that issue found one bug (the above) plus a mix of reset patterns elsewhere — most intentional, some undocumented. The patterns themselves are fine; the lack of a shared rule was the maintenance hazard.
+
+## Guidance
+
+**Allowed resets:**
+
+1. **On dialog open / close lifecycle for local draft state — use `useDialogFormReset`.** This is the standard shape, and the helper is required for it. The hook lives at [src/shared/ui/dialog/useDialogFormReset.ts](src/shared/ui/dialog/useDialogFormReset.ts) and is re-exported from `@/shared/ui/dialog`. It requires a `reason` string so every call site documents its trigger and UX intent inline. Pick `trigger: 'on-close'` (default) for the normal "close = cancel = fresh next open" flow; pick `trigger: 'on-open'` only when stale submit/error state on the parent could leak into the next open. Existing call sites: [UploadDestinationDialog](src/features/files/components/UploadDestinationDialog.tsx), [RefundRequestDialog](src/features/invoices/components/dialogs/RefundRequestDialog.tsx), [IntakePreviewDialog](src/features/intake/components/IntakePreviewDialog.tsx), [ConfirmationDialog](src/shared/components/ConfirmationDialog.tsx), [CreateEngagementDialog](src/features/engagements/pages/EngagementsPage.tsx).
+
+   Don't reinvent the `useEffect(() => { if (!isOpen) … }, [isOpen])` shape inline. Code review should reject hand-rolled versions of this pattern.
+
+2. **On successful submit.** Once the action has landed, the form is "done" — clearing is the expected next state. Reset inside the success path of the submit handler, not in a `useEffect`. Existing example: [LineItemEditorDialog.handleSaveAndAddAnother](src/features/invoices/components/LineItemEditorDialog.tsx).
+
+3. **Switching to a different record / entity to edit.** Going from "edit milestone A" to "edit milestone B" inside the same panel is a record switch, not a UI control toggle — reset is correct. Use `formKey` increment + `key={formKey}` on the form to remount cleanly. Existing examples: [MatterMilestonesPanel](src/features/matters/components/milestones/MatterMilestonesPanel.tsx), [MatterExpensesPanel](src/features/matters/components/expenses/MatterExpensesPanel.tsx), [MatterNotesPanel](src/features/matters/components/notes/MatterNotesPanel.tsx).
+
+**Documented exceptions to the helper rule (rule 1).** These are legitimate and stay as-is:
+
+- **Mutation-hook `.reset()` owned by an external library.** [AddContactDialog](src/shared/ui/contacts/AddContactDialog.tsx) calls `createContact.reset()` inside `handleClose` because that reset belongs to the `useCreateContact` mutation hook, not to local component state. The helper is for local draft state; mutation libraries already own their own reset surface.
+- **Lazy init from a prop where the parent's mount boundary is the lifecycle.** [LineItemEditorDialog](src/features/invoices/components/LineItemEditorDialog.tsx) uses `useState(() => item ?? newLineItem())` because callers remount the dialog per record. The lifecycle boundary is parent remount, not `isOpen`.
+- **`key={formKey}` remount after submit/cancel** (the Matter\* panels listed above).
+
+**Forbidden resets:**
+
+4. **Switching tabs, modes, steps, or panels inside the same form** must preserve any field whose meaning is compatible across both sides. Example: sign-in and sign-up share `email` and `password` — toggling modes must not clear them. Tabs inside a single form (fee-structure tabs in `CreateEngagementDialog`) must not clear other sections' input.
+
+5. **Conditional rendering of a field across modes** is fine — when the field unmounts (e.g. `confirmPassword` hidden in signin mode), its state stays in the parent's `formData` and reappears on toggle back. Do not "clean up" formData when the input unmounts.
+
+6. **`key={mode}` / `key={activeTab}` on a `<Form>` or input** force a remount and lose input. Don't use this as a reset mechanism. The two legitimate uses of a `key`-driven remount are (a) switching between different records to edit (rule 3), and (b) explicit "reset form" buttons.
+
+## Implementation rules
+
+- **Standard dialog reset → `useDialogFormReset` only.** The hook's required `reason` field is the documentation surface. Hand-rolled `useEffect(() => { if (!isOpen) … }, [isOpen])` for local form state is rejected on review.
+
+- **Comment the documented exceptions** (mutation-hook `.reset()`, lazy init from prop, `formKey` remount) with a one-line note that names the trigger and points back to this doc. This prevents the next contributor from migrating an exception into the helper or copy-pasting an exception's shape into a new dialog where the helper would have been correct.
+
+- **Regression test mode toggles.** Any form with a mode/tab/step toggle that shares fields across sides needs a test that types into a shared field, toggles, and asserts the value persists. See [src/shared/components/\_\_tests\_\_/AuthForm.modeToggle.test.tsx](src/shared/components/__tests__/AuthForm.modeToggle.test.tsx) for the reference shape.
+
+- **Do not generalize further.** The helper covers the dialog-isOpen-local-draft-state case only. It is intentionally not extended to cover tab/mode/step toggles (those should not reset at all), record-switch remounts, or mutation-hook resets. If a sixth distinct dialog-reset pattern appears, prefer documenting it as another exception above rather than overloading the hook.
+
+## Anti-pattern (what triggered #585)
+
+```tsx
+// ❌ Don't do this
+const handleToggleMode = () => {
+  setMode(nextMode);
+  setFormData({ name: '', email: '', password: '', confirmPassword: '' });
+};
+```
+
+```tsx
+// ✅ Do this — fields that exist in both modes keep their value
+const handleToggleMode = () => {
+  setMode(nextMode);
+  setError('');
+  setMessage('');
+};
+```

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/shared/ui/Button';
 import { Input, Textarea, Combobox, Switch, type ComboboxOption } from '@/shared/ui/input';
 import { Tabs, type TabItem } from '@/shared/ui/tabs/Tabs';
 import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
-import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { InfiniteScroll } from '@/shared/ui/layout/InfiniteScroll';
 import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
@@ -288,15 +288,21 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
   const [isLoadingIntakes, setIsLoadingIntakes] = useState(false);
   const [intakesError, setIntakesError] = useState<string | null>(null);
 
-  // Reset state each time the dialog opens.
-  useEffect(() => {
-    if (!isOpen) return;
-    setForm(EMPTY_FORM);
-    setErrors({});
-    setHasAttemptedSubmit(false);
-    setSubmitting(false);
-    setSubmitError(null);
-  }, [isOpen]);
+  // Note: fee-structure tab switches inside this form must NOT clear fields —
+  // those are handled by `updateField('feeStructure', …)` which preserves all
+  // other form state.
+  useDialogFormReset({
+    isOpen,
+    trigger: 'on-open',
+    reason: 'Each open starts a fresh draft; clears any stale submit error or in-flight flag from a previously-interrupted attempt.',
+    reset: () => {
+      setForm(EMPTY_FORM);
+      setErrors({});
+      setHasAttemptedSubmit(false);
+      setSubmitting(false);
+      setSubmitError(null);
+    },
+  });
 
   // Fetch accepted intakes (client-side search filtering) on dialog open.
   useEffect(() => {

--- a/src/features/files/components/UploadDestinationDialog.tsx
+++ b/src/features/files/components/UploadDestinationDialog.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 import { Briefcase, Inbox } from 'lucide-preact';
 
-import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
 import { Combobox, type ComboboxOption } from '@/shared/ui/input/Combobox';
 import { Button } from '@/shared/ui/Button';
 import { Icon } from '@/shared/ui/Icon';
@@ -55,14 +55,14 @@ export const UploadDestinationDialog = ({
     enabled: isOpen,
   });
 
-  // Reset selection whenever the dialog reopens so a stale prior pick doesn't
-  // bleed into the new session.
-  useEffect(() => {
-    if (!isOpen) {
+  useDialogFormReset({
+    isOpen,
+    reason: 'Stale prior pick or in-flight upload list must not bleed into the next open.',
+    reset: () => {
       setDestinationValue('');
       setUploadingFiles([]);
-    }
-  }, [isOpen]);
+    },
+  });
 
   const options: ComboboxOption[] = useMemo(() => {
     const matterOptions = matters.map((matter) => ({

--- a/src/features/intake/components/IntakePreviewDialog.tsx
+++ b/src/features/intake/components/IntakePreviewDialog.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { ExternalLink } from 'lucide-preact';
 
-import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/Button';
 import { WidgetPreviewFrame } from '@/features/settings/components/WidgetPreviewFrame';
 import { getPublicFormUrl } from '@/features/intake/components/EmbedCodeBlock';
@@ -37,12 +37,14 @@ export const IntakePreviewDialog = ({
   const [isPublishing, setIsPublishing] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isOpen) {
+  useDialogFormReset({
+    isOpen,
+    reason: 'Cancelled publish flow — clear in-flight + error state on close.',
+    reset: () => {
       setIsPublishing(false);
       setPublishError(null);
-    }
-  }, [isOpen]);
+    },
+  });
 
   const previewConfig: WidgetPreviewConfig = {
     name: practiceName ?? undefined,

--- a/src/features/invoices/components/LineItemEditorDialog.tsx
+++ b/src/features/invoices/components/LineItemEditorDialog.tsx
@@ -34,6 +34,9 @@ export const LineItemEditorDialog = ({
   const step = (billingIncrementMinutes && billingIncrementMinutes > 0)
     ? billingIncrementMinutes / 60
     : 0.1;
+  // Lazy init from the `item` prop. Parents remount this dialog per record
+  // (key={item.id} or unmount-on-close), so no re-sync effect is needed.
+  // See docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
   const [formData, setFormData] = useState<InvoiceLineItem>(() => item ?? newLineItem());
 
   const updateField = useCallback((patch: Partial<InvoiceLineItem>) => {
@@ -55,6 +58,7 @@ export const LineItemEditorDialog = ({
   const handleSaveAndAddAnother = useCallback(() => {
     if (item !== null || !canSave) return;
     onSave(formData);
+    // Reset on successful submit — user explicitly requested to add another.
     setFormData(newLineItem());
   }, [item, canSave, formData, onSave]);
 

--- a/src/features/invoices/components/dialogs/RefundRequestDialog.tsx
+++ b/src/features/invoices/components/dialogs/RefundRequestDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'preact/hooks';
-import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { useState } from 'preact/hooks';
+import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/Button';
 import { CurrencyInput, Textarea } from '@/shared/ui/input';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
@@ -25,13 +25,15 @@ export const RefundRequestDialog = ({
   const [reason, setReason] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!isOpen) {
+  useDialogFormReset({
+    isOpen,
+    reason: 'Cancelled refund workflow — clear draft on close.',
+    reset: () => {
       setAmount(undefined);
       setReason('');
       setError(null);
-    }
-  }, [isOpen]);
+    },
+  });
 
   const handleSubmit = () => {
     if (loading) return;

--- a/src/features/matters/components/expenses/MatterExpensesPanel.tsx
+++ b/src/features/matters/components/expenses/MatterExpensesPanel.tsx
@@ -51,6 +51,8 @@ export const MatterExpensesPanel = ({
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingExpense, setEditingExpense] = useState<MatterExpense | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<MatterExpense | null>(null);
+  // Increment-on-record-switch + `key={formKey}` remount. See
+  // docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
   const [formKey, setFormKey] = useState(0);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);

--- a/src/features/matters/components/milestones/MatterMilestonesPanel.tsx
+++ b/src/features/matters/components/milestones/MatterMilestonesPanel.tsx
@@ -47,6 +47,10 @@ export const MatterMilestonesPanel = ({
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingMilestone, setEditingMilestone] = useState<MatterMilestone | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<MatterMilestone | null>(null);
+  // `formKey` increments when switching to a different milestone to edit.
+  // `key={formKey}` on the <form> remounts it so the previous record's input
+  // doesn't bleed in. Triggered only by record switch / open / cancel — never
+  // by a tab/mode toggle. See docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
   const [formKey, setFormKey] = useState(0);
   const [formState, setFormState] = useState({
     description: '',

--- a/src/features/matters/components/notes/MatterNotesPanel.tsx
+++ b/src/features/matters/components/notes/MatterNotesPanel.tsx
@@ -51,6 +51,8 @@ export const MatterNotesPanel = ({
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingNote, setEditingNote] = useState<MatterNote | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<MatterNote | null>(null);
+  // Increment-on-record-switch + `key={formKey}` remount. See
+  // docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
   const [formKey, setFormKey] = useState(0);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -247,14 +247,11 @@ const AuthForm = ({
     if (onModeChange) {
       onModeChange(nextMode);
     }
+    // Do NOT clear formData here — email/password (and name/confirmPassword)
+    // must survive a mode toggle so users don't have to retype shared fields.
+    // See docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
     setError('');
     setMessage('');
-    setFormData({
-      name: initialName ?? '',
-      email: initialEmail ?? '',
-      password: '',
-      confirmPassword: ''
-    });
   };
 
   return (

--- a/src/shared/components/ConfirmationDialog.tsx
+++ b/src/shared/components/ConfirmationDialog.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { useId } from 'preact/hooks';
 import { AlertTriangle } from 'lucide-preact';
 
 import { Icon } from '@/shared/ui/Icon';
-import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
 import { FormActions } from '@/shared/ui/form';
 import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { handleError } from '@/shared/utils/errorHandler';
@@ -58,15 +58,17 @@ export default function ConfirmationDialog({
   const [passwordError, setPasswordError] = useState<string | null>(null);
 
   // Clear input and error when modal closes
-  useEffect(() => {
-    if (!isOpen) {
+  useDialogFormReset({
+    isOpen,
+    reason: 'Cancelled confirmation — clear typed confirmation text, password, and any errors on close.',
+    reset: () => {
       setInputValue('');
       setError(null);
       setIsLoading(false);
       setPasswordValue('');
       setPasswordError(null);
-    }
-  }, [isOpen]);
+    },
+  });
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();

--- a/src/shared/components/__tests__/AuthForm.modeToggle.test.tsx
+++ b/src/shared/components/__tests__/AuthForm.modeToggle.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Regression test for issue #585: switching between signin and signup must
+ * preserve already-entered shared fields (email + password). Adjacent fields
+ * (name, confirmPassword) only exist in signup mode and must reappear when
+ * toggling back into it.
+ *
+ * If this test fails, `handleToggleMode` in src/shared/components/AuthForm.tsx
+ * is most likely clearing formData again — see the convention doc at
+ * docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/preact';
+
+vi.mock('@/shared/lib/authClient', () => ({
+  getClient: vi.fn(),
+}));
+
+// Bypass react-i18next (it pulls in real React, which conflicts with Preact in
+// this test project). The toggle queries below match against returned keys.
+vi.mock('@/shared/i18n/hooks', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: () => Promise.resolve(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: unknown }) => children,
+}));
+
+import AuthForm from '@/shared/components/AuthForm';
+
+const typeInto = (el: HTMLElement, value: string) => {
+  fireEvent.input(el, { target: { value } });
+};
+
+describe('AuthForm — input persistence across mode toggles (issue #585)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves email and password when toggling signin → signup', () => {
+    render(
+      <AuthForm
+        defaultMode="signin"
+        showGoogleSignIn={false}
+        showHeader={false}
+      />
+    );
+
+    const signinEmail = screen.getByTestId('signin-email-input') as HTMLInputElement;
+    const signinPassword = screen.getByTestId('signin-password-input') as HTMLInputElement;
+    typeInto(signinEmail, 'user@example.com');
+    typeInto(signinPassword, 'secretpw123');
+    expect(signinEmail.value).toBe('user@example.com');
+    expect(signinPassword.value).toBe('secretpw123');
+
+    const toggle = screen.getByRole('button', { name: /signin\.noAccount/ });
+    fireEvent.click(toggle);
+
+    const signupEmail = screen.getByTestId('signup-email-input') as HTMLInputElement;
+    const signupPassword = screen.getByTestId('signup-password-input') as HTMLInputElement;
+    expect(signupEmail.value).toBe('user@example.com');
+    expect(signupPassword.value).toBe('secretpw123');
+  });
+
+  it('preserves email and password when toggling signup → signin', () => {
+    render(
+      <AuthForm
+        defaultMode="signup"
+        showGoogleSignIn={false}
+        showHeader={false}
+      />
+    );
+
+    const signupEmail = screen.getByTestId('signup-email-input') as HTMLInputElement;
+    const signupPassword = screen.getByTestId('signup-password-input') as HTMLInputElement;
+    typeInto(signupEmail, 'jane@example.com');
+    typeInto(signupPassword, 'anothersecret');
+    expect(signupEmail.value).toBe('jane@example.com');
+    expect(signupPassword.value).toBe('anothersecret');
+
+    const toggle = screen.getByRole('button', { name: /signup\.hasAccount/ });
+    fireEvent.click(toggle);
+
+    const signinEmail = screen.getByTestId('signin-email-input') as HTMLInputElement;
+    const signinPassword = screen.getByTestId('signin-password-input') as HTMLInputElement;
+    expect(signinEmail.value).toBe('jane@example.com');
+    expect(signinPassword.value).toBe('anothersecret');
+  });
+
+  it('preserves signup-only fields (name, confirmPassword) when toggling away and back', () => {
+    render(
+      <AuthForm
+        defaultMode="signup"
+        showGoogleSignIn={false}
+        showHeader={false}
+      />
+    );
+
+    typeInto(screen.getByTestId('signup-name-input'), 'Jane Doe');
+    typeInto(screen.getByTestId('signup-email-input'), 'jane@example.com');
+    typeInto(screen.getByTestId('signup-password-input'), 'secretpw123');
+    typeInto(screen.getByTestId('signup-confirm-password-input'), 'secretpw123');
+
+    fireEvent.click(screen.getByRole('button', { name: /signup\.hasAccount/ }));
+    expect(screen.queryByTestId('signup-name-input')).toBeNull();
+    expect(screen.queryByTestId('signup-confirm-password-input')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /signin\.noAccount/ }));
+    expect((screen.getByTestId('signup-name-input') as HTMLInputElement).value).toBe('Jane Doe');
+    expect((screen.getByTestId('signup-confirm-password-input') as HTMLInputElement).value).toBe('secretpw123');
+    expect((screen.getByTestId('signup-email-input') as HTMLInputElement).value).toBe('jane@example.com');
+    expect((screen.getByTestId('signup-password-input') as HTMLInputElement).value).toBe('secretpw123');
+  });
+
+  it('preserves input across repeated toggles', () => {
+    render(
+      <AuthForm
+        defaultMode="signin"
+        showGoogleSignIn={false}
+        showHeader={false}
+      />
+    );
+
+    typeInto(screen.getByTestId('signin-email-input'), 'flip@example.com');
+    typeInto(screen.getByTestId('signin-password-input'), 'flipflip');
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByRole('button', { name: /signin\.noAccount/ }));
+      fireEvent.click(screen.getByRole('button', { name: /signup\.hasAccount/ }));
+    }
+
+    expect((screen.getByTestId('signin-email-input') as HTMLInputElement).value).toBe('flip@example.com');
+    expect((screen.getByTestId('signin-password-input') as HTMLInputElement).value).toBe('flipflip');
+  });
+});

--- a/src/shared/ui/contacts/AddContactDialog.tsx
+++ b/src/shared/ui/contacts/AddContactDialog.tsx
@@ -27,6 +27,8 @@ export const AddContactDialog = ({
   const submitLabel = createContact.submitting ? 'Sending...' : submitText;
 
   const handleClose = () => {
+    // Reset on dialog close — cancelled workflow starts fresh next open.
+    // See docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
     createContact.reset();
     onClose();
   };

--- a/src/shared/ui/dialog/__tests__/useDialogFormReset.test.tsx
+++ b/src/shared/ui/dialog/__tests__/useDialogFormReset.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for `useDialogFormReset`. Verifies that:
+ *   - on-close: fires only when isOpen goes (or is) false
+ *   - on-open: fires only when isOpen goes (or is) true
+ *   - latest `reset` closure is invoked even if the prop changes between renders
+ *   - flipping `trigger` between renders re-binds without leaking calls
+ *
+ * If these break, callers may silently lose form-state-reset behavior or — worse —
+ * fire stale resets that clobber the wrong inputs. See
+ * docs/solutions/conventions/form-reset-pattern-2026-05-18.md.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/preact';
+import { useDialogFormReset } from '@/shared/ui/dialog/useDialogFormReset';
+
+describe('useDialogFormReset', () => {
+  describe('on-close trigger (default)', () => {
+    it('fires reset on initial mount when isOpen is false', () => {
+      const reset = vi.fn();
+      renderHook(() => useDialogFormReset({ isOpen: false, reset, reason: 'test' }));
+      expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire on initial mount when isOpen is true', () => {
+      const reset = vi.fn();
+      renderHook(() => useDialogFormReset({ isOpen: true, reset, reason: 'test' }));
+      expect(reset).not.toHaveBeenCalled();
+    });
+
+    it('fires reset when isOpen transitions true → false', () => {
+      const reset = vi.fn();
+      const { rerender } = renderHook(
+        ({ isOpen }: { isOpen: boolean }) =>
+          useDialogFormReset({ isOpen, reset, reason: 'test' }),
+        { initialProps: { isOpen: true } }
+      );
+      expect(reset).not.toHaveBeenCalled();
+      rerender({ isOpen: false });
+      expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when isOpen transitions false → true', () => {
+      const reset = vi.fn();
+      const { rerender } = renderHook(
+        ({ isOpen }: { isOpen: boolean }) =>
+          useDialogFormReset({ isOpen, reset, reason: 'test' }),
+        { initialProps: { isOpen: false } }
+      );
+      reset.mockClear();
+      rerender({ isOpen: true });
+      expect(reset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on-open trigger', () => {
+    it('fires reset on initial mount when isOpen is true', () => {
+      const reset = vi.fn();
+      renderHook(() =>
+        useDialogFormReset({ isOpen: true, reset, reason: 'test', trigger: 'on-open' })
+      );
+      expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire on initial mount when isOpen is false', () => {
+      const reset = vi.fn();
+      renderHook(() =>
+        useDialogFormReset({ isOpen: false, reset, reason: 'test', trigger: 'on-open' })
+      );
+      expect(reset).not.toHaveBeenCalled();
+    });
+
+    it('fires reset when isOpen transitions false → true', () => {
+      const reset = vi.fn();
+      const { rerender } = renderHook(
+        ({ isOpen }: { isOpen: boolean }) =>
+          useDialogFormReset({ isOpen, reset, reason: 'test', trigger: 'on-open' }),
+        { initialProps: { isOpen: false } }
+      );
+      expect(reset).not.toHaveBeenCalled();
+      rerender({ isOpen: true });
+      expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when isOpen transitions true → false', () => {
+      const reset = vi.fn();
+      const { rerender } = renderHook(
+        ({ isOpen }: { isOpen: boolean }) =>
+          useDialogFormReset({ isOpen, reset, reason: 'test', trigger: 'on-open' }),
+        { initialProps: { isOpen: true } }
+      );
+      reset.mockClear();
+      rerender({ isOpen: false });
+      expect(reset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closure capture', () => {
+    it('invokes the latest reset, not the one passed at mount', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+      const { rerender } = renderHook(
+        ({ reset }: { reset: () => void }) =>
+          useDialogFormReset({ isOpen: true, reset, reason: 'test' }),
+        { initialProps: { reset: first } }
+      );
+      rerender({ reset: second });
+      rerender({ reset: second }); // dummy rerender to ensure deps aren't tripping reset
+      // Now flip isOpen to false to fire on-close.
+      const { rerender: rerender2 } = renderHook(
+        ({ isOpen, reset }: { isOpen: boolean; reset: () => void }) =>
+          useDialogFormReset({ isOpen, reset, reason: 'test' }),
+        { initialProps: { isOpen: true, reset: first } }
+      );
+      rerender2({ isOpen: true, reset: second });
+      rerender2({ isOpen: false, reset: second });
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-fire when reset reference changes without isOpen changing', () => {
+      const reset = vi.fn();
+      const { rerender } = renderHook(
+        ({ reset: r }: { reset: () => void }) =>
+          useDialogFormReset({ isOpen: true, reset: r, reason: 'test', trigger: 'on-open' }),
+        { initialProps: { reset } }
+      );
+      expect(reset).toHaveBeenCalledTimes(1);
+      rerender({ reset: vi.fn() });
+      rerender({ reset: vi.fn() });
+      // Original reset still 1; new resets never called because isOpen didn't change.
+      expect(reset).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/shared/ui/dialog/index.ts
+++ b/src/shared/ui/dialog/index.ts
@@ -21,3 +21,6 @@ export type { DialogFooterProps } from './DialogFooter';
 
 export { InfoListDialog } from './InfoListDialog';
 export type { InfoListDialogProps, InfoListDialogItem } from './InfoListDialog';
+
+export { useDialogFormReset } from './useDialogFormReset';
+export type { UseDialogFormResetOptions } from './useDialogFormReset';

--- a/src/shared/ui/dialog/useDialogFormReset.ts
+++ b/src/shared/ui/dialog/useDialogFormReset.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+/**
+ * Hook for the standard dialog-form reset pattern: tie a `reset()` callback to
+ * the dialog's `isOpen` lifecycle so draft form state goes back to defaults
+ * between dialog uses.
+ *
+ * Required everywhere a dialog owns local form state that should not survive
+ * across separate uses. See
+ * docs/solutions/conventions/form-reset-pattern-2026-05-18.md for the full
+ * convention, including the documented exceptions.
+ *
+ * `reason` is required and intentionally unused at runtime — it forces callers
+ * to name the trigger and UX intent inline, so reviewers can tell at a glance
+ * whether a reset is safe (close/cancel/open lifecycle) or accidentally bound
+ * to a UI control change (tab toggle / mode switch / step navigation, which
+ * must NOT clear input).
+ */
+export interface UseDialogFormResetOptions {
+  /** The dialog's open state. The hook reacts to its transitions. */
+  isOpen: boolean;
+  /**
+   * Reset callback. May read state via closure; the hook always invokes the
+   * latest version, so callers don't need to memoize.
+   */
+  reset: () => void;
+  /**
+   * Short human-readable note explaining when and why this reset fires.
+   * Required to keep call sites self-documenting.
+   *
+   * Example: "Cancelled refund workflow — clear draft on close."
+   */
+  reason: string;
+  /**
+   * When the reset fires.
+   * - `'on-close'` (default): runs when `isOpen` is `false` after a change.
+   *   Use for the typical "close = cancel = fresh next open" flow.
+   * - `'on-open'`: runs when `isOpen` is `true` after a change. Use when a
+   *   previously-interrupted submit/error state on the parent could leak
+   *   into the next open and should be cleared at that moment.
+   */
+  trigger?: 'on-open' | 'on-close';
+}
+
+export function useDialogFormReset({
+  isOpen,
+  reset,
+  trigger = 'on-close',
+}: UseDialogFormResetOptions): void {
+  const resetRef = useRef(reset);
+  resetRef.current = reset;
+
+  useEffect(() => {
+    if (trigger === 'on-close' && !isOpen) {
+      resetRef.current();
+      return;
+    }
+    if (trigger === 'on-open' && isOpen) {
+      resetRef.current();
+    }
+  }, [isOpen, trigger]);
+}


### PR DESCRIPTION
## Summary

- **Fixes [#585](https://github.com/Blawby/blawby-ai-chatbot/issues/585).** `AuthForm.handleToggleMode` was clearing `formData` on every mode switch, forcing users to retype their email and password to flip between sign-in and sign-up. Removed the reset.
- **Standardizes the dialog-reset pattern.** The codebase audit triggered by #585 surfaced 5 dialogs with hand-rolled `useEffect(() => { if (!isOpen) … }, [isOpen])` resets, all slightly different. Introduces a small `useDialogFormReset` hook in `@/shared/ui/dialog` for this exact case, with a required `reason: string` field so every call site documents its trigger and UX intent inline.
- **Documents the convention.** New [docs/solutions/conventions/form-reset-pattern-2026-05-18.md](docs/solutions/conventions/form-reset-pattern-2026-05-18.md) names the helper as the required path for standard dialog-local-state resets, and lists the three legitimate exceptions (mutation-hook `.reset()`, lazy init from prop, record-switch `formKey` remount) with the existing call sites tagged.

## What changed

| Area | Files |
|---|---|
| Bug fix | `src/shared/components/AuthForm.tsx` |
| New hook | `src/shared/ui/dialog/useDialogFormReset.ts`, exported from `src/shared/ui/dialog/index.ts` |
| Migrated to helper | `EngagementsPage.tsx` (CreateEngagementDialog, `on-open`), `UploadDestinationDialog.tsx`, `RefundRequestDialog.tsx`, `IntakePreviewDialog.tsx`, `ConfirmationDialog.tsx` |
| Exception comments only | `AddContactDialog.tsx`, `LineItemEditorDialog.tsx`, `MatterMilestonesPanel.tsx`, `MatterExpensesPanel.tsx`, `MatterNotesPanel.tsx` |
| Tests | `src/shared/components/__tests__/AuthForm.modeToggle.test.tsx` (4 cases), `src/shared/ui/dialog/__tests__/useDialogFormReset.test.tsx` (10 cases), `config/vitest/vitest.config.ts` (register the new shared/components test glob) |
| Docs | `docs/solutions/conventions/form-reset-pattern-2026-05-18.md` |

## Why a helper, given YAGNI

Five hand-rolled call sites of the same shape is the trigger for extracting; the goal is to make the safe reset path obvious and the exceptions explicit. The helper is deliberately narrow — it covers `isOpen`-driven local draft reset only. Tab/mode/step toggles, record-switch remounts, and mutation-hook resets are *not* in scope and are kept as documented exceptions.

## Test plan

- [x] `npx vitest run --project component` — 19 files, 113 tests passing locally, including:
  - `AuthForm.modeToggle` — types into shared fields, toggles signin↔signup, asserts values survive (verified by temporarily reintroducing the bug; all 4 cases failed as expected, then reverted).
  - `useDialogFormReset` — 10 cases covering both triggers, initial-mount semantics, transitions, and latest-closure invocation.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on every touched file — clean.
- [ ] Reviewer smoke test: open `/auth`, type email + password in sign-in, click "Sign up", confirm fields stay populated. Toggle a couple of times to be sure.

## Notes for reviewers

- The `reason` field on `useDialogFormReset` is intentionally unused at runtime. It's there to force the call site to spell out *why* this reset exists — code review should reject calls with vague or copy-pasted reasons. If you see one in this PR, please push back.
- `CreateEngagementDialog` keeps `trigger: 'on-open'` (not the default `on-close`) because stale `submitting` / `submitError` flags from a previously-interrupted attempt would otherwise leak into the next open. Other migrations use the default `on-close`.
- I deliberately did **not** generalize the helper to cover the mutation-hook reset in `AddContactDialog` or the `formKey` remount pattern in the Matter\* panels — those exception comments are intentional and the convention doc explains why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form inputs now persist correctly when switching between sign-in and sign-up modes, preserving your entered data.
  * Improved state management in dialogs for more consistent and reliable behavior.

* **Documentation**
  * Added guidelines for form state reset handling across the application.

* **Tests**
  * Added comprehensive test coverage for form input persistence during mode switches and dialog state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->