### PR TITLE
feat(org-switcher): Better-Auth org switcher + pre-checkout practice naming

### DIFF
--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1087,7 +1087,14 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const renderSidebarTree = (forceExpanded: boolean) => {
     if (!sidebarConfig || !sidebarOrg || !practiceSlug) return undefined;
     const commonProps = {
-      org: { name: sidebarOrg.name, initial: sidebarOrg.initial, subtitle: sidebarOrg.plan },
+      org: {
+        id: currentPractice?.id,
+        slug: currentPractice?.slug,
+        name: sidebarOrg.name,
+        initial: sidebarOrg.initial,
+        subtitle: sidebarOrg.plan,
+        logoUrl: currentPractice?.logo ?? null,
+      },
       user: sidebarUser,
       collapsed: isDesktopSidebarCollapsed,
       forceExpanded,

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1089,7 +1089,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     const commonProps = {
       org: {
         id: currentPractice?.id,
-        slug: currentPractice?.slug,
+        slug: currentPractice?.slug || practiceSlug,
         name: sidebarOrg.name,
         initial: sidebarOrg.initial,
         subtitle: sidebarOrg.plan,

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -101,7 +101,7 @@ export const OnboardingFlow = ({
     return [];
   }, [orgsHook?.data]);
   const membershipsLoading = Boolean(orgsHook?.isPending) && memberships.length === 0;
-  const needsPracticeStep = !membershipsLoading && memberships.length === 0;
+  const needsPracticeStep = membershipsLoading || memberships.length === 0;
 
   const handlePersonalInfoComplete = async (data: Partial<OnboardingFormData>) => {
     const mergedData = {

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useTranslation } from '@/shared/i18n/hooks';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { getPreferencesCategory, updatePreferencesCategory } from '@/shared/lib/preferencesApi';
-import { updateUser, getSession } from '@/shared/lib/authClient';
+import { updateUser, getSession, useListOrganizations } from '@/shared/lib/authClient';
 import type { OnboardingFormData } from '@/shared/types/onboarding';
 import { sanitizeOnboardingPersonalInfo } from '@/shared/types/onboarding';
 import type { OnboardingPreferences } from '@/shared/types/preferences';
 import PersonalInfoStep from './PersonalInfoStep';
+import PracticeNameStep from './PracticeNameStep';
 
 // The UseCase step is currently not rendered; we ship a default useCase shape so
 // existing backend consumers keep getting the payload they expect. If a real use-case
@@ -86,15 +87,40 @@ export const OnboardingFlow = ({
   }, [active, sessionUserId, sessionUserName]);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [step, setStep] = useState<'personal' | 'practice'>('personal');
+  // Reactive membership list — empty means we need to collect a practice name
+  // before completing onboarding so checkout can be minted with a real
+  // referenceId (see docs/solutions/conventions/better-auth-active-organization-id-pointer-2026-05-15.md).
+  const orgsHook = useListOrganizations() as { data?: unknown; isPending?: boolean };
+  const memberships = useMemo(() => {
+    const raw = orgsHook?.data;
+    if (Array.isArray(raw)) return raw;
+    if (raw && typeof raw === 'object' && Array.isArray((raw as { data?: unknown }).data)) {
+      return (raw as { data: unknown[] }).data;
+    }
+    return [];
+  }, [orgsHook?.data]);
+  const membershipsLoading = Boolean(orgsHook?.isPending) && memberships.length === 0;
+  const needsPracticeStep = !membershipsLoading && memberships.length === 0;
 
-  const handleStepComplete = async (data: Partial<OnboardingFormData>) => {
+  const handlePersonalInfoComplete = async (data: Partial<OnboardingFormData>) => {
     const mergedData = {
       ...onboardingData,
       ...data
     };
 
     setOnboardingData(mergedData);
+
+    if (needsPracticeStep) {
+      setStep('practice');
+      return;
+    }
+
     await handleComplete(mergedData);
+  };
+
+  const handlePracticeCreated = async () => {
+    await handleComplete(onboardingData);
   };
 
   const handleComplete = async (data?: OnboardingFormData) => {
@@ -161,17 +187,30 @@ export const OnboardingFlow = ({
 
   const resolvedTestId = testId ?? 'onboarding-flow';
 
+  const derivedPracticeName = (() => {
+    const candidate = (onboardingData.personalInfo.fullName ?? sessionUserName).trim();
+    return candidate.length > 0 ? `${candidate}'s Practice` : '';
+  })();
+
   return (
     <div
       className={`h-full bg-transparent flex flex-col ${className}`}
       data-testid={resolvedTestId}
     >
-      <PersonalInfoStep
-        data={onboardingData.personalInfo}
-        isSubmitting={isSubmitting}
-        requireName={requiresNameCollection}
-        onComplete={async (data) => await handleStepComplete({ personalInfo: data })}
-      />
+      {step === 'personal' ? (
+        <PersonalInfoStep
+          data={onboardingData.personalInfo}
+          isSubmitting={isSubmitting}
+          requireName={requiresNameCollection}
+          onComplete={async (data) => await handlePersonalInfoComplete({ personalInfo: data })}
+        />
+      ) : (
+        <PracticeNameStep
+          defaultName={derivedPracticeName}
+          isSubmitting={isSubmitting}
+          onComplete={handlePracticeCreated}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/onboarding/components/PracticeNameStep.tsx
+++ b/src/features/onboarding/components/PracticeNameStep.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { z } from 'zod';
 import { authClient, getSession } from '@/shared/lib/authClient';
 import { useToastContext } from '@/shared/contexts/ToastContext';
+import { slugify, unwrapCreated, type CreatedOrg } from '@/shared/lib/orgCreation';
 
 interface PracticeNameData extends FormData {
   practiceName: string;
@@ -19,26 +20,6 @@ const practiceNameSchema = z.object({
     .min(2, 'Practice name must be at least 2 characters')
     .max(120, 'Practice name is too long'),
 });
-
-const slugify = (name: string): string =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-type CreatedOrg = { id?: string | null; slug?: string | null; name?: string | null };
-
-const unwrapCreated = (result: unknown): CreatedOrg | null => {
-  if (!result || typeof result !== 'object') return null;
-  const record = result as Record<string, unknown>;
-  const data = (record.data ?? result) as Record<string, unknown> | null;
-  if (!data || typeof data !== 'object') return null;
-  return {
-    id: typeof data.id === 'string' ? data.id : null,
-    slug: typeof data.slug === 'string' ? data.slug : null,
-    name: typeof data.name === 'string' ? data.name : null,
-  };
-};
 
 interface PracticeNameStepProps {
   /** Default value (e.g. derived from the user's full name). */
@@ -56,6 +37,7 @@ const PracticeNameStep = ({
   const { showError } = useToastContext();
   const [localSubmitting, setLocalSubmitting] = useState(false);
   const mountedRef = useRef(true);
+  const submittingRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -65,10 +47,15 @@ const PracticeNameStep = ({
   }, []);
 
   const handleSubmit = async (formData: PracticeNameData) => {
-    if (parentSubmitting || localSubmitting) return;
+    if (parentSubmitting || submittingRef.current) return;
+    submittingRef.current = true;
     setLocalSubmitting(true);
     try {
       const name = formData.practiceName.trim();
+      if (!name) {
+        showError('Practice name is required', 'Enter a practice name to continue.');
+        return;
+      }
       const proposedSlug = slugify(name);
       const created = unwrapCreated(
         await authClient.organization.create({
@@ -89,6 +76,7 @@ const PracticeNameStep = ({
       const message = error instanceof Error ? error.message : 'Please try again.';
       showError('Could not create practice', message);
     } finally {
+      submittingRef.current = false;
       if (mountedRef.current) {
         setLocalSubmitting(false);
       }

--- a/src/features/onboarding/components/PracticeNameStep.tsx
+++ b/src/features/onboarding/components/PracticeNameStep.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { Building2 } from 'lucide-preact';
+import { Button } from '@/shared/ui/Button';
+import { Logo } from '@/shared/ui/Logo';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, type FormData } from '@/shared/ui/form';
+import { Input } from '@/shared/ui/input';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { z } from 'zod';
+import { authClient, getSession } from '@/shared/lib/authClient';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+
+interface PracticeNameData extends FormData {
+  practiceName: string;
+}
+
+const practiceNameSchema = z.object({
+  practiceName: z
+    .string()
+    .min(2, 'Practice name must be at least 2 characters')
+    .max(120, 'Practice name is too long'),
+});
+
+const slugify = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+type CreatedOrg = { id?: string | null; slug?: string | null; name?: string | null };
+
+const unwrapCreated = (result: unknown): CreatedOrg | null => {
+  if (!result || typeof result !== 'object') return null;
+  const record = result as Record<string, unknown>;
+  const data = (record.data ?? result) as Record<string, unknown> | null;
+  if (!data || typeof data !== 'object') return null;
+  return {
+    id: typeof data.id === 'string' ? data.id : null,
+    slug: typeof data.slug === 'string' ? data.slug : null,
+    name: typeof data.name === 'string' ? data.name : null,
+  };
+};
+
+interface PracticeNameStepProps {
+  /** Default value (e.g. derived from the user's full name). */
+  defaultName?: string;
+  /** Fired after the org is created and activated. Receives the created org. */
+  onComplete: (org: CreatedOrg) => Promise<void> | void;
+  isSubmitting?: boolean;
+}
+
+const PracticeNameStep = ({
+  defaultName = '',
+  onComplete,
+  isSubmitting: parentSubmitting = false,
+}: PracticeNameStepProps) => {
+  const { showError } = useToastContext();
+  const [localSubmitting, setLocalSubmitting] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const handleSubmit = async (formData: PracticeNameData) => {
+    if (parentSubmitting || localSubmitting) return;
+    setLocalSubmitting(true);
+    try {
+      const name = formData.practiceName.trim();
+      const proposedSlug = slugify(name);
+      const created = unwrapCreated(
+        await authClient.organization.create({
+          name,
+          ...(proposedSlug ? { slug: proposedSlug } : {}),
+        })
+      );
+      if (!created?.id) {
+        throw new Error('Practice was not created');
+      }
+      await authClient.organization.setActive({ organizationId: created.id });
+      await getSession().catch(() => undefined);
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('auth:session-updated'));
+      }
+      await onComplete(created);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Please try again.';
+      showError('Could not create practice', message);
+    } finally {
+      if (mountedRef.current) {
+        setLocalSubmitting(false);
+      }
+    }
+  };
+
+  const submitting = parentSubmitting || localSubmitting;
+
+  return (
+    <div className="min-h-screen bg-transparent flex flex-col justify-center px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-md">
+        <div className="flex justify-center mb-6">
+          <Logo size="lg" />
+        </div>
+
+        <h2 className="mt-6 text-center text-2xl font-semibold tracking-tight text-input-text">
+          Name your practice
+        </h2>
+        <p className="mt-2 text-center text-sm text-input-placeholder">
+          This is the workspace your team and clients will see. You can fine-tune the details later.
+        </p>
+      </div>
+
+      <div className="mt-8 mx-auto w-full max-w-md">
+        <div className="card py-8 px-6 sm:px-10">
+          <Form<PracticeNameData>
+            onSubmit={async (formData: PracticeNameData): Promise<void> => {
+              await handleSubmit(formData);
+            }}
+            initialData={{ practiceName: defaultName }}
+            schema={practiceNameSchema}
+          >
+            <div className="space-y-4">
+              <FormField name="practiceName">
+                {({ value, error, onChange }) => (
+                  <FormItem>
+                    <FormLabel>Practice name</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        required
+                        value={(value as string) || ''}
+                        onChange={(next) => onChange(next)}
+                        placeholder="Acme Law"
+                        icon={Building2}
+                        iconClassName="h-5 w-5 text-input-placeholder"
+                        error={error?.message}
+                      />
+                    </FormControl>
+                    {error && <FormMessage>{error.message}</FormMessage>}
+                  </FormItem>
+                )}
+              </FormField>
+            </div>
+
+            <div className="mt-6 space-y-3">
+              <Button
+                type="submit"
+                disabled={submitting}
+                variant="primary"
+                size="lg"
+                className="w-full"
+              >
+                {submitting ? (
+                  <LoadingSpinner size="md" ariaLabel="Creating practice" />
+                ) : (
+                  'Create practice'
+                )}
+              </Button>
+            </div>
+          </Form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PracticeNameStep;

--- a/src/features/practice-onboarding/components/CreatePracticeDialog.tsx
+++ b/src/features/practice-onboarding/components/CreatePracticeDialog.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'preact/hooks';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { Dialog } from '@/shared/ui/dialog/Dialog';
+import { DialogBody } from '@/shared/ui/dialog/DialogBody';
+import { DialogFooter } from '@/shared/ui/dialog/DialogFooter';
+import { Input } from '@/shared/ui/input';
+import { Button } from '@/shared/ui/Button';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { useNavigation } from '@/shared/utils/navigation';
+import { authClient, getSession } from '@/shared/lib/authClient';
+
+type CreatedOrg = {
+  id?: string | null;
+  slug?: string | null;
+  name?: string | null;
+};
+
+const slugify = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const unwrapCreated = (result: unknown): CreatedOrg | null => {
+  if (!result || typeof result !== 'object') return null;
+  const record = result as Record<string, unknown>;
+  const data = (record.data ?? result) as Record<string, unknown> | null;
+  if (!data || typeof data !== 'object') return null;
+  return {
+    id: typeof data.id === 'string' ? data.id : null,
+    slug: typeof data.slug === 'string' ? data.slug : null,
+    name: typeof data.name === 'string' ? data.name : null,
+  };
+};
+
+interface CreatePracticeDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called after the new practice is created and activated. */
+  onCreated?: (org: CreatedOrg) => void;
+}
+
+export const CreatePracticeDialog = ({ isOpen, onClose, onCreated }: CreatePracticeDialogProps) => {
+  const { showError, showSuccess } = useToastContext();
+  const { navigate } = useNavigation();
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleClose = () => {
+    if (submitting) return;
+    setName('');
+    onClose();
+  };
+
+  const handleSubmit = async (event?: Event) => {
+    event?.preventDefault();
+    const trimmed = name.trim();
+    if (trimmed.length < 2) {
+      showError('Practice name is too short', 'Use at least 2 characters.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const proposedSlug = slugify(trimmed);
+      const created = unwrapCreated(
+        await authClient.organization.create({
+          name: trimmed,
+          ...(proposedSlug ? { slug: proposedSlug } : {}),
+        })
+      );
+
+      if (!created?.id) {
+        throw new Error('Practice was not created');
+      }
+
+      await authClient.organization.setActive({ organizationId: created.id });
+      await getSession().catch(() => undefined);
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('auth:session-updated'));
+      }
+
+      showSuccess('Practice created', `${created.name ?? trimmed} is ready to go.`);
+      onCreated?.(created);
+      setName('');
+      onClose();
+
+      if (created.slug) {
+        navigate(`/practice/${encodeURIComponent(created.slug)}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Please try again.';
+      showError('Could not create practice', message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Create a practice"
+      description="Set up a new workspace. You can fine-tune the details after it's live."
+    >
+      <form onSubmit={handleSubmit}>
+        <DialogBody>
+          <div className="space-y-4">
+            <Input
+              type="text"
+              label="Practice name"
+              placeholder="Acme Law"
+              value={name}
+              onChange={setName}
+              required
+              disabled={submitting}
+            />
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="ghost" onClick={handleClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" disabled={submitting}>
+            {submitting ? <LoadingSpinner size="md" ariaLabel="Creating practice" /> : 'Create practice'}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+};
+
+export default CreatePracticeDialog;

--- a/src/features/practice-onboarding/components/CreatePracticeDialog.tsx
+++ b/src/features/practice-onboarding/components/CreatePracticeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useRef, useState } from 'preact/hooks';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { Dialog } from '@/shared/ui/dialog/Dialog';
 import { DialogBody } from '@/shared/ui/dialog/DialogBody';
@@ -8,30 +8,7 @@ import { Button } from '@/shared/ui/Button';
 import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { useNavigation } from '@/shared/utils/navigation';
 import { authClient, getSession } from '@/shared/lib/authClient';
-
-type CreatedOrg = {
-  id?: string | null;
-  slug?: string | null;
-  name?: string | null;
-};
-
-const slugify = (name: string): string =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-const unwrapCreated = (result: unknown): CreatedOrg | null => {
-  if (!result || typeof result !== 'object') return null;
-  const record = result as Record<string, unknown>;
-  const data = (record.data ?? result) as Record<string, unknown> | null;
-  if (!data || typeof data !== 'object') return null;
-  return {
-    id: typeof data.id === 'string' ? data.id : null,
-    slug: typeof data.slug === 'string' ? data.slug : null,
-    name: typeof data.name === 'string' ? data.name : null,
-  };
-};
+import { slugify, unwrapCreated, type CreatedOrg } from '@/shared/lib/orgCreation';
 
 interface CreatePracticeDialogProps {
   isOpen: boolean;
@@ -45,6 +22,7 @@ export const CreatePracticeDialog = ({ isOpen, onClose, onCreated }: CreatePract
   const { navigate } = useNavigation();
   const [name, setName] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
 
   const handleClose = () => {
     if (submitting) return;
@@ -54,11 +32,13 @@ export const CreatePracticeDialog = ({ isOpen, onClose, onCreated }: CreatePract
 
   const handleSubmit = async (event?: Event) => {
     event?.preventDefault();
+    if (submittingRef.current) return;
     const trimmed = name.trim();
     if (trimmed.length < 2) {
       showError('Practice name is too short', 'Use at least 2 characters.');
       return;
     }
+    submittingRef.current = true;
     setSubmitting(true);
     try {
       const proposedSlug = slugify(trimmed);
@@ -91,6 +71,7 @@ export const CreatePracticeDialog = ({ isOpen, onClose, onCreated }: CreatePract
       const message = error instanceof Error ? error.message : 'Please try again.';
       showError('Could not create practice', message);
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { usePracticeConfig } from '@/shared/hooks/usePracticeConfig';
 import type { UIPracticeConfig } from '@/shared/hooks/usePracticeConfig';
 import { handleError as _handleError } from '@/shared/utils/errorHandler';
 import { useWorkspaceResolver } from '@/shared/hooks/useWorkspaceResolver';
+import { useEnsureActiveOrganization } from '@/shared/hooks/useEnsureActiveOrganization';
 import {
   getWorkspaceHomePath,
 } from '@/shared/utils/workspace';
@@ -226,6 +227,12 @@ function AppShell() {
   const location = useLocation();
   const { navigate } = useNavigation();
   const { session, isPending: sessionPending } = useSessionContext();
+  // Recovery for the legitimate null active_organization_id state described in
+  // docs/solutions/conventions/better-auth-active-organization-id-pointer-2026-05-15.md.
+  // Idempotent and gated on completedOnboarding+!activeOrgId, so it no-ops for
+  // first-time users (handled by onboarding) and for users whose org is already
+  // active.
+  useEnsureActiveOrganization();
   const onboardingIncomplete =
     Boolean(session?.user) &&
     !session?.user?.is_anonymous &&
@@ -791,6 +798,24 @@ function PracticeAppRoute({
   useEffect(() => {
     if (isPending || !session?.user || !resolvedPracticeId) return;
 
+    // Only sync when the resolver's currentPractice is for the URL we are on.
+    // Without this gate, a stale practices snapshot (e.g. right after a new
+    // org was created via the switcher) makes currentPractice fall back to a
+    // *different* practice, and we'd PUT setActivePractice with the OLD id —
+    // reverting the switcher's intentional setActive call. See feat/org-switcher
+    // bug investigation 2026-05-22.
+    const resolverMatchesUrl =
+      hasPracticeSlug && currentPractice?.slug === normalizedPracticeSlug;
+    if (!resolverMatchesUrl) return;
+
+    // During a switcher-driven route transition, this OLD route can still be
+    // mounted while `session.active_organization_id` has already been flipped
+    // to the destination org. Its effect would then revert backend to *this*
+    // route's old practice id. Guard by re-checking the live URL against this
+    // route's slug — if the user has already navigated away, do not revert.
+    const liveUrlSegment = `/practice/${encodeURIComponent(normalizedPracticeSlug)}`;
+    if (!location.path.startsWith(liveUrlSegment)) return;
+
     // If the backend session doesn't match the route-selected practice ID,
     // synchronize it to ensure correct permission/role resolution.
     if (resolvedPracticeId && backendActiveOrgId !== resolvedPracticeId) {
@@ -810,7 +835,16 @@ function PracticeAppRoute({
         cancelled = true;
       };
     }
-  }, [resolvedPracticeId, session?.user, isPending, backendActiveOrgId]);
+  }, [
+    resolvedPracticeId,
+    session?.user,
+    isPending,
+    backendActiveOrgId,
+    currentPractice?.slug,
+    normalizedPracticeSlug,
+    hasPracticeSlug,
+    location.path,
+  ]);
 
   // Only block on loading if we have no practice data yet. If currentPractice
   // is already available (from the module cache), proceed immediately —

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -237,10 +237,6 @@ function AppShell() {
     Boolean(session?.user) &&
     !session?.user?.is_anonymous &&
     session?.user?.onboarding_complete !== true;
-  const completedOnboarding =
-    Boolean(session?.user) &&
-    !session?.user?.is_anonymous &&
-    session?.user?.onboarding_complete === true;
   const isPublicRoute = location.path.startsWith('/public/');
   const isAuthRoute = location.path.startsWith('/auth');
   const isPricingRoute = location.path.startsWith('/pricing');

--- a/src/pages/PracticeHomePage.tsx
+++ b/src/pages/PracticeHomePage.tsx
@@ -79,7 +79,12 @@ const PracticeHomePage = () => {
   // showing the previous org's name (see feat/org-switcher 2026-05-22).
   const urlPracticeSlug = useMemo(() => {
     const match = location.path.match(/^\/practice\/([^/]+)/);
-    return match ? decodeURIComponent(match[1]) : null;
+    if (!match) return null;
+    try {
+      return decodeURIComponent(match[1]);
+    } catch {
+      return null;
+    }
   }, [location.path]);
   const { currentPractice, practices } = useWorkspaceResolver({
     practiceSlug: urlPracticeSlug,

--- a/src/pages/PracticeHomePage.tsx
+++ b/src/pages/PracticeHomePage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useLocation } from 'preact-iso';
 import { Plus, UserPlus, Check, X, ArrowRight } from 'lucide-preact';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useWorkspaceResolver } from '@/shared/hooks/useWorkspaceResolver';
@@ -71,7 +72,18 @@ const RECENT_INTAKES: IntakeRow[] = [
 
 const PracticeHomePage = () => {
   const { session } = useSessionContext();
-  const { currentPractice, practices } = useWorkspaceResolver();
+  const location = useLocation();
+  // Read the slug from the URL so the resolver picks `currentPractice` for the
+  // workspace we're on — not the snapshot's last-active practice. Without this,
+  // a switcher-driven navigation to /practice/<other-slug> leaves the sidebar
+  // showing the previous org's name (see feat/org-switcher 2026-05-22).
+  const urlPracticeSlug = useMemo(() => {
+    const match = location.path.match(/^\/practice\/([^/]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+  }, [location.path]);
+  const { currentPractice, practices } = useWorkspaceResolver({
+    practiceSlug: urlPracticeSlug,
+  });
   const { navigate } = useNavigation();
   const [desktopCollapsed, setDesktopCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
@@ -140,7 +152,13 @@ const PracticeHomePage = () => {
     practiceSlug ? (
       <PracticeSidebar
         practiceSlug={practiceSlug}
-        org={{ name: orgName, initial: orgInitial }}
+        org={{
+          id: currentPractice?.id,
+          slug: currentPractice?.slug ?? practiceSlug,
+          name: orgName,
+          initial: orgInitial,
+          logoUrl: currentPractice?.logo ?? null,
+        }}
         user={sidebarUser}
         collapsed={desktopCollapsed}
         forceExpanded={forceExpanded}

--- a/src/shared/hooks/useEnsureActiveOrganization.ts
+++ b/src/shared/hooks/useEnsureActiveOrganization.ts
@@ -1,0 +1,136 @@
+import { useEffect, useState, useCallback, useRef } from 'preact/hooks';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
+import { authClient, getSession } from '@/shared/lib/authClient';
+
+type MembershipOrg = { id?: string | null };
+
+// Better Auth's organization plugin endpoint lists every org the user is a
+// member of, regardless of which one is currently active on the session. The
+// worker's /api/practice/list endpoint requires an active-org context and
+// returns 403 when it is missing — using it here would defeat the purpose of
+// the recovery (see docs/solutions/conventions/better-auth-active-organization-id-pointer-2026-05-15.md).
+async function listMembershipOrgs(): Promise<MembershipOrg[]> {
+  const result = await authClient.organization.list();
+  const data = (result as { data?: unknown })?.data ?? result;
+  if (!Array.isArray(data)) {
+    throw new Error('authClient.organization.list returned a non-array response');
+  }
+  return data as MembershipOrg[];
+}
+
+async function setActiveOrganization(organizationId: string): Promise<void> {
+  await authClient.organization.setActive({ organizationId });
+}
+
+const resolvedForUserIds = new Set<string>();
+const inFlightForUserIds = new Map<string, Promise<void>>();
+
+const dropMemo = () => {
+  resolvedForUserIds.clear();
+  inFlightForUserIds.clear();
+};
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('auth:session-cleared', dropMemo);
+}
+
+const isSubscriptionSuccessReturn = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('subscription') === 'success';
+};
+
+const getActiveOrganizationId = (
+  session: { session?: Record<string, unknown> | null } | null | undefined
+): string | null => {
+  const value = session?.session?.active_organization_id;
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+};
+
+async function runRecovery(userId: string): Promise<void> {
+  const existing = inFlightForUserIds.get(userId);
+  if (existing) return existing;
+  if (resolvedForUserIds.has(userId)) return;
+
+  const promise = (async () => {
+    try {
+      const orgs = await listMembershipOrgs();
+      const firstId = typeof orgs[0]?.id === 'string' ? orgs[0].id : null;
+      if (!firstId) {
+        // Verified-empty: user genuinely has zero orgs. Memoize as terminal so
+        // the gate stops asking on every render.
+        resolvedForUserIds.add(userId);
+        return;
+      }
+      await setActiveOrganization(firstId);
+      await getSession();
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('auth:session-updated'));
+      }
+      console.info('[Workspace] auto-activated first practice (no active_organization_id on session)');
+      resolvedForUserIds.add(userId);
+    } catch (error) {
+      // Transient failure (network, 5xx, setActive rejection, etc.) — do NOT
+      // memoize. Next render is allowed to retry; one bad request mustn't
+      // permanently lock a user out of recovery.
+      console.warn('[Workspace] failed to auto-activate practice', error);
+    } finally {
+      inFlightForUserIds.delete(userId);
+    }
+  })();
+
+  inFlightForUserIds.set(userId, promise);
+  return promise;
+}
+
+export function useEnsureActiveOrganization() {
+  const { session, isPending, isAnonymous } = useSessionContext();
+  const [isResolving, setIsResolving] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const userId = session?.user?.id ?? null;
+  const onboardingComplete = session?.user?.onboarding_complete === true;
+  const activeOrgId = getActiveOrganizationId(session);
+
+  const eligible = Boolean(
+    !isPending &&
+    userId &&
+    !isAnonymous &&
+    onboardingComplete &&
+    !activeOrgId &&
+    !resolvedForUserIds.has(userId)
+  );
+
+  useEffect(() => {
+    if (!eligible || !userId) return;
+    if (isSubscriptionSuccessReturn()) return;
+
+    setIsResolving(true);
+    void runRecovery(userId).finally(() => {
+      if (mountedRef.current) {
+        setIsResolving(false);
+      }
+    });
+  }, [eligible, userId]);
+
+  const forceResolve = useCallback(async (): Promise<void> => {
+    if (!userId) return;
+    setIsResolving(true);
+    try {
+      await runRecovery(userId);
+    } finally {
+      if (mountedRef.current) {
+        setIsResolving(false);
+      }
+    }
+  }, [userId]);
+
+  return { isResolving, forceResolve };
+}
+
+export default useEnsureActiveOrganization;

--- a/src/shared/lib/authClient.ts
+++ b/src/shared/lib/authClient.ts
@@ -193,6 +193,22 @@ export const useActiveMemberRole = () => {
   return client.useActiveMemberRole();
 };
 
+// Reactive hook over the user's full membership list. Backed by Better Auth's
+// organization plugin (/api/auth/organization/list); safe to call from the
+// null-active-org state (see useEnsureActiveOrganization).
+export const useListOrganizations = () => {
+  const client = getAuthClient();
+  return client.useListOrganizations();
+};
+
+// Reactive hook over the currently-active organization on the session.
+// Returns null when no org has been activated (a legitimate cold-login state —
+// not a subscription signal).
+export const useActiveOrganization = () => {
+  const client = getAuthClient();
+  return client.useActiveOrganization();
+};
+
 export const getSession = async (...args: Parameters<AuthClientType['getSession']>): Promise<AuthSessionPayload | null> => {
   const result = await getAuthClient().getSession(...args);
   return unwrapSessionData(result);

--- a/src/shared/lib/orgCreation.ts
+++ b/src/shared/lib/orgCreation.ts
@@ -1,0 +1,23 @@
+export type CreatedOrg = {
+  id?: string | null;
+  slug?: string | null;
+  name?: string | null;
+};
+
+export const slugify = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+export const unwrapCreated = (result: unknown): CreatedOrg | null => {
+  if (!result || typeof result !== 'object') return null;
+  const record = result as Record<string, unknown>;
+  const data = (record.data ?? result) as Record<string, unknown> | null;
+  if (!data || typeof data !== 'object') return null;
+  return {
+    id: typeof data.id === 'string' ? data.id : null,
+    slug: typeof data.slug === 'string' ? data.slug : null,
+    name: typeof data.name === 'string' ? data.name : null,
+  };
+};

--- a/src/shared/ui/nav/ClientSidebar.tsx
+++ b/src/shared/ui/nav/ClientSidebar.tsx
@@ -1,5 +1,6 @@
 import { Sparkles } from 'lucide-preact';
 import { Sidebar } from '@/shared/ui/nav/Sidebar';
+import { OrgSwitcherMenu } from '@/shared/ui/nav/OrgSwitcherMenu';
 import { SidebarProfileMenu } from '@/shared/ui/nav/SidebarProfileMenu';
 import { useNavigation } from '@/shared/utils/navigation';
 import { signOut } from '@/shared/utils/auth';
@@ -17,10 +18,16 @@ export interface ClientSidebarUser {
 }
 
 export interface ClientSidebarOrg {
+  /** When provided, the org row becomes a switcher anchored on this active org. */
+  id?: string;
   name: string;
   initial: string;
   /** Defaults to "Client Portal". */
   subtitle?: string;
+  /** Optional slug — present for the switcher to render checkmarks consistently. */
+  slug?: string;
+  /** Optional uploaded logo URL; falls back to the initials badge when absent. */
+  logoUrl?: string | null;
 }
 
 export interface ClientSidebarProps {
@@ -87,19 +94,33 @@ export const ClientSidebar = ({
       collapsed={isCollapsed}
       onToggleCollapsed={toggle}
     >
-      <Sidebar.Org
-        name={org.name}
-        subtitle={org.subtitle ?? 'Client Portal'}
-        logo={
-          <span
-            aria-hidden="true"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[rgb(var(--accent-500))] text-sm font-bold text-[rgb(var(--accent-foreground))]"
-          >
-            {org.initial}
-          </span>
-        }
-        onCollapseClick={toggle}
-      />
+      {org.id ? (
+        <OrgSwitcherMenu
+          org={{
+            id: org.id,
+            name: org.name,
+            initial: org.initial,
+            subtitle: org.subtitle ?? 'Client Portal',
+            logoUrl: org.logoUrl ?? null,
+          }}
+          collapsed={isCollapsed}
+          onCollapseClick={toggle}
+        />
+      ) : (
+        <Sidebar.Org
+          name={org.name}
+          subtitle={org.subtitle ?? 'Client Portal'}
+          logo={
+            <span
+              aria-hidden="true"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[rgb(var(--accent-500))] text-sm font-bold text-[rgb(var(--accent-foreground))]"
+            >
+              {org.initial}
+            </span>
+          }
+          onCollapseClick={toggle}
+        />
+      )}
       {sidebarConfig.sections.map((section, idx) => (
         <Sidebar.Section
           key={section.label ?? `section-${idx}`}

--- a/src/shared/ui/nav/OrgSwitcherMenu.tsx
+++ b/src/shared/ui/nav/OrgSwitcherMenu.tsx
@@ -1,0 +1,285 @@
+import type { ComponentChildren, FunctionComponent, JSX } from 'preact';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import { Check, Plus, Building2, ChevronsUpDown } from 'lucide-preact';
+import { Sidebar } from './Sidebar';
+import { Icon } from '@/shared/ui/Icon';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { cn } from '@/shared/utils/cn';
+import { useNavigation } from '@/shared/utils/navigation';
+import {
+  authClient,
+  getSession,
+  useListOrganizations,
+} from '@/shared/lib/authClient';
+import { CreatePracticeDialog } from '@/features/practice-onboarding/components/CreatePracticeDialog';
+
+export interface OrgSwitcherOrg {
+  id: string;
+  name: string;
+  initial: string;
+  /** Defaults to "Practice". */
+  subtitle?: string;
+  /** Optional logo URL — falls back to a colored initial badge. */
+  logoUrl?: string | null;
+}
+
+type MembershipRecord = {
+  id?: string | null;
+  name?: string | null;
+  slug?: string | null;
+  // The org plugin tags client memberships with a role on the membership row;
+  // we use this to decide whether to route to /practice/ or /client/.
+  role?: string | null;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const unwrapOrgList = (raw: unknown): MembershipRecord[] => {
+  if (!raw) return [];
+  const data = isPlainObject(raw) && 'data' in raw ? (raw as { data: unknown }).data : raw;
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter(isPlainObject)
+    .map((record) => ({
+      id: typeof record.id === 'string' ? record.id : null,
+      name: typeof record.name === 'string' ? record.name : null,
+      slug: typeof record.slug === 'string' ? record.slug : null,
+      role: typeof record.role === 'string' ? record.role : null,
+    }));
+};
+
+const initialFor = (name: string | null | undefined): string => {
+  const ch = name?.trim().charAt(0);
+  return ch ? ch.toUpperCase() : '?';
+};
+
+const subtitleFor = (role: string | null | undefined): string =>
+  role === 'client' ? 'Client portal' : 'Practice';
+
+const routeFor = (slug: string, role: string | null | undefined): string =>
+  role === 'client'
+    ? `/client/${encodeURIComponent(slug)}`
+    : `/practice/${encodeURIComponent(slug)}`;
+
+export interface OrgSwitcherMenuProps {
+  /** Currently-active org rendered as the trigger row. */
+  org: OrgSwitcherOrg;
+  /** When true, anchor as a fixed flyout to the right of the trigger (collapsed rail). */
+  collapsed?: boolean;
+  /** Forwards to Sidebar.Org so the row's collapse button still works. */
+  onCollapseClick?: () => void;
+  className?: string;
+}
+
+export const OrgSwitcherMenu: FunctionComponent<OrgSwitcherMenuProps> = ({
+  org,
+  collapsed = false,
+  onCollapseClick,
+  className,
+}) => {
+  const { navigate } = useNavigation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [switchingId, setSwitchingId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const orgsHook = useListOrganizations() as { data?: unknown; isPending?: boolean };
+  const memberships = unwrapOrgList(orgsHook?.data);
+  const loading = Boolean(orgsHook?.isPending);
+
+  // Match the SidebarProfileMenu pattern: fixed positioning when collapsed so
+  // the menu escapes the sidebar's overflow-hidden inner container.
+  const [fixedStyle, setFixedStyle] = useState<JSX.CSSProperties>({});
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !collapsed) return;
+    const updatePosition = () => {
+      const trigger = containerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      setFixedStyle({
+        position: 'fixed',
+        left: `${rect.right + 12}px`,
+        top: `${rect.top}px`,
+      });
+    };
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isOpen, collapsed]);
+
+  const handleSelect = useCallback(
+    async (membership: MembershipRecord) => {
+      const targetId = typeof membership.id === 'string' ? membership.id : null;
+      if (!targetId) return;
+      if (targetId === org.id) {
+        setIsOpen(false);
+        return;
+      }
+      setSwitchingId(targetId);
+      try {
+        await authClient.organization.setActive({ organizationId: targetId });
+        await getSession().catch(() => undefined);
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('auth:session-updated'));
+        }
+        setIsOpen(false);
+        if (membership.slug) {
+          navigate(routeFor(membership.slug, membership.role));
+        }
+      } catch (error) {
+        // Better Auth surfaces typed errors in its response envelope; in practice
+        // an explicit toast belongs upstream in the caller. Keep the menu open so
+        // the user can retry without losing context.
+        console.warn('[OrgSwitcherMenu] Failed to switch active organization', error);
+      } finally {
+        setSwitchingId(null);
+      }
+    },
+    [navigate, org.id]
+  );
+
+  const triggerLogo = (
+    <span
+      aria-hidden="true"
+      className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-md bg-[rgb(var(--accent-500))] text-sm font-bold text-[rgb(var(--accent-foreground))]"
+    >
+      {org.logoUrl ? (
+        <img src={org.logoUrl} alt="" className="h-full w-full object-cover" />
+      ) : (
+        org.initial
+      )}
+    </span>
+  );
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <Sidebar.Org
+        name={org.name}
+        subtitle={org.subtitle ?? 'Practice'}
+        logo={triggerLogo}
+        onClick={() => setIsOpen((v) => !v)}
+        onCollapseClick={onCollapseClick}
+      />
+      {isOpen ? (
+        <div
+          role="menu"
+          aria-label="Switch practice"
+          className={
+            collapsed
+              ? 'z-50 w-72 rounded-xl border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
+              : 'absolute left-0 right-0 top-full z-50 mt-2 rounded-xl border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
+          }
+          style={collapsed ? fixedStyle : undefined}
+        >
+          <div className="px-2 pb-1 pt-2">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--sidebar-section-label))]">
+              Switch practice
+            </p>
+          </div>
+          {loading && memberships.length === 0 ? (
+            <div className="flex items-center justify-center px-2 py-4">
+              <LoadingSpinner size="sm" ariaLabel="Loading practices" />
+            </div>
+          ) : memberships.length === 0 ? (
+            <div className="px-2 py-3 text-[12px] text-[rgb(var(--sidebar-text-secondary))]">
+              You&apos;re not a member of any practice yet.
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-0.5 px-1 py-1">
+              {memberships.map((membership) => {
+                const id = membership.id ?? '';
+                const isActive = id === org.id;
+                const name = membership.name ?? 'Untitled practice';
+                const isSwitching = switchingId === id;
+                return (
+                  <li key={id || name}>
+                    <button
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={isActive}
+                      onClick={() => {
+                        void handleSelect(membership);
+                      }}
+                      disabled={isSwitching}
+                      className={cn(
+                        'flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
+                        isActive
+                          ? 'bg-[rgb(var(--sidebar-hover-bg))] text-[rgb(var(--sidebar-text))]'
+                          : 'text-[rgb(var(--sidebar-text))] hover:bg-[rgb(var(--sidebar-hover-bg))]'
+                      )}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-[rgb(var(--accent-500))] text-[11px] font-bold text-[rgb(var(--accent-foreground))]"
+                      >
+                        {initialFor(name)}
+                      </span>
+                      <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate">{name}</span>
+                        <span className="truncate text-[11px] text-[rgb(var(--sidebar-text-secondary))]">
+                          {subtitleFor(membership.role)}
+                        </span>
+                      </span>
+                      {isActive ? (
+                        <Icon icon={Check} className="h-4 w-4 text-accent-utility" aria-hidden />
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <Separator />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setIsOpen(false);
+              setCreateOpen(true);
+            }}
+            className="flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] text-[rgb(var(--sidebar-text))] transition-colors hover:bg-[rgb(var(--sidebar-hover-bg))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50"
+          >
+            <Icon icon={Plus} className="h-4 w-4 text-[rgb(var(--sidebar-text-secondary))]" aria-hidden />
+            <span>Create practice</span>
+          </button>
+        </div>
+      ) : null}
+      <CreatePracticeDialog isOpen={createOpen} onClose={() => setCreateOpen(false)} />
+    </div>
+  );
+};
+
+const Separator: FunctionComponent = () => (
+  <div className="my-1 px-1">
+    <div className="h-px bg-[rgb(var(--sidebar-divider))]" />
+  </div>
+);
+
+// Re-export icon used in chrome elsewhere to keep tree-shaken imports stable.
+export const OrgSwitcherIcons = { Building2, ChevronsUpDown };
+
+export type OrgSwitcherChildren = ComponentChildren;
+export default OrgSwitcherMenu;

--- a/src/shared/ui/nav/OrgSwitcherMenu.tsx
+++ b/src/shared/ui/nav/OrgSwitcherMenu.tsx
@@ -82,6 +82,7 @@ export const OrgSwitcherMenu: FunctionComponent<OrgSwitcherMenuProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [switchingId, setSwitchingId] = useState<string | null>(null);
+  const switchingRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const orgsHook = useListOrganizations() as { data?: unknown; isPending?: boolean };
   const memberships = unwrapOrgList(orgsHook?.data);
@@ -132,12 +133,14 @@ export const OrgSwitcherMenu: FunctionComponent<OrgSwitcherMenuProps> = ({
 
   const handleSelect = useCallback(
     async (membership: MembershipRecord) => {
+      if (switchingRef.current) return;
       const targetId = typeof membership.id === 'string' ? membership.id : null;
       if (!targetId) return;
       if (targetId === org.id) {
         setIsOpen(false);
         return;
       }
+      switchingRef.current = true;
       setSwitchingId(targetId);
       try {
         await authClient.organization.setActive({ organizationId: targetId });
@@ -155,6 +158,7 @@ export const OrgSwitcherMenu: FunctionComponent<OrgSwitcherMenuProps> = ({
         // the user can retry without losing context.
         console.warn('[OrgSwitcherMenu] Failed to switch active organization', error);
       } finally {
+        switchingRef.current = false;
         setSwitchingId(null);
       }
     },
@@ -213,7 +217,7 @@ export const OrgSwitcherMenu: FunctionComponent<OrgSwitcherMenuProps> = ({
                 const id = membership.id ?? '';
                 const isActive = id === org.id;
                 const name = membership.name ?? 'Untitled practice';
-                const isSwitching = switchingId === id;
+                const isSwitching = switchingId !== null;
                 return (
                   <li key={id || name}>
                     <button

--- a/src/shared/ui/nav/PracticeSidebar.tsx
+++ b/src/shared/ui/nav/PracticeSidebar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import { Sidebar } from '@/shared/ui/nav/Sidebar';
+import { OrgSwitcherMenu } from '@/shared/ui/nav/OrgSwitcherMenu';
 import { SidebarProfileMenu } from '@/shared/ui/nav/SidebarProfileMenu';
 import { useNavigation } from '@/shared/utils/navigation';
 import { signOut } from '@/shared/utils/auth';
@@ -19,10 +20,16 @@ export interface PracticeSidebarUser {
 }
 
 export interface PracticeSidebarOrg {
+  /** When provided, the org row becomes a switcher anchored on this active org. */
+  id?: string;
   name: string;
   initial: string;
   /** Defaults to "Practice". */
   subtitle?: string;
+  /** Optional slug — present for the switcher to render checkmarks consistently. */
+  slug?: string;
+  /** Optional uploaded logo URL; falls back to the initials badge when absent. */
+  logoUrl?: string | null;
 }
 
 export interface PracticeSidebarProps {
@@ -119,19 +126,33 @@ export const PracticeSidebar = ({
       collapsed={isCollapsed}
       onToggleCollapsed={toggle}
     >
-      <Sidebar.Org
-        name={org.name}
-        subtitle={org.subtitle ?? 'Practice'}
-        logo={
-          <span
-            aria-hidden="true"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[rgb(var(--accent-500))] text-sm font-bold text-[rgb(var(--accent-foreground))]"
-          >
-            {org.initial}
-          </span>
-        }
-        onCollapseClick={toggle}
-      />
+      {org.id ? (
+        <OrgSwitcherMenu
+          org={{
+            id: org.id,
+            name: org.name,
+            initial: org.initial,
+            subtitle: org.subtitle ?? 'Practice',
+            logoUrl: org.logoUrl ?? null,
+          }}
+          collapsed={isCollapsed}
+          onCollapseClick={toggle}
+        />
+      ) : (
+        <Sidebar.Org
+          name={org.name}
+          subtitle={org.subtitle ?? 'Practice'}
+          logo={
+            <span
+              aria-hidden="true"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[rgb(var(--accent-500))] text-sm font-bold text-[rgb(var(--accent-foreground))]"
+            >
+              {org.initial}
+            </span>
+          }
+          onCollapseClick={toggle}
+        />
+      )}
       {sidebarConfig.sections.map((section, idx) => (
         <Sidebar.Section
           key={section.label ?? `section-${idx}`}

--- a/worker/migrations/20260522_restore_conversation_last_message_content.sql
+++ b/worker/migrations/20260522_restore_conversation_last_message_content.sql
@@ -1,0 +1,13 @@
+-- Restore conversations.last_message_content on environments where
+-- 20260401_remove_local_matters_tables.sql ran AFTER 20260318_add_conversation_last_message_content.sql.
+--
+-- 20260401 rebuilds the `conversations` table via INSERT INTO conversations_new SELECT … FROM conversations,
+-- and its column list (lines 54-73) does NOT include `last_message_content`. On environments where the
+-- 20260318 migration ran first (i.e. the column existed in `conversations` at the time of the rebuild),
+-- the rebuild silently dropped the column. Staging escaped this because 20260401 had been applied months
+-- earlier; 20260318 then added the column to the already-rebuilt table. Prod and any fresh env hit it.
+--
+-- This migration restores the column. Pre-applied to local and staging via INSERT into d1_migrations so
+-- the tracker stays consistent without re-running ALTER (which would fail since the column already exists).
+
+ALTER TABLE conversations ADD COLUMN last_message_content TEXT;


### PR DESCRIPTION
## Summary

- **Org switcher** in the practice/client sidebar — opens a popover listing all memberships via `authClient.useListOrganizations()`, marks the active org, lets users switch (`authClient.organization.setActive` + navigate) or create a new practice via a footer row.
- **Pre-checkout practice naming** — `OnboardingFlow` adds a `PracticeNameStep` after `PersonalInfoStep` when the user has zero memberships. Creates the org via `authClient.organization.create` so the active org exists *before* Stripe checkout — closes the post-checkout race documented in [`docs/solutions/conventions/better-auth-active-organization-id-pointer-2026-05-15.md`](../blob/feat/org-switcher/docs/solutions/conventions/better-auth-active-organization-id-pointer-2026-05-15.md).
- **`useEnsureActiveOrganization` recovery hook** — restored verbatim per the May-2026 convention doc (memoization-of-failure P0 fix preserved). Mounted once in `AppShell`. Uses Better-Auth direct endpoints (`organization.list` + `setActive`), not the worker proxy routes that 403 from the null state.
- **`PracticeAppRoute` setActivePractice guards** — gated on (a) resolver `currentPractice.slug` matching URL slug, and (b) live `location.path` still matching this route's slug. Prevents the OLD route from reverting backend session when a switcher-driven navigation is in flight.
- **`PracticeHomePage` URL-driven resolver** — reads slug from `useLocation()` so the sidebar label follows the URL, not a cached snapshot.

### Production D1 fix bundled in

While testing, discovered prod D1 (`e4ed51fa-…`) was missing 9 migrations including `20260512_add_conversation_lifecycle.sql` — surfacing as runtime `D1_ERROR: table conversations has no column named lifecycle_status`. Applied all 9 to prod and 6 to staging. Discovered a **latent migration bug**: `20260401_remove_local_matters_tables.sql` rebuilds `conversations` via an `INSERT INTO conversations_new SELECT …` whose column list omits `last_message_content`. On envs where that rebuild ran *after* `20260318` added the column, the column is silently dropped. Added `20260522_restore_conversation_last_message_content.sql` to restore it, pre-applied on local/staging via tracker insert.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — only preexisting `completedOnboarding` unused-vars warning (cleaned up by staging PR #611, will be gone after merging staging)
- [x] `npm run test` — same pass/fail set as staging baseline (608 pass, 2 unrelated failures)
- [x] `npm run test:e2e -- intake specs` — same pass/fail as staging baseline (6 pass, 2 unrelated AI/Stripe failures, both confirmed preexisting)
- [x] Manual browser walkthrough on `https://local.blawby.com`:
  - Sign up → `PersonalInfoStep` → `PracticeNameStep` → org created, session active, lands in practice workspace ✓
  - Switcher menu lists both orgs, ✓ on active ✓
  - Click inactive org → URL updates, session updates, sidebar label updates ✓
  - "+ Create practice" → dialog → creates org, activates, navigates to new practice workspace ✓
- [ ] Multi-org owner cold-login recovery (recovery hook auto-picks first org) — not exercised in browser, relies on convention doc reasoning.

## Out of scope

- A dedicated `/select-practice` first-run page (deliberately deferred — see plan, "Deliberate tradeoff").
- Re-ordering / pinning / favoriting orgs in the switcher.
- Editing org logo / accent color from the create dialog (existing `PracticeOnboardingPage` still owns deeper setup).

## Backend coordination

Pre-checkout practice creation means the backend's post-checkout webhook should be idempotent (no-op if `referenceId` already maps to a real org) OR skipped when `subscription.upgrade` receives a `referenceId`. Flagging for the backend reviewer.

## Notes for reviewer

- One pre-existing lint error survives on this branch (`completedOnboarding` unused-vars in `src/index.tsx`). Staging PR #611 already cleans this up; merging staging into this branch will resolve it.
- Two e2e specs fail on this branch but also fail on staging baseline — `widget-intake-ai-fires hours-question regression guard` and `widget-intake-flow submit reaches Stripe`. Unrelated to this work; flagging for separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added practice creation flow allowing users to name and establish new practices during onboarding.
  * Introduced organization switcher menu in navigation for seamless switching between practices and workspaces.
  * Added practice naming step for users without existing organizations during initial setup.

* **Bug Fixes**
  * Restored missing conversation data column in database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->