### PR TITLE
fix(engagements): cap getEngagementForMatter page size at 100

### DIFF
--- a/src/features/engagements/api/engagementsApi.ts
+++ b/src/features/engagements/api/engagementsApi.ts
@@ -245,7 +245,7 @@ export async function getEngagementForMatter(
   if (!practiceId) throw new Error('practiceId is required');
   if (!matterId) throw new Error('matterId is required');
 
-  const limit = 200;
+  const limit = 100;
   let page = 1;
   // Guard against unbounded loops if backend pagination is malformed.
   const MAX_PAGES = 100;


### PR DESCRIPTION
## Summary
- Backend rejects `limit > 100` on `GET /api/engagement-contracts/:practiceId`, so `getEngagementForMatter` was failing in production (`?page=1&limit=200`).
- Drop the per-page request from 200 to 100 to stay within the backend's documented max.
- `MAX_PAGES = 100` still gives ~10k-record headroom for the paginated lookup.

## Test plan
- [ ] Load a matter that has an engagement contract on staging; confirm the engagement panel renders without the 400/500 from the contracts endpoint.
- [ ] Verify network tab shows `?page=1&limit=100` and a 200 response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized internal API pagination efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->