### PR TITLE
[codex] fix auth routing uploads and pwa cache

### DIFF
--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -74,20 +74,18 @@ export const clientIntakeInvite = (intakeId: string): string =>
 	`/api/practice-client-intakes/${encodeSegment(intakeId)}/invite`;
 
 
-export const intakeFilesPath = (intakeUuid: string): string =>
-	`/api/practice-client-intakes/${encodeSegment(intakeUuid)}/files`;
-
-export const intakeFilePresignPath = (intakeUuid: string): string =>
-	`${intakeFilesPath(intakeUuid)}/presign`;
-
-export const intakeFileConfirmPath = (intakeUuid: string, uploadId: string): string =>
-	`${intakeFilesPath(intakeUuid)}/${encodeSegment(uploadId)}/confirm`;
-
-export const intakeFileItemPath = (intakeUuid: string, fileId: string): string =>
-	`${intakeFilesPath(intakeUuid)}/${encodeSegment(fileId)}`;
-
 export const uploadDownloadPath = (uploadId: string): string =>
 	`/api/uploads/${encodeSegment(uploadId)}/download`;
+
+export const uploadsPath = (): string => '/api/uploads';
+
+export const uploadPresignPath = (): string => `${uploadsPath()}/presign`;
+
+export const uploadItemPath = (uploadId: string): string =>
+	`${uploadsPath()}/${encodeSegment(uploadId)}`;
+
+export const uploadConfirmPath = (uploadId: string): string =>
+	`${uploadItemPath(uploadId)}/confirm`;
 
 export const matterCollectionPath = (practiceId: string): string => `/api/matters/${encodeSegment(practiceId)}`;
 

--- a/src/features/intake/api/intakeFilesApi.ts
+++ b/src/features/intake/api/intakeFilesApi.ts
@@ -1,14 +1,15 @@
 import {
-  intakeFileConfirmPath,
-  intakeFileItemPath,
-  intakeFilePresignPath,
-  intakeFilesPath,
+  uploadConfirmPath,
+  uploadItemPath,
+  uploadPresignPath,
+  uploadsPath,
 } from '@/config/urls';
 import { apiClient, isHttpError } from '@/shared/lib/apiClient';
 import {
   uploadViaPresignedUrl,
   type UploadProgress,
 } from '@/shared/lib/presignedUpload';
+import type { BackendUploadRecord, BackendUploadsListResponse } from '@/shared/types/wire';
 
 export type { UploadProgress };
 
