### PR TITLE
fix(routing): remove /pricing guards that trapped subscribers with null active_organization_id

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -234,22 +234,15 @@ function AppShell() {
     Boolean(session?.user) &&
     !session?.user?.is_anonymous &&
     session?.user?.onboarding_complete === true;
-  const sessionRecord = session?.session as Record<string, unknown> | undefined;
-  const activeOrganizationId = typeof sessionRecord?.active_organization_id === 'string'
-    && sessionRecord.active_organization_id.trim().length > 0
-    ? sessionRecord.active_organization_id
-    : null;
   const isPublicRoute = location.path.startsWith('/public/');
   const isAuthRoute = location.path.startsWith('/auth');
   const isPricingRoute = location.path.startsWith('/pricing');
   const isClientRoute = location.path.startsWith('/client/');
-  const isSubscriptionSuccessReturn = location.query.subscription === 'success';
   const shouldFetchWorkspacePractices =
     !isPublicRoute &&
     !isAuthRoute &&
     !isPricingRoute &&
-    (!onboardingIncomplete || isClientRoute) &&
-    (!completedOnboarding || Boolean(activeOrganizationId) || isClientRoute);
+    (!onboardingIncomplete || isClientRoute);
   const {
     defaultWorkspace,
     currentPractice,
@@ -279,14 +272,13 @@ function AppShell() {
   }, [currentPractice?.accentColor, currentPractice?.slug]);
 
   const authenticatedHomePath = useMemo(() => {
-    if (completedOnboarding && !activeOrganizationId) return null;
     const fallbackSlug = currentPractice?.slug ?? practices[0]?.slug ?? null;
     return resolveAuthenticatedHomePath({
       defaultWorkspace,
       fallbackSlug,
       hasPracticeMembership,
     });
-  }, [activeOrganizationId, completedOnboarding, currentPractice?.slug, defaultWorkspace, hasPracticeMembership, practices]);
+  }, [currentPractice?.slug, defaultWorkspace, hasPracticeMembership, practices]);
 
   useEffect(() => {
     if (sessionPending) return;
@@ -356,14 +348,6 @@ function AppShell() {
       !user?.is_anonymous &&
       user?.onboarding_complete !== true &&
       !bypassOnboardingForRoute;
-    const needsFirstSubscription =
-      Boolean(user) &&
-      !user?.is_anonymous &&
-      user?.onboarding_complete === true &&
-      !activeOrganizationId &&
-      !bypassOnboardingForRoute &&
-      !isPricingRoute &&
-      !isSubscriptionSuccessReturn;
 
     if (requiresOnboarding) {
       if (!location.path.startsWith('/onboarding') && !location.path.startsWith('/auth')) {
@@ -379,11 +363,6 @@ function AppShell() {
       return;
     }
 
-    if (needsFirstSubscription) {
-      navigate('/pricing', true);
-      return;
-    }
-
     if (!requiresOnboarding && location.path.startsWith('/onboarding')) {
       if (!authenticatedHomePath) {
         return;
@@ -391,10 +370,7 @@ function AppShell() {
       navigate(authenticatedHomePath, true);
     }
   }, [
-    activeOrganizationId,
     authenticatedHomePath,
-    isPricingRoute,
-    isSubscriptionSuccessReturn,
     location.path,
     location.url,
     navigate,
@@ -624,12 +600,7 @@ function RootRoute() {
     !session.user.is_anonymous &&
     session.user.onboarding_complete === true
   );
-  const rootSessionRecord = session?.session as Record<string, unknown> | undefined;
-  const activeOrganizationId = typeof rootSessionRecord?.active_organization_id === 'string'
-    && rootSessionRecord.active_organization_id.trim().length > 0
-    ? rootSessionRecord.active_organization_id
-    : null;
-  const shouldFetchRootPractices = Boolean(completedOnboarding && activeOrganizationId);
+  const shouldFetchRootPractices = Boolean(completedOnboarding);
   const {
     defaultWorkspace,
     practicesLoading,
@@ -646,11 +617,6 @@ function RootRoute() {
   const [subscriptionSyncPending, setSubscriptionSyncPending] = useState(false);
   const [subscriptionSyncError, setSubscriptionSyncError] = useState<unknown>(null);
   const isSubscriptionSuccessReturn = location.query.subscription === 'success';
-  const needsFirstSubscription = Boolean(
-    completedOnboarding &&
-    !activeOrganizationId &&
-    !isSubscriptionSuccessReturn
-  );
   const authenticatedHomePath = useMemo(() => {
     if (!shouldFetchRootPractices) return null;
     const fallbackSlug = currentPractice?.slug ?? practices[0]?.slug ?? null;
@@ -714,17 +680,11 @@ function RootRoute() {
       return;
     }
 
-    if (needsFirstSubscription) {
-      navigate('/pricing', true);
-      return;
-    }
-
     if (isMountedRef.current && authenticatedHomePath) {
       navigate(authenticatedHomePath, true);
     }
   }, [
     authenticatedHomePath,
-    needsFirstSubscription,
     subscriptionSyncPending,
     practicesLoading,
     isPending,


### PR DESCRIPTION
## Summary

- Five guard sites in `src/index.tsx` were hard-redirecting authenticated users with `onboarding_complete: true` but `session.active_organization_id: null` to `/pricing`, trapping subscribed owners on cold login, cookie rotation, and post-Stripe-checkout. Removed them.
- The same regression is documented in `docs/solutions/conventions/better-auth-active-organization-id-pointer-2026-05-15.md`; PR #577 was supposed to fix it once already.
- This PR unblocks subscribers from `/pricing`. The deeper backend issue (`/api/practice/list` 403 when no active org) still wrong-routes owners to `/client/*` — flagged below for backend team.

## Matrix of guards removed (all in `src/index.tsx`)

| # | What | Why it locked subscribers |
|---|------|---------------------------|
| 1 | AppShell `needsFirstSubscription` calc + `navigate('/pricing')` | Treated `!active_organization_id` as "no subscription" |
| 2 | RootRoute `needsFirstSubscription` calc + `navigate('/pricing')` | Same check at `/` |
| 3 | AppShell `shouldFetchWorkspacePractices` `Boolean(activeOrganizationId)` clause | Blocked practice fetch → no recovery path |
| 4 | AppShell `authenticatedHomePath` early-null when `completedOnboarding && !activeOrganizationId` | Left user with no home path |
| 5 | RootRoute `shouldFetchRootPractices` `activeOrganizationId` dependency | Same blocked-fetch effect |

**Diff size:** 1 file, +3 / −43.

## Kept (not subscription locks)

- `PricingPage.tsx` unauthenticated → `/auth` redirect
- RootRoute `?subscription=success` sync effect (post-Stripe recovery)
- PracticeAppRoute `setActivePractice` recovery sync
- `navigateToPricing` user-initiated CTAs in `ClientHomePage`, `AccountPage`, `IntakeTemplatesPage`
- Worker 402 passthrough, engineer allowlist (unrelated)

## Reproduction evidence (account: `demo.owner.local@blawby.test`)

```bash
# Sign in works, returns user
curl -c c.txt -X POST https://staging-api.blawby.com/api/auth/sign-in/email \
  -H "Content-Type: application/json" \
  -d '{"email":"demo.owner.local@blawby.test","password":"<redacted>"}'
# → 200 OK, user with onboarding_complete: true

# Session has null active_organization_id
curl -b c.txt https://staging-api.blawby.com/api/auth/get-session
# → "session": { "active_organization_id": null, ... }

# Frontend's listing endpoint refuses
curl -b c.txt https://staging-api.blawby.com/api/practice/list
# → 403 {"error":"Forbidden","message":"No organization context found"}

# But Better Auth's direct endpoint shows the user IS a member of one org
curl -b c.txt https://staging-api.blawby.com/api/auth/organization/list
# → 200 [{ "id":"8df99606-...", "slug":"demo-owner-local", ... }]
```

## Backend-team note — open API question (not addressed in this PR)

> **Subject:** `/api/practice/list` 403s for subscribed owners with `session.active_organization_id = null` — chicken-and-egg
>
> `/api/practice/list` requires `active_organization_id`. `active_organization_id` only gets set by `setActive({ organizationId })`. The frontend's only way to pick which org to activate is to list memberships first — but listing requires one to already be active. Better Auth's direct `/api/auth/organization/list` returns the membership fine, so the data is there.
>
> Per the convention doc, `active_organization_id` is legitimately `null` in several real states: fresh login on a clean browser, cookie rotation between deploys, multi-org user where none has been marked active, post-Stripe-checkout webhook race, returning subscriber whose org cookie expired.
>
> **Pick one (or push back if both are wrong):**
> 1. `/api/practice/list` should be **identity-scoped, not org-scoped**. "List the orgs this user is in" is by definition a user-level query.
> 2. **Session bootstrap auto-`setActive` on sign-in** so `active_organization_id` is never `null` for a user with memberships. The e2e test at `tests/e2e/pricing-gate-membership.spec.ts:61` already asserts this contract.
> 3. Both.
>
> Frontend hasn't patched it with a workaround (per CLAUDE.md "fix the API contract first"). Waiting on the backend decision before wiring the frontend to match.

## Test plan

- [x] `npm run type-check` — passes
- [x] Reproduced via curl: confirmed session/practice-list/org-list state above
- [ ] Manual: sign in as a subscribed owner at `https://local.blawby.com`, confirm no `/pricing` redirect (owner will land on `/client/dashboard` until backend fix lands — known follow-up)
- [ ] `tests/e2e/pricing-gate-membership.spec.ts` — passes with backend fix; until then the `active_organization_id` assertion at L61 still fails (pre-existing)

## Known follow-up (NOT in this PR)

Subscribed owners now bypass `/pricing` but still wrong-route to `/client/*` because `/api/practice/list` 403 → `hasPracticeMembership=false` → `resolveAuthenticatedHomePath` falls back to `/client/dashboard`. Awaiting backend decision before changing frontend routing further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)