### PR TITLE
feat(auth): enable multi-session client plugin

### DIFF
--- a/src/shared/lib/authClient.ts
+++ b/src/shared/lib/authClient.ts
@@ -1,6 +1,7 @@
 import { createAuthClient } from 'better-auth/react';
 import { organizationClient } from 'better-auth/client/plugins';
 import { anonymousClient } from 'better-auth/client/plugins';
+import { multiSessionClient } from 'better-auth/client/plugins';
 import { stripeClient } from '@better-auth/stripe/client';
 import type { SessionUser, AuthSessionPayload } from '@/shared/types/user';
 import { safeConvertToDate, validateRequiredFields } from '@/shared/types/user';
@@ -82,7 +83,7 @@ function getAuthClient(): AuthClientType {
   if (typeof window === 'undefined') {
     const placeholderBaseURL = getAuthBaseUrl(); // Returns a placeholder during SSR/build, not the real backend URL.
     return createAuthClient({
-      plugins: [organizationClient(), anonymousClient(), stripeClient({ subscription: true })],
+      plugins: [organizationClient(), anonymousClient(), multiSessionClient(), stripeClient({ subscription: true })],
       baseURL: placeholderBaseURL,
       fetchOptions: {
         credentials: 'include'
@@ -92,7 +93,7 @@ function getAuthClient(): AuthClientType {
 
   // Browser context - create the REAL client (only one is ever created and cached)
   const client = createAuthClient({
-    plugins: [organizationClient(), anonymousClient(), stripeClient({ subscription: true })],
+    plugins: [organizationClient(), anonymousClient(), multiSessionClient(), stripeClient({ subscription: true })],
     baseURL: getAuthBaseUrl(),
     fetchOptions: {
       credentials: 'include'


### PR DESCRIPTION
Backend's multi-session plugin issues cookies the browser was ignoring. `authClient` only ever maintained one session at a time and `authClient.multiSession.*` was undefined. Wiring `multiSessionClient()` into the better-auth client closes that gap so multi-session cookies are tracked and `listDeviceSessions` / `setActive` / `revoke` become available for an upcoming session-switcher UI. `signOut` continues to revoke all sessions per the Better Auth docs.

Closes Blawby/blawby-ai-chatbot#586.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