@@ -42,6 +43,13 @@ interface IntakePresignResponse {
   method: string;
   storage_key: string;
   expires_at: string;
+}
+
+interface ConfirmUploadResponse {
+  upload_id: string;
+  public_url: string | null;
+  storage_key: string;
+  status: IntakeFileStatus;
 }
 
 interface ApiEnvelope<T> {
@@ -88,10 +96,11 @@ const normalizeIntakeFile = (raw: unknown): IntakeFile => {
   if (!isRecord(raw)) {
     throw new Error('Invalid intake file payload: expected object.');
   }
+  const uploadId = requiredString(raw.upload_id ?? raw.uploadId, 'upload_id');
   return {
-    id: requiredString(raw.id, 'id'),
-    intakeUuid: requiredString(raw.intake_uuid ?? raw.intakeUuid, 'intake_uuid'),
-    uploadId: requiredString(raw.upload_id ?? raw.uploadId, 'upload_id'),
+    id: uploadId,
+    intakeUuid: requiredString(raw.scope_id, 'scope_id'),
+    uploadId,
     fileName: requiredString(raw.file_name ?? raw.fileName, 'file_name'),
     fileSize: requiredNumber(raw.file_size ?? raw.fileSize, 'file_size'),
     mimeType: optionalString(raw.mime_type ?? raw.mimeType),
@@ -111,11 +120,14 @@ const normalizeIntakeFile = (raw: unknown): IntakeFile => {
   };
 };
 
-const unwrap = <T>(payload: unknown): T => {
-  if (isRecord(payload) && 'data' in payload) {
-    return (payload as ApiEnvelope<T>).data as T;
+const unwrap = <T>(payload: unknown, field?: string): T => {
+  const unwrapped = isRecord(payload) && 'data' in payload
+    ? (payload as ApiEnvelope<T>).data as unknown
+    : payload;
+  if (field && isRecord(unwrapped) && field in unwrapped) {
+    return unwrapped[field] as T;
   }
-  return payload as T;
+  return unwrapped as T;
 };
 
 export interface ListIntakeFilesOptions {
@@ -130,12 +142,20 @@ export const listIntakeFiles = async (
     throw new Error('intakeUuid is required.');
   }
   try {
-    const { data } = await apiClient.get<unknown>(intakeFilesPath(intakeUuid), { signal: options.signal });
-    const unwrapped = unwrap<unknown>(data);
+    const { data } = await apiClient.get<unknown>(uploadsPath(), {
+      params: {
+        scope_type: 'intake',
+        scope_id: intakeUuid,
+        include_deleted: false,
+        limit: 100,
+      },
+      signal: options.signal,
+    });
+    const unwrapped = unwrap<BackendUploadsListResponse | BackendUploadRecord[]>(data);
     const list = Array.isArray(unwrapped)
       ? unwrapped
-      : isRecord(unwrapped) && Array.isArray((unwrapped as { files?: unknown }).files)
-        ? (unwrapped as { files: unknown[] }).files
+      : isRecord(unwrapped) && Array.isArray((unwrapped as { uploads?: unknown }).uploads)
+        ? (unwrapped as { uploads: unknown[] }).uploads
         : [];
     return list.map(normalizeIntakeFile);
   } catch (error) {
@@ -157,11 +177,14 @@ export const presignIntakeUpload = async (
   if (!input.intakeUuid) throw new Error('intakeUuid is required.');
   try {
     const { data } = await apiClient.post<unknown>(
-      intakeFilePresignPath(input.intakeUuid),
+      uploadPresignPath(),
       {
         file_name: input.fileName,
         mime_type: input.mimeType,
         file_size: input.fileSize,
+        scope_type: 'intake',
+        scope_id: input.intakeUuid,
+        is_privileged: true,
       },
       { signal: input.signal },
     );
@@ -187,12 +210,16 @@ export const confirmIntakeUpload = async (
     throw new Error('Missing uploadId');
   }
   try {
-    const { data } = await apiClient.post<unknown>(
-      intakeFileConfirmPath(input.intakeUuid, input.uploadId),
+    await apiClient.post<ConfirmUploadResponse>(
+      uploadConfirmPath(input.uploadId),
       undefined,
       { signal: input.signal },
     );
-    return normalizeIntakeFile(unwrap<unknown>(data));
+    const { data } = await apiClient.get<unknown>(
+      uploadItemPath(input.uploadId),
+      { signal: input.signal },
+    );
+    return normalizeIntakeFile(unwrap<BackendUploadRecord>(data));
   } catch (error) {
     throw new Error(readApiErrorMessage(error, 'Failed to confirm intake upload.'));
   }
@@ -222,7 +249,7 @@ export const deleteIntakeFile = async ({
     throw new Error('A reason is required to delete this file.');
   }
   try {
-    await apiClient.delete<unknown>(intakeFileItemPath(intakeUuid, fileId), {
+    await apiClient.delete<unknown>(uploadItemPath(fileId), {
       body: { reason: trimmedReason },
       signal,
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,6 @@ import { lazy } from 'preact/compat';
 // loads its own bundle on demand the first time the matching route renders.
 const AuthPage = lazy(() => import('@/pages/AuthPage'));
 const AcceptInvitationPage = lazy(() => import('@/pages/AcceptInvitationPage'));
-const ClientHomePage = lazy(() => import('@/pages/ClientHomePage'));
 const PracticeHomePage = lazy(() => import('@/pages/PracticeHomePage'));
 const OnboardingPage = lazy(() => import('@/pages/OnboardingPage'));
 const PricingPage = lazy(() => import('@/pages/PricingPage'));
@@ -98,23 +97,17 @@ const describeError = (error: unknown): string => {
 };
 
 const resolveAuthenticatedHomePath = ({
-  defaultWorkspace,
   fallbackSlug,
   hasPracticeMembership,
 }: {
-  defaultWorkspace: 'practice' | 'client' | 'public';
   fallbackSlug: string | null;
   hasPracticeMembership: boolean;
 }): string | null => {
-  if (!hasPracticeMembership) {
-    return '/client/dashboard';
-  }
-
-  if (!fallbackSlug) {
+  if (!hasPracticeMembership || !fallbackSlug) {
     return null;
   }
 
-  return getWorkspaceHomePath(defaultWorkspace, fallbackSlug);
+  return getWorkspaceHomePath('practice', fallbackSlug);
 };
 
 const DevDebugStylesRoute = () => {
@@ -230,10 +223,6 @@ function AppShell() {
     Boolean(session?.user) &&
     !session?.user?.is_anonymous &&
     session?.user?.onboarding_complete !== true;
-  const completedOnboarding =
-    Boolean(session?.user) &&
-    !session?.user?.is_anonymous &&
-    session?.user?.onboarding_complete === true;
   const isPublicRoute = location.path.startsWith('/public/');
   const isAuthRoute = location.path.startsWith('/auth');
   const isPricingRoute = location.path.startsWith('/pricing');
@@ -244,7 +233,6 @@ function AppShell() {
     !isPricingRoute &&
     (!onboardingIncomplete || isClientRoute);
   const {
-    defaultWorkspace,
     currentPractice,
     practices,
     hasPracticeMembership,
@@ -255,7 +243,7 @@ function AppShell() {
   });
 
   // Apply the active org's brand color at the shell level so routes that
-  // bypass MainApp (e.g. PracticeHomePage, ClientHomePage) still get branded.
+  // bypass MainApp (e.g. PracticeHomePage) still get branded.
   // Persist per-org so the next page load can paint the right brand color on
   // the first frame, before currentPractice has a chance to refetch.
   useEffect(() => {
@@ -274,11 +262,10 @@ function AppShell() {
   const authenticatedHomePath = useMemo(() => {
     const fallbackSlug = currentPractice?.slug ?? practices[0]?.slug ?? null;
     return resolveAuthenticatedHomePath({
-      defaultWorkspace,
       fallbackSlug,
       hasPracticeMembership,
     });
-  }, [currentPractice?.slug, defaultWorkspace, hasPracticeMembership, practices]);
+  }, [currentPractice?.slug, hasPracticeMembership, practices]);
 
   useEffect(() => {
     if (sessionPending) return;
@@ -442,7 +429,7 @@ function AppShell() {
           <Route path="/public/:practiceSlug/conversations/:conversationId" component={PublicWorkspaceRoute} />
           <Route path="/public/:practiceSlug/matters" component={PublicWorkspaceRoute} />
           <Route path="/client" component={App404} />
-          <Route path="/client/dashboard" component={ClientDashboardRoute} />
+          <Route path="/client/dashboard" component={App404} />
           <Route path="/client/:practiceSlug" component={ClientPracticeRoute} workspaceView="home" />
           <Route path="/client/:practiceSlug/conversations" component={ClientPracticeRoute} workspaceView="list" />
           <Route path="/client/:practiceSlug/conversations/:conversationId" component={ClientPracticeRoute} workspaceView="conversation" />
@@ -602,7 +589,6 @@ function RootRoute() {
   );
   const shouldFetchRootPractices = Boolean(completedOnboarding);
   const {
-    defaultWorkspace,
     practicesLoading,
     practicesError,
     currentPractice,
@@ -621,11 +607,10 @@ function RootRoute() {
     if (!shouldFetchRootPractices) return null;
     const fallbackSlug = currentPractice?.slug ?? practices[0]?.slug ?? null;
     return resolveAuthenticatedHomePath({
-      defaultWorkspace,
       fallbackSlug,
       hasPracticeMembership,
     });
-  }, [currentPractice?.slug, defaultWorkspace, hasPracticeMembership, practices, shouldFetchRootPractices]);
+  }, [currentPractice?.slug, hasPracticeMembership, practices, shouldFetchRootPractices]);
 
   useEffect(() => {
     return () => {
@@ -932,14 +917,6 @@ function PracticeAppRoute({
       ) : null}
     </>
   );
-}
-
-function ClientDashboardRoute() {
-  const { session, isPending: sessionIsPending } = useSessionContext();
-
-  if (sessionIsPending) return <LoadingScreen />;
-  if (!session?.user) return <AuthPage />;
-  return <ClientHomePage />;
 }
 
 function ClientPracticeRoute({

--- a/src/shared/hooks/useFileUpload.ts
+++ b/src/shared/hooks/useFileUpload.ts
@@ -84,7 +84,7 @@ export const useFileUpload = ({ practiceId, conversationId, enabled, intakeUuid 
 
   // The composer is upload-ready when either:
   //  - we have a practiceId (legacy worker R2 path), OR
-  //  - we have an intakeUuid (scoped intake files API path).
+  //  - we have an intakeUuid (backend uploads API with intake scope).
   // The intake path takes precedence when set.
   const isReadyToUpload = enabled && Boolean(intakeUuid || practiceId);
 

--- a/tests/e2e/widget-intake-flow.spec.ts
+++ b/tests/e2e/widget-intake-flow.spec.ts
@@ -1658,8 +1658,8 @@ test.describe('Public widget intake flow', () => {
     });
   });
 
-  test('post-submit composer uploads target the scoped intake files endpoint', async ({ anonPage }) => {
-    // Smoke-test that the new scoped path is reachable from the widget page.
+  test('post-submit composer uploads target the uploads endpoint with intake scope', async ({ anonPage }) => {
+    // Smoke-test that the documented uploads path is reachable from the widget page.
     // Drives the routing layer rather than the full UI flow — exercising the
     // full intake → submit → upload chain end-to-end would duplicate the main
     // intake test above and is brittle when the backend isn't seeded. The
@@ -1669,7 +1669,7 @@ test.describe('Public widget intake flow', () => {
     const fakeIntakeUuid = randomUUID();
     let presignSeen = false;
 
-    await anonPage.route(`**/api/practice-client-intakes/${fakeIntakeUuid}/files/presign`, async (route) => {
+    await anonPage.route('**/api/uploads/presign', async (route) => {
       // Only the actual POST is the assertion target — CORS preflights and any
       // unrelated GETs against the same path must fall through so they don't
       // flip presignSeen prematurely.
@@ -1677,19 +1677,21 @@ test.describe('Public widget intake flow', () => {
         await route.fallback();
         return;
       }
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      if (body.scope_type !== 'intake' || body.scope_id !== fakeIntakeUuid) {
+        await route.fallback();
+        return;
+      }
       presignSeen = true;
       await route.fulfill({
-        status: 200,
+        status: 201,
         contentType: 'application/json',
         body: JSON.stringify({
-          success: true,
-          data: {
-            upload_id: randomUUID(),
-            presigned_url: 'https://r2.example.com/sig',
-            method: 'PUT',
-            storage_key: `intakes/${fakeIntakeUuid}/foo`,
-            expires_at: new Date(Date.now() + 60_000).toISOString(),
-          },
+          upload_id: randomUUID(),
+          presigned_url: 'https://r2.example.com/sig',
+          method: 'PUT',
+          storage_key: `intakes/${fakeIntakeUuid}/foo`,
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
         }),
       });
     });
@@ -1697,17 +1699,24 @@ test.describe('Public widget intake flow', () => {
     await anonPage.goto(buildWidgetUrl(practiceSlug), { waitUntil: 'domcontentloaded' });
     await anonPage.evaluate(async (uuid: string) => {
       try {
-        await fetch(`/api/practice-client-intakes/${uuid}/files/presign`, {
+        await fetch('/api/uploads/presign', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ file_name: 't.pdf', mime_type: 'application/pdf', file_size: 5 }),
+          body: JSON.stringify({
+            file_name: 't.pdf',
+            mime_type: 'application/pdf',
+            file_size: 5,
+            scope_type: 'intake',
+            scope_id: uuid,
+            is_privileged: true,
+          }),
         });
       } catch {
         // Network failures in this smoke probe are expected when the route handler isn't hit.
       }
     }, fakeIntakeUuid);
 
-    expect(presignSeen, 'Presign call must reach the scoped intake files path').toBe(true);
+    expect(presignSeen, 'Presign call must reach /api/uploads/presign with intake scope').toBe(true);
   });
 });

--- a/tests/unit/intake/intakeFilesApi.test.ts
+++ b/tests/unit/intake/intakeFilesApi.test.ts
@@ -37,14 +37,14 @@ import {
 const intakeUuid = 'intake-uuid-1';
 
 const verifiedFilePayload = {
-  id: 'file-1',
-  intake_uuid: intakeUuid,
   upload_id: 'upload-1',
   file_name: 'contract.pdf',
   file_size: 1024,
   mime_type: 'application/pdf',
   status: 'verified',
   public_url: null,
+  scope_type: 'intake',
+  scope_id: intakeUuid,
   storage_key: 'r2-key-1',
   is_privileged: true,
   created_at: '2026-05-11T00:00:00Z',
@@ -58,18 +58,26 @@ describe('intakeFilesApi', () => {
   });
 
   describe('listIntakeFiles', () => {
-    it('hits the scoped intake files endpoint and normalizes results', async () => {
-      mockApiClient.get.mockResolvedValueOnce({ data: { data: [verifiedFilePayload] } });
+    it('lists intake-scoped uploads and normalizes results', async () => {
+      mockApiClient.get.mockResolvedValueOnce({ data: { uploads: [verifiedFilePayload] } });
 
       const files = await listIntakeFiles(intakeUuid);
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        `/api/practice-client-intakes/${intakeUuid}/files`,
-        expect.objectContaining({ signal: undefined }),
+        '/api/uploads',
+        expect.objectContaining({
+          params: {
+            scope_type: 'intake',
+            scope_id: intakeUuid,
+            include_deleted: false,
+            limit: 100,
+          },
+          signal: undefined,
+        }),
       );
       expect(files).toEqual([
         expect.objectContaining({
-          id: 'file-1',
+          id: 'upload-1',
           uploadId: 'upload-1',
           fileName: 'contract.pdf',
           status: 'verified',
@@ -100,13 +108,11 @@ describe('intakeFilesApi', () => {
     it('posts to the presign endpoint with snake_case body', async () => {
       mockApiClient.post.mockResolvedValueOnce({
         data: {
-          data: {
-            upload_id: 'upload-2',
-            presigned_url: 'https://r2.example.com/sig',
-            method: 'PUT',
-            storage_key: 'key-2',
-            expires_at: '2026-05-11T01:00:00Z',
-          },
+          upload_id: 'upload-2',
+          presigned_url: 'https://r2.example.com/sig',
+          method: 'PUT',
+          storage_key: 'key-2',
+          expires_at: '2026-05-11T01:00:00Z',
         },
       });
 
@@ -118,8 +124,15 @@ describe('intakeFilesApi', () => {
       });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        `/api/practice-client-intakes/${intakeUuid}/files/presign`,
-        { file_name: 'evidence.png', mime_type: 'image/png', file_size: 2048 },
+        '/api/uploads/presign',
+        {
+          file_name: 'evidence.png',
+          mime_type: 'image/png',
+          file_size: 2048,
+          scope_type: 'intake',
+          scope_id: intakeUuid,
+          is_privileged: true,
+        },
         expect.any(Object),
       );
       expect(response.upload_id).toBe('upload-2');
@@ -127,14 +140,26 @@ describe('intakeFilesApi', () => {
   });
 
   describe('confirmIntakeUpload', () => {
-    it('posts to the confirm endpoint and normalizes the response', async () => {
-      mockApiClient.post.mockResolvedValueOnce({ data: { data: verifiedFilePayload } });
+    it('confirms upload completion, fetches metadata, and normalizes the response', async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        data: {
+          upload_id: 'upload-1',
+          public_url: null,
+          storage_key: 'r2-key-1',
+          status: 'verified',
+        },
+      });
+      mockApiClient.get.mockResolvedValueOnce({ data: verifiedFilePayload });
 
       const file = await confirmIntakeUpload({ intakeUuid, uploadId: 'upload-1' });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
-        `/api/practice-client-intakes/${intakeUuid}/files/upload-1/confirm`,
+        '/api/uploads/upload-1/confirm',
         undefined,
+        expect.any(Object),
+      );
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        '/api/uploads/upload-1',
         expect.any(Object),
       );
       expect(file.status).toBe('verified');
@@ -155,7 +180,7 @@ describe('intakeFilesApi', () => {
       await deleteIntakeFile({ intakeUuid, fileId: 'file-1', reason: 'Wrong file' });
 
       expect(mockApiClient.delete).toHaveBeenCalledWith(
-        `/api/practice-client-intakes/${intakeUuid}/files/file-1`,
+        '/api/uploads/file-1',
         expect.objectContaining({ body: { reason: 'Wrong file' } }),
       );
     });
@@ -171,8 +196,16 @@ describe('intakeFilesApi', () => {
         expires_at: '2026-05-11T01:00:00Z',
       };
       mockApiClient.post
-        .mockResolvedValueOnce({ data: { data: presignedPayload } })
-        .mockResolvedValueOnce({ data: { data: { ...verifiedFilePayload, upload_id: 'upload-x' } } });
+        .mockResolvedValueOnce({ data: presignedPayload })
+        .mockResolvedValueOnce({
+          data: {
+            upload_id: 'upload-x',
+            public_url: null,
+            storage_key: 'key-x',
+            status: 'verified',
+          },
+        });
+      mockApiClient.get.mockResolvedValueOnce({ data: { ...verifiedFilePayload, upload_id: 'upload-x' } });
       mockUploadViaPresignedUrl.mockResolvedValueOnce(undefined);
 
       const file = new File([new Uint8Array([1, 2, 3])], 'doc.pdf', { type: 'application/pdf' });
@@ -180,8 +213,15 @@ describe('intakeFilesApi', () => {
 
       expect(mockApiClient.post).toHaveBeenNthCalledWith(
         1,
-        `/api/practice-client-intakes/${intakeUuid}/files/presign`,
-        { file_name: 'doc.pdf', mime_type: 'application/pdf', file_size: 3 },
+        '/api/uploads/presign',
+        {
+          file_name: 'doc.pdf',
+          mime_type: 'application/pdf',
+          file_size: 3,
+          scope_type: 'intake',
+          scope_id: intakeUuid,
+          is_privileged: true,
+        },
         expect.any(Object),
       );
       expect(mockUploadViaPresignedUrl).toHaveBeenCalledWith(
@@ -193,7 +233,7 @@ describe('intakeFilesApi', () => {
       );
       expect(mockApiClient.post).toHaveBeenNthCalledWith(
         2,
-        `/api/practice-client-intakes/${intakeUuid}/files/upload-x/confirm`,
+        '/api/uploads/upload-x/confirm',
         undefined,
         expect.any(Object),
       );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -225,9 +225,9 @@ export default defineConfig(({ mode }: ConfigEnv) => {
 					skipWaiting: false,
 					clientsClaim: false,
 					cleanupOutdatedCaches: true,
-					// Precache only app shell JS/CSS and PWA icons.
-					// Images, HTML pages, and widget assets are served by Cloudflare Pages directly.
-					globPatterns: ['assets/**/*.{js,css}'],
+					// Precache the SPA shell used by Workbox's navigation fallback plus
+					// app JS/CSS. Widget pages/assets are still excluded by the denylist.
+					globPatterns: ['index.html', 'assets/**/*.{js,css}'],
 					globIgnores: [],
 					navigateFallbackDenylist: [
 						// Never route API or auth requests through the SPA

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -346,8 +346,8 @@ export interface FileAttachment {
   url: string;
   storageKey?: string;
   /**
-   * Upload record id for files stored via the scoped uploads API
-   * (e.g. /api/practice-client-intakes/:uuid/files). When set, downloads
+   * Upload record id for files stored via the backend uploads API
+   * (e.g. /api/uploads with an intake scope). When set, downloads
    * should route through `/api/uploads/:uploadId/download` for a signed
    * URL rather than reading `url` directly.
    */
@@ -355,7 +355,7 @@ export interface FileAttachment {
   /**
    * Origin of the file:
    * - 'worker': legacy /api/files/upload pipeline (worker R2 bucket).
-   * - 'intake': scoped intake files API (backend R2, requires download endpoint).
+   * - 'intake': intake-scoped uploads API (backend R2, requires download endpoint).
    */
   source?: 'worker' | 'intake';
 }


### PR DESCRIPTION
## Summary
- align intake file uploads with the backend `/api/uploads` contract using `scope_type: intake`
- remove the generic `/client/dashboard` post-auth fallback so normal signup/login resolves only to practice routes
- fix the Workbox navigation fallback by precaching `index.html`

## Root Cause
- Intake confirm responses only return upload confirmation fields, but the frontend expected a full intake file row with `id`.
- Root auth routing sent users without a resolved practice membership to `/client/dashboard`.
- Workbox was configured to route navigations to `index.html` without precaching `index.html`.

## Validation
- `npm test -- tests/unit/intake/intakeFilesApi.test.ts`
- `npm run lint`
- `npm run type-check`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured file upload and download workflow to use unified backend API.
  * Improved home page navigation and routing logic.
  * Enhanced offline caching strategy for better PWA support.

* **Tests**
  * Updated integration and unit tests to validate new upload API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->