### PR TITLE
refactor(design-system): replace glass border tokens and glass class aliases

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -230,7 +230,7 @@ Implemented in `src/index.css` as a single component class system (`.btn` + vari
   - **Card-raised** / **side-card**: stronger contrast, `border-default` border. Used for inspector panes and "this is its own thing" subsections.
   - **Panel** (`.panel`): visually similar but `surface-section` background. The structural container behind cards.
 
-**Legacy gradient overlays.** `.card`, `.card-surface`, and `.glass-card` currently apply two background-image gradients (a 135° highlight, a radial accent-tinted halo) over their solid background. **These violate the Flat-By-Default and No-Decoration rules and are deprecated.** Future `polish` / `distill` passes should strip them and leave the solid `surface-card` color alone.
+**Glass aliases removed.** `.glass-card`, `.glass-panel`, and `.glass-input` are deprecated shims in `index.css` that resolve to `.card`, `.panel`, and `.input-surface` respectively. New code must use the canonical names. The `glass-*` names will be removed in a future cleanup pass.
 
 ### Inputs
 
@@ -291,7 +291,7 @@ Concrete guardrails. The Don'ts here directly mirror PRODUCT.md's anti-reference
 - **Don't** use gradient orbs as background decoration. The current `accentBackdropVariant: 'settings'` and `'workspace'` variants are legacy; remove existing instances and do not add new ones. (Anti-ref: *Generic AI tool template*.)
 - **Don't** use accent-tinted glow shadows on buttons. The current `btn-primary` shadow is legacy and should be flattened. (Rule: *No-Glow*.)
 - **Don't** apply gradient overlays to cards. The current `.card` / `.card-surface` background-image gradients are decorative and conflict with Flat-By-Default; strip them on the next polish pass.
-- **Don't** use glassmorphism as a default treatment. The `btn-inverted` glass-blur variant and `--surface-glass` token are legacy. Glass is permitted only as a deliberate scrim above content (e.g., the mobile sidebar overlay), never as a primary surface treatment.
+- **Don't** use glassmorphism as a default treatment. The `btn-inverted` variant and `--surface-glass` token are removed. The `glass-card`, `glass-panel`, and `glass-input` class names are deprecated aliases — use `card`, `panel`, and `input-surface` instead. The `border-line-glass` Tailwind token is also deprecated; use `border-line-subtle` for dividers and card borders. Glass is permitted only as a deliberate scrim above content (e.g., a fixed overlay), never as a primary surface treatment.
 - **Don't** use `#FFFFFF` or `#000000` literally. All neutrals are tinted slate.
 - **Don't** put Outfit inside the product shell except for a single page-title moment. No Outfit in tables, cards, dialogs, or forms.
 - **Don't** use border-left or border-right greater than 1px as a colored accent stripe. The nav-active indicator uses an inset shadow specifically to avoid this pattern.

--- a/src/app/ErrorBoundary.tsx
+++ b/src/app/ErrorBoundary.tsx
@@ -31,11 +31,11 @@ export class ErrorBoundary extends Component<Props, State> {
     render() {
         if (this.state.hasError) {
             return this.props.fallback || (
-                <div className="p-6 m-4 glass-panel border-accent-error/20 shadow-glass">
+                <div className="p-6 m-4 panel border-accent-error/20 shadow-glass">
                     <h2 className="text-xl font-bold text-accent-error-light mb-4">Something went wrong</h2>
                     <details className="my-4">
                         <summary className="cursor-pointer text-accent-500 font-medium hover:text-accent-400 transition-colors">Error details</summary>
-                        <pre className="mt-2 p-4 bg-surface-workspace/40 dark:bg-surface-utility/10 border border-line-glass/10 rounded-xl overflow-x-auto text-sm text-accent-error/80">{this.state.error?.message}</pre>
+                        <pre className="mt-2 p-4 bg-surface-workspace/40 dark:bg-surface-utility/10 border border-line-subtle rounded-xl overflow-x-auto text-sm text-accent-error/80">{this.state.error?.message}</pre>
                     </details>
                     <Button 
                         variant="primary"

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -581,20 +581,40 @@ export function MainApp({
   // widget is left untouched.
   const hideInspectorChrome = layoutMode === 'desktop' && isAuthenticatedWorkspace;
 
+  const acceptedConversationIntakeId = useMemo(() => {
+    const state = resolveConsultationState(conversationMetadata ?? null);
+    const meta = conversationMetadata as Record<string, unknown> | null | undefined;
+    const statusCandidates = [
+      meta?.triageStatus,
+      meta?.triage_status,
+      meta?.intakeTriageStatus,
+    ];
+    const isAccepted = statusCandidates.some((value) => value === 'accepted');
+    const intakeCandidates = [
+      state?.submission?.intakeUuid,
+      meta?.intakeUuid,
+      meta?.intake_uuid,
+      meta?.intakeId,
+      meta?.intake_id,
+    ];
+    const intakeId = intakeCandidates.find((value): value is string => typeof value === 'string' && value.trim().length > 0);
+    return isAccepted && intakeId ? intakeId : null;
+  }, [conversationMetadata]);
+
   // Pencil rxzde detail header: practice viewers see a primary "Create
-  // Engagement" CTA. The CTA jumps to the engagements page where the existing
-  // creation flow lives. Hidden on non-desktop layouts (Pencil d08Mpc keeps the
-  // mobile detail header spartan — only back + title + overflow menu).
+  // Engagement" CTA for active accepted-intake conversations.
   const createEngagementAction = useMemo(() => {
     if (!isPracticeWorkspace) return null;
     if (!practiceEngagementsPath) return null;
     if (layoutMode !== 'desktop') return null;
+    if (!acceptedConversationIntakeId) return null;
+    const target = `${practiceEngagementsPath}?create=1&intakeId=${encodeURIComponent(acceptedConversationIntakeId)}`;
     return (
       <Button
         type="button"
         variant="primary"
         size="sm"
-        onClick={() => navigate(practiceEngagementsPath)}
+        onClick={() => navigate(target)}
         icon={Plus}
         iconClassName="h-4 w-4"
         iconPosition="left"
@@ -602,7 +622,7 @@ export function MainApp({
         Create Engagement
       </Button>
     );
-  }, [isPracticeWorkspace, layoutMode, practiceEngagementsPath, navigate]);
+  }, [acceptedConversationIntakeId, isPracticeWorkspace, layoutMode, practiceEngagementsPath, navigate]);
 
   const conversationHeaderActions = useMemo(() => {
     if (!createEngagementAction) return null;
@@ -702,7 +722,7 @@ export function MainApp({
         src={null}
         name={conversationCaseTitle}
         size="sm"
-        className="ring-1 ring-line-glass/10"
+        className="ring-1 ring-line-subtle"
         status={conversationHeaderPresence.status}
       />
     );
@@ -1090,6 +1110,7 @@ export function MainApp({
                 activeTriageFilter={activeFilter}
                 basePath={practiceIntakesPath ?? '/practice/intakes'}
                 conversationsBasePath={conversationsBasePath}
+                engagementsBasePath={practiceEngagementsPath}
                 practiceName={resolvedPracticeName}
                 practiceLogo={resolvedPracticeLogo}
               />

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -534,7 +534,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
       size="icon-sm"
       onClick={requestWidgetClose}
       aria-label="Close widget"
-      className="text-input-text/60 hover:text-input-text glass-card backdrop-blur-md border border-line-glass/20 shadow-lg"
+      className="text-input-text/60 hover:text-input-text card backdrop-blur-md border border-line-subtle shadow-lg"
     >
       <Icon icon={X} className="h-5 w-5" />
     </Button>
@@ -779,7 +779,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
               />
 
               {isInspectorOpen && activeConversationId && (
-                <aside className="hidden w-80 shrink-0 lg:block lg:w-96 glass-panel overflow-visible shadow-glass ring-1 ring-line-glass/20">
+                <aside className="hidden w-80 shrink-0 lg:block lg:w-96 panel overflow-visible shadow-glass ring-1 ring-line-subtle">
                   <div className="h-full overflow-y-auto">
                     <InspectorPanel
                       entityType="conversation"

--- a/src/features/chat/components/ChatDockedAction.tsx
+++ b/src/features/chat/components/ChatDockedAction.tsx
@@ -31,7 +31,7 @@ export const ChatDockedAction: FunctionComponent<ChatDockedActionProps> = ({
   return (
     <div
       className={cn(
-        'ui-surface-enter mx-2 mb-4 overflow-hidden shadow-glass glass-card p-6 text-input-text border-none',
+        'ui-surface-enter mx-2 mb-4 overflow-hidden shadow-glass card p-6 text-input-text border-none',
         containerClassName
       )}
     >

--- a/src/features/chat/components/ConversationContextPanel.tsx
+++ b/src/features/chat/components/ConversationContextPanel.tsx
@@ -15,7 +15,7 @@ import type { Conversation } from '@/shared/types/conversation';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 
 const sectionTitle = 'text-[11px] font-semibold uppercase tracking-[0.08em] text-input-placeholder';
-const sectionDivider = 'border-t border-line-glass/30 pt-4 mt-4';
+const sectionDivider = 'border-t border-line-subtle pt-4 mt-4';
 
 interface ActivityEntry {
   id: string;
@@ -205,7 +205,7 @@ const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps>
         </div>
       </div>
 
-      <section className="flex flex-col gap-3 border-t border-line-glass/30 pt-4">
+      <section className="flex flex-col gap-3 border-t border-line-subtle pt-4">
         <h3 className={sectionTitle}>{t('workspace.conversationContext.contact', { defaultValue: 'Contact' })}</h3>
         <DetailRow label={t('workspace.conversationContext.name', { defaultValue: 'Name' })} value={contactName} />
         <DetailRow label={t('workspace.conversationContext.email', { defaultValue: 'Email' })} value={email} />

--- a/src/features/chat/components/DraftConversationView.tsx
+++ b/src/features/chat/components/DraftConversationView.tsx
@@ -141,13 +141,13 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-surface-workspace">
-      <header className="flex items-center justify-between gap-3 border-b border-line-glass/30 px-4 py-3 sm:px-6">
+      <header className="flex items-center justify-between gap-3 border-b border-line-subtle px-4 py-3 sm:px-6">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <Avatar
             src={null}
             name={draftContact?.name ?? 'New conversation'}
             size="md"
-            className="ring-1 ring-line-glass/10"
+            className="ring-1 ring-line-subtle"
             status={draftContact?.userId
               ? (onlineUserIds.has(draftContact.userId) ? 'active' : 'offline')
               : undefined}
@@ -172,7 +172,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
         />
       </header>
 
-      <div className="border-b border-line-glass/30 px-4 py-3 sm:px-6">
+      <div className="border-b border-line-subtle px-4 py-3 sm:px-6">
         <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.08em] text-input-placeholder">
           To
         </span>

--- a/src/features/chat/components/Message.tsx
+++ b/src/features/chat/components/Message.tsx
@@ -275,7 +275,7 @@ const Message: FunctionComponent<MessageProps> = memo(({
 						disabled={!onReplyPreviewClick}
 						aria-label="Jump to replied message"
 					>
-						<span className="pointer-events-none absolute left-[-32px] top-1/2 h-[14px] w-[60px] -translate-y-1/2 rounded-tl-xl border-l-[2px] border-t border-line-utility" />
+						<span className="pointer-events-none absolute left-[-32px] top-1/2 h-[14px] w-[60px] -translate-y-1/2 rounded-tl-xl border-l-[2px] border-t border-line-subtle" />
 						{replyPreview.avatar && (
 							<MessageAvatar
 								src={replyPreview.avatar.src}

--- a/src/features/chat/components/MessageActions.tsx
+++ b/src/features/chat/components/MessageActions.tsx
@@ -367,7 +367,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 			{/* Display generated PDF */}
 			{generatedPDF && (
 				<div className="my-2">
-					<div className="flex items-center gap-2 p-3 rounded-xl glass-panel">
+					<div className="flex items-center gap-2 p-3 rounded-xl panel">
 						<div className="w-8 h-8 rounded bg-surface-utility/60 dark:bg-surface-utility/10 flex items-center justify-center flex-shrink-0">
 							<Icon icon={FileIcon} className="w-4 h-4 text-input-text"  />
 						</div>

--- a/src/features/chat/components/MessageAttachments.tsx
+++ b/src/features/chat/components/MessageAttachments.tsx
@@ -103,7 +103,7 @@ const DocumentAttachment: FunctionComponent<DocumentAttachmentProps> = ({ file, 
 
   return (
     <div
-      className="flex items-center gap-2 p-2 rounded-xl glass-panel cursor-pointer my-2 max-w-[300px]"
+      className="flex items-center gap-2 p-2 rounded-xl panel cursor-pointer my-2 max-w-[300px]"
       onClick={() => { void handleClick(); }}
       onKeyDown={handleKeyDown}
       role="button"

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -398,7 +398,7 @@ const MessageComposer = ({
               dropped here in favor of inline flex so the icons live inside the
               pill rather than beside it. */}
           <div className="w-full">
-            <div className={`min-w-0 relative flex w-full items-end gap-1 glass-input min-h-12 ${isInputExpanded ? 'rounded-2xl py-2 px-2' : 'rounded-full py-1 px-2'} ${isInputFocused ? 'ring-2 ring-accent-500/40 border-accent-500/40' : ''}`}>
+            <div className={`min-w-0 relative flex w-full items-end gap-1 input-surface min-h-12 ${isInputExpanded ? 'rounded-2xl py-2 px-2' : 'rounded-full py-1 px-2'} ${isInputFocused ? 'ring-2 ring-accent-500/40 border-accent-500/40' : ''}`}>
               {canShowAttachmentMenu && (
                 <div className="flex-shrink-0 self-end">
                   <FileMenu
@@ -480,7 +480,7 @@ const MessageComposer = ({
                 <div 
                   id="mention-listbox"
                   role="listbox"
-                  className="absolute bottom-full left-2 right-2 z-40 mb-2 overflow-hidden rounded-xl border border-line-glass/10 bg-surface-workspace dark:bg-surface-overlay/95 shadow-glass backdrop-blur-2xl"
+                  className="absolute bottom-full left-2 right-2 z-40 mb-2 overflow-hidden rounded-xl border border-line-subtle bg-surface-workspace dark:bg-surface-overlay/95 shadow-glass backdrop-blur-2xl"
                 >
                   <div className="max-h-56 overflow-y-auto py-1">
                     {filteredMentionCandidates.map((candidate, index) => (

--- a/src/features/chat/components/MessagesListPanel.tsx
+++ b/src/features/chat/components/MessagesListPanel.tsx
@@ -156,7 +156,7 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
               src={null}
               name={draftEntry.contactName ?? 'New conversation'}
               size="md"
-              className="ring-1 ring-line-glass/10"
+              className="ring-1 ring-line-subtle"
             />
             <div className="min-w-0 flex-1">
               <div className="flex items-start justify-between gap-3">

--- a/src/features/chat/components/WorkspaceHomeSection.tsx
+++ b/src/features/chat/components/WorkspaceHomeSection.tsx
@@ -83,7 +83,7 @@ export const WorkspaceHomeSection: FunctionComponent<WorkspaceHomeSectionProps> 
           onCreateInvoice={onCreateInvoice}
         />
         {practiceBillingError ? (
-          <div className="border-b border-line-glass/30" role="alert">
+          <div className="border-b border-line-subtle" role="alert">
             <div className="mx-auto max-w-7xl px-4 py-3 text-sm text-input-text sm:px-6 lg:px-8">
               {practiceBillingError}
             </div>

--- a/src/features/chat/components/WorkspaceSetupSection.tsx
+++ b/src/features/chat/components/WorkspaceSetupSection.tsx
@@ -443,7 +443,7 @@ export const WorkspaceSetupSection: FunctionComponent<WorkspaceSetupSectionProps
           </Page>
         </div>
       </div>
-      <div className="relative flex w-full flex-col items-center gap-5 border-t border-line-glass/30 bg-transparent px-4 py-6 lg:min-h-0 lg:flex-1 lg:basis-1/2 lg:border-t-0 lg:border-l lg:border-l-line-glass/30">
+      <div className="relative flex w-full flex-col items-center gap-5 border-t border-line-subtle bg-transparent px-4 py-6 lg:min-h-0 lg:flex-1 lg:basis-1/2 lg:border-t-0 lg:border-l lg:border-l-line-glass/30">
         <div className="relative flex w-full flex-col items-center gap-5">
           <div className="flex flex-col items-center gap-2">
             <div className="text-xs font-semibold uppercase tracking-[0.35em] text-input-placeholder">
@@ -464,7 +464,7 @@ export const WorkspaceSetupSection: FunctionComponent<WorkspaceSetupSectionProps
               ariaLabel={t('preview.tabsLabel', { defaultValue: 'Public preview tabs' })}
             />
           ) : null}
-          <div className={cn('relative aspect-[9/19.5] w-full max-w-[360px] overflow-hidden', showSidebarPreview ? 'glass-card shadow-glass' : 'glass-panel')}>
+          <div className={cn('relative aspect-[9/19.5] w-full max-w-[360px] overflow-hidden', showSidebarPreview ? 'card shadow-glass' : 'panel')}>
             {showSidebarPreview ? previewContent : (
               <InspectorPanel
                 entityType="conversation"
@@ -485,7 +485,7 @@ export const WorkspaceSetupSection: FunctionComponent<WorkspaceSetupSectionProps
                 showCloseButton={false}
               />
             )}
-            {showSidebarPreview ? <div className="pointer-events-none absolute inset-0 rounded-3xl ring-1 ring-line-glass/10" aria-hidden="true" /> : null}
+            {showSidebarPreview ? <div className="pointer-events-none absolute inset-0 rounded-3xl ring-1 ring-line-subtle" aria-hidden="true" /> : null}
           </div>
         </div>
       </div>

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -999,18 +999,6 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       handleNavActivate();
       return;
     }
-    // Matters > Engagements is a peer route, not a filter; navigate explicitly.
-    if (workspaceSection === 'matters' && id === 'engagements' && item.href) {
-      navigate(item.href);
-      handleNavActivate();
-      return;
-    }
-    // On /engagements, the Matters sub-items still render (Matters owns the rail
-    // section) but selecting one only flips the filter — it doesn't navigate.
-    // Force a route back to /matters so the filter actually takes effect.
-    if (workspaceSection === 'matters' && view === 'engagements' && item.href) {
-      navigate(item.href);
-    }
     handleSecondaryFilterSelect(id);
     handleNavActivate();
   };
@@ -1227,8 +1215,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const mattersContent = resolveViewContent(
     mattersView,
     [mattersStatusFilter, workspacePrefetchData, toggleDetailInspector, detailInspectorOpen, desktopCreate] as const,
-    <div className="flex flex-1 flex-col glass-card">
-      <div className="mx-6 my-6 glass-panel p-5">
+    <div className="flex flex-1 flex-col card">
+      <div className="mx-6 my-6 panel p-5">
         <div className="text-sm text-input-placeholder">
           Your active matters will appear here once a practice connects them to your account.
         </div>
@@ -1243,8 +1231,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const contactsContent = resolveViewContent(
     contactsView,
     [contactsStatusFilter, workspacePrefetchData, toggleDetailInspector, detailInspectorOpen, desktopCreate] as const,
-    <div className="flex flex-1 flex-col glass-card">
-      <div className="mx-6 my-6 glass-panel p-5">
+    <div className="flex flex-1 flex-col card">
+      <div className="mx-6 my-6 panel p-5">
         <p className="text-sm text-input-placeholder">
           Manage contacts and relationship statuses here.
         </p>
@@ -1254,8 +1242,8 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const invoicesContent = resolveViewContent(
     invoicesView,
     [invoicesStatusFilter, toggleDetailInspector, detailInspectorOpen, desktopCreate] as const,
-    <div className="flex flex-1 flex-col glass-card">
-      <div className="mx-6 my-6 glass-panel p-5">
+    <div className="flex flex-1 flex-col card">
+      <div className="mx-6 my-6 panel p-5">
         <p className="text-sm text-input-placeholder">
           Invoice details and payments will appear here.
         </p>

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -61,7 +61,7 @@ const ConversationListEmptyState = ({
 }: { title: string; hint: string }) => (
   <div className="flex h-full flex-1 items-center justify-center px-6 py-10">
     <div className="flex max-w-xs flex-col items-center gap-3 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-glass/20">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-subtle">
         <Icon
           icon={MessageSquare}
           className="h-6 w-6 text-input-placeholder"
@@ -115,7 +115,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
         src={null}
         name={avatarName}
         size="md"
-        className="ring-1 ring-line-glass/10"
+        className="ring-1 ring-line-subtle"
         status={presence.status}
       />
       <div className="min-w-0 flex-1">
@@ -268,7 +268,7 @@ const ConversationListView: FunctionComponent<ConversationListViewProps> = ({
       )}
 
       {showSendMessageButton ? (
-        <div className="border-t border-line-glass/30 bg-transparent px-4 py-4">
+        <div className="border-t border-line-subtle bg-transparent px-4 py-4">
           <Button
             variant="primary"
             size="lg"

--- a/src/features/chat/views/WidgetConversationListView.tsx
+++ b/src/features/chat/views/WidgetConversationListView.tsx
@@ -18,7 +18,7 @@ import { usePresenceContext } from '@/shared/contexts/PresenceContext';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 
 const WidgetConversationListSkeleton = ({ rows = 6 }: { rows?: number }) => (
-  <div className="divide-y divide-line-glass/[0.04] pt-1">
+  <div className="divide-y divide-line-subtle pt-1">
     {Array.from({ length: rows }, (_, i) => {
       const titleW = ['w-32', 'w-40', 'w-28', 'w-36', 'w-44', 'w-32'][i % 6];
       const previewW = ['w-44', 'w-52', 'w-36', 'w-48', 'w-40', 'w-44'][i % 6];
@@ -48,7 +48,7 @@ const WidgetConversationListEmptyState = ({
 }: { title: string; hint: string }) => (
   <div className="flex flex-1 items-center justify-center px-6 py-10">
     <div className="flex max-w-xs flex-col items-center gap-3 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-glass/20">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-subtle">
         <Icon
           icon={MessageSquare}
           className="h-6 w-6 text-input-placeholder"
@@ -133,7 +133,7 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
             })}
           />
         ) : (
-          <div className="pt-1 divide-y divide-line-glass/[0.04]">
+          <div className="pt-1 divide-y divide-line-subtle">
             {sorted.map((conversation) => {
               const preview = previews[conversation.id];
               const contactName = resolveConversationContactName(conversation);
@@ -163,7 +163,7 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
                     src={null}
                     name={avatarName}
                     size="md"
-                    className="ring-2 ring-line-glass/10"
+                    className="ring-2 ring-line-subtle"
                   />
                   <div className="min-w-0 flex-1 space-y-1">
                     <div className="flex items-start justify-between gap-3">

--- a/src/features/chat/views/WorkspaceHomeView.tsx
+++ b/src/features/chat/views/WorkspaceHomeView.tsx
@@ -83,7 +83,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
             type="button"
             onClick={onOpenRecentMessage}
             disabled={!canOpenRecentMessage}
-            className="glass-card px-5 py-5 text-left transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+            className="card px-5 py-5 text-left transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
             aria-label={t('workspace.home.recentMessage')}
           >
             <div className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">
@@ -94,7 +94,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
                 src={recentMessage.avatarSrc ?? null}
                 name={recentMessage.senderLabel}
                 size="md"
-                className="ring-2 ring-line-glass/10"
+                className="ring-2 ring-line-subtle"
               />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center justify-between gap-3">
@@ -117,7 +117,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
           type="button"
           onClick={onSendMessage}
           disabled={!canSendMessage}
-          className="glass-card flex w-full items-center justify-between px-6 py-5 text-left text-input-text transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+          className="card flex w-full items-center justify-between px-6 py-5 text-left text-input-text transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
           aria-label={t('workspace.home.sendMessage')}
         >
           <span className="text-lg font-bold tracking-tight">{t('workspace.home.sendMessage')}</span>
@@ -130,7 +130,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
         </button>
 
         {showConsultationCard && (
-          <div className="glass-card px-5 py-6">
+          <div className="card px-5 py-6">
             <h3 className="text-base font-semibold text-input-text">{resolvedConsultationTitle}</h3>
             <p className="mt-2 text-sm text-input-placeholder">
               {resolvedConsultationDescription}

--- a/src/features/client-dashboard/ClientDashboard.tsx
+++ b/src/features/client-dashboard/ClientDashboard.tsx
@@ -46,7 +46,7 @@ export const ClientDashboard = ({
         onSendMessage={onSendMessage}
       />
       {error ? (
-        <div className="border-b border-line-glass/30" role="alert">
+        <div className="border-b border-line-subtle" role="alert">
           <div className="mx-auto max-w-7xl px-4 py-3 text-sm text-input-text sm:px-6 lg:px-8">
             {error}
           </div>

--- a/src/features/client-dashboard/components/ClientActionRequiredWidget.tsx
+++ b/src/features/client-dashboard/components/ClientActionRequiredWidget.tsx
@@ -34,7 +34,7 @@ export const ClientActionRequiredWidget = ({
   onAction,
 }: ClientActionRequiredWidgetProps) => (
   <Panel className="flex h-full flex-col">
-    <header className="border-b border-line-glass/30 px-5 py-4">
+    <header className="border-b border-line-subtle px-5 py-4">
       <p className="text-sm font-semibold text-input-text">Action required</p>
       <p className="text-xs text-input-placeholder">Things waiting on you</p>
     </header>
@@ -55,7 +55,7 @@ export const ClientActionRequiredWidget = ({
             const ItemIcon = ICONS[item.reason];
             return (
               <Fragment key={item.id}>
-                <div className="rounded-xl border border-line-glass/30 bg-surface px-4 py-3">
+                <div className="rounded-xl border border-line-subtle bg-surface px-4 py-3">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex min-w-0 gap-3">
                       <Icon

--- a/src/features/client-dashboard/components/ClientDashboardHero.tsx
+++ b/src/features/client-dashboard/components/ClientDashboardHero.tsx
@@ -31,13 +31,13 @@ export const ClientDashboardHero = ({
 }: ClientDashboardHeroProps) => {
   const name = typeof practiceName === 'string' ? practiceName.trim() : '';
   return (
-    <section className="border-b border-line-glass/30 lg:border-t lg:border-t-line-glass/20">
+    <section className="border-b border-line-subtle lg:border-t lg:border-t-line-subtle">
       <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 py-5 sm:px-6 lg:px-8">
         <Avatar
           src={practiceLogo}
           name={name}
           size="md"
-          className="ring-2 ring-line-glass/20"
+          className="ring-2 ring-line-subtle"
         />
         <div className="min-w-0 flex-1">
           <p className="truncate text-xs font-semibold uppercase tracking-[0.16em] text-input-placeholder">Your account</p>
@@ -72,8 +72,8 @@ export const ClientDashboardHero = ({
             <div
               key={stat.id}
               className={cn(
-                idx % 2 === 1 ? 'sm:border-l sm:border-line-glass/20' : idx === 2 ? 'lg:border-l lg:border-line-glass/20' : '',
-                'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-line-glass/20 px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8'
+                idx % 2 === 1 ? 'sm:border-l sm:border-line-subtle' : idx === 2 ? 'lg:border-l lg:border-line-subtle' : '',
+                'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-line-subtle px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8'
               )}
             >
               <dt className="text-sm font-medium text-input-placeholder">{stat.label}</dt>

--- a/src/features/client-dashboard/components/ClientMattersGrid.tsx
+++ b/src/features/client-dashboard/components/ClientMattersGrid.tsx
@@ -57,7 +57,7 @@ export const ClientMattersGrid = ({
                 onClick={() => onViewMatter?.(matter.id)}
                 className="block w-full text-left transition-colors hover:bg-surface-utility/20"
               >
-                <div className="flex items-start gap-3 border-b border-line-glass/20 bg-surface-overlay/70 p-5">
+                <div className="flex items-start gap-3 border-b border-line-subtle bg-surface-overlay/70 p-5">
                   <div className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-surface-utility/30">
                     <Icon icon={Briefcase} className="h-5 w-5 text-input-placeholder" aria-hidden />
                   </div>
@@ -68,7 +68,7 @@ export const ClientMattersGrid = ({
                     ) : null}
                   </div>
                 </div>
-                <dl className="divide-y divide-line-glass/20 bg-surface-overlay/60 px-5 py-3 text-sm">
+                <dl className="divide-y divide-line-subtle bg-surface-overlay/60 px-5 py-3 text-sm">
                   <div className="flex justify-between gap-x-4 py-2">
                     <dt className="text-input-placeholder">Status</dt>
                     <dd className="text-input-text">{matter.statusLabel ?? '—'}</dd>

--- a/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
+++ b/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
@@ -30,7 +30,7 @@ const statusClass = (status: ClientInvoiceActivityEntry['status']) => {
   const normalized = String(status).toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
 };
 
 export const ClientRecentInvoicesTable = ({
@@ -46,7 +46,7 @@ export const ClientRecentInvoicesTable = ({
       </h2>
     </div>
     {loading ? (
-      <div className="mt-6 border-t border-line-glass/30">
+      <div className="mt-6 border-t border-line-subtle">
         <div className="mx-auto max-w-7xl px-4 py-5 sm:px-6 lg:px-8">
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
@@ -62,13 +62,13 @@ export const ClientRecentInvoicesTable = ({
         </div>
       </div>
     ) : error ? (
-      <div className="mt-6 border-t border-line-glass/30">
+      <div className="mt-6 border-t border-line-subtle">
         <div className="mx-auto max-w-7xl px-4 py-5 text-sm text-input-text sm:px-6 lg:px-8">
           {error}
         </div>
       </div>
     ) : (
-      <div className="mt-6 overflow-hidden border-t border-line-glass/30">
+      <div className="mt-6 overflow-hidden border-t border-line-subtle">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
             <table className="w-full text-left">
@@ -90,8 +90,8 @@ export const ClientRecentInvoicesTable = ({
                       <tr className="text-sm text-input-text">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
-                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-glass/30 bg-surface-overlay/70" />
-                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-glass/30 bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
                         </th>
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (

--- a/src/features/clients/pages/PracticeContactEditorPage.tsx
+++ b/src/features/clients/pages/PracticeContactEditorPage.tsx
@@ -309,7 +309,7 @@ export function PracticeContactEditorPage({
     >
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
         {loading ? (
-          <div className="rounded-xl border border-line-glass/30 bg-surface-card p-6">
+          <div className="rounded-xl border border-line-subtle bg-surface-card p-6">
             <LoadingBlock label="Loading contact..." />
           </div>
         ) : null}

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -114,9 +114,9 @@ const PendingInvitationDetailPanel = ({
           </div>
         </AccentHeroSurface>
 
-        <section className="glass-panel rounded-2xl">
+        <section className="panel rounded-2xl">
           <ResponsiveDefinitionGrid>
-            <dl className="divide-y divide-line-glass/5">
+            <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
                 <dt className="text-sm font-medium text-input-placeholder">Email</dt>
                 <dd className="mt-1 text-sm text-input-text">{invitation.email}</dd>
@@ -126,7 +126,7 @@ const PendingInvitationDetailPanel = ({
                 <dd className="mt-1 text-sm text-input-text">{roleLabel}</dd>
               </div>
             </dl>
-            <dl className="divide-y divide-line-glass/5">
+            <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
                 <dt className="text-sm font-medium text-input-placeholder">Status</dt>
                 <dd className="mt-1 text-sm text-input-text">Pending</dd>
@@ -227,9 +227,9 @@ const ClientDetailPanel = ({
           </div>
         </AccentHeroSurface>
 
-        <section className="glass-panel rounded-2xl">
+        <section className="panel rounded-2xl">
           <ResponsiveDefinitionGrid>
-            <dl className="divide-y divide-line-glass/5">
+            <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
                 <dt className="text-sm font-medium text-input-placeholder">Email</dt>
                 <dd className="mt-1 text-sm text-input-text">{client.email}</dd>
@@ -239,7 +239,7 @@ const ClientDetailPanel = ({
                 <dd className="mt-1 text-sm text-input-text">{isClientRecord ? formatPhoneNumber(client.phone) : 'Not provided'}</dd>
               </div>
             </dl>
-            <dl className="divide-y divide-line-glass/5">
+            <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
                 <dt className="text-sm font-medium text-input-placeholder">Address</dt>
                 <dd className="mt-1 text-sm text-input-text">{client.addressDisplay ?? 'Not provided'}</dd>
@@ -852,7 +852,7 @@ export const PracticeContactsPage = ({
         <ul>
           {letters.map((letter) => (
             <li key={letter} data-letter={letter}>
-              <div className="sticky top-0 z-10 bg-surface-collection/80 backdrop-blur-sm px-4 py-1.5 text-xs font-semibold text-input-placeholder border-y border-line-glass/10">
+              <div className="sticky top-0 z-10 bg-surface-collection/80 backdrop-blur-sm px-4 py-1.5 text-xs font-semibold text-input-placeholder border-y border-line-subtle">
                 {letter}
               </div>
               {groupedClients[letter].map((client) => {
@@ -934,7 +934,7 @@ export const PracticeContactsPage = ({
   const pendingInvitationListPane = (
     <div className="relative h-full min-h-0 overflow-hidden">
       <div className="h-full overflow-y-auto">
-        <ul className="divide-y divide-line-glass/10">
+        <ul className="divide-y divide-line-subtle">
           {sortedPendingInvitations.map((invitation) => {
             const isSelected = invitation.id === selectedPendingInvitationFromList?.id;
             const roleLabel = getPracticeRoleLabel(normalizePracticeRole(invitation.role) ?? 'client');

--- a/src/features/engagements/api/engagementsApi.ts
+++ b/src/features/engagements/api/engagementsApi.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types/engagement';
 import { encodeSegment } from '@/config/urls';
 import { apiClient, isHttpError } from '@/shared/lib/apiClient';
+import { queryCache } from '@/shared/lib/queryCache';
 
 // ── Engagement statuses that belong in the engagement feature ──────────────────
 export const ENGAGEMENT_STATUSES: EngagementStatus[] = [
@@ -34,6 +35,12 @@ type EngagementContractListPayload = {
 
 type CreateEngagementContractPayload = {
   intake_id: string;
+  contract_body?: string;
+  engagement_notes?: string;
+  proposal_data?: ProposalData;
+};
+
+type PatchEngagementContractPayload = {
   contract_body?: string;
   engagement_notes?: string;
   proposal_data?: ProposalData;
@@ -118,6 +125,17 @@ const normalizeEngagementContract = (raw: unknown): EngagementDetail => {
     created_at: requireString(data, 'created_at'),
     updated_at: optionalString(data.updated_at),
   };
+};
+
+const invalidateEngagementLifecycleCaches = (practiceId: string, engagement?: EngagementDetail | null) => {
+  queryCache.invalidate(`engagement:${practiceId}:`, true);
+  queryCache.invalidate(`matters:${practiceId}:`, true);
+  queryCache.invalidate(`sidebar:counts:${practiceId}`, true);
+  queryCache.invalidate('sidebar:counts:', true);
+  queryCache.invalidate(`files:${practiceId}:`, true);
+  if (engagement?.matter_id) {
+    queryCache.invalidate(`matter:files:${practiceId}:${engagement.matter_id}`);
+  }
 };
 
 // ── List engagements for a practice ──────────────────────────────────────────
@@ -206,7 +224,9 @@ export async function createEngagementContract(
     throw mutationError(error, 'Failed to create engagement');
   }
 
-  return normalizeEngagementContract(raw);
+  const engagement = normalizeEngagementContract(raw);
+  invalidateEngagementLifecycleCaches(practiceId, engagement);
+  return engagement;
 }
 
 export async function getEngagement(
@@ -278,13 +298,22 @@ export async function getEngagementForMatter(
   return null;
 }
 
-// ── Patch proposal_data ────────────────────────────────────────────────────────
-// Always sends the full proposal_data object — never partial updates.
+// ── Patch draft contract ────────────────────────────────────────────────────────
+// Always sends the full proposal_data object when proposal_data changes.
 
 export async function patchEngagementProposal(
   practiceId: string,
   contractId: string,
   proposalData: ProposalData,
+  options: { signal?: AbortSignal } = {}
+): Promise<EngagementDetail> {
+  return patchEngagementContract(practiceId, contractId, { proposal_data: proposalData }, options);
+}
+
+export async function patchEngagementContract(
+  practiceId: string,
+  contractId: string,
+  payload: PatchEngagementContractPayload,
   options: { signal?: AbortSignal } = {}
 ): Promise<EngagementDetail> {
   if (!practiceId) throw new Error('practiceId is required');
@@ -294,15 +323,17 @@ export async function patchEngagementProposal(
   try {
     const result = await apiClient.patch<unknown>(
       `/api/engagement-contracts/${encodeSegment(practiceId)}/${encodeSegment(contractId)}`,
-      { proposal_data: proposalData },
+      payload,
       { signal: options.signal },
     );
     raw = result.data;
   } catch (error) {
-    throw mutationError(error, 'Failed to update proposal');
+    throw mutationError(error, 'Failed to update engagement');
   }
 
-  return normalizeEngagementContract(raw);
+  const engagement = normalizeEngagementContract(raw);
+  invalidateEngagementLifecycleCaches(practiceId, engagement);
+  return engagement;
 }
 
 // ── Send to client ─────────────────────────────────────────────────────────────
@@ -316,13 +347,20 @@ export async function sendEngagementToClient(
   if (!practiceId) throw new Error('practiceId is required');
   if (!contractId) throw new Error('contractId is required');
 
+  if (note?.trim()) {
+    await patchEngagementContract(
+      practiceId,
+      contractId,
+      { engagement_notes: note.trim() },
+      { signal: options.signal },
+    );
+  }
+
   let raw: unknown;
   try {
-    const patchPayload: Record<string, unknown> = { status: 'sent' };
-    if (note?.trim()) patchPayload.engagement_notes = note.trim();
     const result = await apiClient.patch<unknown>(
-      `/api/engagement-contracts/${encodeSegment(practiceId)}/${encodeSegment(contractId)}`,
-      patchPayload,
+      `/api/engagement-contracts/${encodeSegment(practiceId)}/${encodeSegment(contractId)}/status`,
+      { status: 'sent' },
       { signal: options.signal },
     );
     raw = result.data;
@@ -330,7 +368,9 @@ export async function sendEngagementToClient(
     throw mutationError(error, 'Failed to send engagement');
   }
 
-  return normalizeEngagementContract(raw);
+  const engagement = normalizeEngagementContract(raw);
+  invalidateEngagementLifecycleCaches(practiceId, engagement);
+  return engagement;
 }
 
 // ── Mark proposal declined ─────────────────────────────────────────────────────
@@ -355,7 +395,9 @@ export async function declineEngagement(
     throw mutationError(error, 'Failed to decline engagement');
   }
 
-  return normalizeEngagementContract(raw);
+  const engagement = normalizeEngagementContract(raw);
+  invalidateEngagementLifecycleCaches(practiceId, engagement);
+  return engagement;
 }
 
 // ── Client: accept engagement ──────────────────────────────────────────────────
@@ -380,7 +422,9 @@ export async function acceptEngagement(
     throw mutationError(error, 'Failed to accept engagement');
   }
 
-  return normalizeEngagementContract(raw);
+  const engagement = normalizeEngagementContract(raw);
+  invalidateEngagementLifecycleCaches(practiceId, engagement);
+  return engagement;
 }
 
 // ── Staff: override conflict check ────────────────────────────────────────────

--- a/src/features/engagements/components/EngagementDetailSkeleton.tsx
+++ b/src/features/engagements/components/EngagementDetailSkeleton.tsx
@@ -1,7 +1,7 @@
 import { SkeletonLoader } from '@/shared/ui/layout';
 
 const SectionCardSkeleton = ({ rows = 3, chips = 0 }: { rows?: number; chips?: number }) => (
-  <section className="glass-card p-5 sm:p-6 space-y-4">
+  <section className="card p-5 sm:p-6 space-y-4">
     <header className="flex items-center gap-2">
       <SkeletonLoader variant="text" width="w-32" height="h-3" />
     </header>
@@ -26,7 +26,7 @@ const SectionCardSkeleton = ({ rows = 3, chips = 0 }: { rows?: number; chips?: n
 );
 
 const ConversationCardCollapsedSkeleton = () => (
-  <section className="glass-card p-5 sm:p-6 flex items-center justify-between gap-3">
+  <section className="card p-5 sm:p-6 flex items-center justify-between gap-3">
     <div className="flex items-center gap-3 min-w-0">
       <SkeletonLoader variant="text" width="w-24" height="h-3" />
       <SkeletonLoader variant="text" width="w-16" height="h-3" />

--- a/src/features/engagements/pages/ClientEngagementReviewPage.tsx
+++ b/src/features/engagements/pages/ClientEngagementReviewPage.tsx
@@ -227,7 +227,7 @@ const DocumentStatusCard: FunctionComponent<{
   ];
 
   return (
-    <section className="glass-card p-5 space-y-3">
+    <section className="card p-5 space-y-3">
       <header className="flex items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-input-text">Document Status</h3>
         <span className={cn(
@@ -258,7 +258,7 @@ const SignaturePanel: FunctionComponent<{
   onAgreementChange: (checked: boolean) => void;
   disabled: boolean;
 }> = ({ signatureData, agreementChecked, onSignatureChange, onAgreementChange, disabled }) => (
-  <section className="glass-card p-5 space-y-3">
+  <section className="card p-5 space-y-3">
     <h3 className="text-sm font-semibold text-input-text">Your Signature</h3>
     <SignaturePad onChange={onSignatureChange} disabled={disabled} />
     <Checkbox
@@ -284,6 +284,7 @@ const EngagementLetter: FunctionComponent<{
   practiceName: string;
 }> = ({ engagement, proposal, practiceName }) => {
   const clientName = proposal?.client_summary?.client_name ?? engagement.client_name ?? 'Client';
+  const contractBody = engagement.contract_body?.trim();
   const scope = proposal?.representation?.scope_summary;
   const includedServices = proposal?.representation?.included_services ?? [];
   const feeParagraph = buildFeesParagraph(proposal?.fees);
@@ -292,7 +293,7 @@ const EngagementLetter: FunctionComponent<{
 
   return (
     <article className="rounded-2xl border border-card-border bg-surface-card p-6 sm:p-10 space-y-6 leading-relaxed text-input-text">
-      <header className="text-center space-y-2 border-b border-line-glass/20 pb-6">
+      <header className="text-center space-y-2 border-b border-line-subtle pb-6">
         <h1 className="text-xl font-bold uppercase tracking-widest">Engagement Letter</h1>
         <p className="text-sm font-medium">{practiceName}</p>
         <p className="text-xs uppercase tracking-wider text-input-placeholder">
@@ -302,6 +303,10 @@ const EngagementLetter: FunctionComponent<{
 
       <p className="text-sm">Dear {clientName},</p>
 
+      {contractBody ? (
+        <div className="whitespace-pre-wrap text-sm leading-relaxed">{contractBody}</div>
+      ) : (
+        <>
       <p className="text-sm">
         This letter confirms the terms of engagement between you and {practiceName} for legal representation
         in the matter described below. Please review the terms carefully and sign below to indicate your
@@ -342,8 +347,10 @@ const EngagementLetter: FunctionComponent<{
           <p className="text-sm">{noGuarantee}</p>
         </section>
       )}
+        </>
+      )}
 
-      <footer className="border-t border-line-glass/20 pt-6 text-sm">
+      <footer className="border-t border-line-subtle pt-6 text-sm">
         <p>Sincerely,</p>
         <p className="mt-3 font-medium">{practiceName}</p>
       </footer>
@@ -400,16 +407,18 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
     if (!signatureData || !agreementChecked) return;
     setIsAccepting(true);
     try {
-      await acceptEngagement(practiceId, engagement.id);
+      const updated = await acceptEngagement(practiceId, engagement.id);
+      if (!updated.matter_id) {
+        throw new Error('Engagement was accepted, but the backend response did not include a matter_id.');
+      }
       if (!isMountedRef.current) return;
       setAcceptedClick(true);
       showSuccess('Engagement signed', 'Your engagement is confirmed. Redirecting…');
-      if (engagement.conversation_id && conversationsBasePath) {
+      const conversationId = updated.conversation_id ?? engagement.conversation_id;
+      if (conversationId && conversationsBasePath) {
         navigationTimeoutRef.current = setTimeout(() => {
           if (!isMountedRef.current) return;
-          if (engagement.conversation_id) {
-            navigate(`${conversationsBasePath}/${encodeURIComponent(engagement.conversation_id)}`);
-          }
+          navigate(`${conversationsBasePath}/${encodeURIComponent(conversationId)}`);
         }, 1200);
       }
     } catch (err) {
@@ -441,7 +450,7 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
   if (loadError || !engagement) {
     return (
       <div className="min-h-dvh flex flex-col items-center justify-center p-6">
-        <div className="glass-card max-w-md w-full p-8 text-center space-y-4">
+        <div className="card max-w-md w-full p-8 text-center space-y-4">
           <AlertTriangle className="w-10 h-10 text-rose-400 mx-auto" />
           <h1 className="text-lg font-bold text-input-text">Unable to load engagement</h1>
           <p className="text-sm text-input-placeholder">{loadError ?? 'This engagement could not be found.'}</p>
@@ -504,7 +513,7 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
               />
             )}
             {accepted ? (
-              <div className="glass-card p-5 space-y-2 text-center">
+              <div className="card p-5 space-y-2 text-center">
                 <CheckCircle2 className="mx-auto h-8 w-8 text-emerald-500" />
                 <p className="text-sm font-semibold text-emerald-600 dark:text-emerald-300">Engagement signed</p>
                 <p className="text-xs text-input-placeholder">

--- a/src/features/engagements/pages/EngagementDetailPage.tsx
+++ b/src/features/engagements/pages/EngagementDetailPage.tsx
@@ -32,7 +32,7 @@ import type { ChatMessageUI } from '../../../../worker/types';
 import { EngagementDetailSkeleton } from '../components/EngagementDetailSkeleton';
 import {
   declineEngagement,
-  patchEngagementProposal,
+  patchEngagementContract,
   sendEngagementToClient,
 } from '../api/engagementsApi';
 import type {
@@ -48,7 +48,7 @@ import { useEngagementDetail } from '../hooks/useEngagementDetail';
 
 const STATUS_VARIANTS: Record<EngagementStatus, { label: string; className: string }> = {
   draft:    { label: 'Draft',    className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' },
-  sent:     { label: 'Sent',     className: 'bg-surface-overlay/60 text-input-placeholder ring-line-glass/30' },
+  sent:     { label: 'Sent',     className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' },
   accepted: { label: 'Accepted', className: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300' },
   declined: { label: 'Declined', className: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300' },
 };
@@ -66,8 +66,8 @@ const CONFLICT_VARIANTS: Record<ConflictStatus, { label: string; className: stri
   clear:             { label: 'Clear',             className: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300' },
   review_required:   { label: 'Review Required',   className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' },
   conflicted:        { label: 'Conflicted',        className: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300' },
-  unknown:           { label: 'Unknown',           className: 'bg-surface-overlay/60 text-input-placeholder ring-line-glass/30' },
-  insufficient_data: { label: 'Insufficient Data', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-glass/30' },
+  unknown:           { label: 'Unknown',           className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' },
+  insufficient_data: { label: 'Insufficient Data', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' },
 };
 
 // ── Display helpers ──────────────────────────────────────────────────────────
@@ -108,7 +108,7 @@ const SectionCard: FunctionComponent<{
   className?: string;
   action?: ComponentChildren;
 }> = ({ title, children, className, action }) => (
-  <section className={cn('glass-card p-5 sm:p-6 space-y-4', className)}>
+  <section className={cn('card p-5 sm:p-6 space-y-4', className)}>
     <header className="flex items-center justify-between gap-2">
       <h3 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">{title}</h3>
       {action}
@@ -226,11 +226,23 @@ const FeeStructureCard: FunctionComponent<{ proposal: ProposalData | null }> = (
         ))}
       </dl>
       {fees.fee_notes && (
-        <p className="border-t border-line-glass/10 pt-3 text-sm text-input-text">{fees.fee_notes}</p>
+        <p className="border-t border-line-subtle pt-3 text-sm text-input-text">{fees.fee_notes}</p>
       )}
     </SectionCard>
   );
 };
+
+const ContractBodyCard: FunctionComponent<{ engagement: EngagementDetail }> = ({ engagement }) => (
+  <SectionCard title="Contract body">
+    {engagement.contract_body?.trim() ? (
+      <div className="max-h-[360px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-line-subtle bg-surface-overlay/30 p-3 text-sm leading-relaxed text-input-text">
+        {engagement.contract_body}
+      </div>
+    ) : (
+      <p className="text-sm italic text-input-placeholder">Not yet drafted</p>
+    )}
+  </SectionCard>
+);
 
 // ── View-mode right cards ────────────────────────────────────────────────────
 
@@ -450,7 +462,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
   if (isExpanded && isMobile) {
     return (
       <div className="fixed inset-0 z-40 flex flex-col bg-app-background">
-        <header className="flex items-center justify-between border-b border-card-border px-4 py-3">
+        <header className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
           <h2 className="text-base font-semibold text-input-text">Messages</h2>
           <Button variant="ghost" icon={X} onClick={onToggle} aria-label="Close conversation" />
         </header>
@@ -468,7 +480,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
           />
         </div>
         {conversationsBasePath && conversationId && (
-          <div className="border-t border-card-border p-3">
+          <div className="border-t border-line-subtle p-3">
             <Button
               variant="secondary"
               className="w-full"
@@ -483,7 +495,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
   }
 
   return (
-    <section className="glass-card overflow-hidden">
+    <section className="card overflow-hidden">
       <button
         type="button"
         onClick={onToggle}
@@ -501,7 +513,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
         {isExpanded ? <ChevronUp className="h-4 w-4 text-input-placeholder" /> : <ChevronDown className="h-4 w-4 text-input-placeholder" />}
       </button>
       {isExpanded && !isMobile && (
-        <div className="border-t border-line-glass/10">
+        <div className="border-t border-line-subtle">
           <div className="h-[320px] bg-surface-overlay/20">
             <ConversationContent
               isLoading={isLoading}
@@ -516,7 +528,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
             />
           </div>
           {conversationsBasePath && conversationId && targetPracticeId && (
-            <div className="border-t border-line-glass/10 p-3">
+            <div className="border-t border-line-subtle p-3">
               <Button
                 variant="secondary"
                 className="w-full"
@@ -579,6 +591,7 @@ const ConversationContent: FunctionComponent<{
 // ── Edit form ────────────────────────────────────────────────────────────────
 
 type EditFormState = {
+  contractBody: string;
   clientName: string;
   matterSummary: string;
   locationSummary: string;
@@ -610,6 +623,7 @@ const buildEditFormState = (engagement: EngagementDetail): EditFormState => {
   const rep = engagement.proposal_data?.representation;
   const fees = engagement.proposal_data?.fees;
   return {
+    contractBody: engagement.contract_body ?? '',
     clientName: summary?.client_name ?? engagement.client_name ?? '',
     matterSummary: summary?.matter_summary ?? '',
     locationSummary: summary?.location_summary ?? '',
@@ -703,7 +717,7 @@ const EditModeView: FunctionComponent<EditModeViewProps> = ({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="flex items-center justify-between gap-3 border-b border-card-border bg-surface-workspace px-4 py-3 sm:px-6">
+      <header className="flex items-center justify-between gap-3 border-b border-line-subtle bg-surface-workspace px-4 py-3 sm:px-6">
         <Button variant="ghost" icon={X} onClick={onCancel} disabled={saving} aria-label="Cancel" />
         <h1 className="text-base font-semibold text-input-text">Edit engagement</h1>
         <div className="flex items-center gap-2">
@@ -723,6 +737,16 @@ const EditModeView: FunctionComponent<EditModeViewProps> = ({
               {saveError}
             </div>
           )}
+
+          <SectionCard title="Contract body">
+            <Textarea
+              label="Engagement contract"
+              value={form.contractBody}
+              onChange={(v) => update('contractBody', v)}
+              rows={12}
+              disabled={saving}
+            />
+          </SectionCard>
 
           <SectionCard title="Client information">
             <div className="space-y-3">
@@ -912,7 +936,11 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
   const persistProposalChanges = useCallback(async (form: EditFormState): Promise<EngagementDetail | null> => {
     if (!engagement || !practiceId) return null;
     const merged = mergeEditFormIntoProposal(engagement, form);
-    const updated = await patchEngagementProposal(practiceId, engagement.id, merged);
+    const updated = await patchEngagementContract(practiceId, engagement.id, {
+      contract_body: form.contractBody.trim(),
+      engagement_notes: form.engagementNotes.trim(),
+      proposal_data: merged,
+    });
     if (isMountedRef.current) {
       setEngagementCache(updated);
     }
@@ -940,6 +968,10 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
 
   const handleReviewAndSend = useCallback(async (form: EditFormState) => {
     if (isSaving) return;
+    if (!form.contractBody.trim()) {
+      setSaveError('Contract body is required before sending.');
+      return;
+    }
     setIsSaving(true);
     setSaveError(null);
     try {
@@ -1034,7 +1066,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
       <div className="flex h-full flex-col min-h-0">
         <DetailHeader title="Engagement" showBack onBack={onBack} />
         <div className="p-6">
-          <div className="glass-card p-6 text-sm text-rose-400">
+          <div className="card p-6 text-sm text-rose-400">
             {loadError ?? 'Engagement not found.'}
           </div>
         </div>
@@ -1059,6 +1091,10 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
   const clientName = engagement.client_name || 'Unknown Client';
   const matterLabel = getMatterDisplay(engagement);
   const detailTitle = matterLabel !== '—' ? `${clientName} — ${matterLabel}` : clientName;
+  const canSendEngagement = Boolean(engagement.contract_body?.trim());
+  const createdMatterPath = engagement.matter_id
+    ? `${basePath.replace(/\/engagements$/, '/matters')}/${encodeURIComponent(engagement.matter_id)}`
+    : null;
 
   const headerActions = (
     <div className="flex items-center gap-2">
@@ -1068,7 +1104,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
         </Button>
       )}
       {isDraft && (
-        <Button variant="primary" icon={Send} onClick={() => openDialog('send')} disabled={isSubmitting}>
+        <Button variant="primary" icon={Send} onClick={() => openDialog('send')} disabled={isSubmitting || !canSendEngagement}>
           <span className="hidden sm:inline">Send to client</span>
           <span className="sm:hidden">Send</span>
         </Button>
@@ -1085,7 +1121,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
   const statusBanner = (() => {
     if (isSent) {
       return (
-        <div className="rounded-xl border border-line-glass/20 bg-surface-overlay/40 p-4 text-sm text-input-text">
+        <div className="rounded-xl border border-line-subtle bg-surface-overlay/40 p-4 text-sm text-input-text">
           <p className="font-medium">Awaiting client response</p>
           <p className="mt-1 text-input-placeholder">The client received this engagement and will accept or decline online.</p>
         </div>
@@ -1094,8 +1130,21 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
     if (isAccepted) {
       return (
         <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-300">
-          <p className="font-medium">Engagement active</p>
-          <p className="mt-1 text-emerald-700/80 dark:text-emerald-200/80">The client has accepted this engagement.</p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-medium">Engagement active</p>
+              <p className="mt-1 text-emerald-700/80 dark:text-emerald-200/80">
+                {createdMatterPath
+                  ? 'The client accepted this engagement and the matter is linked.'
+                  : 'The client accepted this engagement, but the backend response has not linked a matter_id.'}
+              </p>
+            </div>
+            {createdMatterPath ? (
+              <Button variant="secondary" size="sm" onClick={() => navigate(createdMatterPath)}>
+                View matter
+              </Button>
+            ) : null}
+          </div>
         </div>
       );
     }
@@ -1128,6 +1177,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
           <div className="flex flex-col gap-4">
             {statusBanner}
             <ClientSummaryCard engagement={engagement} />
+            <ContractBodyCard engagement={engagement} />
             <ScopeOfRepresentationCard proposal={proposal} />
             <FeeStructureCard proposal={proposal} />
           </div>

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'preact-iso';
 import { Briefcase, Plus, Search } from 'lucide-preact';
 
 import { Button } from '@/shared/ui/Button';
-import { Input, Textarea, Combobox, Switch, EmailInput, type ComboboxOption } from '@/shared/ui/input';
+import { Input, Textarea, Combobox, type ComboboxOption } from '@/shared/ui/input';
 import { Tabs, type TabItem } from '@/shared/ui/tabs/Tabs';
 import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
 import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
@@ -14,16 +14,22 @@ import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
 import { cn } from '@/shared/utils/cn';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
-import { listIntakes, type IntakeListItem } from '@/features/intake/api/intakesApi';
+import { getPracticeIntake, listIntakes, type IntakeListItem, type PracticeIntakeDetail } from '@/features/intake/api/intakesApi';
 import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
 
-import { createEngagementContract, listEngagements, sendEngagementToClient } from '../api/engagementsApi';
+import { createEngagementContract, listEngagements } from '../api/engagementsApi';
 import type {
   EngagementListItem,
   EngagementStatus,
-  ProposalData,
   ProposalFees,
 } from '../types/engagement';
+import {
+  buildDeterministicContractBody,
+  buildEngagementDraftFormFromIntake,
+  buildProposalDataFromDraft,
+  EMPTY_ENGAGEMENT_DRAFT_FORM,
+  type EngagementDraftForm,
+} from '../utils/engagementDraft';
 import EngagementDetailPage from './EngagementDetailPage';
 
 const PAGE_SIZE = 20;
@@ -47,6 +53,11 @@ const normalizeStatusFilter = (value: string | null | undefined): StatusFilter =
   return 'all';
 };
 
+const resolveQueryValue = (value: string | string[] | null | undefined): string | null => {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+};
+
 type StatusVariant = { label: string; className: string };
 
 const engagementStatusBadge = (status: EngagementStatus | string | undefined): StatusVariant => {
@@ -58,9 +69,9 @@ const engagementStatusBadge = (status: EngagementStatus | string | undefined): S
     case 'draft':
       return { label: 'Draft', className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' };
     case 'sent':
-      return { label: 'Sent', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-glass/30' };
+      return { label: 'Sent', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' };
     default:
-      return { label: '—', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-glass/30' };
+      return { label: '—', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' };
   }
 };
 
@@ -150,119 +161,37 @@ const EngagementMobileCard: FunctionComponent<{
 
 // ── Create Engagement dialog ─────────────────────────────────────────────────
 
-type FeeStructure = 'flat' | 'hourly' | 'contingency' | 'retainer';
-
-const FEE_TABS: ReadonlyArray<{ id: FeeStructure; label: string; banner: string }> = [
-  { id: 'flat', label: 'Flat fee', banner: 'Single fixed fee for the entire scope of representation.' },
-  { id: 'hourly', label: 'Hourly', banner: 'Billed against a retainer at the attorney hourly rate.' },
-  { id: 'contingency', label: 'Contingency', banner: 'Fees recovered as a percentage of any settlement or award.' },
-  { id: 'retainer', label: 'Retainer', banner: 'Recurring retainer held in trust and drawn against work performed.' },
+const BILLING_TYPE_OPTIONS: ComboboxOption[] = [
+  { value: 'fixed', label: 'Fixed fee' },
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'contingency', label: 'Contingency' },
+  { value: 'retainer', label: 'Retainer' },
+  { value: 'pro_bono', label: 'Pro bono' },
 ];
 
-// Templates surface in the dropdown but are not persisted today — the backend
-// template-rendering layer populates contract_body on send. When a templates
-// API exists, swap the static list for a fetched one.
-const TEMPLATE_OPTIONS: ComboboxOption[] = [
-  { value: 'standard', label: 'Standard Engagement Agreement' },
-  { value: 'flat-fee', label: 'Flat Fee Agreement' },
-  { value: 'hourly', label: 'Hourly Engagement Agreement' },
-  { value: 'contingency', label: 'Contingency Fee Agreement' },
-  { value: 'retainer', label: 'Retainer Agreement' },
+const RISK_STATUS_OPTIONS: ComboboxOption[] = [
+  { value: 'unknown', label: 'Unknown' },
+  { value: 'clear', label: 'Clear' },
+  { value: 'review_required', label: 'Review required' },
+  { value: 'conflicted', label: 'Conflicted' },
+  { value: 'insufficient_data', label: 'Insufficient data' },
 ];
 
-const PRACTICE_AREA_OPTIONS: ComboboxOption[] = [
-  { value: 'family', label: 'Family Law' },
-  { value: 'personal-injury', label: 'Personal Injury' },
-  { value: 'estate-planning', label: 'Estate Planning' },
-  { value: 'criminal-defense', label: 'Criminal Defense' },
-  { value: 'business', label: 'Business Law' },
+const JURISDICTION_STATUS_OPTIONS: ComboboxOption[] = [
+  { value: 'unknown', label: 'Unknown' },
+  { value: 'supported', label: 'Supported' },
+  { value: 'unsupported', label: 'Unsupported' },
 ];
 
-const JURISDICTION_OPTIONS: ComboboxOption[] = [
-  { value: 'CA', label: 'California' },
-  { value: 'NY', label: 'New York' },
-  { value: 'TX', label: 'Texas' },
-  { value: 'FL', label: 'Florida' },
-  { value: 'IL', label: 'Illinois' },
-];
+type CreateErrors = Partial<Record<keyof EngagementDraftForm, string>>;
 
-type CreateForm = {
-  intakeId: string;
-  engagementName: string;
-  practiceArea: string;
-  jurisdiction: string;
-  templateId: string;
-  feeStructure: FeeStructure;
-  flatFeeAmount: string;
-  hourlyRate: string;
-  contingencyRate: string;
-  retainerAmount: string;
-  internalNotes: string;
-  sendToClient: boolean;
-  recipientEmail: string;
-  messagePreview: string;
-};
-
-type CreateErrors = Partial<Record<keyof CreateForm, string>>;
-
-const EMPTY_FORM: CreateForm = {
-  intakeId: '',
-  engagementName: '',
-  practiceArea: '',
-  jurisdiction: '',
-  templateId: '',
-  feeStructure: 'flat',
-  flatFeeAmount: '',
-  hourlyRate: '',
-  contingencyRate: '',
-  retainerAmount: '',
-  internalNotes: '',
-  sendToClient: false,
-  recipientEmail: '',
-  messagePreview: '',
-};
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-const validateForm = (form: CreateForm): CreateErrors => {
+const validateForm = (form: EngagementDraftForm): CreateErrors => {
   const errors: CreateErrors = {};
-  if (!form.intakeId) errors.intakeId = 'Client is required';
-  if (!form.engagementName.trim()) errors.engagementName = 'Engagement name is required';
-  if (!form.templateId) errors.templateId = 'Template is required';
-  if (form.sendToClient && !EMAIL_REGEX.test(form.recipientEmail.trim())) {
-    errors.recipientEmail = 'A valid recipient email is required';
-  }
+  if (!form.intakeId) errors.intakeId = 'Accepted intake is required';
+  if (!form.matterSummary.trim()) errors.matterSummary = 'Matter summary is required';
+  if (!form.scopeSummary.trim()) errors.scopeSummary = 'Scope summary is required';
+  if (!form.contractBody.trim()) errors.contractBody = 'Contract body is required before creating an engagement';
   return errors;
-};
-
-const buildProposalData = (form: CreateForm, intake: IntakeListItem | null): ProposalData => {
-  const fees: ProposalFees = {
-    billing_type: form.feeStructure,
-    fixed_fee_amount: form.feeStructure === 'flat' && form.flatFeeAmount ? Number(form.flatFeeAmount) : null,
-    hourly_rate_attorney: form.feeStructure === 'hourly' && form.hourlyRate ? Number(form.hourlyRate) : null,
-    contingency_percentage: form.feeStructure === 'contingency' && form.contingencyRate ? Number(form.contingencyRate) : null,
-    retainer_amount: form.feeStructure === 'retainer' && form.retainerAmount ? Number(form.retainerAmount) : null,
-    fee_notes: null,
-  };
-
-  return {
-    representation: {
-      scope_summary: form.engagementName.trim(),
-    },
-    fees,
-    risk_review: {
-      conflict_status: 'unknown',
-      jurisdiction_status: 'unknown',
-    },
-    client_summary: {
-      client_name: intake?.metadata?.name?.trim() || null,
-      matter_summary: form.engagementName.trim() || null,
-    },
-    draft_meta: {
-      version: 1,
-      generated_at: new Date().toISOString(),
-    },
-  };
 };
 
 interface CreateEngagementDialogProps {
@@ -270,6 +199,7 @@ interface CreateEngagementDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onCreated: (engagementId: string) => void;
+  initialIntakeId?: string | null;
 }
 
 const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = ({
@@ -277,34 +207,34 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
   isOpen,
   onClose,
   onCreated,
+  initialIntakeId = null,
 }) => {
-  const [form, setForm] = useState<CreateForm>(EMPTY_FORM);
+  const [form, setForm] = useState<EngagementDraftForm>(EMPTY_ENGAGEMENT_DRAFT_FORM);
   const [errors, setErrors] = useState<CreateErrors>({});
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const [intakes, setIntakes] = useState<IntakeListItem[]>([]);
+  const [selectedIntakeDetail, setSelectedIntakeDetail] = useState<PracticeIntakeDetail | null>(null);
   const [isLoadingIntakes, setIsLoadingIntakes] = useState(false);
+  const [isLoadingIntakeDetail, setIsLoadingIntakeDetail] = useState(false);
   const [intakesError, setIntakesError] = useState<string | null>(null);
 
-  // Note: fee-structure tab switches inside this form must NOT clear fields —
-  // those are handled by `updateField('feeStructure', …)` which preserves all
-  // other form state.
   useDialogFormReset({
     isOpen,
     trigger: 'on-open',
     reason: 'Each open starts a fresh draft; clears any stale submit error or in-flight flag from a previously-interrupted attempt.',
     reset: () => {
-      setForm(EMPTY_FORM);
+      setForm({ ...EMPTY_ENGAGEMENT_DRAFT_FORM, intakeId: initialIntakeId ?? '' });
       setErrors({});
       setHasAttemptedSubmit(false);
       setSubmitting(false);
       setSubmitError(null);
+      setSelectedIntakeDetail(null);
     },
   });
 
-  // Fetch accepted intakes (client-side search filtering) on dialog open.
   useEffect(() => {
     if (!isOpen || !practiceId) return;
     const controller = new AbortController();
@@ -320,6 +250,12 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
       .then((result) => {
         if (controller.signal.aborted) return;
         setIntakes(result.intakes);
+        if (initialIntakeId) {
+          const selected = result.intakes.find((intake) => intake.uuid === initialIntakeId);
+          if (selected) {
+            setForm((prev) => buildEngagementDraftFormFromIntake(selected, prev));
+          }
+        }
       })
       .catch((error) => {
         if (controller.signal.aborted) return;
@@ -330,11 +266,11 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
       });
 
     return () => controller.abort();
-  }, [isOpen, practiceId]);
+  }, [initialIntakeId, isOpen, practiceId]);
 
   const selectedIntake = useMemo(
-    () => intakes.find((intake) => intake.uuid === form.intakeId) ?? null,
-    [intakes, form.intakeId],
+    () => selectedIntakeDetail ?? intakes.find((intake) => intake.uuid === form.intakeId) ?? null,
+    [intakes, form.intakeId, selectedIntakeDetail],
   );
 
   const intakeOptions = useMemo<ComboboxOption[]>(
@@ -352,16 +288,30 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
     [intakes],
   );
 
-  // Auto-fill recipient email from selected intake.
   useEffect(() => {
-    if (!selectedIntake) return;
-    const email = selectedIntake.metadata?.email?.trim();
-    if (email) {
-      setForm((prev) => (prev.recipientEmail ? prev : { ...prev, recipientEmail: email }));
+    if (!isOpen || !practiceId || !form.intakeId) {
+      setSelectedIntakeDetail(null);
+      return;
     }
-  }, [selectedIntake]);
+    const controller = new AbortController();
+    setIsLoadingIntakeDetail(true);
+    getPracticeIntake(practiceId, form.intakeId, { signal: controller.signal })
+      .then((detail) => {
+        if (controller.signal.aborted) return;
+        setSelectedIntakeDetail(detail);
+        setForm((prev) => buildEngagementDraftFormFromIntake(detail, prev));
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setSubmitError(error instanceof Error ? error.message : 'Failed to load intake details');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setIsLoadingIntakeDetail(false);
+      });
+    return () => controller.abort();
+  }, [form.intakeId, isOpen, practiceId]);
 
-  const updateField = useCallback(<K extends keyof CreateForm>(field: K, value: CreateForm[K]) => {
+  const updateField = useCallback(<K extends keyof EngagementDraftForm>(field: K, value: EngagementDraftForm[K]) => {
     setForm((prev) => ({ ...prev, [field]: value }));
     if (hasAttemptedSubmit) {
       setErrors((prev) => {
@@ -373,6 +323,20 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
     }
   }, [hasAttemptedSubmit]);
 
+  const handleIntakeChange = useCallback((value: string) => {
+    const intake = intakes.find((entry) => entry.uuid === value);
+    setSelectedIntakeDetail(null);
+    setForm((prev) => (
+      intake
+        ? buildEngagementDraftFormFromIntake(intake, { ...prev, intakeId: value, contractBody: '' })
+        : { ...prev, intakeId: value }
+    ));
+  }, [intakes]);
+
+  const refreshContractBody = useCallback(() => {
+    setForm((prev) => ({ ...prev, contractBody: buildDeterministicContractBody(prev) }));
+  }, []);
+
   const handleSubmit = useCallback(async () => {
     setHasAttemptedSubmit(true);
     setSubmitError(null);
@@ -382,22 +346,13 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
 
     setSubmitting(true);
     try {
-      const proposalData = buildProposalData(form, selectedIntake);
+      const proposalData = buildProposalDataFromDraft(form);
       const created = await createEngagementContract(practiceId, {
         intake_id: form.intakeId,
-        engagement_notes: form.internalNotes.trim() || undefined,
+        contract_body: form.contractBody.trim(),
+        engagement_notes: form.engagementNotes.trim() || undefined,
         proposal_data: proposalData,
       });
-
-      if (form.sendToClient) {
-        try {
-          await sendEngagementToClient(practiceId, created.id, form.messagePreview.trim() || undefined);
-        } catch (error) {
-          setSubmitError(error instanceof Error ? error.message : 'Engagement created, but failed to send.');
-          setSubmitting(false);
-          return;
-        }
-      }
 
       onCreated(created.id);
     } catch (error) {
@@ -405,23 +360,21 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
     } finally {
       setSubmitting(false);
     }
-  }, [form, practiceId, selectedIntake, onCreated]);
+  }, [form, practiceId, onCreated]);
 
   const handleClose = useCallback(() => {
     if (submitting) return;
     onClose();
   }, [onClose, submitting]);
 
-  const activeFeeTab = FEE_TABS.find((t) => t.id === form.feeStructure) ?? FEE_TABS[0];
-
   return (
     <Dialog
       isOpen={isOpen}
       onClose={handleClose}
       title="Create engagement"
-      description="Start a new engagement agreement from an intake. You can review and edit it before sending."
+      description="Draft an engagement contract from an accepted intake before sending it to the client."
       disableBackdropClick={submitting}
-      contentClassName="max-w-2xl"
+      contentClassName="max-w-4xl"
     >
       <DialogBody className="space-y-5">
         {submitError && (
@@ -430,21 +383,21 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
           </div>
         )}
 
-        {/* Client section */}
         <section className="space-y-2">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Client</h3>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Source intake</h3>
           {selectedIntake ? (
             <SelectedIntakeCard
               intake={selectedIntake}
+              detailLoading={isLoadingIntakeDetail}
               onClear={() => updateField('intakeId', '')}
             />
           ) : (
             <>
               <Combobox
-                placeholder={isLoadingIntakes ? 'Loading clients…' : 'Search for a client…'}
+                placeholder={isLoadingIntakes ? 'Loading accepted intakes…' : 'Search accepted intakes…'}
                 options={intakeOptions}
                 value={form.intakeId}
-                onChange={(value) => updateField('intakeId', value)}
+                onChange={handleIntakeChange}
                 disabled={submitting || isLoadingIntakes}
                 searchable
               />
@@ -454,124 +407,146 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
           {intakesError && <p className="text-sm text-rose-400">{intakesError}</p>}
         </section>
 
-        {/* Engagement details */}
-        <section className="space-y-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Engagement details</h3>
+        <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <Input
-            label="Engagement name"
-            placeholder="e.g., Personal Injury Representation Agreement"
-            value={form.engagementName}
-            onChange={(value) => updateField('engagementName', value)}
+            label="Client name"
+            value={form.clientName}
+            onChange={(value) => updateField('clientName', value)}
             disabled={submitting}
-            error={errors.engagementName}
+          />
+          <Input
+            label="Practice area"
+            value={form.practiceArea}
+            onChange={(value) => updateField('practiceArea', value)}
+            disabled={submitting}
+          />
+          <Input
+            label="Matter summary"
+            value={form.matterSummary}
+            onChange={(value) => updateField('matterSummary', value)}
+            disabled={submitting}
+            error={errors.matterSummary}
+          />
+          <Input
+            label="Location summary"
+            value={form.locationSummary}
+            onChange={(value) => updateField('locationSummary', value)}
+            disabled={submitting}
+          />
+        </section>
+
+        <section className="space-y-3">
+          <Textarea
+            label="Goals summary"
+            value={form.goalsSummary}
+            onChange={(value) => updateField('goalsSummary', value)}
+            rows={2}
+            disabled={submitting}
+          />
+          <Textarea
+            label="Scope summary"
+            value={form.scopeSummary}
+            onChange={(value) => updateField('scopeSummary', value)}
+            rows={3}
+            disabled={submitting}
+            error={errors.scopeSummary}
+          />
+          <Textarea
+            label="Included services (one per line)"
+            value={form.includedServices}
+            onChange={(value) => updateField('includedServices', value)}
+            rows={3}
+            disabled={submitting}
+          />
+          <Textarea
+            label="Excluded services (one per line)"
+            value={form.excludedServices}
+            onChange={(value) => updateField('excludedServices', value)}
+            rows={3}
+            disabled={submitting}
           />
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Combobox
-              label="Practice area"
-              placeholder="Select practice area"
-              options={PRACTICE_AREA_OPTIONS}
-              value={form.practiceArea}
-              onChange={(value) => updateField('practiceArea', value)}
+            <Textarea
+              label="Client identity notes"
+              value={form.clientIdentityNotes}
+              onChange={(value) => updateField('clientIdentityNotes', value)}
+              rows={2}
               disabled={submitting}
-              searchable
             />
-            <Combobox
-              label="Jurisdiction"
-              placeholder="Select state"
-              options={JURISDICTION_OPTIONS}
-              value={form.jurisdiction}
-              onChange={(value) => updateField('jurisdiction', value)}
+            <Textarea
+              label="Jurisdiction notes"
+              value={form.jurisdictionNotes}
+              onChange={(value) => updateField('jurisdictionNotes', value)}
+              rows={2}
               disabled={submitting}
-              searchable
             />
-          </div>
-          <div>
-            <Combobox
-              label="Template"
-              placeholder="Select a template…"
-              options={TEMPLATE_OPTIONS}
-              value={form.templateId}
-              onChange={(value) => updateField('templateId', value)}
-              disabled={submitting}
-              searchable
-            />
-            {errors.templateId && <p className="mt-1 text-xs text-rose-400">{errors.templateId}</p>}
           </div>
         </section>
 
-        {/* Fee structure */}
         <section className="space-y-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Fee structure</h3>
-          <Tabs
-            items={FEE_TABS.map((t) => ({ id: t.id, label: t.label }))}
-            activeId={form.feeStructure}
-            onChange={(id) => updateField('feeStructure', id as FeeStructure)}
-          />
-          <div className="rounded-lg border border-card-border bg-surface-card px-3 py-2 text-xs text-input-placeholder">
-            {activeFeeTab.banner}
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Fees</h3>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <Combobox label="Billing type" options={BILLING_TYPE_OPTIONS} value={form.billingType} onChange={(value) => updateField('billingType', value)} disabled={submitting} />
+            <Input label="Fixed fee amount" type="number" value={form.fixedFeeAmount} onChange={(value) => updateField('fixedFeeAmount', value)} disabled={submitting} />
+            <Input label="Retainer amount" type="number" value={form.retainerAmount} onChange={(value) => updateField('retainerAmount', value)} disabled={submitting} />
+            <Input label="Attorney hourly rate" type="number" value={form.hourlyRateAttorney} onChange={(value) => updateField('hourlyRateAttorney', value)} disabled={submitting} />
+            <Input label="Admin hourly rate" type="number" value={form.hourlyRateAdmin} onChange={(value) => updateField('hourlyRateAdmin', value)} disabled={submitting} />
+            <Input label="Contingency percentage" type="number" value={form.contingencyPercentage} onChange={(value) => updateField('contingencyPercentage', value)} disabled={submitting} />
           </div>
-          <FeeAmountInput
-            structure={form.feeStructure}
-            flatFee={form.flatFeeAmount}
-            hourly={form.hourlyRate}
-            contingency={form.contingencyRate}
-            retainer={form.retainerAmount}
-            disabled={submitting}
-            onChange={updateField}
-          />
+          <Input label="Payment frequency" value={form.paymentFrequency} onChange={(value) => updateField('paymentFrequency', value)} disabled={submitting} />
+          <Textarea label="Fee notes" value={form.feeNotes} onChange={(value) => updateField('feeNotes', value)} rows={2} disabled={submitting} />
         </section>
 
-        {/* Internal notes */}
-        <section className="space-y-2">
+        <section className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Risk review</h3>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Combobox label="Conflict status" options={RISK_STATUS_OPTIONS} value={form.conflictStatus} onChange={(value) => updateField('conflictStatus', value as EngagementDraftForm['conflictStatus'])} disabled={submitting} />
+            <Combobox label="Jurisdiction status" options={JURISDICTION_STATUS_OPTIONS} value={form.jurisdictionStatus} onChange={(value) => updateField('jurisdictionStatus', value as EngagementDraftForm['jurisdictionStatus'])} disabled={submitting} />
+          </div>
+          <Textarea label="Risk notes (one per line)" value={form.riskNotes} onChange={(value) => updateField('riskNotes', value)} rows={2} disabled={submitting} />
+          <Textarea label="Open questions (one per line)" value={form.openQuestions} onChange={(value) => updateField('openQuestions', value)} rows={2} disabled={submitting} />
+        </section>
+
+        <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Input label="Urgency" value={form.urgency} onChange={(value) => updateField('urgency', value)} disabled={submitting} />
+          <Input label="Court date" type="date" value={form.courtDate} onChange={(value) => updateField('courtDate', value)} disabled={submitting} />
+          <Input label="Desired outcome" value={form.desiredOutcome} onChange={(value) => updateField('desiredOutcome', value)} disabled={submitting} />
+          <Input label="Opposing party" value={form.opposingParty} onChange={(value) => updateField('opposingParty', value)} disabled={submitting} />
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Contract body</h3>
+            <Button type="button" variant="secondary" size="sm" onClick={refreshContractBody} disabled={submitting}>
+              Regenerate draft
+            </Button>
+          </div>
           <Textarea
-            label="Internal notes (optional)"
-            placeholder="Add internal notes for your team…"
-            value={form.internalNotes}
-            onChange={(value) => updateField('internalNotes', value)}
+            label="Contract body"
+            value={form.contractBody}
+            onChange={(value) => updateField('contractBody', value)}
+            rows={12}
+            disabled={submitting}
+            error={errors.contractBody}
+          />
+          <Textarea
+            label="Engagement notes"
+            value={form.engagementNotes}
+            onChange={(value) => updateField('engagementNotes', value)}
             rows={3}
             disabled={submitting}
           />
         </section>
-
-        {/* Send to client */}
-        <section className="space-y-3 border-t border-card-border pt-4">
-          <Switch
-            label="Send to client after creation"
-            value={form.sendToClient}
-            onChange={(value) => updateField('sendToClient', value)}
-            disabled={submitting}
-          />
-          {form.sendToClient && (
-            <div className="space-y-3 pl-1">
-              <EmailInput
-                label="Recipient email"
-                placeholder="client@example.com"
-                value={form.recipientEmail}
-                onChange={(value) => updateField('recipientEmail', value)}
-                disabled={submitting}
-                error={errors.recipientEmail}
-              />
-              <Textarea
-                label="Message preview"
-                placeholder="Please review the attached engagement agreement…"
-                value={form.messagePreview}
-                onChange={(value) => updateField('messagePreview', value)}
-                rows={3}
-                disabled={submitting}
-              />
-            </div>
-          )}
-        </section>
       </DialogBody>
       <DialogFooter>
         <span className="mr-auto self-center text-xs text-input-placeholder hidden sm:inline">
-          You can edit the engagement before sending.
+          Create the draft first, then review and send from the detail page.
         </span>
         <Button variant="secondary" onClick={handleClose} disabled={submitting}>
           Cancel
         </Button>
         <Button variant="primary" onClick={handleSubmit} disabled={submitting} icon={Plus}>
-          {submitting ? 'Creating…' : (form.sendToClient ? 'Create and send' : 'Create engagement')}
+          {submitting ? 'Creating…' : 'Create engagement'}
         </Button>
       </DialogFooter>
     </Dialog>
@@ -579,9 +554,10 @@ const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = (
 };
 
 const SelectedIntakeCard: FunctionComponent<{
-  intake: IntakeListItem;
+  intake: IntakeListItem | PracticeIntakeDetail;
+  detailLoading?: boolean;
   onClear: () => void;
-}> = ({ intake, onClear }) => {
+}> = ({ intake, detailLoading = false, onClear }) => {
   const name = intake.metadata?.name?.trim() || 'Anonymous lead';
   const email = intake.metadata?.email?.trim() || '';
   const subject = resolveIntakeTitle(intake.metadata, '');
@@ -591,6 +567,7 @@ const SelectedIntakeCard: FunctionComponent<{
         <p className="truncate font-medium text-input-text">{name}</p>
         <p className="truncate text-sm text-input-placeholder">{email}</p>
         {subject && <p className="mt-1 truncate text-xs text-input-placeholder">{subject}</p>}
+        {detailLoading ? <p className="mt-1 text-xs text-input-placeholder">Loading intake details…</p> : null}
       </div>
       <button
         type="button"
@@ -600,63 +577,6 @@ const SelectedIntakeCard: FunctionComponent<{
         Change
       </button>
     </div>
-  );
-};
-
-const FeeAmountInput: FunctionComponent<{
-  structure: FeeStructure;
-  flatFee: string;
-  hourly: string;
-  contingency: string;
-  retainer: string;
-  disabled: boolean;
-  onChange: <K extends keyof CreateForm>(field: K, value: CreateForm[K]) => void;
-}> = ({ structure, flatFee, hourly, contingency, retainer, disabled, onChange }) => {
-  if (structure === 'flat') {
-    return (
-      <Input
-        label="Flat fee amount"
-        placeholder="$0"
-        type="number"
-        value={flatFee}
-        onChange={(value) => onChange('flatFeeAmount', value)}
-        disabled={disabled}
-      />
-    );
-  }
-  if (structure === 'hourly') {
-    return (
-      <Input
-        label="Hourly rate"
-        placeholder="$0 / hour"
-        type="number"
-        value={hourly}
-        onChange={(value) => onChange('hourlyRate', value)}
-        disabled={disabled}
-      />
-    );
-  }
-  if (structure === 'contingency') {
-    return (
-      <Input
-        label="Contingency rate"
-        placeholder="0%"
-        type="number"
-        value={contingency}
-        onChange={(value) => onChange('contingencyRate', value)}
-        disabled={disabled}
-      />
-    );
-  }
-  return (
-    <Input
-      label="Retainer amount"
-      placeholder="$0"
-      type="number"
-      value={retainer}
-      onChange={(value) => onChange('retainerAmount', value)}
-      disabled={disabled}
-    />
   );
 };
 
@@ -686,6 +606,9 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
   const pathSegments = pathSuffix.replace(/^\/+/, '').split('/').filter(Boolean);
   const selectedEngagementId = pathSegments[0] ? decodeURIComponent(pathSegments[0]) : null;
   const detailMode: 'view' | 'edit' = pathSegments[1] === 'edit' ? 'edit' : 'view';
+  const queryCreate = resolveQueryValue(location.query?.create);
+  const queryIntakeId = resolveQueryValue(location.query?.intakeId);
+  const shouldOpenCreateFromQuery = !selectedEngagementId && (queryCreate === '1' || Boolean(queryIntakeId));
 
   // Tab state — initialized from sidebar prop, page-internal tabs take over.
   const sidebarTab = normalizeStatusFilter(activeStatusFilter);
@@ -705,6 +628,12 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
   // Create dialog
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [refreshCounter, setRefreshCounter] = useState(0);
+
+  useEffect(() => {
+    if (shouldOpenCreateFromQuery) {
+      setIsCreateDialogOpen(true);
+    }
+  }, [shouldOpenCreateFromQuery]);
 
   const {
     items: engagements,
@@ -752,7 +681,10 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
 
   const handleCloseCreate = useCallback(() => {
     setIsCreateDialogOpen(false);
-  }, []);
+    if (shouldOpenCreateFromQuery) {
+      location.route(basePath, true);
+    }
+  }, [basePath, location, shouldOpenCreateFromQuery]);
 
   const handleEngagementCreated = useCallback((engagementId: string) => {
     setIsCreateDialogOpen(false);
@@ -817,7 +749,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
   return (
     <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
       {/* Desktop header */}
-      <header className="hidden md:flex items-center justify-between gap-4 border-b border-card-border px-6 py-5">
+      <header className="hidden md:flex items-center justify-between gap-4 border-b border-line-subtle px-6 py-5">
         <h1 className="text-xl font-semibold text-input-text">Engagements</h1>
         <div className="flex items-center gap-3">
           <div className="w-72">
@@ -842,7 +774,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
       </header>
 
       {/* Tab row (desktop + mobile) */}
-      <div className="border-b border-card-border bg-surface-workspace">
+      <div className="border-b border-line-subtle bg-surface-workspace">
         <Tabs
           items={tabItems}
           activeId={activeTab}
@@ -852,7 +784,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
       </div>
 
       {/* Mobile search */}
-      <div className="md:hidden px-4 py-3 border-b border-card-border">
+      <div className="md:hidden px-4 py-3 border-b border-line-subtle">
         <Input
           type="search"
           placeholder="Search engagements…"
@@ -940,6 +872,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
           isOpen={isCreateDialogOpen}
           onClose={handleCloseCreate}
           onCreated={handleEngagementCreated}
+          initialIntakeId={queryIntakeId}
         />
       )}
     </div>

--- a/src/features/engagements/types/engagement.ts
+++ b/src/features/engagements/types/engagement.ts
@@ -97,6 +97,7 @@ export interface EngagementListItem {
   conversation_id?: string | null;
   organization_id: string;
   contract_body?: string | null;
+  billing_snapshot?: unknown | null;
   engagement_notes?: string | null;
   sent_at?: string | null;
   accepted_at?: string | null;

--- a/src/features/engagements/utils/engagementDraft.ts
+++ b/src/features/engagements/utils/engagementDraft.ts
@@ -1,0 +1,228 @@
+import type { IntakeListItem, PracticeIntakeDetail } from '@/features/intake/api/intakesApi';
+import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
+import type { ProposalData, ProposalFees } from '@/features/engagements/types/engagement';
+
+export type EngagementDraftForm = {
+  intakeId: string;
+  contractBody: string;
+  engagementNotes: string;
+  clientName: string;
+  matterSummary: string;
+  locationSummary: string;
+  goalsSummary: string;
+  scopeSummary: string;
+  includedServices: string;
+  excludedServices: string;
+  clientIdentityNotes: string;
+  jurisdictionNotes: string;
+  billingType: string;
+  fixedFeeAmount: string;
+  hourlyRateAttorney: string;
+  hourlyRateAdmin: string;
+  contingencyPercentage: string;
+  retainerAmount: string;
+  paymentFrequency: string;
+  feeNotes: string;
+  conflictStatus: ProposalData['risk_review']['conflict_status'];
+  jurisdictionStatus: ProposalData['risk_review']['jurisdiction_status'];
+  riskNotes: string;
+  openQuestions: string;
+  practiceArea: string;
+  urgency: string;
+  desiredOutcome: string;
+  opposingParty: string;
+  courtDate: string;
+  conversationId: string;
+};
+
+type IntakeLike = IntakeListItem | PracticeIntakeDetail;
+
+export const EMPTY_ENGAGEMENT_DRAFT_FORM: EngagementDraftForm = {
+  intakeId: '',
+  contractBody: '',
+  engagementNotes: '',
+  clientName: '',
+  matterSummary: '',
+  locationSummary: '',
+  goalsSummary: '',
+  scopeSummary: '',
+  includedServices: '',
+  excludedServices: '',
+  clientIdentityNotes: '',
+  jurisdictionNotes: '',
+  billingType: '',
+  fixedFeeAmount: '',
+  hourlyRateAttorney: '',
+  hourlyRateAdmin: '',
+  contingencyPercentage: '',
+  retainerAmount: '',
+  paymentFrequency: '',
+  feeNotes: '',
+  conflictStatus: 'unknown',
+  jurisdictionStatus: 'unknown',
+  riskNotes: '',
+  openQuestions: '',
+  practiceArea: '',
+  urgency: '',
+  desiredOutcome: '',
+  opposingParty: '',
+  courtDate: '',
+  conversationId: '',
+};
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+
+const stringValue = (value: unknown): string => (
+  typeof value === 'string' ? value.trim() : ''
+);
+
+const nullableString = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const numberOrNull = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const lines = (value: string): string[] | null => {
+  const entries = value
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return entries.length > 0 ? entries : null;
+};
+
+const firstString = (...values: unknown[]): string => {
+  for (const value of values) {
+    const resolved = stringValue(value);
+    if (resolved) return resolved;
+  }
+  return '';
+};
+
+export const buildEngagementDraftFormFromIntake = (
+  intake: IntakeLike,
+  current: EngagementDraftForm = EMPTY_ENGAGEMENT_DRAFT_FORM,
+): EngagementDraftForm => {
+  const metadata = asRecord(intake.metadata);
+  const customFields = asRecord(metadata.custom_fields ?? metadata.customFields);
+  const address = asRecord(metadata.address);
+  const locationSummary = [
+    stringValue(address.city),
+    stringValue(address.state),
+  ].filter(Boolean).join(', ');
+  const matterSummary = resolveIntakeTitle(metadata, firstString(metadata.description, metadata.title, metadata.intake_title, ''));
+  const desiredOutcome = firstString((intake as PracticeIntakeDetail).desired_outcome, metadata.desired_outcome);
+  const practiceArea = firstString((intake as PracticeIntakeDetail).practice_area, metadata.practice_area, metadata.practice_service_uuid, customFields.practice_area);
+  const urgency = firstString((intake as PracticeIntakeDetail).urgency, metadata.urgency);
+  const opposingParty = firstString(metadata.opposing_party, customFields.opposing_party);
+  const courtDate = firstString((intake as PracticeIntakeDetail).court_date, metadata.court_date, customFields.court_date);
+
+  const next: EngagementDraftForm = {
+    ...current,
+    intakeId: intake.uuid,
+    clientName: firstString(metadata.name, (intake as PracticeIntakeDetail).client_name, current.clientName),
+    matterSummary: current.matterSummary || matterSummary,
+    locationSummary: current.locationSummary || locationSummary,
+    goalsSummary: current.goalsSummary || desiredOutcome,
+    scopeSummary: current.scopeSummary || matterSummary,
+    practiceArea: current.practiceArea || practiceArea,
+    urgency: current.urgency || urgency,
+    desiredOutcome: current.desiredOutcome || desiredOutcome,
+    opposingParty: current.opposingParty || opposingParty,
+    courtDate: current.courtDate || courtDate,
+    conversationId: current.conversationId || firstString(intake.conversation_id, metadata.conversation_id),
+  };
+
+  return {
+    ...next,
+    contractBody: current.contractBody || buildDeterministicContractBody(next),
+  };
+};
+
+export const buildProposalDataFromDraft = (form: EngagementDraftForm): ProposalData => {
+  const fees: ProposalFees = {
+    billing_type: nullableString(form.billingType),
+    fixed_fee_amount: numberOrNull(form.fixedFeeAmount),
+    hourly_rate_attorney: numberOrNull(form.hourlyRateAttorney),
+    hourly_rate_admin: numberOrNull(form.hourlyRateAdmin),
+    contingency_percentage: numberOrNull(form.contingencyPercentage),
+    retainer_amount: numberOrNull(form.retainerAmount),
+    payment_frequency: nullableString(form.paymentFrequency),
+    fee_notes: nullableString(form.feeNotes),
+  };
+
+  return {
+    client_summary: {
+      client_name: nullableString(form.clientName),
+      matter_summary: nullableString(form.matterSummary),
+      location_summary: nullableString(form.locationSummary),
+      goals_summary: nullableString(form.goalsSummary),
+    },
+    representation: {
+      scope_summary: form.scopeSummary.trim(),
+      included_services: lines(form.includedServices),
+      excluded_services: lines(form.excludedServices),
+      client_identity_notes: nullableString(form.clientIdentityNotes),
+      jurisdiction_notes: nullableString(form.jurisdictionNotes),
+    },
+    fees,
+    risk_review: {
+      conflict_status: form.conflictStatus,
+      jurisdiction_status: form.jurisdictionStatus,
+      risk_notes: lines(form.riskNotes),
+      open_questions: lines(form.openQuestions),
+    },
+    source_snapshot: {
+      intake_uuid: nullableString(form.intakeId),
+      conversation_id: nullableString(form.conversationId),
+      matter_id: null,
+      practice_area: nullableString(form.practiceArea),
+      urgency: nullableString(form.urgency),
+      desired_outcome: nullableString(form.desiredOutcome),
+      opposing_party: nullableString(form.opposingParty),
+      court_date: nullableString(form.courtDate),
+    },
+    draft_meta: {
+      generated_at: new Date().toISOString(),
+      generated_by: 'staff',
+      version: 1,
+    },
+  };
+};
+
+export const buildDeterministicContractBody = (form: EngagementDraftForm): string => {
+  const clientName = form.clientName.trim() || 'Client';
+  const matterSummary = form.matterSummary.trim() || 'the legal matter described in the intake';
+  const scopeSummary = form.scopeSummary.trim() || matterSummary;
+  const goalsSummary = form.goalsSummary.trim();
+  const feeNotes = form.feeNotes.trim();
+  const included = lines(form.includedServices);
+  const excluded = lines(form.excludedServices);
+
+  return [
+    `Engagement Letter for ${clientName}`,
+    '',
+    `This engagement letter confirms the proposed representation for ${matterSummary}.`,
+    '',
+    'Scope of Representation',
+    scopeSummary,
+    included ? `Included services:\n${included.map((item) => `- ${item}`).join('\n')}` : '',
+    excluded ? `Excluded services:\n${excluded.map((item) => `- ${item}`).join('\n')}` : '',
+    goalsSummary ? `Client goals:\n${goalsSummary}` : '',
+    '',
+    'Fees and Billing',
+    feeNotes || 'Fee terms will be governed by the billing details in this engagement agreement.',
+    '',
+    'Client Acknowledgment',
+    'By accepting this engagement, the client confirms they have reviewed the scope, billing terms, and responsibilities described in this agreement.',
+    '',
+    'No Guarantee',
+    'The practice will provide legal services diligently and professionally, but no outcome is guaranteed.',
+  ].filter((part) => part.trim().length > 0).join('\n\n');
+};

--- a/src/features/files/components/FileDetailDrawer.tsx
+++ b/src/features/files/components/FileDetailDrawer.tsx
@@ -142,7 +142,7 @@ export const FileDetailDrawer = ({ file, isOpen, onClose }: FileDetailDrawerProp
           <div className="flex-1 overflow-y-auto px-4 py-6">
             <FileDetailContent file={file} />
           </div>
-          <div className="border-t border-line-glass/30 px-4 py-3">
+          <div className="border-t border-line-subtle px-4 py-3">
             <Actions file={file} onClose={onClose} />
           </div>
         </div>

--- a/src/features/files/components/FilesCollectionPanel.tsx
+++ b/src/features/files/components/FilesCollectionPanel.tsx
@@ -1,0 +1,157 @@
+import type { ComponentChildren } from 'preact';
+import { useState } from 'preact/hooks';
+
+import { UploadDropzone } from '@/shared/ui/upload/organisms/UploadDropzone';
+import { UploadQueueRow } from '@/shared/ui/upload/molecules/UploadQueueRow';
+import { cn } from '@/shared/utils/cn';
+
+import { FilesGrid } from './FilesGrid';
+import { FilesList } from './FilesList';
+import { FilesViewToggle, type FilesViewMode } from './FilesViewToggle';
+import { FileDetailDrawer } from './FileDetailDrawer';
+import {
+  DROPZONE_INSTRUCTION_TEXT,
+  DROPZONE_VALIDATION_TEXT,
+} from '@/features/files/constants';
+import type { OrgFile } from '@/features/files/utils/fileCategory';
+
+export type FilesCollectionUpload = {
+  id: string;
+  file: File;
+  progress: number;
+};
+
+interface FilesCollectionPanelProps {
+  files: OrgFile[];
+  isLoading?: boolean;
+  header?: ComponentChildren;
+  className?: string;
+  contentClassName?: string;
+  emptyState?: ComponentChildren;
+  showEmptyState?: boolean;
+  canUpload?: boolean;
+  uploadDisabled?: boolean;
+  uploadingFiles?: FilesCollectionUpload[];
+  onFilesSelected?: (files: File[]) => void;
+  viewMode?: FilesViewMode;
+  onViewModeChange?: (mode: FilesViewMode) => void;
+  defaultViewMode?: FilesViewMode;
+  showViewToggle?: boolean;
+  onFileClick?: (file: OrgFile) => void;
+  useDetailDrawer?: boolean;
+}
+
+export const FilesCollectionPanel = ({
+  files,
+  isLoading = false,
+  header,
+  className,
+  contentClassName,
+  emptyState,
+  showEmptyState = true,
+  canUpload = false,
+  uploadDisabled = false,
+  uploadingFiles = [],
+  onFilesSelected,
+  viewMode,
+  onViewModeChange,
+  defaultViewMode = 'grid',
+  showViewToggle = true,
+  onFileClick,
+  useDetailDrawer = true,
+}: FilesCollectionPanelProps) => {
+  const [internalViewMode, setInternalViewMode] = useState<FilesViewMode>(defaultViewMode);
+  const [detailFile, setDetailFile] = useState<OrgFile | null>(null);
+  const resolvedViewMode = viewMode ?? internalViewMode;
+  const isControlledViewMode = viewMode !== undefined;
+
+  const handleViewModeChange = (mode: FilesViewMode) => {
+    if (!isControlledViewMode) setInternalViewMode(mode);
+    onViewModeChange?.(mode);
+  };
+
+  const handleFileClick = (file: OrgFile) => {
+    if (onFileClick) {
+      onFileClick(file);
+      return;
+    }
+    if (useDetailDrawer) setDetailFile(file);
+  };
+
+  const renderedEmptyState = showEmptyState ? emptyState : null;
+  const hasEmptyState = renderedEmptyState !== null && renderedEmptyState !== undefined;
+  const shouldRenderFiles = isLoading || files.length > 0 || hasEmptyState;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {header ? (
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">{header}</div>
+          {showViewToggle ? (
+            <FilesViewToggle value={resolvedViewMode} onChange={handleViewModeChange} />
+          ) : null}
+        </div>
+      ) : null}
+
+      {canUpload && onFilesSelected ? (
+        <UploadDropzone
+          onFilesSelected={onFilesSelected}
+          instructionText={DROPZONE_INSTRUCTION_TEXT}
+          validationText={DROPZONE_VALIDATION_TEXT}
+          disabled={uploadDisabled}
+        />
+      ) : null}
+
+      {uploadingFiles.length > 0 ? (
+        <div className="space-y-2">
+          {uploadingFiles.map((entry) => (
+            <UploadQueueRow
+              key={entry.id}
+              fileName={entry.file.name}
+              mimeType={entry.file.type || 'application/octet-stream'}
+              fileSize={entry.file.size}
+              status="uploading"
+              progress={entry.progress}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {!header && showViewToggle ? (
+        <div className="flex justify-end">
+          <FilesViewToggle value={resolvedViewMode} onChange={handleViewModeChange} />
+        </div>
+      ) : null}
+
+      {shouldRenderFiles ? (
+        <div className={contentClassName}>
+          {resolvedViewMode === 'list' ? (
+            <FilesList
+              files={files}
+              isLoading={isLoading}
+              emptyState={renderedEmptyState}
+              onFileClick={handleFileClick}
+            />
+          ) : (
+            <FilesGrid
+              files={files}
+              isLoading={isLoading}
+              emptyState={renderedEmptyState}
+              onFileClick={handleFileClick}
+            />
+          )}
+        </div>
+      ) : null}
+
+      {useDetailDrawer && !onFileClick ? (
+        <FileDetailDrawer
+          file={detailFile}
+          isOpen={detailFile !== null}
+          onClose={() => setDetailFile(null)}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default FilesCollectionPanel;

--- a/src/features/files/components/FilesInspectorPanel.tsx
+++ b/src/features/files/components/FilesInspectorPanel.tsx
@@ -87,9 +87,9 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
   return (
     <aside
       aria-label="File details"
-      className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-line-glass/30 bg-surface-card"
+      className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-surface-card"
     >
-      <header className="flex items-center justify-between border-b border-line-glass/30 px-4 py-3">
+      <header className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
         <h2 className="text-sm font-semibold text-input-text">Details</h2>
         <button
           type="button"
@@ -153,7 +153,7 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
         </dl>
       </div>
 
-      <footer className="flex gap-2 border-t border-line-glass/30 px-4 py-3">
+      <footer className="flex gap-2 border-t border-line-subtle px-4 py-3">
         <Button
           variant="secondary"
           size="sm"

--- a/src/features/files/components/FilesPageView.tsx
+++ b/src/features/files/components/FilesPageView.tsx
@@ -9,7 +9,7 @@ import { SegmentedFilter } from '@/shared/ui/tabs/SegmentedFilter';
 import { CollectionToolbar } from '@/shared/ui/collection/CollectionToolbar';
 import { useMobileDetection } from '@/shared/hooks/useMobileDetection';
 
-import { FilesGrid } from './FilesGrid';
+import { FilesCollectionPanel } from './FilesCollectionPanel';
 import { FileDetailDrawer } from './FileDetailDrawer';
 import { FilesInspectorPanel } from './FilesInspectorPanel';
 import { UploadDestinationDialog } from './UploadDestinationDialog';
@@ -140,10 +140,12 @@ export const FilesPageView = ({ practiceId, practiceSlug, scope, userId = null }
               description={`No files match ${search ? `"${search}"` : 'the current filter'}.`}
             />
           ) : (
-            <FilesGrid
+            <FilesCollectionPanel
               files={filteredFiles}
               isLoading={isLoading}
               onFileClick={setSelectedFile}
+              showEmptyState={false}
+              showViewToggle={false}
             />
           )}
         </div>

--- a/src/features/files/components/FilesViewToggle.tsx
+++ b/src/features/files/components/FilesViewToggle.tsx
@@ -19,7 +19,7 @@ const buttonClass = (active: boolean) => cn(
 
 export const FilesViewToggle = ({ value, onChange }: FilesViewToggleProps) => (
   <div
-    className="inline-flex items-center gap-1 rounded-lg border border-line-glass/30 bg-surface-panel/60 p-1"
+    className="inline-flex items-center gap-1 rounded-lg border border-line-subtle bg-surface-panel/60 p-1"
     role="group"
     aria-label="File view mode"
   >

--- a/src/features/files/components/UploadDestinationDialog.tsx
+++ b/src/features/files/components/UploadDestinationDialog.tsx
@@ -192,7 +192,7 @@ export const UploadDestinationDialog = ({
           </div>
         ) : null}
         {!isLoading && options.length === 0 && !error ? (
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-line-glass/20 bg-surface-panel/50 px-3 py-3 text-sm text-input-placeholder">
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-3 text-sm text-input-placeholder">
             <span className="min-w-0 flex-1">
               {clientUserId
                 ? "You don't have any matters or intakes yet. Open a conversation with the practice to get started."
@@ -213,7 +213,7 @@ export const UploadDestinationDialog = ({
             emptyStateLabel={null}
           />
         ) : options.length > 0 ? (
-          <p className="rounded-xl border border-line-glass/20 bg-surface-panel/50 px-3 py-4 text-sm text-input-placeholder">
+          <p className="rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-4 text-sm text-input-placeholder">
             Pick a destination above to enable the upload area.
           </p>
         ) : null}

--- a/src/features/intake/components/DocumentChecklist.tsx
+++ b/src/features/intake/components/DocumentChecklist.tsx
@@ -91,7 +91,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
   const canComplete = requiredCompleted === requiredCount;
 
   return (
-    <div className="glass-card p-6 max-w-2xl">
+    <div className="card p-6 max-w-2xl">
       {/* Header */}
       <div className="mb-6">
         <h3 className="text-lg font-semibold text-input-text mb-2">
@@ -118,7 +118,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
             className={`border rounded-xl p-4 transition-all duration-300 ${
               dragOverId === doc.id 
                 ? 'border-accent-500 bg-accent-500/10 scale-[1.02]' 
-                : 'border-line-glass/10 bg-surface-utility/5'
+                : 'border-line-subtle bg-surface-utility/5'
             }`}
             onDrop={(e) => handleDrop(doc.id, e)}
             onDragOver={(e) => handleDragOver(doc.id, e)}
@@ -209,7 +209,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
       </div>
 
       {/* Actions */}
-      <div className="flex items-center justify-between pt-4 border-t border-line-default">
+      <div className="flex items-center justify-between pt-4 border-t border-line-subtle">
         <Button
           variant="ghost"
           onClick={onSkip}

--- a/src/features/intake/components/EmbedCodeBlock.tsx
+++ b/src/features/intake/components/EmbedCodeBlock.tsx
@@ -125,7 +125,7 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
         <p className="text-sm text-input-placeholder">
           Share the direct link or install the widget script on your site.
         </p>
-        <div className="glass-panel rounded-xl px-4 py-3">
+        <div className="panel rounded-xl px-4 py-3">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
               <p className="text-xs font-medium uppercase tracking-widest text-input-placeholder">Public link</p>
@@ -150,7 +150,7 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
           Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code> to load this intake flow.
         </p>
         <div className="relative group">
-          <pre className="bg-elevation-2 overflow-x-auto rounded-xl border border-line-glass/30 p-4 pr-20 text-sm font-mono text-input-text">
+          <pre className="bg-elevation-2 overflow-x-auto rounded-xl border border-line-subtle p-4 pr-20 text-sm font-mono text-input-text">
             {snippet}
           </pre>
           <Button
@@ -176,7 +176,7 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
             ref={textareaRef}
             readOnly
             value={snippet}
-            className="w-full resize-none rounded-md border border-line-glass/20 bg-surface-ground p-3 font-mono text-sm text-input-text"
+            className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-input-text"
             rows={6}
             aria-label="Embed snippet"
           />
@@ -236,7 +236,7 @@ export function EmbedCodeDialog({ isOpen, onClose, practiceSlug, templateSlug }:
           ref={textareaRef}
           readOnly
           value={snippet}
-          className="w-full resize-none rounded-md border border-line-glass/20 bg-surface-ground p-3 font-mono text-sm text-input-text"
+          className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-input-text"
           rows={6}
           aria-label="Embed snippet"
         />

--- a/src/features/intake/components/IntakeFilesPanel.tsx
+++ b/src/features/intake/components/IntakeFilesPanel.tsx
@@ -6,21 +6,11 @@ import { Button } from '@/shared/ui/Button';
 import { Icon } from '@/shared/ui/Icon';
 import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
 import { Textarea } from '@/shared/ui/input';
-import { UploadDropzone } from '@/shared/ui/upload/organisms/UploadDropzone';
-import { UploadQueueRow } from '@/shared/ui/upload/molecules/UploadQueueRow';
 import { useToastContext } from '@/shared/contexts/ToastContext';
-import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { useIntakeFiles } from '@/features/intake/hooks/useIntakeFiles';
 import type { IntakeFile } from '@/features/intake/api/intakeFilesApi';
 
-import { FilesGrid } from '@/features/files/components/FilesGrid';
-import { FilesList } from '@/features/files/components/FilesList';
-import { FilesViewToggle, type FilesViewMode } from '@/features/files/components/FilesViewToggle';
-import { FileDetailDrawer } from '@/features/files/components/FileDetailDrawer';
-import {
-  DROPZONE_INSTRUCTION_TEXT,
-  DROPZONE_VALIDATION_TEXT,
-} from '@/features/files/constants';
+import { FilesCollectionPanel } from '@/features/files/components/FilesCollectionPanel';
 import type { OrgFile } from '@/features/files/utils/fileCategory';
 
 interface IntakeFilesPanelProps {
@@ -72,8 +62,6 @@ export const IntakeFilesPanel: FunctionComponent<IntakeFilesPanelProps> = ({
   const [pendingDelete, setPendingDelete] = useState<IntakeFile | null>(null);
   const [deleteReason, setDeleteReason] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
-  const [detailFile, setDetailFile] = useState<OrgFile | null>(null);
-  const [viewMode, setViewMode] = useState<FilesViewMode>('grid');
 
   const handleFilesSelected = async (selected: File[]) => {
     if (!canUpload) return;
@@ -117,67 +105,23 @@ export const IntakeFilesPanel: FunctionComponent<IntakeFilesPanelProps> = ({
 
   const orgFiles = useMemo(() => files.map(intakeFileToOrgFile), [files]);
 
-  const emptyState = (
-    <WorkspacePlaceholderState
-      icon={FileText}
-      title="No files uploaded yet"
-      description={canUpload
-        ? 'Drag and drop files into the area above to attach them to this intake.'
-        : 'No files have been attached to this intake.'}
-    />
-  );
-
   return (
     <section
       className={`rounded-xl border border-card-border bg-surface-card p-4 sm:p-6 ${className ?? ''}`}
     >
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <Icon icon={FileText} className="h-4 w-4 text-input-placeholder" />
-          <h3 className="text-sm font-semibold text-input-text">Files</h3>
-        </div>
-        <FilesViewToggle value={viewMode} onChange={setViewMode} />
-      </div>
-
-      {canUpload ? (
-        <UploadDropzone
-          onFilesSelected={(selected) => void handleFilesSelected(selected)}
-          instructionText={DROPZONE_INSTRUCTION_TEXT}
-          validationText={DROPZONE_VALIDATION_TEXT}
-          className="mb-4"
-        />
-      ) : null}
-
-      {uploadingFiles.length > 0 ? (
-        <div className="mb-4 space-y-2">
-          {uploadingFiles.map((entry) => (
-            <UploadQueueRow
-              key={entry.id}
-              fileName={entry.file.name}
-              mimeType={entry.file.type || 'application/octet-stream'}
-              fileSize={entry.file.size}
-              status="uploading"
-              progress={entry.progress}
-            />
-          ))}
-        </div>
-      ) : null}
-
-      {viewMode === 'list' ? (
-        <FilesList
-          files={orgFiles}
-          isLoading={false}
-          emptyState={emptyState}
-          onFileClick={(file) => setDetailFile(file)}
-        />
-      ) : (
-        <FilesGrid
-          files={orgFiles}
-          isLoading={false}
-          emptyState={emptyState}
-          onFileClick={(file) => setDetailFile(file)}
-        />
-      )}
+      <FilesCollectionPanel
+        files={orgFiles}
+        canUpload={canUpload}
+        uploadingFiles={uploadingFiles}
+        onFilesSelected={(selected) => void handleFilesSelected(selected)}
+        showEmptyState={false}
+        header={(
+          <div className="flex min-w-0 items-center gap-2">
+            <Icon icon={FileText} className="h-4 w-4 text-input-placeholder" />
+            <h3 className="text-sm font-semibold text-input-text">Files</h3>
+          </div>
+        )}
+      />
 
       {canDelete && orgFiles.length > 0 ? (
         <div className="mt-4 space-y-2 text-xs">
@@ -193,12 +137,6 @@ export const IntakeFilesPanel: FunctionComponent<IntakeFilesPanelProps> = ({
           ))}
         </div>
       ) : null}
-
-      <FileDetailDrawer
-        file={detailFile}
-        isOpen={detailFile !== null}
-        onClose={() => setDetailFile(null)}
-      />
 
       <Dialog
         isOpen={pendingDelete !== null}

--- a/src/features/intake/components/IntakePaymentForm.tsx
+++ b/src/features/intake/components/IntakePaymentForm.tsx
@@ -317,11 +317,11 @@ export const IntakePaymentForm: FunctionComponent<IntakePaymentFormProps> = ({
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
       {(!stripe || !elements) && (
-        <div className="flex justify-center rounded-xl border border-line-glass/30 bg-surface-panel/60 px-4 py-3 backdrop-blur-md">
+        <div className="flex justify-center rounded-xl border border-line-subtle bg-surface-panel/60 px-4 py-3 backdrop-blur-md">
           <LoadingSpinner size="sm" ariaLabel="Loading secure payment form" />
         </div>
       )}
-      <div className={variant === 'card' ? "glass-panel p-5" : "rounded-xl border border-line-glass/30 bg-surface-panel/60 p-4"}>
+      <div className={variant === 'card' ? "panel p-5" : "rounded-xl border border-line-subtle bg-surface-panel/60 p-4"}>
         <PaymentElement options={{ layout: 'tabs' }} />
       </div>
 
@@ -338,7 +338,7 @@ export const IntakePaymentForm: FunctionComponent<IntakePaymentFormProps> = ({
       )}
 
       {status === 'succeeded' && (
-        <div className="glass-card p-6 text-center border-emerald-500/30">
+        <div className="card p-6 text-center border-emerald-500/30">
           <div className="flex justify-center mb-4">
             <div className="rounded-full bg-emerald-500/20 p-3 shadow-lg shadow-emerald-500/20">
               <svg className="h-8 w-8 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -352,7 +352,7 @@ export const IntakePaymentForm: FunctionComponent<IntakePaymentFormProps> = ({
           <p className="text-input-placeholder">
             Thank you! Your payment was successful and your case details are being processed. A member of our team will contact you at the information you provided.
           </p>
-          <div className="mt-4 border-t border-line-glass/30 pt-4 text-xs text-emerald-700 dark:text-emerald-300">
+          <div className="mt-4 border-t border-line-subtle pt-4 text-xs text-emerald-700 dark:text-emerald-300">
             Payment processed successfully. You will receive confirmation if an email is on file.
           </div>
         </div>

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardList,
   Clock,
   CreditCard,
+  FileText,
   Mail,
   MessageSquare,
   Phone,
@@ -23,6 +24,7 @@ import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
 import { Textarea } from '@/shared/ui/input';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
+import { useNavigation } from '@/shared/utils/navigation';
 import { apiClient, isHttpError } from '@/shared/lib/apiClient';
 import { cn } from '@/shared/utils/cn';
 import {
@@ -254,7 +256,7 @@ const DetailSkeleton: FunctionComponent<{ onBack: () => void }> = ({ onBack }) =
             <MessageRowSkeleton lineWidths={['w-64', 'w-44']} />
           </div>
         </div>
-        <aside className="hidden xl:block space-y-4 border-l border-card-border bg-surface-panel p-6">
+        <aside className="hidden xl:block space-y-4 border-l border-line-subtle bg-surface-panel p-6">
           <SkeletonLoader variant="button" width="w-full" />
           <SkeletonLoader variant="button" width="w-full" />
           <div className="rounded-xl border border-card-border bg-surface-card p-4 space-y-3">
@@ -278,6 +280,7 @@ type IntakeDetailPageProps = {
   practiceId: string | null;
   intakeId: string;
   conversationsBasePath?: string | null;
+  engagementsBasePath?: string | null;
   practiceName: string;
   practiceLogo: string | null;
   onBack: () => void;
@@ -287,6 +290,7 @@ type IntakeDetailPageProps = {
 export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   practiceId,
   intakeId,
+  engagementsBasePath,
   practiceName,
   practiceLogo,
   onBack,
@@ -294,6 +298,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
 }) => {
   const { showSuccess, showError } = useToastContext();
   const { session } = useSessionContext();
+  const { navigate } = useNavigation();
 
   const {
     data: intakeData,
@@ -804,6 +809,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     name ? `${name} intake` : 'Untitled intake',
   );
   const canReplyInIntake = Boolean(intake.conversation_id && effectiveTriageStatus === 'accepted');
+  const engagementCreatePath = `${engagementsBasePath ?? '/practice/engagements'}?create=1&intakeId=${encodeURIComponent(intake.uuid)}`;
   const enrichmentFields: IntakeFieldDefinition[] = (
     activeTemplate?.fields ?? DEFAULT_INTAKE_TEMPLATE.fields
   ).filter((f) => f.phase === 'enrichment');
@@ -824,14 +830,26 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   })();
 
   const statusBadge = (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium ring-1 ring-inset',
-        triageBadgeClass(effectiveTriageStatus),
-      )}
-    >
-      {triageLabel(effectiveTriageStatus)}
-    </span>
+    <div className="flex items-center gap-2">
+      <span
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium ring-1 ring-inset',
+          triageBadgeClass(effectiveTriageStatus),
+        )}
+      >
+        {triageLabel(effectiveTriageStatus)}
+      </span>
+      {effectiveTriageStatus === 'accepted' ? (
+        <Button
+          variant="primary"
+          size="sm"
+          icon={FileText}
+          onClick={() => navigate(engagementCreatePath)}
+        >
+          Create engagement
+        </Button>
+      ) : null}
+    </div>
   );
 
   const intakeDetailsCard = (
@@ -917,7 +935,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
 
   const conversationCard = intake.conversation_id ? (
     <Card className="flex min-h-[420px] flex-col p-0 overflow-hidden">
-      <div className="border-b border-card-border p-4 sm:px-6 sm:py-5">
+      <div className="border-b border-line-subtle p-4 sm:px-6 sm:py-5">
         <SectionLabel>Conversation</SectionLabel>
         <p className="mt-1 text-xs text-input-placeholder">Continue the client thread from this intake.</p>
       </div>
@@ -956,7 +974,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         )}
       </div>
       {canReplyInIntake ? (
-        <div className="border-t border-card-border px-4 py-4">
+        <div className="border-t border-line-subtle px-4 py-4">
           <MessageComposer
             inputValue={composerValue}
             setInputValue={setComposerValue}
@@ -1052,7 +1070,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <Avatar
           name={name ?? ''}
           size="md"
-          className="bg-surface-utility/40 text-input-text ring-1 ring-line-glass/20"
+          className="bg-surface-utility/40 text-input-text ring-1 ring-line-subtle"
         />
         <div className="min-w-0">
           <p className="truncate text-sm font-semibold text-input-text">{name ?? 'Unnamed lead'}</p>
@@ -1086,6 +1104,19 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
       ) : null}
     </Card>
   );
+
+  const engagementActionCard = effectiveTriageStatus === 'accepted' ? (
+    <Card className="p-4">
+      <Button
+        variant="primary"
+        className="w-full"
+        icon={FileText}
+        onClick={() => navigate(engagementCreatePath)}
+      >
+        Create engagement
+      </Button>
+    </Card>
+  ) : null;
 
   return (
     <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
@@ -1122,8 +1153,9 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           </div>
 
           {/* Desktop right panel */}
-          <aside className="hidden xl:flex flex-col gap-4 border-l border-card-border bg-surface-panel p-6">
+          <aside className="hidden xl:flex flex-col gap-4 border-l border-line-subtle bg-surface-panel p-6">
             {isPending ? <div className="flex flex-col gap-3">{triageActions}</div> : null}
+            {engagementActionCard}
             {aboutCard}
           </aside>
         </div>

--- a/src/features/intake/pages/IntakeTemplatesPage.tsx
+++ b/src/features/intake/pages/IntakeTemplatesPage.tsx
@@ -346,7 +346,7 @@ type StatPillProps = {
 
 function _StatPill({ label, value }: StatPillProps) {
   return (
-    <div className="rounded-xl border border-line-glass/30 bg-surface-card px-3 py-2">
+    <div className="rounded-xl border border-line-subtle bg-surface-card px-3 py-2">
       <p className="text-lg font-semibold text-input-text">{value}</p>
       <p className="text-xs text-input-placeholder">{label}</p>
     </div>
@@ -411,7 +411,7 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
     <div
       className={cn(
         'rounded-xl border bg-surface-card transition-colors',
-        isActive ? 'border-line-utility border-l-[3px] border-l-accent-500' : 'border-line-utility',
+        isActive ? 'border-line-subtle border-l-[3px] border-l-accent-500' : 'border-line-subtle',
       )}
     >
       <div className="flex items-center gap-2 p-3.5">
@@ -452,7 +452,7 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
         ) : null}
       </div>
       {hasBody && isOpen ? (
-        <div className="border-t border-line-utility/60 px-2.5 pb-2.5 pt-1.5">{children}</div>
+        <div className="border-t border-line-subtle px-2.5 pb-2.5 pt-1.5">{children}</div>
       ) : null}
     </div>
   );
@@ -550,7 +550,7 @@ function QuestionRow({ label, isSelected, isLocked, badgeLabel, onSelect, onRemo
 
 function LockedFieldChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-line-utility bg-surface-input px-2 py-0.5 text-[11px] font-medium text-input-placeholder">
+    <span className="inline-flex items-center gap-1 rounded-full border border-line-subtle bg-surface-input px-2 py-0.5 text-[11px] font-medium text-input-placeholder">
       <Lock className="h-3 w-3" />
       {label}
     </span>
@@ -563,7 +563,7 @@ function AddInlineButton({ children, onClick, disabled = false }: { children: st
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="mt-1 flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-line-utility/70 px-2 py-1.5 text-xs font-medium text-input-placeholder transition-colors hover:border-line-utility hover:text-input-text disabled:cursor-not-allowed disabled:opacity-50"
+      className="mt-1 flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-line-subtle px-2 py-1.5 text-xs font-medium text-input-placeholder transition-colors hover:border-line-subtle hover:text-input-text disabled:cursor-not-allowed disabled:opacity-50"
     >
       <Plus className="h-3.5 w-3.5" />
       {children}
@@ -626,7 +626,7 @@ function TemplateCard({
   const publicUrl = getPublicFormUrl(practiceSlug, template.slug);
 
   return (
-    <article className="glass-card flex min-h-[230px] flex-col justify-between overflow-hidden rounded-2xl">
+    <article className="card flex min-h-[230px] flex-col justify-between overflow-hidden rounded-2xl">
       <div
         role="button"
         tabIndex={0}
@@ -1090,7 +1090,7 @@ function TemplateEditor({
         onInput={(event) => handleNameChange((event.currentTarget as HTMLInputElement).value)}
         placeholder="New intake form"
         disabled={isSaving}
-        className="w-full min-w-0 rounded-lg border border-transparent bg-transparent px-2 py-1 text-base font-semibold text-input-text outline-none transition-colors placeholder:text-input-placeholder hover:border-line-glass/40 focus:border-line-glass/60 focus:bg-surface-utility/10"
+        className="w-full min-w-0 rounded-lg border border-transparent bg-transparent px-2 py-1 text-base font-semibold text-input-text outline-none transition-colors placeholder:text-input-placeholder hover:border-line-subtle focus:border-line-subtle focus:bg-surface-utility/10"
         aria-label="Form title"
       />
       {slugError ? <p className="mt-1 text-xs text-rose-500">{slugError}</p> : null}
@@ -1462,7 +1462,7 @@ function TemplateEditor({
             <button
               type="button"
               disabled
-              className="flex items-center justify-between rounded-lg border border-line-utility bg-surface-input px-3 py-2 text-left text-sm text-input-text"
+              className="flex items-center justify-between rounded-lg border border-line-subtle bg-surface-input px-3 py-2 text-left text-sm text-input-text"
             >
               <span>Free text</span>
               <ChevronDown className="h-4 w-4 text-input-placeholder" />
@@ -1643,7 +1643,7 @@ function TemplateEditor({
   const showCloseButton = effectiveSelectedItemId !== 'none' && effectiveSelectedItemId !== 'contact';
   const inspectorPanel = (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-line-utility px-4 py-3">
+      <div className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
         <p className="text-sm font-semibold text-input-text">{inspectorTitle}</p>
         {showCloseButton ? (
           <button
@@ -1668,7 +1668,7 @@ function TemplateEditor({
         : inspectorTitle;
       return (
         <div className="flex h-full flex-col">
-          <header className="flex items-center gap-2 border-b border-line-utility px-3 py-3">
+          <header className="flex items-center gap-2 border-b border-line-subtle px-3 py-3">
             <Button
               type="button"
               variant="icon"
@@ -1688,7 +1688,7 @@ function TemplateEditor({
     if (mobileView === 'preview') {
       return (
         <div className="flex h-full flex-col">
-          <header className="flex items-center gap-2 border-b border-line-utility px-3 py-3">
+          <header className="flex items-center gap-2 border-b border-line-subtle px-3 py-3">
             <Button
               type="button"
               variant="icon"
@@ -1719,7 +1719,7 @@ function TemplateEditor({
 
     return (
       <div className="flex h-full flex-col">
-        <header className="flex items-center gap-2 border-b border-line-utility px-3 py-3">
+        <header className="flex items-center gap-2 border-b border-line-subtle px-3 py-3">
           <Button
             type="button"
             variant="icon"
@@ -1731,7 +1731,7 @@ function TemplateEditor({
           <h1 className="flex-1 text-center text-sm font-semibold text-input-text">Question Builder</h1>
           <span className="w-8" aria-hidden="true" />
         </header>
-        <div className="flex items-center justify-center gap-2 border-b border-line-utility px-3 py-2">
+        <div className="flex items-center justify-center gap-2 border-b border-line-subtle px-3 py-2">
           <Button
             type="button"
             variant="secondary"
@@ -1810,7 +1810,7 @@ type TemplateListViewProps = {
 function FormCardSkeleton({ titleWidth = 'w-32' }: { titleWidth?: string }) {
   return (
     <div
-      className="glass-card flex min-h-[230px] flex-col rounded-2xl p-5"
+      className="card flex min-h-[230px] flex-col rounded-2xl p-5"
       aria-hidden="true"
     >
       <div className="flex items-start justify-between gap-3">
@@ -1935,9 +1935,9 @@ function TemplateListView({
             type="button"
             onClick={onNew}
             disabled={isSaving}
-            className="glass-card flex min-h-[230px] flex-col items-center justify-center rounded-2xl border border-dashed border-line-glass/50 p-5 text-center transition-colors hover:border-line-glass/80 disabled:cursor-not-allowed disabled:opacity-60"
+            className="card flex min-h-[230px] flex-col items-center justify-center rounded-2xl border border-dashed border-line-subtle p-5 text-center transition-colors hover:border-line-subtle disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <span className="rounded-2xl border border-line-glass/30 bg-surface-card p-3 text-input-text">
+            <span className="rounded-2xl border border-line-subtle bg-surface-card p-3 text-input-text">
               <Plus className="h-6 w-6" />
             </span>
             <span className="mt-4 text-sm font-semibold text-input-text">

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -67,6 +67,7 @@ type IntakesPageProps = {
   practiceId: string | null;
   basePath?: string;
   conversationsBasePath?: string | null;
+  engagementsBasePath?: string | null;
   practiceName: string;
   practiceLogo: string | null;
   activeTriageFilter?: string | null;
@@ -76,6 +77,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
   practiceId,
   basePath = '/practice/intakes',
   conversationsBasePath,
+  engagementsBasePath,
   practiceName,
   practiceLogo,
   activeTriageFilter = 'all',
@@ -204,6 +206,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
         practiceId={practiceId}
         intakeId={selectedIntakeId}
         conversationsBasePath={conversationsBasePath}
+        engagementsBasePath={engagementsBasePath}
         practiceName={practiceName}
         practiceLogo={practiceLogo}
         onBack={handleBack}
@@ -274,7 +277,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
     <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
       {/* Header (desktop only — mobile hides because the workspace shell already
           renders its own mobile header with the section title). */}
-      <header className="hidden md:flex items-center justify-between gap-4 border-b border-card-border px-6 py-5">
+      <header className="hidden md:flex items-center justify-between gap-4 border-b border-line-subtle px-6 py-5">
         <h1 className="text-xl font-semibold text-input-text">All Responses</h1>
         <div className="w-72">
           <Input
@@ -289,7 +292,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
       </header>
 
       {/* Mobile filter tabs */}
-      <div className="md:hidden border-b border-card-border bg-surface-workspace">
+      <div className="md:hidden border-b border-line-subtle bg-surface-workspace">
         <Tabs
           items={tabItems}
           activeId={mobileFilter}
@@ -299,7 +302,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
       </div>
 
       {/* Mobile search */}
-      <div className="md:hidden px-4 py-3 border-b border-card-border">
+      <div className="md:hidden px-4 py-3 border-b border-line-subtle">
         <Input
           type="search"
           placeholder="Search responses…"

--- a/src/features/invoices/components/InvoiceDetailSkeleton.tsx
+++ b/src/features/invoices/components/InvoiceDetailSkeleton.tsx
@@ -17,7 +17,7 @@ export const InvoiceDetailSkeleton = () => (
       {/* Total / Paid / Due tiles */}
       <div className="grid gap-3 sm:grid-cols-3">
         {[0, 1, 2].map((i) => (
-          <div key={i} className="glass-panel p-4 space-y-2">
+          <div key={i} className="panel p-4 space-y-2">
             <SkeletonLoader variant="text" width="w-20" height="h-3" />
             <SkeletonLoader variant="text" width="w-24" height="h-5" />
           </div>
@@ -25,11 +25,11 @@ export const InvoiceDetailSkeleton = () => (
       </div>
 
       {/* Line-items table */}
-      <div className="glass-panel overflow-hidden">
-        <div className="border-b border-line-glass/30 px-4 py-3">
+      <div className="panel overflow-hidden">
+        <div className="border-b border-line-subtle px-4 py-3">
           <SkeletonLoader variant="text" width="w-24" height="h-4" />
         </div>
-        <div className="divide-y divide-line-glass/20">
+        <div className="divide-y divide-line-subtle">
           {[0, 1, 2, 3, 4].map((i) => (
             <div key={i} className="grid grid-cols-[2fr_1fr_0.5fr_1fr_1fr] gap-4 px-4 py-3">
               <SkeletonLoader variant="text" height="h-3" width={i % 2 === 0 ? 'w-48' : 'w-40'} />
@@ -45,7 +45,7 @@ export const InvoiceDetailSkeleton = () => (
       {/* Payments / Refunds / Notes row */}
       <div className="grid gap-4 lg:grid-cols-3">
         {[0, 1, 2].map((i) => (
-          <div key={i} className="glass-panel p-4 space-y-3">
+          <div key={i} className="panel p-4 space-y-3">
             <SkeletonLoader variant="text" width="w-32" height="h-4" />
             <SkeletonLoader variant="text" width="w-44" height="h-3" />
             <SkeletonLoader variant="text" width="w-28" height="h-3" />

--- a/src/features/invoices/components/InvoiceLineItemsForm.tsx
+++ b/src/features/invoices/components/InvoiceLineItemsForm.tsx
@@ -62,7 +62,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
       </div>
 
       {lineItems.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-line-glass/30 p-8 text-center bg-surface-utility/20">
+        <div className="rounded-xl border border-dashed border-line-subtle p-8 text-center bg-surface-utility/20">
            <p className="text-sm text-input-placeholder">No line items added yet.</p>
            {!readOnly ? (
              <Button
@@ -76,7 +76,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
            ) : null}
         </div>
       ) : (
-        <ul className="divide-y divide-line-glass/30 border-y border-line-glass/30">
+        <ul className="divide-y divide-line-subtle border-y border-line-subtle">
           {lineItems.map((item, index) => {
             const itemTotal = item.line_total ?? asMajor(0);
             const qtyFormatted = formatQuantity(item.quantity, billingIncrementMinutes);

--- a/src/features/invoices/components/InvoicePreview.tsx
+++ b/src/features/invoices/components/InvoicePreview.tsx
@@ -128,7 +128,7 @@ export const InvoicePreview = ({
         {/* Render centered "paper" inside the preview panel. The panel keeps its
           background; the invoice itself is presented as a white sheet centered
           with a subtle shadow and spacing to emulate Stripe's preview look. */}
-        <div className="w-full max-w-[760px] h-[min(720px,calc(100svh-12rem))] min-h-[560px] max-h-[720px] bg-white rounded-lg shadow-lg border border-slate-200" style={{ ...root }}>
+        <div className="w-full max-w-[760px] h-[min(720px,calc(100svh-12rem))] min-h-[560px] max-h-[720px] bg-white rounded-lg shadow-lg border border-line-subtle" style={{ ...root }}>
         <div className="relative flex h-full flex-col overflow-hidden">
           {/* ── Scrollable body ── */}
           <div className="flex-1 overflow-y-auto" style={{ padding: '2rem 2rem 3rem' }}>

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -288,15 +288,15 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         toolbar={toolbar}
         emptyState={emptyMessage ?? 'No invoices found'}
         errorState={error ? (
-          <div className="glass-panel rounded-xl p-4 text-sm text-red-300">
+          <div className="panel rounded-xl p-4 text-sm text-red-300">
             Failed to load invoices: {error}
           </div>
         ) : undefined}
         loading={loading}
         loadingLabel="Loading invoices"
-        className="glass-panel rounded-xl overflow-hidden"
+        className="panel rounded-xl overflow-hidden"
         tableClassName="text-left text-sm"
-        rowClassName="border-b border-line-glass/20 last:border-b-0"
+        rowClassName="border-b border-line-subtle last:border-b-0"
         bodyClassName="bg-transparent"
         stickyHeader
         density="compact"
@@ -305,7 +305,7 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         onLoadMore={onLoadMore}
       />
       {footer ? (
-        <div className="border-t border-line-glass/30 px-4 py-3 text-sm text-input-placeholder">
+        <div className="border-t border-line-subtle px-4 py-3 text-sm text-input-placeholder">
           <div>{footer}</div>
         </div>
       ) : null}

--- a/src/features/invoices/components/LineItemEditorDialog.tsx
+++ b/src/features/invoices/components/LineItemEditorDialog.tsx
@@ -107,7 +107,7 @@ export const LineItemEditorDialog = ({
           />
         </div>
 
-        <div className="flex items-center justify-between border-t border-line-glass/20 pt-3">
+        <div className="flex items-center justify-between border-t border-line-subtle pt-3">
           <span className="text-sm text-input-placeholder">Total</span>
           <span className="text-lg font-semibold text-input-text">
             {formatCurrency(formData.line_total ?? asMajor(0))}

--- a/src/features/invoices/components/SendInvoiceDialog.tsx
+++ b/src/features/invoices/components/SendInvoiceDialog.tsx
@@ -81,7 +81,7 @@ export const SendInvoiceDialog = ({
       )}
 
       <DialogBody className="space-y-4">
-        <div className="rounded-xl border border-line-glass/10 bg-surface-utility/40 dark:bg-surface-utility/10 p-4">
+        <div className="rounded-xl border border-line-subtle bg-surface-utility/40 dark:bg-surface-utility/10 p-4">
           <p className="text-sm text-input-placeholder">Send this invoice now?</p>
           <p className="mt-1 text-base font-semibold text-input-text">
             Total due: {formatCurrency(totalAmount)}
@@ -99,7 +99,7 @@ export const SendInvoiceDialog = ({
 
         {/* Embedded invoice preview — visual confirmation before send */}
         {hasPreview && (
-          <div className="rounded-xl border border-line-glass/20 bg-surface-workspace p-3 overflow-y-auto max-h-[28rem]">
+          <div className="rounded-xl border border-line-subtle bg-surface-workspace p-3 overflow-y-auto max-h-[28rem]">
             <InvoicePreview
               title={previewTitle ?? 'Invoice'}
               referenceLabel={previewReferenceLabel}

--- a/src/features/invoices/components/detail/InvoiceLineItemsTable.tsx
+++ b/src/features/invoices/components/detail/InvoiceLineItemsTable.tsx
@@ -22,7 +22,7 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
         <div className="px-5 py-8 text-center text-sm text-input-placeholder">No line items.</div>
       ) : (
         <div className="mt-3 overflow-x-auto">
-          <table className="min-w-full divide-y divide-line-glass/30 text-sm">
+          <table className="min-w-full divide-y divide-line-subtle text-sm">
             <thead>
               <tr className="text-left text-xs uppercase tracking-wider text-input-placeholder bg-surface-utility/30">
                 <th className="px-5 py-3 font-medium">Description</th>
@@ -31,7 +31,7 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
                 <th className="px-5 py-3 w-32 text-right font-medium">Amount</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-line-glass/20">
+            <tbody className="divide-y divide-line-subtle">
               {lineItems.map((item) => (
                 <tr key={item.id}>
                   <td className="px-5 py-3 text-input-text">{item.description || <i>No description</i>}</td>

--- a/src/features/invoices/components/detail/InvoicePaymentsSection.tsx
+++ b/src/features/invoices/components/detail/InvoicePaymentsSection.tsx
@@ -29,7 +29,7 @@ export const InvoicePaymentsSection = ({ payments }: InvoicePaymentsSectionProps
         {payments.map((payment) => (
           <li
             key={payment.id}
-            className="flex items-start justify-between gap-3 rounded-xl border border-line-glass/20 bg-surface-utility/20 px-4 py-3"
+            className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
           >
             <div className="min-w-0">
               <p className="text-sm font-medium text-input-text">{formatCurrency(payment.amount)}</p>

--- a/src/features/invoices/components/detail/InvoiceRefundsSection.tsx
+++ b/src/features/invoices/components/detail/InvoiceRefundsSection.tsx
@@ -43,7 +43,7 @@ export const InvoiceRefundsSection = ({
           return (
             <div
               key={`request-${request.id}`}
-              className="flex items-start justify-between gap-3 rounded-xl border border-line-glass/20 bg-surface-utility/20 px-4 py-3"
+              className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
             >
               <div className="min-w-0">
                 <p className="text-sm font-medium text-input-text">
@@ -71,7 +71,7 @@ export const InvoiceRefundsSection = ({
         {refunds.map((refund) => (
           <div
             key={`refund-${refund.id}`}
-            className="flex items-start justify-between gap-3 rounded-xl border border-line-glass/20 bg-surface-utility/20 px-4 py-3"
+            className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
           >
             <div className="min-w-0">
               <p className="text-sm font-medium text-input-text">{formatCurrency(refund.amount)}</p>

--- a/src/features/invoices/components/list/InvoiceFilterChips.tsx
+++ b/src/features/invoices/components/list/InvoiceFilterChips.tsx
@@ -65,7 +65,7 @@ const Chip = ({
     className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${
       active
         ? 'border-accent-foreground/50 bg-accent-foreground/10 text-[rgb(var(--accent-foreground))]'
-        : 'border-line-glass/30 bg-surface-utility/30 text-input-placeholder hover:text-input-text'
+        : 'border-line-subtle bg-surface-utility/30 text-input-placeholder hover:text-input-text'
     }`}
   >
     {children}

--- a/src/features/invoices/components/refunds/RefundRequestReviewDialog.tsx
+++ b/src/features/invoices/components/refunds/RefundRequestReviewDialog.tsx
@@ -102,7 +102,7 @@ export const RefundRequestReviewDialog = ({
       disableBackdropClick={loading}
     >
       <DialogBody className="space-y-4">
-        <div className="rounded-xl border border-line-glass/20 bg-surface-utility/30 px-4 py-3 text-sm">
+        <div className="rounded-xl border border-line-subtle bg-surface-utility/30 px-4 py-3 text-sm">
           <div className="flex items-center justify-between">
             <span className="text-input-placeholder">Amount</span>
             <span className="font-semibold text-input-text">
@@ -120,7 +120,7 @@ export const RefundRequestReviewDialog = ({
             <RefundRequestStatusBadge status={request.status} />
           </div>
           {request.reason ? (
-            <div className="mt-3 border-t border-line-glass/20 pt-3">
+            <div className="mt-3 border-t border-line-subtle pt-3">
               <p className="text-xs text-input-placeholder">Reason</p>
               <p className="mt-1 text-input-text">{request.reason}</p>
             </div>

--- a/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
@@ -158,27 +158,27 @@ export function ClientInvoiceDetailPage({
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
-          <div className="glass-panel p-4">
+          <div className="panel p-4">
             <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Total</p>
             <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.total)}</p>
           </div>
-          <div className="glass-panel p-4">
+          <div className="panel p-4">
             <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Amount paid</p>
             <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.amountPaid)}</p>
           </div>
-          <div className="glass-panel p-4">
+          <div className="panel p-4">
             <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Amount due</p>
             <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.amountDue)}</p>
           </div>
         </div>
 
-        <div className="glass-panel overflow-hidden">
-          <div className="border-b border-line-glass/30 px-4 py-3">
+        <div className="panel overflow-hidden">
+          <div className="border-b border-line-subtle px-4 py-3">
             <h2 className="text-base font-semibold text-input-text">Line items</h2>
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
-              <thead className="border-b border-line-glass/30 text-xs uppercase tracking-[0.08em] text-input-placeholder">
+              <thead className="border-b border-line-subtle text-xs uppercase tracking-[0.08em] text-input-placeholder">
                 <tr>
                   <th className="px-4 py-3 text-left">Description</th>
                   <th className="px-4 py-3 text-left">Type</th>
@@ -189,7 +189,7 @@ export function ClientInvoiceDetailPage({
               </thead>
               <tbody>
                 {detail.lineItems.map((item) => (
-                  <tr key={item.id} className="border-b border-line-glass/20 last:border-b-0">
+                  <tr key={item.id} className="border-b border-line-subtle last:border-b-0">
                     <td className="px-4 py-3 text-input-text">{item.description || '—'}</td>
                     <td className="px-4 py-3 text-input-text">{item.type}</td>
                     <td className="px-4 py-3 text-right text-input-text">{item.quantity}</td>
@@ -203,14 +203,14 @@ export function ClientInvoiceDetailPage({
         </div>
 
         <div className="grid gap-4 lg:grid-cols-3">
-          <div className="glass-panel p-4">
+          <div className="panel p-4">
             <h3 className="text-sm font-semibold text-input-text">Payment history</h3>
             {detail.payments.length === 0 ? (
               <p className="mt-2 text-sm text-input-placeholder">No payment history available.</p>
             ) : (
               <ul className="mt-2 space-y-2 text-sm">
                 {detail.payments.map((payment) => (
-                  <li key={payment.id} className="rounded-xl border border-line-glass/20 px-3 py-2">
+                  <li key={payment.id} className="rounded-xl border border-line-subtle px-3 py-2">
                     <p className="font-medium text-input-text">{formatCurrency(payment.amount)} • {payment.status}</p>
                     <p className="text-xs text-input-placeholder">{renderEventDate(payment.paidAt)}</p>
                   </li>
@@ -219,14 +219,14 @@ export function ClientInvoiceDetailPage({
             )}
           </div>
 
-          <div className="glass-panel p-4">
+          <div className="panel p-4">
             <h3 className="text-sm font-semibold text-input-text">Refund history</h3>
             {detail.refunds.length === 0 ? (
               <p className="mt-2 text-sm text-input-placeholder">No refunds for this invoice.</p>
             ) : (
               <ul className="mt-2 space-y-2 text-sm">
                 {detail.refunds.map((refund) => (
-                  <li key={refund.id} className="rounded-xl border border-line-glass/20 px-3 py-2">
+                  <li key={refund.id} className="rounded-xl border border-line-subtle px-3 py-2">
                     <p className="font-medium text-input-text">{formatCurrency(refund.amount)} • {refund.status}</p>
                     <p className="text-xs text-input-placeholder">{renderEventDate(refund.createdAt)}</p>
                   </li>
@@ -235,7 +235,7 @@ export function ClientInvoiceDetailPage({
             )}
           </div>
 
-          <div className="glass-panel p-4">
+          <div className="panel p-4">
             <h3 className="text-sm font-semibold text-input-text">Request refund</h3>
             <div className="mt-3 space-y-3">
               <Input
@@ -271,7 +271,7 @@ export function ClientInvoiceDetailPage({
             ) : (
               <ol className="mt-2 space-y-2 text-sm">
                 {detail.refundRequests.map((request) => (
-                  <li key={request.id} className="rounded-xl border border-line-glass/20 px-3 py-2">
+                  <li key={request.id} className="rounded-xl border border-line-subtle px-3 py-2">
                     <p className="font-medium text-input-text">{request.status}</p>
                     <p className="text-xs text-input-placeholder">{renderEventDate(request.createdAt)}</p>
                     {request.reason ? <p className="mt-1 text-xs text-input-placeholder">{request.reason}</p> : null}

--- a/src/features/matters/components/MatterDetailSkeleton.tsx
+++ b/src/features/matters/components/MatterDetailSkeleton.tsx
@@ -68,7 +68,7 @@ export const MatterDetailSkeleton = () => (
 
     {/* Case details panel — header + 8 read-only field rows */}
     <section className="card mx-4 mt-4 rounded-2xl">
-      <div className="flex items-center justify-between border-b border-card-border px-6 py-4">
+      <div className="flex items-center justify-between border-b border-line-subtle px-6 py-4">
         <SkeletonLoader variant="text" height="h-3.5" width="w-24" rounded="rounded-md" />
         <div className="skeleton-bar h-px w-8 rounded" />
       </div>

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -238,7 +238,7 @@ export const MatterSummaryCards = ({
             )}
           </div>
           <div
-            className={cn(summaryItemBase, '@3xl:border-l @3xl:border-card-border @3xl:pl-6', revealClass)}
+            className={cn(summaryItemBase, '@3xl:border-l @3xl:border-line-subtle @3xl:pl-6', revealClass)}
             style={{ animationDelay: '60ms' }}
           >
             <div className="flex items-center gap-2">
@@ -258,7 +258,7 @@ export const MatterSummaryCards = ({
             )}
           </div>
           <div
-            className={cn(summaryItemBase, '@3xl:border-l @3xl:border-card-border @3xl:pl-6', revealClass)}
+            className={cn(summaryItemBase, '@3xl:border-l @3xl:border-line-subtle @3xl:pl-6', revealClass)}
             style={{ animationDelay: '120ms' }}
           >
             <div className="flex items-center gap-2">

--- a/src/features/matters/components/files/MatterFilesPanel.tsx
+++ b/src/features/matters/components/files/MatterFilesPanel.tsx
@@ -1,24 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
-import { Folder } from 'lucide-preact';
 
-import { UploadDropzone } from '@/shared/ui/upload/organisms/UploadDropzone';
-import { UploadQueueRow } from '@/shared/ui/upload/molecules/UploadQueueRow';
 import { useToastContext } from '@/shared/contexts/ToastContext';
-import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import {
   listUploadsByScope,
   uploadFileViaBackend,
   type BackendUploadRecord,
 } from '@/shared/lib/uploadsApi';
 
-import { FilesGrid } from '@/features/files/components/FilesGrid';
-import { FilesList } from '@/features/files/components/FilesList';
-import { FilesViewToggle, type FilesViewMode } from '@/features/files/components/FilesViewToggle';
-import { FileDetailDrawer } from '@/features/files/components/FileDetailDrawer';
-import {
-  DROPZONE_INSTRUCTION_TEXT,
-  DROPZONE_VALIDATION_TEXT,
-} from '@/features/files/constants';
+import { FilesCollectionPanel } from '@/features/files/components/FilesCollectionPanel';
 import type { OrgFile } from '@/features/files/utils/fileCategory';
 
 interface MatterFilesPanelProps {
@@ -58,8 +47,6 @@ export function MatterFilesPanel({ matterId, matterTitle = null, isPrivilegedUpl
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [uploadingFiles, setUploadingFiles] = useState<UploadingPanelFile[]>([]);
-  const [detailFile, setDetailFile] = useState<OrgFile | null>(null);
-  const [viewMode, setViewMode] = useState<FilesViewMode>('grid');
   const abortRef = useRef<AbortController | null>(null);
   const { showSuccess, showError } = useToastContext();
   const isUploading = uploadingFiles.length > 0;
@@ -126,71 +113,21 @@ export function MatterFilesPanel({ matterId, matterTitle = null, isPrivilegedUpl
 
   const orgFiles = uploads.map((record) => recordToOrgFile(record, matterId, matterTitle));
 
-  const handleFileClick = (file: OrgFile) => {
-    setDetailFile(file);
-  };
-
-  const emptyState = (
-    <WorkspacePlaceholderState
-      icon={Folder}
-      title="No files yet"
-      description="Drag and drop files into the area above to upload them to this matter."
-    />
-  );
-
   return (
     <div className="space-y-4">
-      <UploadDropzone
+      <FilesCollectionPanel
+        files={orgFiles}
+        isLoading={loading && orgFiles.length === 0}
+        canUpload
+        uploadDisabled={isUploading}
+        uploadingFiles={uploadingFiles}
         onFilesSelected={(files) => { void handleUploadBatch(files); }}
-        instructionText={DROPZONE_INSTRUCTION_TEXT}
-        validationText={DROPZONE_VALIDATION_TEXT}
-        disabled={isUploading}
+        showEmptyState={false}
       />
-
-      {uploadingFiles.length > 0 ? (
-        <div className="space-y-2">
-          {uploadingFiles.map((entry) => (
-            <UploadQueueRow
-              key={entry.id}
-              fileName={entry.file.name}
-              mimeType={entry.file.type || 'application/octet-stream'}
-              fileSize={entry.file.size}
-              status="uploading"
-              progress={entry.progress}
-            />
-          ))}
-        </div>
-      ) : null}
 
       {error ? (
         <div className="status-error rounded-xl px-3 py-2 text-sm">{error}</div>
       ) : null}
-
-      <div className="flex justify-end">
-        <FilesViewToggle value={viewMode} onChange={setViewMode} />
-      </div>
-
-      {viewMode === 'list' ? (
-        <FilesList
-          files={orgFiles}
-          isLoading={loading && orgFiles.length === 0}
-          emptyState={emptyState}
-          onFileClick={handleFileClick}
-        />
-      ) : (
-        <FilesGrid
-          files={orgFiles}
-          isLoading={loading && orgFiles.length === 0}
-          emptyState={emptyState}
-          onFileClick={handleFileClick}
-        />
-      )}
-
-      <FileDetailDrawer
-        file={detailFile}
-        isOpen={detailFile !== null}
-        onClose={() => setDetailFile(null)}
-      />
     </div>
   );
 }

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/features/matters/components/MatterDetailPanel';
 import { type WorkSubTab } from '@/features/matters/components/MatterWorkTab';
 import { type BillingSubTab } from '@/features/matters/components/MatterBillingTab';
-import { createEngagementContract, getEngagementForMatter } from '@/features/engagements/api/engagementsApi';
+import { getEngagementForMatter } from '@/features/engagements/api/engagementsApi';
 import type { EngagementDetail } from '@/features/engagements/types/engagement';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useToastContext } from '@/shared/contexts/ToastContext';
@@ -463,7 +463,7 @@ export const PracticeMattersPage = ({
   const [engagementLoading, setEngagementLoading] = useState(false);
   const [engagementError, setEngagementError] = useState<string | null>(null);
   const [engagementRetryCount, setEngagementRetryCount] = useState(0);
-  const [engagementCreating, setEngagementCreating] = useState(false);
+  const [engagementCreating] = useState(false);
 
   // ── Person / service / assignee options ───────────────────────────────────
   const [clientOptions, setClientOptions] = useState<MatterOption[]>([]);
@@ -1088,27 +1088,11 @@ export const PracticeMattersPage = ({
       if (selectedMatterId) goToDetail(selectedMatterId, 'billing');
       return;
     }
-    if (!activePracticeId || !selectedMatterId || engagementCreating) return;
-
-    setEngagementCreating(true);
-    setEngagementError(null);
-    try {
-      // TODO(#555): legacy matter-detail create-engagement flow. Under the new contract,
-      // engagements are created from intakes (matter_id is set server-side on acceptance).
-      // This call will fail at runtime if reached, since selectedMatterId is a matter UUID,
-      // not an intake UUID. Per #555 memory, matters always have engagements — this path is
-      // expected to be unreachable in practice and will be removed in a follow-up.
-      const created = await createEngagementContract(activePracticeId, { intake_id: selectedMatterId });
-      setEngagement(created);
-      setEngagementRetryCount((count) => count + 1);
-      showSuccess('Engagement created', 'The engagement agreement is ready to review.');
-    } catch (error) {
-      setEngagementError(error instanceof Error ? error.message : 'Failed to create engagement');
-      showError('Could not create engagement', error instanceof Error ? error.message : 'Please try again.');
-    } finally {
-      setEngagementCreating(false);
-    }
-  }, [activePracticeId, engagement, engagementCreating, goToDetail, selectedMatterId, showError, showSuccess]);
+    if (!selectedMatterId || engagementCreating) return;
+    const message = 'This matter does not have a linked engagement. Accepted intake work now creates matters from accepted engagement contracts.';
+    setEngagementError(message);
+    showError('Missing engagement', message);
+  }, [engagement, engagementCreating, goToDetail, selectedMatterId, showError]);
 
   // ── Matter CRUD ───────────────────────────────────────────────────────────
   const handleUpdateMatter = useCallback(async (values: MatterFormState) => {
@@ -1828,7 +1812,7 @@ export const PracticeMattersPage = ({
             onAddTask: () => goToDetail(selectedMatterDetail.id, 'work', 'tasks'),
             onAddNote: () => goToDetail(selectedMatterDetail.id, 'notes'),
             onUploadFile: () => goToDetail(selectedMatterDetail.id, 'files'),
-            engagementActionLabel: engagement ? 'View engagement' : 'Create engagement',
+            engagementActionLabel: engagement ? 'View engagement' : 'Missing engagement',
             onEngagementAction: () => void handleEngagementPrimaryAction(),
             engagementActionLoading: engagementCreating,
             moreMenuItems: [

--- a/src/features/media/components/FileMenu.tsx
+++ b/src/features/media/components/FileMenu.tsx
@@ -144,10 +144,10 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
         aria-haspopup="menu"
         aria-controls="attachment-menu"
         aria-expanded={isOpen}
-        className={`shadow-lg border disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-glass/30 focus-visible:ring-offset-0 active:scale-100 ${
+        className={`shadow-lg border disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-subtle focus-visible:ring-offset-0 active:scale-100 ${
           isOpen
-            ? 'bg-surface-utility/20 border-line-glass/35'
-            : 'bg-surface-utility/10 border-line-glass/20 hover:bg-surface-utility/20 hover:border-line-glass/30 hover:scale-105'
+            ? 'bg-surface-utility/20 border-line-subtle'
+            : 'bg-surface-utility/10 border-line-subtle hover:bg-surface-utility/20 hover:border-line-subtle hover:scale-105'
         }`}
         icon={Plus} iconClassName="w-5 h-5"
       />
@@ -159,7 +159,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
           aria-labelledby="attachment-menu-button"
           className={`
             absolute bottom-full left-0 mb-2 min-w-[220px]
-            p-1 rounded-xl border border-line-glass/30 bg-surface-overlay/95 backdrop-blur-2xl shadow-glass transition-all duration-200
+            p-1 rounded-xl border border-line-subtle bg-surface-overlay/95 backdrop-blur-2xl shadow-glass transition-all duration-200
             ${isClosing ? 'opacity-0 scale-95 pointer-events-none' : 'opacity-100 scale-100'}
           `}
           style={{ zIndex: THEME.zIndex.fileMenu }}
@@ -183,7 +183,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
               role="menuitem"
               onClick={openCamera}
               onMouseDown={preventPointerFocus}
-              className="file-menu-item py-3 border-t border-line-glass/10 text-xs sm:text-sm"
+              className="file-menu-item py-3 border-t border-line-subtle text-xs sm:text-sm"
             >
               <span>Take Photo</span>
               <Icon icon={Camera} className="w-5 h-5" aria-hidden="true"  />
@@ -196,7 +196,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
       {errorMessage && (
         <div
           role="alert" aria-live="polite"
-          className="absolute bottom-full left-0 mb-2 min-w-[250px] p-3 glass-card border-accent-error/30 bg-accent-error/10"
+          className="absolute bottom-full left-0 mb-2 min-w-[250px] p-3 card border-accent-error/30 bg-accent-error/10"
           style={{ zIndex: THEME.zIndex.fileMenu + 1 }}
         >
           <div className="flex items-start gap-2">

--- a/src/features/media/components/MediaControls.tsx
+++ b/src/features/media/components/MediaControls.tsx
@@ -165,7 +165,7 @@ const MediaControls: FunctionComponent<MediaControlsProps> = ({
 				aria-label="Record audio message"
 				aria-pressed={isRecording}
 				disabled={permissionDenied}
-				className="shadow-lg border bg-surface-utility/10 border-line-glass/20 hover:bg-surface-utility/20 hover:border-line-glass/30 hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-glass/30 focus-visible:ring-offset-0 active:scale-100"
+				className="shadow-lg border bg-surface-utility/10 border-line-subtle hover:bg-surface-utility/20 hover:border-line-subtle hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-subtle focus-visible:ring-offset-0 active:scale-100"
 			>
 				<Icon icon={Mic} className="w-5 h-5" aria-hidden="true"  />
 			</Button>

--- a/src/features/modals/components/CameraCaptureButton.tsx
+++ b/src/features/modals/components/CameraCaptureButton.tsx
@@ -16,7 +16,7 @@ const CameraCaptureButton: FunctionComponent<CameraCaptureButtonProps> = ({ onCl
       onClick={onClick}
       disabled={disabled}
       title="Take photo"
-      className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full glass-panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-utility/10 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
+      className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-utility/10 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
       aria-label="Take photo"
     >
       <Icon icon={Camera} className="w-16 h-16 text-input-text"  />

--- a/src/features/modals/components/CameraDialog.tsx
+++ b/src/features/modals/components/CameraDialog.tsx
@@ -126,7 +126,7 @@ const CameraDialog: FunctionComponent<CameraDialogProps> = ({
             <p>{error}</p>
           </div>
         )}
-        <div className="relative w-full h-full overflow-hidden bg-surface-app-frame flex-grow border-t border-line-utility">
+        <div className="relative w-full h-full overflow-hidden bg-surface-app-frame flex-grow border-t border-line-subtle">
           <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-cover" />
           <canvas ref={canvasRef} style={{ display: 'none' }} />
         </div>

--- a/src/features/onboarding/components/InfoCard.tsx
+++ b/src/features/onboarding/components/InfoCard.tsx
@@ -47,7 +47,7 @@ export const InfoCard = ({
   };
 
   const variantClasses: Record<InfoCardVariant, string> = {
-    default: 'glass-panel text-input-text',
+    default: 'panel text-input-text',
     blue: 'status-info',
     amber: 'status-warning',
     green: 'status-success',

--- a/src/features/onboarding/steps/StripeOnboardingStep.tsx
+++ b/src/features/onboarding/steps/StripeOnboardingStep.tsx
@@ -66,7 +66,7 @@ export function StripeOnboardingStep({
       )}
 
       {showStatus && (
-        <div className="glass-card p-4 space-y-2">
+        <div className="card p-4 space-y-2">
           {statusItems.map((item) => (
             <div key={item.label} className="flex items-center justify-between text-sm">
               <span className="text-input-placeholder">{item.label}</span>

--- a/src/features/practice-dashboard/components/BillingActionsWidget.tsx
+++ b/src/features/practice-dashboard/components/BillingActionsWidget.tsx
@@ -28,7 +28,7 @@ export const BillingActionsWidget = ({
 }: BillingActionsWidgetProps) => {
   return (
     <Panel className="flex h-full flex-col">
-      <header className="flex items-center justify-between border-b border-line-glass/30 px-5 py-4">
+      <header className="flex items-center justify-between border-b border-line-subtle px-5 py-4">
         <div>
           <p className="text-sm font-semibold text-input-text">Billing Actions</p>
           <p className="text-xs text-input-placeholder">Matters that need billing attention</p>
@@ -52,7 +52,7 @@ export const BillingActionsWidget = ({
           <div className="space-y-4">
             {actions.map((action) => (
               <Fragment key={action.id}>
-                <div className="rounded-xl border border-line-glass/30 bg-surface px-4 py-3">
+                <div className="rounded-xl border border-line-subtle bg-surface px-4 py-3">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex gap-3">
                       <div className="text-lg" aria-hidden="true">{ICONS[action.reason]}</div>

--- a/src/features/practice-dashboard/components/DashboardHero.tsx
+++ b/src/features/practice-dashboard/components/DashboardHero.tsx
@@ -25,10 +25,10 @@ export const DashboardHero = ({
   onWindowChange,
   onCreateInvoice
 }: DashboardHeroProps) => (
-  <section className="border-b border-line-glass/30 lg:border-t lg:border-t-line-glass/20">
+  <section className="border-b border-line-subtle lg:border-t lg:border-t-line-glass/20">
     <div className="mx-auto flex max-w-7xl items-center gap-6 px-4 py-5 sm:px-6 lg:px-8">
       <h1 className="shrink-0 text-base font-semibold text-input-text">Cashflow</h1>
-      <div role="group" aria-label="Time window" className="flex shrink-0 gap-x-8 border-l border-line-glass/30 pl-6 text-sm font-semibold">
+      <div role="group" aria-label="Time window" className="flex shrink-0 gap-x-8 border-l border-line-subtle pl-6 text-sm font-semibold">
         {(Object.keys(WINDOW_LABELS) as BillingWindow[]).map((window) => (
           <Button
             key={window}
@@ -64,8 +64,8 @@ export const DashboardHero = ({
           <div
             key={stat.id}
             className={cn(
-              statIdx % 2 === 1 ? 'sm:border-l sm:border-line-glass/20' : statIdx === 2 ? 'lg:border-l lg:border-line-glass/20' : '',
-              'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-line-glass/20 px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8'
+              statIdx % 2 === 1 ? 'sm:border-l sm:border-line-subtle' : statIdx === 2 ? 'lg:border-l lg:border-line-subtle' : '',
+              'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-line-subtle px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8'
             )}
           >
             <dt className="text-sm font-medium text-input-placeholder">{stat.label}</dt>

--- a/src/features/practice-dashboard/components/DashboardSummaryCards.tsx
+++ b/src/features/practice-dashboard/components/DashboardSummaryCards.tsx
@@ -35,9 +35,9 @@ export const DashboardSummaryCards = ({ stats, loading = false }: DashboardSumma
         key={stat.id}
         className={[
           'px-5 py-6 sm:px-6',
-          index > 0 ? 'border-t border-line-glass/20' : '',
-          index % 2 === 1 ? 'sm:border-l sm:border-line-glass/20' : '',
-          index > 1 ? 'sm:border-t sm:border-line-glass/20' : '',
+          index > 0 ? 'border-t border-line-subtle' : '',
+          index % 2 === 1 ? 'sm:border-l sm:border-line-subtle' : '',
+          index > 1 ? 'sm:border-t sm:border-line-subtle' : '',
           'grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]'
         ].join(' ')}
       >

--- a/src/features/practice-dashboard/components/OutstandingPaymentsWidget.tsx
+++ b/src/features/practice-dashboard/components/OutstandingPaymentsWidget.tsx
@@ -18,7 +18,7 @@ export const OutstandingPaymentsWidget = ({
   onViewInvoices
 }: OutstandingPaymentsWidgetProps) => (
   <Panel className="flex h-full flex-col">
-    <header className="border-b border-line-glass/30 px-5 py-4">
+    <header className="border-b border-line-subtle px-5 py-4">
       <p className="text-sm font-semibold text-input-text">Outstanding Payments</p>
       <p className="text-xs text-input-placeholder">Invoices awaiting payment</p>
     </header>
@@ -52,7 +52,7 @@ export const OutstandingPaymentsWidget = ({
         <p className="text-sm text-input-placeholder">No unpaid invoices.</p>
       )}
     </div>
-    <footer className="border-t border-line-glass/30 px-5 py-4">
+    <footer className="border-t border-line-subtle px-5 py-4">
       <Button size="sm" className="w-full" onClick={() => onViewInvoices?.()}>
         View billing
       </Button>

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -36,9 +36,9 @@ const statusClass = (status: ActivityEntry['status']) => {
   const normalized = status.toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  if (normalized === 'draft') return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
-  if (normalized === 'sent' || normalized === 'pending') return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
-  return 'bg-surface-overlay/80 text-input-placeholder ring-line-glass/20';
+  if (normalized === 'draft') return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
+  if (normalized === 'sent' || normalized === 'pending') return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
+  return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
 };
 
 export const RecentActivityTable = ({ days, loading = false, error = null, onOpenInvoice }: RecentActivityTableProps) => (
@@ -49,7 +49,7 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
       </h2>
     </div>
     {loading ? (
-      <div className="mt-6 border-t border-line-glass/30">
+      <div className="mt-6 border-t border-line-subtle">
         <div className="mx-auto max-w-7xl px-4 py-5 sm:px-6 lg:px-8">
           <div className="space-y-3">
             {[1, 2, 3, 4, 5].map(i => (
@@ -65,13 +65,13 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
         </div>
       </div>
     ) : error ? (
-      <div className="mt-6 border-t border-line-glass/30">
+      <div className="mt-6 border-t border-line-subtle">
         <div className="mx-auto max-w-7xl px-4 py-5 text-sm text-input-text sm:px-6 lg:px-8">
           {error}
         </div>
       </div>
     ) : (
-      <div className="mt-6 overflow-hidden border-t border-line-glass/30">
+      <div className="mt-6 overflow-hidden border-t border-line-subtle">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
             <table className="w-full text-left">
@@ -98,8 +98,8 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                       <tr className="text-sm text-input-text">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
-                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-glass/30 bg-surface-overlay/70" />
-                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-glass/30 bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
                         </th>
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -9,7 +9,7 @@ import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatDate } from '@/shared/utils/dateTime';
 import type { RecentClient } from '@/features/practice-dashboard/hooks/usePracticeBillingData';
 
-const neutralTone = 'ring-line-glass/20 bg-surface-overlay/80 text-input-placeholder';
+const neutralTone = 'ring-line-subtle bg-surface-overlay/80 text-input-placeholder';
 const statusTone: Record<string, string> = {
   paid: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   overdue: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
@@ -64,7 +64,7 @@ export const RecentClientsGrid = ({
               key={client.id}
               className="overflow-hidden rounded-xl bg-surface-overlay/80 outline outline-1 outline-line-glass/40 backdrop-blur-xl"
             >
-              <div className="flex items-center gap-x-4 border-b border-line-glass/20 bg-surface-overlay/70 p-6">
+              <div className="flex items-center gap-x-4 border-b border-line-subtle bg-surface-overlay/70 p-6">
                 <Avatar 
                   src={client.avatarUrl} 
                   name={client.name} 
@@ -93,7 +93,7 @@ export const RecentClientsGrid = ({
                 </DropdownMenu>
               </div>
               {client.lastInvoice ? (
-                <dl className="-my-3 divide-y divide-line-glass/20 bg-surface-overlay/60 px-6 py-4 text-sm">
+                <dl className="-my-3 divide-y divide-line-subtle bg-surface-overlay/60 px-6 py-4 text-sm">
                   <div className="flex justify-between gap-x-4 py-3">
                     <dt className="text-input-placeholder">Last invoice</dt>
                     <dd className="text-input-text">

--- a/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
@@ -11,7 +11,7 @@ import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
 const statusTone: Record<string, string> = {
   accepted: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   declined: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
-  pending_review: 'ring-line-glass/20 bg-surface-overlay/80 text-input-placeholder',
+  pending_review: 'ring-line-subtle bg-surface-overlay/80 text-input-placeholder',
 };
 
 type RecentIntakesGridProps = {
@@ -70,11 +70,11 @@ export const RecentIntakesGrid = ({
             return (
               <li
                 key={intake.uuid}
-                className="glass-card flex flex-col overflow-hidden"
+                className="card flex flex-col overflow-hidden"
               >
                 <button
                   className={
-                    `flex w-full items-center gap-x-4 border-b border-line-glass/20 p-6 text-left ${actionable ? 'cursor-pointer focus-visible:ring-2 focus-visible:ring-accent-400 focus:outline-none' : ''}`
+                    `flex w-full items-center gap-x-4 border-b border-line-subtle p-6 text-left ${actionable ? 'cursor-pointer focus-visible:ring-2 focus-visible:ring-accent-400 focus:outline-none' : ''}`
                   }
                   role={actionable ? 'button' : undefined}
                   tabIndex={actionable ? 0 : -1}
@@ -98,7 +98,7 @@ export const RecentIntakesGrid = ({
                   </div>
                   {/* actions removed — whole card is clickable */}
                 </button>
-                <dl className="-my-3 divide-y divide-line-glass/20 px-6 py-4 text-sm">
+                <dl className="-my-3 divide-y divide-line-subtle px-6 py-4 text-sm">
                   <div className="flex justify-between gap-x-4 py-3">
                     <dt className="text-input-placeholder">Date Submitted</dt>
                     <dd className="text-input-text">

--- a/src/features/practice-setup/components/StripeCheckpointCard.tsx
+++ b/src/features/practice-setup/components/StripeCheckpointCard.tsx
@@ -29,7 +29,7 @@ export function StripeCheckpointCard({
   const statusLabel = isInProgress ? 'In progress' : 'Not started';
 
   return (
-    <div className="glass-card mt-4 space-y-4 border border-line-glass/40 p-4 text-input-text">
+    <div className="card mt-4 space-y-4 border border-line-subtle p-4 text-input-text">
       <div className="flex items-start gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-accent-500/12 text-lg text-[rgb(var(--accent-foreground))]">
           $
@@ -39,7 +39,7 @@ export function StripeCheckpointCard({
           <p className="text-sm text-input-placeholder">{body}</p>
         </div>
       </div>
-      <div className="flex items-center justify-between gap-3 rounded-2xl border border-line-glass/30 bg-surface-utility/10 px-3 py-2">
+      <div className="flex items-center justify-between gap-3 rounded-2xl border border-line-subtle bg-surface-utility/10 px-3 py-2">
         <div>
           <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-input-placeholder">Stripe status</div>
           <div className="text-sm font-medium">{statusLabel}</div>

--- a/src/features/practice/components/WorkspacePracticeDetailsError.tsx
+++ b/src/features/practice/components/WorkspacePracticeDetailsError.tsx
@@ -33,7 +33,7 @@ export function WorkspacePracticeDetailsError({
       tabIndex={-1}
       ref={dialogRef}
     >
-    <div className="max-w-lg glass-panel p-6 text-center">
+    <div className="max-w-lg panel p-6 text-center">
         <h1 id="workspace-error-heading" className="text-2xl font-semibold text-input-text">
           {t('workspace.error.title')}
         </h1>

--- a/src/features/pricing/components/PricingView.tsx
+++ b/src/features/pricing/components/PricingView.tsx
@@ -166,7 +166,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
           </div>
         ) : null}
 
-        <div className="mt-6 glass-card px-5 py-6 md:px-7 md:py-8">
+        <div className="mt-6 card px-5 py-6 md:px-7 md:py-8">
           <div className="flex flex-col items-start text-left">
             <h1 data-testid="pricing-page-title" className="text-3xl font-semibold tracking-tight text-input-text md:text-4xl">
               {plan.displayName || plan.name}

--- a/src/features/reports/components/ReportCard.tsx
+++ b/src/features/reports/components/ReportCard.tsx
@@ -40,12 +40,12 @@ export const ReportCard: FunctionComponent<ReportCardProps> = ({ definition, onC
       type="button"
       onClick={onClick}
       className={cn(
-        'flex w-full flex-col gap-2 rounded-2xl border border-line-glass/20 bg-surface-utility/5 p-4 text-left transition hover:bg-surface-utility/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
+        'flex w-full flex-col gap-2 rounded-2xl border border-line-subtle bg-surface-utility/5 p-4 text-left transition hover:bg-surface-utility/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
         className,
       )}
     >
       <div className="flex items-center justify-between">
-        <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line-glass/30 bg-surface-utility/10">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
           <Icon className="h-4 w-4 text-input-placeholder" aria-hidden="true" />
         </div>
         {definition.phase === 3 ? (

--- a/src/features/reports/components/ReportFilters.tsx
+++ b/src/features/reports/components/ReportFilters.tsx
@@ -75,7 +75,7 @@ export const ReportFilters: FunctionComponent<ReportFiltersProps> = ({ filters, 
               <select
                 value={current}
                 onChange={(e) => set(f.id, (e.currentTarget as HTMLSelectElement).value)}
-                className="h-9 rounded-md border border-line-glass/30 bg-surface-utility/5 px-2 text-sm text-input-text"
+                className="h-9 rounded-md border border-line-subtle bg-surface-utility/5 px-2 text-sm text-input-text"
               >
                 {f.options.map((o) => (
                   <option key={o.value} value={o.value}>{o.label}</option>

--- a/src/features/reports/pages/reports/DeliveryDetailView.tsx
+++ b/src/features/reports/pages/reports/DeliveryDetailView.tsx
@@ -80,27 +80,27 @@ export const DeliveryDetailView: FunctionComponent<DeliveryDetailViewProps> = ({
         <p className="mt-1 text-sm font-mono text-input-placeholder">{delivery.id}</p>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className="rounded-2xl border border-line-glass/20 p-3">
+        <div className="rounded-2xl border border-line-subtle p-3">
           <p className="text-xs text-input-placeholder">Status</p>
           <p className={`text-sm font-medium ${STATUS_COLOR[delivery.status] ?? ''}`}>{delivery.status}</p>
         </div>
-        <div className="rounded-2xl border border-line-glass/20 p-3">
+        <div className="rounded-2xl border border-line-subtle p-3">
           <p className="text-xs text-input-placeholder">Created</p>
           <p className="text-sm text-input-text">{new Date(delivery.createdAt).toLocaleString()}</p>
         </div>
         {delivery.completedAt ? (
-          <div className="rounded-2xl border border-line-glass/20 p-3">
+          <div className="rounded-2xl border border-line-subtle p-3">
             <p className="text-xs text-input-placeholder">Completed</p>
             <p className="text-sm text-input-text">{new Date(delivery.completedAt).toLocaleString()}</p>
           </div>
         ) : null}
         {typeof delivery.byteSize === 'number' ? (
-          <div className="rounded-2xl border border-line-glass/20 p-3">
+          <div className="rounded-2xl border border-line-subtle p-3">
             <p className="text-xs text-input-placeholder">File size</p>
             <p className="text-sm text-input-text">{delivery.byteSize.toLocaleString()} bytes</p>
           </div>
         ) : null}
-        <div className="rounded-2xl border border-line-glass/20 p-3 sm:col-span-2">
+        <div className="rounded-2xl border border-line-subtle p-3 sm:col-span-2">
           <p className="text-xs text-input-placeholder">Recipients</p>
           <p className="text-sm text-input-text">
             {delivery.recipients.length === 0 ? '—' : delivery.recipients.join(', ')}

--- a/src/features/search/components/CommandPalette.tsx
+++ b/src/features/search/components/CommandPalette.tsx
@@ -154,7 +154,7 @@ export function CommandPalette({
       <div id="command-palette-title" className="sr-only">
         Global search
       </div>
-      <div className="flex items-center gap-2 px-4 border-b border-line-utility">
+      <div className="flex items-center gap-2 px-4 border-b border-line-subtle">
         <Search size={18} className="text-input-text/60" aria-hidden="true" />
         {parsed.scopes.length > 0 ? <ScopePills scopes={parsed.scopes} /> : null}
         <input
@@ -373,7 +373,7 @@ function EmptyState({ message }: { message: string }) {
 
 function Footer() {
   return (
-    <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-line-utility text-[11px] text-input-text/60">
+    <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-line-subtle text-[11px] text-input-text/60">
       <div className="flex gap-3">
         <span>↑↓ navigate</span>
         <span>↵ open</span>

--- a/src/features/settings/components/EmailSettingsSection.tsx
+++ b/src/features/settings/components/EmailSettingsSection.tsx
@@ -40,7 +40,7 @@ export const EmailSettingsSection = ({
             id="feedback-emails"
             checked={receiveFeedbackEmails}
             onChange={(e) => onFeedbackChange(e.currentTarget.checked)}
-            className="w-4 h-4 text-accent-500 bg-transparent border-line-glass/30 rounded focus:ring-accent-500 focus:ring-2"
+            className="w-4 h-4 text-accent-500 bg-transparent border-line-subtle rounded focus:ring-accent-500 focus:ring-2"
           />
           <label htmlFor="feedback-emails" className="text-sm text-input-text cursor-pointer">
             {feedbackLabel}

--- a/src/features/settings/components/SettingsNotice.tsx
+++ b/src/features/settings/components/SettingsNotice.tsx
@@ -20,7 +20,7 @@ export const SettingsNotice = ({
   'aria-live': ariaLive
 }: SettingsNoticeProps) => {
   const variantClasses: Record<SettingsNoticeVariant, string> = {
-  info: 'glass-panel text-input-text',
+  info: 'panel text-input-text',
     warning: 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200',
     danger: 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200'
   };

--- a/src/features/settings/components/WidgetPreviewFrame.tsx
+++ b/src/features/settings/components/WidgetPreviewFrame.tsx
@@ -68,7 +68,7 @@ export const WidgetPreviewFrame = ({
   return (
     <div className="w-full">
       {showTitle ? <h3 className="mb-3 text-sm font-semibold text-input-text">{title}</h3> : null}
-      <div className="mx-auto w-full max-w-[390px] overflow-hidden rounded-xl border border-line-glass/40 bg-surface-card shadow-glass">
+      <div className="mx-auto w-full max-w-[390px] overflow-hidden rounded-xl border border-line-subtle bg-surface-card shadow-glass">
         <div className={cn('relative w-full overflow-hidden bg-surface-ground', viewportClassName)}>
           <WidgetPreviewApp
             key={previewKey}

--- a/src/features/settings/pages/AppDetailPage.tsx
+++ b/src/features/settings/pages/AppDetailPage.tsx
@@ -97,7 +97,7 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
           label={app.name}
           labelNode={(
             <div className="flex items-center gap-4">
-              <div className="glass-input w-16 h-16 rounded-full flex items-center justify-center border border-line-glass/30 overflow-hidden">
+              <div className="input-surface w-16 h-16 rounded-full flex items-center justify-center border border-line-subtle overflow-hidden">
                 {app.logo ? (
                   <img
                     src={app.logo}

--- a/src/features/settings/pages/AppsPage.tsx
+++ b/src/features/settings/pages/AppsPage.tsx
@@ -32,7 +32,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
               label={app.name}
               labelNode={(
                 <div className="flex items-center gap-4">
-                  <div className="w-12 h-12 rounded-xl glass-panel flex items-center justify-center overflow-hidden">
+                  <div className="w-12 h-12 rounded-xl panel flex items-center justify-center overflow-hidden">
                     {app.logo ? (
                       <img
                         src={app.logo}

--- a/src/features/settings/pages/MFAEnrollmentPage.tsx
+++ b/src/features/settings/pages/MFAEnrollmentPage.tsx
@@ -232,7 +232,7 @@ export const MFAEnrollmentPage = ({
 
           {/* QR Code */}
           <div className="flex justify-center">
-            <div className="glass-panel p-4 rounded-xl">
+            <div className="panel p-4 rounded-xl">
               {/* Mock QR Code - in real app, you'd use a QR code library */}
               <div className="w-48 h-48 bg-surface-base rounded flex items-center justify-center">
                 <div className="text-center">

--- a/src/features/settings/pages/PracticeCoveragePage.tsx
+++ b/src/features/settings/pages/PracticeCoveragePage.tsx
@@ -294,7 +294,7 @@ export const PracticeCoveragePage = ({ className, onBack }: PracticeCoveragePage
               Round billable time to this many minutes when entries are created.
             </SettingsHelperText>
           </div>
-          <div className="glass-panel rounded-xl p-4">
+          <div className="panel rounded-xl p-4">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
               <div className="w-full max-w-[220px]">
                 <label className="mb-2 block text-sm font-medium text-input-text" htmlFor="billing-increment-minutes">

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -641,7 +641,7 @@ export const PracticePage = ({ className, onBack }: PracticePageProps) => {
                   }))}
                   disabled={isSaving}
                   aria-label={practiceText.brandColorAriaLabel}
-                  className="h-10 w-16 rounded-xl border border-line-glass bg-surface-card p-1"
+                  className="h-10 w-16 rounded-xl border border-line-subtle bg-surface-card p-1"
                 />
                 <Input
                   aria-label={practiceText.brandColorHexAria}

--- a/src/index.css
+++ b/src/index.css
@@ -478,20 +478,23 @@
   }
 
   /* ============================================================
-     Legacy glass aliases
-     `glass-*` names are compatibility shims for the card/panel/input
-     primitives above. New code should use card, panel, or input-surface.
+     Deprecated glass aliases — do not use in new code.
+     Use card, panel, or input-surface instead.
+     These shims exist only for backwards-compat during migration
+     and will be removed once all call sites are updated.
      ============================================================ */
+
+  .glass-card { @apply card; }
+  .glass-panel { @apply panel; }
+  .glass-input { @apply input-surface; }
 
   .dark .glass-panel {
     background-color: rgb(var(--surface-section));
     box-shadow: var(--panel-shadow);
   }
 
-  /* .list-panel-card-gradient: legacy accent-tinted top fade on collection list
-     panels. Deprecated as Tenant-Identity-Rule drift (the accent bleeding into
-     chrome). Class retained as a no-op so existing call sites keep resolving;
-     the panel now adopts its container's plain surface. */
+  /* .list-panel-card-gradient: legacy no-op shim, retained so existing
+     call sites keep resolving without errors. */
 
   .input-surface:focus,
   .input-surface.isOpen,
@@ -505,19 +508,23 @@
       0 0 0 2px rgb(var(--accent-ring));
   }
 
+  .input-surface.isError:focus,
+  .input-surface.isError,
   .glass-input.isError:focus,
   .glass-input.isError {
     @apply ring-0;
-    box-shadow: 
+    box-shadow:
       var(--input-shadow),
       0 0 0 2px rgb(var(--error-500) / 0.4),
       0 0 12px rgb(var(--error-500) / 0.2);
   }
 
+  .input-surface.isSuccess:focus,
+  .input-surface.isSuccess,
   .glass-input.isSuccess:focus,
   .glass-input.isSuccess {
     @apply ring-0;
-    box-shadow: 
+    box-shadow:
       var(--input-shadow),
       0 0 0 2px rgb(var(--success-500) / 0.4),
       0 0 12px rgb(var(--success-500) / 0.2);

--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -160,7 +160,7 @@ const Card = ({ tone = 'default', children }: { tone?: 'default' | 'error'; chil
         "mx-auto max-w-xl rounded-2xl border p-6 text-sm",
         tone === 'error'
           ? "border-accent-error/30 bg-accent-error/5 text-accent-error-foreground backdrop-blur-xl"
-          : "glass-card text-input-text"
+          : "card text-input-text"
       )}
     >
       {children}

--- a/src/pages/ClientHomePage.tsx
+++ b/src/pages/ClientHomePage.tsx
@@ -118,7 +118,7 @@ const ClientHomePage = () => {
           items={clientNextStepsItems}
         />
 
-        <div className="glass-panel p-6 space-y-4">
+        <div className="panel p-6 space-y-4">
           <div>
             <h2 className="text-lg text-heading">Manage your account</h2>
             <p className="text-sm text-secondary">

--- a/src/pages/DebugChatPage.tsx
+++ b/src/pages/DebugChatPage.tsx
@@ -198,7 +198,7 @@ export default function DebugChatPage() {
         </p>
       </header>
 
-      <section className="glass-panel space-y-3 rounded-xl p-4">
+      <section className="panel space-y-3 rounded-xl p-4">
         <div className="flex flex-wrap items-center gap-2">
           <Button variant="secondary" size="sm" onClick={resetState}>
             Reset chat

--- a/src/pages/DebugConversationsPage.tsx
+++ b/src/pages/DebugConversationsPage.tsx
@@ -367,7 +367,7 @@ export default function DebugConversationsPage() {
                 type="button"
                 variant="icon"
                 size="icon-sm"
-                className="border border-line-glass/30 bg-surface-workspace/10 hover:bg-surface-workspace/15"
+                className="border border-line-subtle bg-surface-workspace/10 hover:bg-surface-workspace/15"
                 aria-label="Open conversation details"
                 onClick={() => setIsConversationDetailsOpen(true)}
               >
@@ -379,7 +379,7 @@ export default function DebugConversationsPage() {
                 type="button"
                 variant="icon"
                 size="icon-sm"
-                className="border border-line-glass/30 bg-surface-utility/10 hover:bg-surface-utility/20"
+                className="border border-line-subtle bg-surface-utility/10 hover:bg-surface-utility/20"
                 aria-label="Open conversation details"
                 onClick={() => setIsConversationDetailsOpen(true)}
               >
@@ -411,7 +411,7 @@ export default function DebugConversationsPage() {
         <div className="flex flex-wrap items-center gap-2">
           <Icon icon={MessagesSquare} className="h-6 w-6 text-accent-500" aria-hidden="true"  />
           <h1 className="text-2xl font-semibold text-input-text">Debug Conversations</h1>
-          <span className="rounded-full border border-line-glass/30 bg-surface-panel/60 px-2.5 py-1 text-xs font-medium text-input-placeholder">
+          <span className="rounded-full border border-line-subtle bg-surface-panel/60 px-2.5 py-1 text-xs font-medium text-input-placeholder">
             No API
           </span>
         </div>
@@ -470,17 +470,17 @@ export default function DebugConversationsPage() {
       >
         <DialogBody className="space-y-4 text-sm text-input-text">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div className="glass-panel rounded-xl p-3">
+            <div className="panel rounded-xl p-3">
               <div className="text-xs uppercase tracking-wide text-input-placeholder">Workspace</div>
               <div className="mt-1 font-semibold capitalize">{workspaceKind}</div>
             </div>
-            <div className="glass-panel rounded-xl p-3">
+            <div className="panel rounded-xl p-3">
               <div className="text-xs uppercase tracking-wide text-input-placeholder">Conversation ID</div>
               <div className="mt-1 break-all font-mono text-xs">{activeConversationId}</div>
             </div>
           </div>
           {activeConversation?.user_info?.title ? (
-            <div className="glass-panel rounded-xl p-3">
+            <div className="panel rounded-xl p-3">
               <div className="text-xs uppercase tracking-wide text-input-placeholder">Title</div>
               <div className="mt-1 font-semibold">{String(activeConversation.user_info.title)}</div>
             </div>

--- a/src/pages/DebugDialogsPage.tsx
+++ b/src/pages/DebugDialogsPage.tsx
@@ -669,7 +669,7 @@ function PreviewSurface({
       style={!isIframe && theme === 'light' ? { backgroundAttachment: 'scroll' } : undefined}
     >
       {onReplay && (
-        <div className="mb-4 flex justify-between items-center border-b border-line-glass/10 pb-2">
+        <div className="mb-4 flex justify-between items-center border-b border-line-subtle pb-2">
           <span className={cn(
             "rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider",
             theme === 'light' ? "bg-accent-500/10 text-accent-600" : "bg-accent-400/20 text-accent-300"
@@ -848,7 +848,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
   }, [item.previewId]);
 
   return (
-    <article id={`gall-card-${item.previewId}`} className="space-y-4 rounded-3xl glass-panel p-6">
+    <article id={`gall-card-${item.previewId}`} className="space-y-4 rounded-3xl panel p-6">
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-bold text-input-text">{item.name}</h2>
@@ -875,7 +875,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
           <div className="space-y-2 min-h-[320px]">
             <p className="text-[10px] font-bold uppercase tracking-widest text-input-placeholder">Light Mode</p>
             <div 
-              className="widget-shell-gradient relative overflow-visible rounded-2xl border border-line-glass/10 p-4 shadow-glass" 
+              className="widget-shell-gradient relative overflow-visible rounded-2xl border border-line-subtle p-4 shadow-glass" 
               style={{ backgroundAttachment: 'scroll', isolation: 'isolate' }}
             >
               {isLoaded && frameSrcBase ? (
@@ -897,7 +897,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
           <div className="space-y-2 min-h-[320px]">
             <p className="text-[10px] font-bold uppercase tracking-widest text-input-placeholder">Dark Mode</p>
             <div 
-              className="relative overflow-visible rounded-2xl border border-line-glass/30 bg-surface-workspace p-4 shadow-glass dark"
+              className="relative overflow-visible rounded-2xl border border-line-subtle bg-surface-workspace p-4 shadow-glass dark"
               style={{ isolation: 'isolate' }}
             >
               {isLoaded && frameSrcBase ? (
@@ -938,7 +938,7 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
     return (
       <PreviewSurface onReplay={replayAnimations}>
         <div className="mx-auto flex min-h-screen max-w-2xl items-center justify-center p-8">
-          <div className="glass-card w-full p-8 text-center">
+          <div className="card w-full p-8 text-center">
             <p className="text-lg font-semibold text-input-text">Preview not found</p>
             <p className="mt-2 text-sm text-input-placeholder">
               The requested dialog preview does not exist.

--- a/src/pages/DebugMatterPage.tsx
+++ b/src/pages/DebugMatterPage.tsx
@@ -308,12 +308,12 @@ export default function DebugMatterPage() {
       </header>
 
       <section className="grid gap-6 lg:grid-cols-[360px_minmax(0,1fr)]">
-        <aside className="glass-panel overflow-hidden">
-          <div className="flex items-center justify-between border-b border-line-glass/30 px-4 py-3">
+        <aside className="panel overflow-hidden">
+          <div className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
             <h2 className="text-sm font-semibold text-input-text">Matters</h2>
             <Button size="xs" onClick={() => setEditorState('create')}>New</Button>
           </div>
-          <ul className="divide-y divide-line-glass/20">
+          <ul className="divide-y divide-line-subtle">
             {matters.map((matter) => (
               <MatterListItem
                 key={matter.id}
@@ -356,7 +356,7 @@ export default function DebugMatterPage() {
                   className="px-0 py-0"
                 />
                 <nav
-                  className="flex items-end gap-0 border-b border-line-glass/20 px-5"
+                  className="flex items-end gap-0 border-b border-line-subtle px-5"
                   aria-label="Matter sections"
                 >
                   {detailTabs.map((tab) => {
@@ -394,8 +394,8 @@ export default function DebugMatterPage() {
 
               {activeTab === 'overview' ? (
                 <div className="space-y-4">
-                  <section className="glass-panel overflow-hidden">
-                    <div className="border-b border-line-glass/20 px-6 py-4">
+                  <section className="panel overflow-hidden">
+                    <div className="border-b border-line-subtle px-6 py-4">
                       <h3 className="text-sm font-semibold text-input-text">Matter description</h3>
                     </div>
                     {isDescriptionEditing ? (
@@ -453,13 +453,13 @@ export default function DebugMatterPage() {
               ) : null}
 
               {activeTab === 'messages' ? (
-                <section className="glass-panel p-6 text-sm text-input-placeholder">
+                <section className="panel p-6 text-sm text-input-placeholder">
                   Message thread preview placeholder for UI layout work.
                 </section>
               ) : null}
 
               {activeTab === 'activity' ? (
-                <section className="glass-panel p-6">
+                <section className="panel p-6">
                   <ActivityTimeline
                     items={activityItems}
                     showComposer

--- a/src/pages/DebugStylesPage.tsx
+++ b/src/pages/DebugStylesPage.tsx
@@ -77,25 +77,27 @@ export default function DebugStylesPage() {
       <header className="space-y-2">
         <h1 className="text-2xl font-semibold text-input-text">Debug Style Reference</h1>
         <p className="text-sm text-input-placeholder">
-          Dev-only style inventory for button variants, glass surfaces, and nav state tokens.
+          Dev-only style inventory for button variants, surfaces, and nav state tokens.
         </p>
       </header>
 
-
       <section className="space-y-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Surfaces</h2>
+        <p className="text-sm text-input-placeholder">
+          Use <code>card</code>, <code>panel</code>, or <code>input-surface</code>. The <code>glass-*</code> names are deprecated aliases and must not be used in new code.
+        </p>
         <div className="grid gap-4 md:grid-cols-3">
-          <div className="glass-card p-4">
-            <p className="font-medium text-input-text">glass-card</p>
-            <p className="text-sm text-input-placeholder">Prominent container</p>
+          <div className="card p-4">
+            <p className="font-medium text-input-text">card</p>
+            <p className="text-sm text-input-placeholder">Content cards. <code>bg-surface-card</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
           </div>
-          <div className="glass-panel p-4">
-            <p className="font-medium text-input-text">glass-panel</p>
-            <p className="text-sm text-input-placeholder">Section container</p>
+          <div className="panel p-4">
+            <p className="font-medium text-input-text">panel</p>
+            <p className="text-sm text-input-placeholder">Section containers. <code>bg-surface-section</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
           </div>
-          <div className="glass-input rounded-xl p-4">
-            <p className="font-medium text-input-text">glass-input</p>
-            <p className="text-sm text-input-placeholder">Input-like surface</p>
+          <div className="input-surface rounded-xl p-4">
+            <p className="font-medium text-input-text">input-surface</p>
+            <p className="text-sm text-input-placeholder">Input backgrounds. <code>bg-surface-input</code>, <code>border-subtle</code>, <code>rounded-xl</code>.</p>
           </div>
         </div>
       </section>
@@ -107,7 +109,7 @@ export default function DebugStylesPage() {
         </p>
         <div className="grid gap-3 md:grid-cols-2">
           {buttonVariants.map((variant) => (
-            <div key={variant} className="glass-panel flex items-center gap-3 rounded-xl p-3">
+            <div key={variant} className="panel flex items-center gap-3 rounded-xl p-3">
               <Button variant={variant}>{variant}</Button>
               <code className="text-xs text-input-placeholder">variant=&quot;{variant}&quot;</code>
             </div>
@@ -117,7 +119,7 @@ export default function DebugStylesPage() {
 
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Button Sizes</h2>
-        <div className="glass-panel flex flex-wrap items-center gap-3 rounded-xl p-3">
+        <div className="panel flex flex-wrap items-center gap-3 rounded-xl p-3">
           {buttonSizes.map((size) => (
             <Button key={size} size={size} variant="secondary">
               {size}
@@ -191,43 +193,43 @@ export default function DebugStylesPage() {
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Input States</h2>
         <p className="text-sm text-input-placeholder">
-          Status is communicated through colored rings while preserving the glass material.
+          Status is communicated through colored rings on the <code>input-surface</code> base.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="glass-panel rounded-xl p-4 space-y-4">
+          <div className="panel rounded-xl p-4 space-y-4">
             <div className="space-y-1">
               <label htmlFor="defaultInput" className="text-xs font-medium text-input-placeholder">Default / Focus</label>
-              <input 
+              <input
                 id="defaultInput"
-                className="glass-input w-full rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-accent-500/30" 
-                placeholder="Standard state" 
+                className="input-surface w-full rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-accent-500/30"
+                placeholder="Standard state"
               />
             </div>
             <div className="space-y-1">
-              <label htmlFor="errorInput" className="text-xs font-medium text-input-placeholder">Error (ring-red)</label>
-              <input 
+              <label htmlFor="errorInput" className="text-xs font-medium text-input-placeholder">Error</label>
+              <input
                 id="errorInput"
-                className="glass-input w-full rounded-xl px-3 py-2 text-sm ring-2 ring-red-500/40 focus:ring-red-500/60" 
-                placeholder="Invalid value" 
+                className="input-surface w-full rounded-xl px-3 py-2 text-sm ring-2 ring-accent-error/40 focus:ring-accent-error/60"
+                placeholder="Invalid value"
               />
             </div>
           </div>
-          <div className="glass-panel rounded-xl p-4 space-y-4">
+          <div className="panel rounded-xl p-4 space-y-4">
             <div className="space-y-1">
-              <label htmlFor="successInput" className="text-xs font-medium text-input-placeholder">Success (ring-green)</label>
-              <input 
+              <label htmlFor="successInput" className="text-xs font-medium text-input-placeholder">Success</label>
+              <input
                 id="successInput"
-                className="glass-input w-full rounded-xl px-3 py-2 text-sm ring-2 ring-green-500/40 focus:ring-green-500/60" 
-                placeholder="Valid value" 
+                className="input-surface w-full rounded-xl px-3 py-2 text-sm ring-2 ring-accent-success/40 focus:ring-accent-success/60"
+                placeholder="Valid value"
               />
             </div>
             <div className="space-y-1">
               <label htmlFor="disabledInput" className="text-xs font-medium text-input-placeholder">Disabled</label>
-              <input 
+              <input
                 id="disabledInput"
                 disabled
-                className="glass-input w-full rounded-xl px-3 py-2 text-sm opacity-50 cursor-not-allowed focus:ring-0" 
-                placeholder="Locked" 
+                className="input-surface w-full rounded-xl px-3 py-2 text-sm opacity-50 cursor-not-allowed focus:ring-0"
+                placeholder="Locked"
               />
             </div>
           </div>
@@ -240,7 +242,7 @@ export default function DebugStylesPage() {
           Height baseline should align with Combobox for `md` controls.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="glass-panel rounded-xl p-4">
+          <div className="panel rounded-xl p-4">
             <Input
               label="Input"
               value={inputValue}
@@ -248,7 +250,7 @@ export default function DebugStylesPage() {
               placeholder="Enter matter title"
             />
           </div>
-          <div className="glass-panel rounded-xl p-4">
+          <div className="panel rounded-xl p-4">
             <Combobox
               label="Combobox"
               value={comboboxValue}
@@ -257,7 +259,7 @@ export default function DebugStylesPage() {
               placeholder="Pick a stage"
             />
           </div>
-          <div className="glass-panel rounded-xl p-4">
+          <div className="panel rounded-xl p-4">
             <CurrencyInput
               label="Currency Input"
               value={currencyValue}
@@ -265,14 +267,14 @@ export default function DebugStylesPage() {
               placeholder="0"
             />
           </div>
-          <div className="glass-panel rounded-xl p-4">
+          <div className="panel rounded-xl p-4">
             <DatePicker
               label="Date Picker"
               value={dateValue}
               onChange={setDateValue}
             />
           </div>
-          <div className="glass-panel rounded-xl p-4 md:col-span-2">
+          <div className="panel rounded-xl p-4 md:col-span-2">
             <Textarea
               label="Textarea"
               rows={3}
@@ -290,7 +292,7 @@ export default function DebugStylesPage() {
           One component, four modes. `multiple` and `allowCustomValues` toggle behavior; this is not a separate component.
         </p>
         <div className="grid gap-4 md:grid-cols-2 overflow-visible">
-          <div className="glass-panel relative z-40 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-40 rounded-xl p-4 overflow-visible">
             <Combobox
               label="Single (dropdown mode)"
               value={selectValue}
@@ -299,7 +301,7 @@ export default function DebugStylesPage() {
               searchable={false}
             />
           </div>
-          <div className="glass-panel relative z-40 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-40 rounded-xl p-4 overflow-visible">
             <Combobox
               label="Single (searchable)"
               placeholder="Pick a stage"
@@ -309,7 +311,7 @@ export default function DebugStylesPage() {
               leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-input-placeholder')}
             />
           </div>
-          <div className="glass-panel relative z-30 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-30 rounded-xl p-4 overflow-visible">
             <Combobox
               label="Multi (chips)"
               placeholder="Pick one or more stages"
@@ -321,7 +323,7 @@ export default function DebugStylesPage() {
               leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-input-placeholder')}
             />
           </div>
-          <div className="glass-panel relative z-30 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-30 rounded-xl p-4 overflow-visible">
             <Combobox
               label="Combobox (multi + custom)"
               placeholder="Type to add tags"
@@ -336,17 +338,13 @@ export default function DebugStylesPage() {
         </div>
       </section>
 
-      {/* ================================================================== */}
-      {/* Avatar & User Components                                            */}
-      {/* ================================================================== */}
-
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Avatar Sizes &amp; Status</h2>
         <p className="text-sm text-input-placeholder">
           Five sizes (<code>xs sm md lg xl</code>) with optional <code>status</code> dot (<code>active</code> = emerald, <code>inactive</code> = amber).
           Image falls back to initials extracted from <code>name</code>.
         </p>
-        <div className="glass-panel rounded-xl p-4">
+        <div className="panel rounded-xl p-4">
           <div className="flex flex-wrap items-end gap-6">
             {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
               <div key={size} className="flex flex-col items-center gap-2">
@@ -371,9 +369,9 @@ export default function DebugStylesPage() {
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">StackedAvatars</h2>
         <p className="text-sm text-input-placeholder">
-          Pass a <code>users</code> array and a <code>max</code> cap. Overflow renders a <code>+N</code> badge using the <code>glass-input</code> surface.
+          Pass a <code>users</code> array and a <code>max</code> cap. Overflow renders a <code>+N</code> badge using the <code>input-surface</code> surface.
         </p>
-        <div className="glass-panel rounded-xl p-4 flex flex-wrap items-center gap-8">
+        <div className="panel rounded-xl p-4 flex flex-wrap items-center gap-8">
           <div className="flex flex-col gap-1">
             <StackedAvatars users={sampleUsers} size="sm" max={3} />
             <code className="text-[10px] text-input-placeholder">size=sm max=3</code>
@@ -400,7 +398,7 @@ export default function DebugStylesPage() {
           Pass <code>onClick</code> to make it a button (adds hover + focus ring).
         </p>
         <div className="grid gap-3 md:grid-cols-2">
-          <div className="glass-panel rounded-xl p-1">
+          <div className="panel rounded-xl p-1">
             <UserCard
               name="Alice Chen"
               secondary="alice@lawfirm.com"
@@ -409,7 +407,7 @@ export default function DebugStylesPage() {
               status="active"
             />
           </div>
-          <div className="glass-panel rounded-xl p-1">
+          <div className="panel rounded-xl p-1">
             <UserCard
               name="Bob Ramirez"
               secondary="bob@lawfirm.com"
@@ -419,7 +417,7 @@ export default function DebugStylesPage() {
               trailing={<Button size="xs" variant="ghost">Manage</Button>}
             />
           </div>
-          <div className="glass-panel rounded-xl overflow-hidden">
+          <div className="panel rounded-xl overflow-hidden">
             <UserCard
               name="Carol Singh"
               secondary="carol@lawfirm.com"
@@ -427,7 +425,7 @@ export default function DebugStylesPage() {
               onClick={() => alert('UserCard clicked')}
             />
           </div>
-          <div className="glass-panel rounded-xl overflow-hidden">
+          <div className="panel rounded-xl overflow-hidden">
             <UserCard
               name="David Kim"
               secondary="Member"

--- a/src/pages/PaymentResultPage.tsx
+++ b/src/pages/PaymentResultPage.tsx
@@ -52,7 +52,7 @@ const OUTCOMES: Record<PaymentOutcome, OutcomeConfig> = {
     headline: 'Verifying your payment…',
     body: 'Please wait a moment while we confirm your payment status.',
     badge: 'Checking status',
-    badgeClass: 'bg-slate-500/15 text-slate-300 border-slate-500/25',
+    badgeClass: 'bg-surface-utility/15 text-input-placeholder border-line-subtle',
   },
 };
 
@@ -105,9 +105,9 @@ const PaymentResultPage: FunctionComponent<{ practiceSlug?: string }> = ({ pract
             <Logo />
           </div>
           
-          <div className="glass-card p-8 sm:p-10 space-y-6">
+          <div className="card p-8 sm:p-10 space-y-6">
             <div className="flex justify-center">
-              <div className="rounded-full bg-surface-subtle/50 p-4 border border-line-glass/30 shadow-sm">
+              <div className="rounded-full bg-surface-subtle/50 p-4 border border-line-subtle shadow-sm">
                 <Icon className={`w-10 h-10 ${config.iconColor}`} aria-hidden="true" />
               </div>
             </div>

--- a/src/pages/PracticeHomePage.tsx
+++ b/src/pages/PracticeHomePage.tsx
@@ -270,7 +270,7 @@ const PracticeHomePage = () => {
                         <Check className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />
                       </span>
                     ) : (
-                      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full border border-line-utility text-[10px] font-semibold text-input-text">
+                      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full border border-line-subtle text-[10px] font-semibold text-input-text">
                         {idx + 1}
                       </span>
                     )}

--- a/src/shared/components/AnnouncementBanner.tsx
+++ b/src/shared/components/AnnouncementBanner.tsx
@@ -21,19 +21,19 @@ interface AnnouncementBannerProps {
 
 const toneStyles: Record<AnnouncementTone, { container: string; title: string; body: string; rail: string }> = {
   warning: {
-    container: 'border-line-glass/40 bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
+    container: 'border-line-subtle bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
     title: 'text-input-text',
     body: 'text-input-placeholder',
     rail: 'bg-amber-500/70'
   },
   info: {
-    container: 'border-line-glass/40 bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
+    container: 'border-line-subtle bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
     title: 'text-input-text',
     body: 'text-input-placeholder',
     rail: 'bg-sky-500/70'
   },
   success: {
-    container: 'border-line-glass/40 bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
+    container: 'border-line-subtle bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
     title: 'text-input-text',
     body: 'text-input-placeholder',
     rail: 'bg-emerald-500/70'
@@ -41,9 +41,9 @@ const toneStyles: Record<AnnouncementTone, { container: string; title: string; b
 };
 
 const flatToneStyles: Record<AnnouncementTone, string> = {
-  warning: 'border border-line-glass/30 bg-surface-panel/40 text-input-text backdrop-blur-xl',
-  info: 'border border-line-glass/30 bg-surface-panel/40 text-input-text backdrop-blur-xl',
-  success: 'border border-line-glass/30 bg-surface-panel/40 text-input-text backdrop-blur-xl'
+  warning: 'border border-line-subtle bg-surface-panel/40 text-input-text backdrop-blur-xl',
+  info: 'border border-line-subtle bg-surface-panel/40 text-input-text backdrop-blur-xl',
+  success: 'border border-line-subtle bg-surface-panel/40 text-input-text backdrop-blur-xl'
 };
 
 const AnnouncementBanner = ({

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -267,7 +267,7 @@ const AuthForm = ({
         </div>
       )}
 
-      <div className={variant === 'card' ? "glass-card py-8 px-4 sm:px-10" : "w-full"}>
+      <div className={variant === 'card' ? "card py-8 px-4 sm:px-10" : "w-full"}>
         {showGoogleSignIn && (
           <div className="mb-6">
             <Button
@@ -295,7 +295,7 @@ const AuthForm = ({
         {showGoogleSignIn && (
           <div className="relative mb-6">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-line-glass/30" />
+              <div className="w-full border-t border-line-subtle" />
             </div>
             <div className="relative flex justify-center text-sm">
               <span className="px-2 bg-[rgb(var(--surface-overlay))] text-input-placeholder font-medium">{t('common.orContinueWithEmail')}</span>
@@ -410,13 +410,13 @@ const AuthForm = ({
           </div>
 
           {error && (
-            <div className="mt-4 rounded-xl glass-panel border-accent-error/20 p-3">
+            <div className="mt-4 rounded-xl panel border-accent-error/20 p-3">
               <p className="text-sm text-accent-error-light">{error}</p>
             </div>
           )}
 
           {message && (
-            <div className="mt-4 rounded-xl glass-panel border-emerald-500/20 p-3">
+            <div className="mt-4 rounded-xl panel border-emerald-500/20 p-3">
               <p className="text-sm text-emerald-400">{message}</p>
             </div>
           )}

--- a/src/shared/components/ConfirmationDialog.tsx
+++ b/src/shared/components/ConfirmationDialog.tsx
@@ -162,7 +162,7 @@ export default function ConfirmationDialog({
                     onMouseDown={(e) => e.stopPropagation()}
                     placeholder={`Type "${confirmationValue}" to confirm`}
                     className={cn(
-                      'glass-input w-full rounded-xl px-3 py-2 text-sm',
+                      'input-surface w-full rounded-xl px-3 py-2 text-sm',
                       error ? 'isError' : ''
                     )}
                     aria-invalid={Boolean(error)}
@@ -206,7 +206,7 @@ export default function ConfirmationDialog({
                       onMouseDown={(e) => e.stopPropagation()}
                       placeholder={passwordPlaceholder}
                       className={cn(
-                        'glass-input w-full rounded-xl px-3 py-2 text-sm',
+                        'input-surface w-full rounded-xl px-3 py-2 text-sm',
                         passwordError ? 'isError' : ''
                       )}
                       aria-invalid={Boolean(passwordError)}

--- a/src/shared/components/DebugOverlay.tsx
+++ b/src/shared/components/DebugOverlay.tsx
@@ -188,7 +188,7 @@ export const DebugOverlay: FunctionComponent<DebugOverlayProps> = ({ isVisible =
       aria-label="Debug information overlay"
       aria-live="polite"
     >
-      <div className="glass-panel p-4 text-xs font-mono text-input-text">
+      <div className="panel p-4 text-xs font-mono text-input-text">
         <div className="mb-2 flex justify-between items-center">
           <strong>Debug Overlay</strong>
           <button
@@ -237,7 +237,7 @@ export const DebugOverlay: FunctionComponent<DebugOverlayProps> = ({ isVisible =
         </div>
         
         {isExpanded && (
-          <div className="mt-2 pt-2 border-t border-line-glass/40" role="region" aria-label="Additional debug information">
+          <div className="mt-2 pt-2 border-t border-line-subtle" role="region" aria-label="Additional debug information">
             <div className="text-xs text-input-placeholder">
               <div>Press <kbd className="bg-surface-utility/40 px-1 rounded">Esc</kbd> to collapse</div>
               <div>Press <kbd className="bg-surface-utility/40 px-1 rounded">Enter</kbd> or <kbd className="bg-surface-utility/40 px-1 rounded">Space</kbd> to toggle</div>

--- a/src/shared/components/MobileTopNav.tsx
+++ b/src/shared/components/MobileTopNav.tsx
@@ -16,7 +16,7 @@ const MobileTopNav = ({
   return (
     <div
       aria-hidden={!isVisible}
-      className={`fixed top-0 left-0 right-0 glass-panel rounded-none border-b border-line-glass/30 lg:hidden z-50 pt-safe transition-all duration-300 ease-out ${
+      className={`fixed top-0 left-0 right-0 panel rounded-none border-b border-line-subtle lg:hidden z-50 pt-safe transition-all duration-300 ease-out ${
         isVisible
           ? 'translate-y-0 opacity-100 pointer-events-auto'
           : '-translate-y-full opacity-0 pointer-events-none'

--- a/src/shared/components/PlaceholderPage.tsx
+++ b/src/shared/components/PlaceholderPage.tsx
@@ -26,7 +26,7 @@ export const PlaceholderPage = ({ title, subtitle, sections }: PlaceholderPagePr
       {sections.map((section) => (
         <div
           key={section.title}
-          className="glass-card p-5 space-y-2"
+          className="card p-5 space-y-2"
         >
           <div>
             <h2 className="text-lg font-semibold text-input-text">{section.title}</h2>

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -72,6 +72,9 @@ const prefetchPracticeFilesChunk = prefetchLazyChunk(
 const prefetchClientFilesChunk = prefetchLazyChunk(
   () => import('@/features/files/pages/ClientFilesPage')
 );
+const prefetchEngagementsChunk = prefetchLazyChunk(
+  () => import('@/features/engagements/pages/EngagementsPage')
+);
 
 export type NavCtx = {
   practiceSlug: string;
@@ -198,10 +201,17 @@ const buildPracticeRail = (basePath: string): NavRailItem[] => [
     label: 'Matters',
     icon: Briefcase,
     href: `${basePath}/matters`,
-    // /engagements lives under Matters in the unified sidebar (per Pencil GtRGH).
-    matchHrefs: [`${basePath}/matters`, `${basePath}/engagements`],
+    matchHrefs: [`${basePath}/matters`],
     expandable: true,
     prefetch: prefetchMattersChunk,
+  },
+  {
+    id: 'engagements',
+    label: 'Engagements',
+    icon: FileText,
+    href: `${basePath}/engagements`,
+    matchHrefs: [`${basePath}/engagements`],
+    prefetch: prefetchEngagementsChunk,
   },
   {
     id: 'conversations',
@@ -349,8 +359,6 @@ const buildMattersSecondary = (basePath: string, workspace: 'practice' | 'client
     return [{
       label: 'Stage',
       items: [
-        // Engagements is a peer route but lives under Matters in the unified sidebar (Pencil GtRGH).
-        { id: 'engagements', label: 'Engagements', href: `${basePath}/engagements` },
         { id: 'all', label: 'All', href: `${basePath}/matters` },
         { id: 'new', label: 'New', href: `${basePath}/matters` },
         { id: 'active', label: 'Active', href: `${basePath}/matters` },
@@ -501,8 +509,6 @@ const buildSecondary = (basePath: string, section: WorkspaceSection, workspace: 
       return buildSettingsSecondary(basePath, canAccessPractice);
     case 'home':
       return buildHomeSecondary(basePath, workspace);
-    case 'engagements':
-      return buildMattersSecondary(basePath, workspace);
     default:
       return undefined;
   }

--- a/src/shared/ui/Accordion.tsx
+++ b/src/shared/ui/Accordion.tsx
@@ -105,7 +105,7 @@ const Accordion: FunctionComponent<AccordionProps> = ({
     <AccordionContext.Provider value={contextValue}>
       <div 
         data-slot="accordion" 
-        className={cn("w-full border border-line-glass/30 rounded-xl", className)}
+        className={cn("w-full border border-line-subtle rounded-xl", className)}
       >
         {children}
       </div>

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -8,7 +8,6 @@ type ButtonVariant =
   | 'secondary'
   | 'ghost'
   | 'icon'
-  | 'inverted'
   | 'danger'
   | 'warning'
   | 'danger-ghost'
@@ -90,7 +89,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     secondary: 'btn-secondary',
     ghost: 'btn-ghost',
     icon: 'btn-icon',
-    inverted: 'btn-inverted',
     danger: 'btn-danger',
     warning: 'btn-warning',
     'danger-ghost': 'btn-danger-ghost',
@@ -111,7 +109,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     return `btn-${resolvedSize}`;
   };
 
-  const hasVariantOverride = /\bbtn-(primary|secondary|ghost|icon|inverted|danger|warning|danger-ghost|accent-ghost|outline|link|menu-item|tab)\b/.test(className);
+  const hasVariantOverride = /\bbtn-(primary|secondary|ghost|icon|danger|warning|danger-ghost|accent-ghost|outline|link|menu-item|tab)\b/.test(className);
   const hasSizeOverride = /\bbtn-(xs|sm|md|lg|icon-xs|icon-sm|icon-md|icon-lg)\b/.test(className);
 
   const classes = [

--- a/src/shared/ui/ButtonGroup.tsx
+++ b/src/shared/ui/ButtonGroup.tsx
@@ -21,8 +21,8 @@ export function ButtonGroup({
         '[&>*]:rounded-none',
         orientation === 'horizontal' && '[&>*:first-child]:rounded-l-full [&>*:last-child]:rounded-r-full',
         orientation === 'vertical' && '[&>*:first-child]:rounded-t-xl [&>*:last-child]:rounded-b-xl',
-        '[&>*+*]:border-l [&>*+*]:border-line-glass/20',
-        orientation === 'vertical' && '[&>*+*]:border-l-0 [&>*+*]:border-t [&>*+*]:border-line-glass/20',
+        '[&>*+*]:border-l [&>*+*]:border-line-subtle',
+        orientation === 'vertical' && '[&>*+*]:border-l-0 [&>*+*]:border-t [&>*+*]:border-line-subtle',
         className,
       )}
     >

--- a/src/shared/ui/Divider.tsx
+++ b/src/shared/ui/Divider.tsx
@@ -15,9 +15,9 @@ export function Divider({
   className,
 }: DividerProps) {
   const variantClasses = {
-    default: 'border-line-glass/30',
-    subtle: 'border-line-glass/15',
-    strong: 'border-line-glass/40',
+    default: 'border-line-subtle',
+    subtle: 'border-line-subtle/50',
+    strong: 'border-line-subtle',
   };
 
   if (orientation === 'vertical') {

--- a/src/shared/ui/DragDropOverlay.tsx
+++ b/src/shared/ui/DragDropOverlay.tsx
@@ -61,13 +61,13 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
         {/* Icon stack — overlapping "talk + image + doc" tiles to mirror the
             reference. Tilted at slight angles so they read as a sticker stack. */}
         <div className="relative h-16 w-20">
-          <div className="absolute left-1 top-1 flex h-12 w-12 -rotate-12 items-center justify-center rounded-2xl bg-accent-500/90 shadow-lg ring-1 ring-line-glass/30">
+          <div className="absolute left-1 top-1 flex h-12 w-12 -rotate-12 items-center justify-center rounded-2xl bg-accent-500/90 shadow-lg ring-1 ring-line-subtle">
             <Icon icon={MessageSquare} className="h-6 w-6 text-[rgb(var(--accent-foreground))]" aria-hidden="true" />
           </div>
-          <div className="absolute right-0 top-0 flex h-12 w-12 rotate-6 items-center justify-center rounded-2xl bg-input-text/85 shadow-lg ring-1 ring-line-glass/30">
+          <div className="absolute right-0 top-0 flex h-12 w-12 rotate-6 items-center justify-center rounded-2xl bg-input-text/85 shadow-lg ring-1 ring-line-subtle">
             <Icon icon={FileText} className="h-6 w-6 text-surface-app-frame" aria-hidden="true" />
           </div>
-          <div className="absolute bottom-0 left-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-accent-500 shadow-lg ring-1 ring-line-glass/30">
+          <div className="absolute bottom-0 left-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-accent-500 shadow-lg ring-1 ring-line-subtle">
             <Icon icon={Image} className="h-6 w-6 text-[rgb(var(--accent-foreground))]" aria-hidden="true" />
           </div>
         </div>

--- a/src/shared/ui/Kbd.tsx
+++ b/src/shared/ui/Kbd.tsx
@@ -9,7 +9,7 @@ interface KbdProps {
 export const Kbd = ({ children, className }: KbdProps) => (
   <kbd
     className={cn(
-      'inline-flex min-w-[1.5em] items-center justify-center rounded border border-line-glass/40 bg-surface-utility/40 px-1.5 py-0.5 font-mono text-xs text-input-text',
+      'inline-flex min-w-[1.5em] items-center justify-center rounded border border-line-subtle bg-surface-utility/40 px-1.5 py-0.5 font-mono text-xs text-input-text',
       className
     )}
   >

--- a/src/shared/ui/activity/ActivityTimeline.tsx
+++ b/src/shared/ui/activity/ActivityTimeline.tsx
@@ -177,7 +177,7 @@ export const ActivityTimeline = ({
                   </span>
                 </div>
               ) : (
-                <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-glass/30 shadow-sm">
+                <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-subtle shadow-sm">
                   {item.type === 'paid' ? (
                     <Icon icon={CheckCircle2} aria-hidden="true" className="h-5 w-5 text-accent-success"  />
                   ) : TYPE_ICONS[item.type] ? (
@@ -351,7 +351,7 @@ export const ActivityTimeline = ({
           name={composerPerson?.name ?? 'You'}
           src={composerPerson?.imageUrl ?? null}
           size="sm"
-          className="ring-1 ring-line-glass/30 bg-surface-utility/10 text-input-text dark:ring-line-glass/40 sm:mt-1"
+          className="ring-1 ring-line-subtle bg-surface-utility/10 text-input-text dark:ring-line-subtle sm:mt-1"
         />
         <form className="flex-auto space-y-2" onSubmit={handleSubmit}>
           <MarkdownUploadTextarea

--- a/src/shared/ui/address/AddressExperienceForm.tsx
+++ b/src/shared/ui/address/AddressExperienceForm.tsx
@@ -309,7 +309,7 @@ export const AddressExperienceForm = ({
   const containerClasses = cn(
     variant === 'plain'
       ? 'w-full'
-      : 'glass-panel rounded-xl p-6',
+      : 'panel rounded-xl p-6',
     className
   );
 

--- a/src/shared/ui/badges/OnboardingStatusBadge.tsx
+++ b/src/shared/ui/badges/OnboardingStatusBadge.tsx
@@ -32,7 +32,7 @@ export const OnboardingStatusBadge = ({
   const baseClasses = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium transition-colors flex-shrink-0';
   
   const statusClasses = {
-    completed: 'text-input-placeholder bg-surface-overlay/60 border border-line-glass/30',
+    completed: 'text-input-placeholder bg-surface-overlay/60 border border-line-subtle',
     pending: 'text-amber-600 dark:text-amber-400 bg-transparent border border-amber-300 dark:border-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20',
     incomplete: 'text-red-600 dark:text-red-400 bg-transparent border border-red-300 dark:border-red-600 hover:bg-red-50 dark:hover:bg-red-900/20'
   };

--- a/src/shared/ui/badges/StatusBadge.tsx
+++ b/src/shared/ui/badges/StatusBadge.tsx
@@ -6,7 +6,7 @@ export type StatusVariant = 'active' | 'pending' | 'inactive' | 'suspended' | 'c
 const STATUS_CLASSES: Record<StatusVariant, string> = {
   active: 'status-success',
   pending: 'status-warning',
-  inactive: 'glass-input text-input-placeholder',
+  inactive: 'input-surface text-input-placeholder',
   suspended: 'status-error',
   cancelled: 'status-error',
   completed: 'status-info',

--- a/src/shared/ui/collection/CollectionToolbar.tsx
+++ b/src/shared/ui/collection/CollectionToolbar.tsx
@@ -36,7 +36,7 @@ export const CollectionToolbar = ({
   return (
     <section
       className={cn(
-        'rounded-2xl border border-line-glass/30 bg-surface-panel/70 backdrop-blur-xl',
+        'rounded-2xl border border-line-subtle bg-surface-panel/70 backdrop-blur-xl',
         compact ? 'p-3' : 'p-4 sm:p-5',
         className
       )}

--- a/src/shared/ui/dialog/Dialog.tsx
+++ b/src/shared/ui/dialog/Dialog.tsx
@@ -114,7 +114,7 @@ export const Dialog: FunctionComponent<DialogProps> = ({
         aria-describedby={description ? descriptionId : ariaDescribedBy}
         tabIndex={-1}
         className={cn(
-          'ui-surface-enter glass-card relative flex max-h-[90dvh] w-full max-w-lg flex-col rounded-2xl text-input-text',
+          'ui-surface-enter card relative flex max-h-[90dvh] w-full max-w-lg flex-col rounded-2xl text-input-text',
           contentClassName
         )}
       >

--- a/src/shared/ui/dialog/InfoListDialog.tsx
+++ b/src/shared/ui/dialog/InfoListDialog.tsx
@@ -67,7 +67,7 @@ export const InfoListDialog: FunctionComponent<InfoListDialogProps> = ({
       <DialogHeader onClose={onClose} showCloseButton className="pb-2">
         <div className="flex items-start gap-3">
           {HeaderIcon ? (
-            <div className="glass-input mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl">
+            <div className="input-surface mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl">
               <Icon icon={HeaderIcon} className={headerIconClassName ?? 'h-5 w-5 text-input-text'} aria-hidden="true" />
             </div>
           ) : null}

--- a/src/shared/ui/input/Combobox.tsx
+++ b/src/shared/ui/input/Combobox.tsx
@@ -109,7 +109,7 @@ function Chip({
         compact ? 'min-h-8 px-3 py-1 text-sm' : 'px-2 py-0.5',
         isCustom
           ? 'border-accent-500/25 bg-accent-500/12 text-accent-utility'
-          : 'border-line-utility/10 bg-surface-utility/10 text-input-text'
+          : 'border-line-subtle bg-surface-utility/10 text-input-text'
       )}
     >
       <span className="truncate">{label}</span>
@@ -580,7 +580,7 @@ export function Combobox({
           onClick={() => (isOpen ? close() : open())}
           onKeyDown={handleKeyDown}
           className={cn(
-            'glass-input relative flex w-full gap-2 rounded-xl px-3 py-2.5 transition-all duration-200',
+            'input-surface relative flex w-full gap-2 rounded-xl px-3 py-2.5 transition-all duration-200',
             isOpen && 'isOpen',
             'items-center',
             !disabled && 'cursor-pointer'
@@ -602,13 +602,13 @@ export function Combobox({
           onMouseDown={(e) => e.preventDefault()}
           className={cn(
             'z-[60] w-full overflow-hidden rounded-xl absolute',
-            'bg-surface-overlay shadow-glass border border-line-glass/20',
+            'bg-surface-overlay shadow-glass border border-line-subtle',
             hideTrigger ? 'top-0 mt-1' : (direction === 'up' ? 'bottom-full mb-1 top-auto' : 'top-full mt-1')
           )}
         >
           {/* Search input */}
           {searchable && (
-            <div className="border-b border-line-glass/10 px-2 py-2">
+            <div className="border-b border-line-subtle px-2 py-2">
               <input
                 ref={inputRef}
                 type="text"
@@ -696,11 +696,11 @@ export function Combobox({
           </div>
 
           {resolvedFooter ? (
-            <div className="border-t border-line-glass/10 px-2 py-2">
+            <div className="border-t border-line-subtle px-2 py-2">
               {resolvedFooter}
             </div>
           ) : allowCustomValues && filteredOptions.length === 0 && !showAddRow ? (
-            <div className="flex items-center gap-2 border-t border-line-glass/10 px-3 py-2 text-xs text-input-placeholder">
+            <div className="flex items-center gap-2 border-t border-line-subtle px-3 py-2 text-xs text-input-placeholder">
               <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded bg-accent-500/20 text-accent-utility">
                 <Icon icon={Plus} className="h-3 w-3" />
               </span>

--- a/src/shared/ui/input/CurrencyInput.tsx
+++ b/src/shared/ui/input/CurrencyInput.tsx
@@ -84,7 +84,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     variant === 'error' || error ? 'isError' : '',
     variant === 'success' && 'isSuccess',

--- a/src/shared/ui/input/DatePicker.tsx
+++ b/src/shared/ui/input/DatePicker.tsx
@@ -115,7 +115,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
   const inputClasses = cn(
     'w-full min-h-[44px] rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'appearance-none glass-input border-none',
+    'appearance-none input-surface border-none',
     sizeClasses[size],
     variantClasses[variant],
     disabled && 'opacity-50 cursor-not-allowed',

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -105,7 +105,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     iconPaddingClasses[size],
     variantClasses[variant],

--- a/src/shared/ui/input/FileInput.tsx
+++ b/src/shared/ui/input/FileInput.tsx
@@ -218,7 +218,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
       {showFileList && files.length > 0 && (
         <div className="mt-3 space-y-2">
           {files.map((file, index) => (
-            <div key={index} className="glass-input flex items-center justify-between p-2 rounded">
+            <div key={index} className="input-surface flex items-center justify-between p-2 rounded">
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-input-text truncate">
                   {file.name}

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -107,7 +107,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     icon && iconPaddingClasses[size],
     variant === 'error' || displayError ? 'isError' : '',

--- a/src/shared/ui/input/LogoUploadInput.tsx
+++ b/src/shared/ui/input/LogoUploadInput.tsx
@@ -127,7 +127,7 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
           </svg>
         )}
         <div
-          className="absolute inset-1 overflow-hidden rounded-full glass-panel border-white/10"
+          className="absolute inset-1 overflow-hidden rounded-full panel border-white/10"
           style={{ width: size, height: size, left: 4, top: 4 }}
         >
         {hasImage ? (

--- a/src/shared/ui/input/MarkdownUploadTextarea.tsx
+++ b/src/shared/ui/input/MarkdownUploadTextarea.tsx
@@ -274,16 +274,16 @@ export const MarkdownUploadTextarea = ({
         </label>
       ) : null}
 
-      <div className="overflow-hidden rounded-2xl border border-line-glass/30 bg-surface-panel/80 shadow-glass backdrop-blur-xl dark:bg-surface-overlay/70">
+      <div className="overflow-hidden rounded-2xl border border-line-subtle bg-surface-panel/80 shadow-glass backdrop-blur-xl dark:bg-surface-overlay/70">
         {showTabs ? (
-          <div className="flex items-center justify-between gap-3 border-b border-line-glass/30 bg-surface-panel/70 px-2 py-2 dark:bg-surface-overlay/80">
+          <div className="flex items-center justify-between gap-3 border-b border-line-subtle bg-surface-panel/70 px-2 py-2 dark:bg-surface-overlay/80">
             <div className="flex min-w-0 items-center gap-2 @xl:flex @xl:flex-none @xl:items-center @xl:gap-1">
               <button
                 type="button"
                 className={cn(
                   'rounded-xl px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'write'
-                    ? 'bg-surface-workspace/90 text-input-text shadow-sm ring-1 ring-line-glass/25 dark:bg-surface-overlay/90'
+                    ? 'bg-surface-workspace/90 text-input-text shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
                     : 'text-input-placeholder hover:text-input-text'
                 )}
                 onClick={() => setActiveTab('write')}
@@ -295,7 +295,7 @@ export const MarkdownUploadTextarea = ({
                 className={cn(
                   'rounded-xl px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'preview'
-                    ? 'bg-surface-workspace/90 text-input-text shadow-sm ring-1 ring-line-glass/25 dark:bg-surface-overlay/90'
+                    ? 'bg-surface-workspace/90 text-input-text shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
                     : 'text-input-placeholder hover:text-input-text'
                 )}
                 onClick={() => setActiveTab('preview')}
@@ -308,7 +308,7 @@ export const MarkdownUploadTextarea = ({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-line-glass/25 bg-surface-overlay/40 text-input-placeholder transition-colors hover:text-input-text"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-line-subtle bg-surface-overlay/40 text-input-placeholder transition-colors hover:text-input-text"
                     aria-label="Formatting options"
                   >
                     <Icon icon={MoreVertical} className="h-4 w-4" aria-hidden="true" />
@@ -319,21 +319,21 @@ export const MarkdownUploadTextarea = ({
                     onSelect={() => prependToLine('# ', 'Heading')}
                     className="flex items-center gap-2 rounded-xl px-3 py-2"
                   >
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-glass/20 bg-surface-overlay/50 text-xs font-semibold">H</span>
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-surface-overlay/50 text-xs font-semibold">H</span>
                     <span>Heading</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => replaceSelection('**', '**', 'bold text')}
                     className="flex items-center gap-2 rounded-xl px-3 py-2"
                   >
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-glass/20 bg-surface-overlay/50 text-xs font-semibold">B</span>
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-surface-overlay/50 text-xs font-semibold">B</span>
                     <span>Bold</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => replaceSelection('*', '*', 'italic text')}
                     className="flex items-center gap-2 rounded-xl px-3 py-2"
                   >
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-glass/20 bg-surface-overlay/50 text-xs italic font-semibold">I</span>
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-surface-overlay/50 text-xs italic font-semibold">I</span>
                     <span>Italic</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
@@ -493,7 +493,7 @@ export const MarkdownUploadTextarea = ({
                     {value}
                   </ReactMarkdown>
                 ) : (
-                  <div className="mt-2 flex justify-center rounded border border-line-glass/20 bg-surface-panel p-2 dark:border-line-glass/40 dark:bg-surface-panel/40">
+                  <div className="mt-2 flex justify-center rounded border border-line-subtle bg-surface-panel p-2 dark:border-line-subtle dark:bg-surface-panel/40">
                     <LoadingSpinner size="sm" ariaLabel="Loading preview" />
                   </div>
                 )}
@@ -505,7 +505,7 @@ export const MarkdownUploadTextarea = ({
         )}
 
         {showFooter ? (
-          <div className="flex flex-col gap-2 border-t border-line-glass/30 px-4 py-2 text-sm @xl:flex-row @xl:items-center @xl:justify-between">
+          <div className="flex flex-col gap-2 border-t border-line-subtle px-4 py-2 text-sm @xl:flex-row @xl:items-center @xl:justify-between">
             <div className="flex items-center gap-2 text-input-placeholder">
               {uploadsEnabled ? (
                 <>
@@ -543,7 +543,7 @@ export const MarkdownUploadTextarea = ({
       ) : null}
 
       {uploadItems.length > 0 && (
-        <div className="space-y-1 rounded-xl border border-line-glass/30 bg-surface-overlay/50 px-3 py-2">
+        <div className="space-y-1 rounded-xl border border-line-subtle bg-surface-overlay/50 px-3 py-2">
           {uploadItems.map((item) => (
             <div key={item.id} className="flex items-center gap-2 text-xs text-input-placeholder">
               <Icon icon={FileText} className="h-4 w-4" aria-hidden="true"  />

--- a/src/shared/ui/input/NumberInput.tsx
+++ b/src/shared/ui/input/NumberInput.tsx
@@ -92,7 +92,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     showControls && 'pr-20',
     variantClasses[variant],
@@ -187,7 +187,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
               disabled={disabled || !canIncrement}
               className={cn(
                 'flex items-center justify-center border-l border-input-border',
-                'glass-input hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
+                'input-surface hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 controlSizeClasses[size],
                 'rounded-tr-xl'
@@ -201,7 +201,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
               disabled={disabled || !canDecrement}
               className={cn(
                 'flex items-center justify-center border-l border-t border-input-border',
-                'glass-input hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
+                'input-surface hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 controlSizeClasses[size],
                 'rounded-br-xl'

--- a/src/shared/ui/input/PINInput.tsx
+++ b/src/shared/ui/input/PINInput.tsx
@@ -117,10 +117,10 @@ export function PINInput({
           disabled={disabled}
           aria-label={`Digit ${i + 1}`}
           className={cn(
-            'glass-input text-center font-medium rounded-xl',
+            'input-surface text-center font-medium rounded-xl',
             sizeClasses[size],
             'focus-visible:outline-none',
-            error && 'glass-input isError',
+            error && 'input-surface isError',
             'disabled:opacity-45 disabled:cursor-not-allowed',
             'transition-all duration-200',
           )}

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -95,7 +95,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     iconPaddingClasses[size],
     variantClasses[variant],

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -374,7 +374,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     showCountryCode ? null : iconPaddingClasses[size],
     showValidation && trimmedValue.length > 0 ? rightIconPaddingClasses[size] : null,
@@ -417,7 +417,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
               aria-haspopup="listbox"
               aria-label={`Select country. Current: ${currentCountry.name} (+${currentCountry.callingCode})`}
               className={cn(
-                'inline-flex items-center rounded-l-xl rounded-r-none text-input-text hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500 transition-colors glass-input border-r border-line-glass/20',
+                'inline-flex items-center rounded-l-xl rounded-r-none text-input-text hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500 transition-colors input-surface border-r border-line-subtle',
                 sizeClasses[size],
                 disabled && 'opacity-50 cursor-not-allowed',
               )}
@@ -429,10 +429,10 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
 
             {isDropdownOpen && (
               <div
-                className="absolute z-10 glass-panel border border-line-glass/30 rounded-xl shadow-glass w-64 top-full left-0 mt-1"
+                className="absolute z-10 panel border border-line-subtle rounded-xl shadow-glass w-64 top-full left-0 mt-1"
                 role="dialog"
               >
-                <div className="p-2 border-b border-line-glass/20">
+                <div className="p-2 border-b border-line-subtle">
                   <div className="relative">
                     <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-input-placeholder" aria-hidden="true" />
                     <input
@@ -446,7 +446,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
                       onKeyDown={handleSearchKeyDown}
                       placeholder="Search country or code"
                       aria-label="Search country"
-                      className="w-full pl-7 pr-2 py-1 text-sm rounded-md glass-input border-none focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500/30"
+                      className="w-full pl-7 pr-2 py-1 text-sm rounded-md input-surface border-none focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500/30"
                     />
                   </div>
                 </div>

--- a/src/shared/ui/input/RadioGroupWithDescriptions.tsx
+++ b/src/shared/ui/input/RadioGroupWithDescriptions.tsx
@@ -21,7 +21,7 @@ export const RadioGroupWithDescriptions = ({
 }: RadioGroupWithDescriptionsProps) => (
   <fieldset className={className}>
     <legend className="mb-1 block text-sm font-medium text-input-text">{label}</legend>
-    <div className="glass-card overflow-hidden rounded-2xl">
+    <div className="card overflow-hidden rounded-2xl">
       {options.map((option, index) => {
         const isSelected = value === option.value;
         const isFirst = index === 0;
@@ -33,7 +33,7 @@ export const RadioGroupWithDescriptions = ({
             aria-label={option.label}
             className={cn(
               'relative flex cursor-pointer items-start gap-3 px-4 py-3 text-left transition-colors',
-              !isFirst && 'border-t border-line-glass/20',
+              !isFirst && 'border-t border-line-subtle',
               'focus-within:outline-none focus-within:ring-2 ring-inset focus-within:ring-accent-500/50 focus-within:ring-inset',
               isSelected
                 ? 'bg-surface-panel/40 ring-1 ring-inset ring-accent-500/45 text-input-text'
@@ -54,7 +54,7 @@ export const RadioGroupWithDescriptions = ({
                 'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border',
                 isSelected
                   ? 'border-accent-500/50 bg-accent-500/20'
-                  : 'border-line-glass/40 bg-surface-panel/20'
+                  : 'border-line-subtle bg-surface-panel/20'
               )}
               aria-hidden="true"
             >

--- a/src/shared/ui/input/Switch.tsx
+++ b/src/shared/ui/input/Switch.tsx
@@ -43,7 +43,7 @@ export const Switch = ({
   const trackClasses = disabled
     ? value
       ? 'border-transparent bg-accent-500/35 dark:bg-accent-400/30'
-      : 'border border-line-glass/30 bg-neutral-200 dark:bg-neutral-700/80'
+      : 'border border-line-subtle bg-neutral-200 dark:bg-neutral-700/80'
     : value
       ? 'border-transparent bg-accent-500 focus:ring-accent-500'
       : 'border border-neutral-400/35 bg-neutral-300 focus:ring-neutral-400 dark:border-neutral-500/40 dark:bg-neutral-600';

--- a/src/shared/ui/input/Textarea.tsx
+++ b/src/shared/ui/input/Textarea.tsx
@@ -152,7 +152,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
     resizeClasses[resize],
     variantClasses[variant],
     disabled && 'opacity-50 cursor-not-allowed',
-    variant === 'default' ? 'glass-input border-input-border' : 'bg-input-bg',
+    variant === 'default' ? 'input-surface border-input-border' : 'bg-input-bg',
     className
   );
 

--- a/src/shared/ui/input/URLInput.tsx
+++ b/src/shared/ui/input/URLInput.tsx
@@ -123,7 +123,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
   const inputClasses = cn(
     'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
     'focus:outline-none transition-all duration-200',
-    'glass-input border-none',
+    'input-surface border-none',
     sizeClasses[size],
     iconPaddingClasses[size],
     variantClasses[variant],

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -908,7 +908,7 @@ export const InspectorPanel = ({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
-      <div className="flex items-center justify-between border-b border-line-glass/30 px-4 py-3">
+      <div className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
         <h2 className="text-sm font-semibold text-input-text">
           {entityType === 'conversation'
             ? 'Conversation Info'

--- a/src/shared/ui/inspector/MobileInspectorOverlay.tsx
+++ b/src/shared/ui/inspector/MobileInspectorOverlay.tsx
@@ -79,7 +79,7 @@ export const MobileInspectorOverlay: FunctionComponent<MobileInspectorOverlayPro
         aria-modal="true"
         aria-label="Inspector"
         tabIndex={-1}
-        className="ui-surface-enter-right absolute inset-y-0 right-0 flex w-full max-w-2xl flex-col overflow-visible bg-surface-nav-secondary rounded-r-none rounded-l-2xl shadow-glass ring-1 ring-line-glass/20"
+        className="ui-surface-enter-right absolute inset-y-0 right-0 flex w-full max-w-2xl flex-col overflow-visible bg-surface-nav-secondary rounded-r-none rounded-l-2xl shadow-glass ring-1 ring-line-subtle"
       >
         {/* Visible close button — backdrop click + Escape are kept as fallback
             paths, but a dedicated control matches the rest of our drawer chrome

--- a/src/shared/ui/layout/BottomBar.tsx
+++ b/src/shared/ui/layout/BottomBar.tsx
@@ -10,7 +10,7 @@ export const BottomBar = ({
   children,
   className
 }: BottomBarProps) => (
-  <div className={cn('border-t border-line-glass/30 bg-transparent', className)}>
+  <div className={cn('border-t border-line-subtle bg-transparent', className)}>
     {children}
   </div>
 );

--- a/src/shared/ui/layout/ContentWithPreview.tsx
+++ b/src/shared/ui/layout/ContentWithPreview.tsx
@@ -58,7 +58,7 @@ export function ContentWithPreview({
       </div>
       <div
         className={cn(
-          'bg-surface-panel min-h-0 overflow-y-auto border-l border-line-glass/40',
+          'bg-surface-panel min-h-0 overflow-y-auto border-l border-line-subtle',
           previewClassName
         )}
       >

--- a/src/shared/ui/layout/DetailHeader.tsx
+++ b/src/shared/ui/layout/DetailHeader.tsx
@@ -92,7 +92,7 @@ export const DetailHeader = ({
   if (!secondaryRow) return headerRow;
 
   return (
-    <div className={cn('flex flex-col border-b border-card-border bg-transparent', className)}>
+    <div className={cn('flex flex-col border-b border-line-subtle bg-transparent', className)}>
       {headerRow}
       <div className="flex flex-wrap items-center gap-x-5 gap-y-1 px-4 pb-2 text-xs text-input-placeholder">
         {secondaryRow}

--- a/src/shared/ui/layout/Panel.tsx
+++ b/src/shared/ui/layout/Panel.tsx
@@ -10,7 +10,7 @@ export const Panel = ({
   children,
   className
 }: PanelProps) => (
-  <div className={cn('glass-panel', className)}>
+  <div className={cn('panel', className)}>
     {children}
   </div>
 );

--- a/src/shared/ui/layout/PanelSectionHeader.tsx
+++ b/src/shared/ui/layout/PanelSectionHeader.tsx
@@ -19,7 +19,7 @@ export const PanelSectionHeader = ({
   actions,
   className
 }: PanelSectionHeaderProps) => (
-  <header className={cn('flex flex-wrap items-center justify-between gap-3 border-b border-line-glass/30 px-6 py-4', className)}>
+  <header className={cn('flex flex-wrap items-center justify-between gap-3 border-b border-line-subtle px-6 py-4', className)}>
     <div>
       <h3 className="text-sm font-semibold text-input-text">{title}</h3>
       {(subtitle !== undefined) && (

--- a/src/shared/ui/layout/ResponsiveDefinitionGrid.tsx
+++ b/src/shared/ui/layout/ResponsiveDefinitionGrid.tsx
@@ -19,7 +19,7 @@ export const ResponsiveDefinitionGrid = ({
   return (
     <div
       className={cn(
-        'grid grid-cols-1 divide-y divide-line-glass/5 @2xl:grid-cols-2 @2xl:divide-x @2xl:divide-y-0 @2xl:divide-line-glass/5',
+        'grid grid-cols-1 divide-y divide-line-subtle @2xl:grid-cols-2 @2xl:divide-x @2xl:divide-y-0 @2xl:divide-line-subtle',
         className
       )}
     >

--- a/src/shared/ui/layout/SectionDivider.tsx
+++ b/src/shared/ui/layout/SectionDivider.tsx
@@ -10,9 +10,9 @@ export const SectionDivider = ({
   variant = 'default'
 }: SectionDividerProps) => {
   const variantClasses = {
-    default: 'border-line-glass/30',
-    subtle: 'border-line-glass/15',
-    strong: 'border-line-glass/40'
+    default: 'border-line-subtle',
+    subtle: 'border-line-subtle/50',
+    strong: 'border-line-subtle',
   };
 
   return (

--- a/src/shared/ui/layout/SplitView.tsx
+++ b/src/shared/ui/layout/SplitView.tsx
@@ -32,7 +32,7 @@ export const SplitView = ({
     <div className={cn('grid h-full min-h-0 w-full', gridClassName, className)}>
       <aside
         className={cn(
-          'min-h-0 border-b border-line-glass/30 md:border-b-0 md:border-r md:overflow-y-auto',
+          'min-h-0 border-b border-line-subtle md:border-b-0 md:border-r md:overflow-y-auto',
           primaryClassName
         )}
       >
@@ -44,7 +44,7 @@ export const SplitView = ({
       {hasTertiary && (
         <aside
           className={cn(
-            'hidden min-h-0 border-t border-line-glass/30 md:border-t-0 md:border-l md:overflow-y-auto xl:block',
+            'hidden min-h-0 border-t border-line-subtle md:border-t-0 md:border-l md:overflow-y-auto xl:block',
             tertiaryClassName
           )}
         >

--- a/src/shared/ui/layout/WorkspacePlaceholderState.tsx
+++ b/src/shared/ui/layout/WorkspacePlaceholderState.tsx
@@ -46,9 +46,9 @@ export const WorkspacePlaceholderState = ({
   className,
 }: WorkspacePlaceholderStateProps) => (
   <div className={cn('flex h-full items-center justify-center p-6', className)}>
-    <div className="glass-panel w-full max-w-lg rounded-[28px] border border-line-glass/25 px-8 py-8 text-center shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl">
+    <div className="panel w-full max-w-lg rounded-[28px] border border-line-subtle px-8 py-8 text-center shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl">
       {icon ? (
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-line-glass/30 bg-surface-utility/10">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
           <Icon icon={icon} className="h-6 w-6 text-input-placeholder" aria-hidden="true" />
         </div>
       ) : null}

--- a/src/shared/ui/list/EntityList.tsx
+++ b/src/shared/ui/list/EntityList.tsx
@@ -97,7 +97,7 @@ export function EntityList<T extends { id: string }>({
               key={item.id}
               type="button"
               className={cn(
-                'w-full text-left transition-colors duration-150 border-b border-line-glass/[0.04]',
+                'w-full text-left transition-colors duration-150 border-b border-line-subtle',
                 isSelected ? SELECTED_ACCENT_SURFACE_CLASS : 'hover:bg-surface-utility/40',
                 onSelect && 'cursor-pointer'
               )}

--- a/src/shared/ui/list/List.tsx
+++ b/src/shared/ui/list/List.tsx
@@ -54,7 +54,7 @@ export function List({ items, divided = true, className }: ListProps) {
         <div key={i} role="listitem">
           <ListItem {...item} />
           {divided && i < items.length - 1 && (
-            <div className="mx-3 border-t border-line-glass/10" />
+            <div className="mx-3 border-t border-line-subtle" />
           )}
         </div>
       ))}

--- a/src/shared/ui/overlays/ContextMenu.tsx
+++ b/src/shared/ui/overlays/ContextMenu.tsx
@@ -47,12 +47,12 @@ export function ContextMenu({ children, items, className }: ContextMenuProps) {
         <div
           ref={menuRef}
           role="menu"
-          className="fixed z-[100] min-w-[160px] rounded-xl glass-panel py-1.5 shadow-lg"
+          className="fixed z-[100] min-w-[160px] rounded-xl panel py-1.5 shadow-lg"
           style={{ top: position.y, left: position.x }}
         >
           {items.map((item, i) => {
             if (item.divider) {
-              return <div key={i} className="my-1 border-t border-line-glass/15" />;
+              return <div key={i} className="my-1 border-t border-line-subtle" />;
             }
             return (
               <button

--- a/src/shared/ui/overlays/Drawer.tsx
+++ b/src/shared/ui/overlays/Drawer.tsx
@@ -113,7 +113,7 @@ export function Drawer({
         aria-label={title}
         tabIndex={-1}
         className={cn(
-          'fixed flex flex-col glass-panel rounded-none',
+          'fixed flex flex-col panel rounded-none',
           positionClasses[side],
           sizeMap[side][size],
           side !== 'bottom' && 'h-full',
@@ -124,7 +124,7 @@ export function Drawer({
         )}
       >
         {title && (
-          <div className="flex items-center justify-between px-5 py-4 border-b border-line-glass/15">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-line-subtle">
             <h2 className="text-base font-semibold text-input-text">{title}</h2>
             <button
               type="button"

--- a/src/shared/ui/overlays/Popover.tsx
+++ b/src/shared/ui/overlays/Popover.tsx
@@ -88,7 +88,7 @@ export function Popover({
       {isOpen && (
         <div
           className={cn(
-            'absolute z-[100] min-w-[200px] rounded-xl glass-panel p-3',
+            'absolute z-[100] min-w-[200px] rounded-xl panel p-3',
             'shadow-lg',
             sideStyles[placement] ?? sideStyles['bottom-start'],
             className,

--- a/src/shared/ui/profile/atoms/Avatar.tsx
+++ b/src/shared/ui/profile/atoms/Avatar.tsx
@@ -15,7 +15,7 @@ interface AvatarProps {
   name: string;
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   className?: string;
-  /** Override the inner circle background. Defaults to 'glass-input'.
+  /** Override the inner circle background. Defaults to 'input-surface'.
    *  Pass a solid Tailwind class (e.g. 'bg-surface-overlay') when
    *  rendering inside StackedAvatars to prevent backdrop-blur bleed-through.
    */
@@ -90,7 +90,7 @@ export const Avatar = ({ src, name, size = 'md', className = '', bgClassName, st
 
   return (
     <div className={`${sizeClasses[size]} relative flex-shrink-0 rounded-full ${className}`}>
-      <div className={`${bgClassName ?? 'glass-input'} h-full w-full rounded-full text-input-text flex items-center justify-center overflow-hidden shadow-sm ring-1 ring-line-glass/10`}>
+      <div className={`${bgClassName ?? 'input-surface'} h-full w-full rounded-full text-input-text flex items-center justify-center overflow-hidden shadow-sm ring-1 ring-line-subtle`}>
         {sanitizedImageUrl && !hasImgError ? (
           <img 
             src={sanitizedImageUrl} 

--- a/src/shared/ui/profile/molecules/ProfileButton.tsx
+++ b/src/shared/ui/profile/molecules/ProfileButton.tsx
@@ -21,7 +21,7 @@ export const ProfileButton = ({
     return (
       <button
         onClick={onClick}
-        className={`glass-input w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mx-auto ${className}`}
+        className={`input-surface w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mx-auto ${className}`}
         title={name}
         aria-label={`User profile for ${name}`}
       >

--- a/src/shared/ui/profile/molecules/ProfileDropdown.tsx
+++ b/src/shared/ui/profile/molecules/ProfileDropdown.tsx
@@ -32,7 +32,7 @@ export const ProfileDropdown = ({
       role="menu"
       aria-orientation="vertical"
       aria-label="Profile menu"
-      className={`absolute bottom-full right-0 mb-2 w-full max-w-xs rounded-xl shadow-glass border border-line-glass/30 py-2 z-50 bg-surface-overlay ${className}`}
+      className={`absolute bottom-full right-0 mb-2 w-full max-w-xs rounded-xl shadow-glass border border-line-subtle py-2 z-50 bg-surface-overlay ${className}`}
     >
       {/* Settings */}
       <ProfileMenuItem
@@ -42,7 +42,7 @@ export const ProfileDropdown = ({
       />
 
       {/* Separator */}
-      <div className="border-t border-line-glass/30 my-1" />
+      <div className="border-t border-line-subtle my-1" />
       
       {/* Help */}
       <ProfileMenuItem
@@ -61,7 +61,7 @@ export const ProfileDropdown = ({
       {/* Error message display */}
       {signOutError && (
         <>
-          <div className="border-t border-line-glass/30 my-1" />
+          <div className="border-t border-line-subtle my-1" />
           <div className="px-3 py-2 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border-l-2 border-red-200 dark:border-red-800">
             {signOutError}
           </div>

--- a/src/shared/ui/profile/molecules/StackedAvatars.tsx
+++ b/src/shared/ui/profile/molecules/StackedAvatars.tsx
@@ -67,7 +67,7 @@ export const StackedAvatars = ({
       {showOverflow && overflowCount > 0 && (
         <div
           className={cn(
-            'glass-input rounded-full text-input-text font-semibold flex items-center justify-center',
+            'input-surface rounded-full text-input-text font-semibold flex items-center justify-center',
             ringClasses,
             config.badge
           )}

--- a/src/shared/ui/profile/molecules/UserCard.tsx
+++ b/src/shared/ui/profile/molecules/UserCard.tsx
@@ -58,7 +58,7 @@ export const UserCard = ({
             {name}
           </p>
           {badge && (
-            <span className="shrink-0 inline-flex items-center rounded-full glass-input px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[rgb(var(--input-placeholder))]">
+            <span className="shrink-0 inline-flex items-center rounded-full input-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[rgb(var(--input-placeholder))]">
               {badge}
             </span>
           )}

--- a/src/shared/ui/profile/organisms/UserProfileDisplay.tsx
+++ b/src/shared/ui/profile/organisms/UserProfileDisplay.tsx
@@ -144,8 +144,8 @@ export const UserProfileDisplay = ({
   if (loading) {
     return (
       <div className={`flex items-center ${isCollapsed ? 'justify-center py-2' : 'gap-3 px-3 py-2'}`}>
-        <div className="glass-input w-8 h-8 rounded-full animate-pulse" />
-        {!isCollapsed && <div className="glass-input w-20 h-4 rounded animate-pulse" />}
+        <div className="input-surface w-8 h-8 rounded-full animate-pulse" />
+        {!isCollapsed && <div className="input-surface w-20 h-4 rounded animate-pulse" />}
       </div>
     );
   }

--- a/src/shared/ui/tag/TagInput.tsx
+++ b/src/shared/ui/tag/TagInput.tsx
@@ -487,8 +487,8 @@ export const TagInput = forwardRef<HTMLInputElement, TagInputProps>(({
             id={listboxId}
             role="listbox"
             className={cn(
-              'absolute z-50 w-full mt-1 glass-panel',
-              'border border-line-glass/30 rounded-xl shadow-glass',
+              'absolute z-50 w-full mt-1 panel',
+              'border border-line-subtle rounded-xl shadow-glass',
               'max-h-60 overflow-y-auto'
             )}
           >

--- a/src/shared/ui/tag/atoms/Tag.tsx
+++ b/src/shared/ui/tag/atoms/Tag.tsx
@@ -29,7 +29,7 @@ export const Tag = ({
   'aria-label': ariaLabel
 }: TagProps) => {
   const variantClasses = {
-    default: 'glass-input text-input-text',
+    default: 'input-surface text-input-text',
     primary: 'bg-accent-100 text-accent-800 dark:bg-accent-900/30 dark:text-accent-300',
     success: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
     warning: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',

--- a/src/shared/ui/upload/molecules/FileCard.tsx
+++ b/src/shared/ui/upload/molecules/FileCard.tsx
@@ -66,8 +66,8 @@ export const FileCard = ({
   if (variant === 'tile') {
     const fileType = getFileTypeConfig(fileName, mimeType);
     const tileClassName = cn(
-      'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-line-glass/30 bg-surface-card text-left transition-all',
-      onClick ? 'cursor-pointer hover:border-line-glass/60 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-accent-500' : '',
+      'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-surface-card text-left transition-all',
+      onClick ? 'cursor-pointer hover:border-line-subtle hover:shadow-md focus:outline-none focus:ring-2 focus:ring-accent-500' : '',
       className
     );
     const shouldShowTileStatus = status === 'uploading'
@@ -166,7 +166,7 @@ export const FileCard = ({
     return (
       <div className={cn(
         'relative rounded-2xl overflow-hidden flex-shrink-0',
-        'glass-panel transition-all duration-200',
+        'panel transition-all duration-200',
         // Make images square, matching the height of file cards
         size === 'sm' ? 'w-14 h-14' : size === 'md' ? 'w-16 h-16' : 'w-20 h-20',
         className

--- a/src/shared/ui/upload/molecules/UploadQueueRow.tsx
+++ b/src/shared/ui/upload/molecules/UploadQueueRow.tsx
@@ -32,7 +32,7 @@ export const UploadQueueRow = ({
   const resolvedProgress = clampProgress(progress);
 
   return (
-    <div className="rounded-xl border border-line-glass/15 bg-surface-utility/35 px-3 py-2">
+    <div className="rounded-xl border border-line-subtle bg-surface-utility/35 px-3 py-2">
       <div className="flex items-start gap-3">
         <FileIcon fileName={fileName} mimeType={mimeType} size="sm" />
         <div className="min-w-0 flex-1">

--- a/src/shared/ui/upload/organisms/UploadDropzone.tsx
+++ b/src/shared/ui/upload/organisms/UploadDropzone.tsx
@@ -47,8 +47,8 @@ export const UploadDropzone = ({
       className={cn(
         'rounded-xl border-2 border-dashed transition-colors',
         'relative flex min-h-[160px] items-center justify-center px-4 py-5',
-        isDragOver ? 'border-accent-500 bg-accent-500/10' : 'border-line-glass/25',
-        disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:border-line-glass/45',
+        isDragOver ? 'border-accent-500 bg-accent-500/10' : 'border-line-subtle',
+        disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:border-line-subtle',
         className
       )}
       onClick={() => {

--- a/src/shared/ui/upload/organisms/UploadSurface.tsx
+++ b/src/shared/ui/upload/organisms/UploadSurface.tsx
@@ -64,7 +64,7 @@ export const UploadSurface = ({
           ))}
         </div>
       ) : emptyStateLabel ? (
-        <div className="mt-3 rounded-xl border border-line-glass/15 px-3 py-4 text-center text-sm text-input-placeholder">
+        <div className="mt-3 rounded-xl border border-line-subtle px-3 py-4 text-center text-sm text-input-placeholder">
           {emptyStateLabel}
         </div>
       ) : null}

--- a/src/shared/utils/workspaceShell.ts
+++ b/src/shared/utils/workspaceShell.ts
@@ -48,9 +48,6 @@ export const getWorkspaceSection = (view: WorkspaceView): WorkspaceSection => {
   if (view === 'invoiceCreate' || view === 'invoiceEdit' || view === 'invoiceDetail') return 'invoices';
   if (view === 'setup' || view === 'contacts') return 'home';
   if (view === 'intakeDetail') return 'intakes';
-  // /engagements lives under Matters in the unified sidebar; route + breadcrumb still drive
-  // the engagements view, but the rail/active state belongs to Matters.
-  if (view === 'engagements') return 'matters';
   // Coverage lives under Settings in the sidebar; route stays at /coverage but the
   // rail/active state belongs to Settings so its dropdown auto-expands.
   if (view === 'coverage') return 'settings';
@@ -199,10 +196,8 @@ export const getWorkspaceDefaultSecondaryFilter = ({
   if (workspaceSection === 'intakes' && isPracticeWorkspace) {
     return 'all';
   }
-  // Matters > Engagements is a peer route rendered as the first sub-item; the default
-  // filter for /matters is the 'all' stage filter, not 'engagements'.
   if (workspaceSection === 'matters' && isPracticeWorkspace) {
-    return view === 'engagements' ? 'engagements' : 'all';
+    return 'all';
   }
   return navSecondary?.[0]?.items[0]?.id ?? null;
 };
@@ -235,11 +230,6 @@ export const getWorkspaceActiveSecondaryFilter = ({
   }
   if (workspaceSection === 'reports' && isPracticeWorkspace) {
     return reportSectionFromPath;
-  }
-  // /engagements is a peer route under the Matters rail item — the active
-  // sub-item must follow the URL, not whatever Matters filter was last picked.
-  if (workspaceSection === 'matters' && view === 'engagements') {
-    return 'engagements';
   }
   return secondaryFilterBySection[workspaceSection] ?? defaultSecondaryFilterId;
 };

--- a/tests/unit/engagements/engagementDraft.test.ts
+++ b/tests/unit/engagements/engagementDraft.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PracticeIntakeDetail } from '@/features/intake/api/intakesApi';
+import {
+  buildDeterministicContractBody,
+  buildEngagementDraftFormFromIntake,
+  buildProposalDataFromDraft,
+  EMPTY_ENGAGEMENT_DRAFT_FORM,
+} from '@/features/engagements/utils/engagementDraft';
+
+const acceptedIntake: PracticeIntakeDetail = {
+  uuid: 'intake-123',
+  organization_id: 'practice-123',
+  conversation_id: 'conversation-123',
+  status: 'succeeded',
+  triage_status: 'accepted',
+  metadata: {
+    email: 'jane@example.com',
+    name: 'Jane Client',
+    title: 'Custody consultation',
+    description: 'Parenting schedule dispute',
+    desired_outcome: 'Protect weekday parenting time',
+    urgency: 'time_sensitive',
+    opposing_party: 'John Other',
+    court_date: '2026-06-15',
+    practice_area: 'Family Law',
+    address: {
+      city: 'Austin',
+      state: 'TX',
+    },
+  },
+  created_at: '2026-05-22T06:52:21.651Z',
+  amount: 0,
+  currency: 'USD',
+  payment_verified: false,
+  stripe_charge_id: null,
+  practice_area: 'Family Law',
+  urgency: 'time_sensitive',
+  desired_outcome: 'Protect weekday parenting time',
+  court_date: '2026-06-15',
+  has_documents: false,
+  household_size: null,
+  income: null,
+  client_name: 'Jane Client',
+};
+
+describe('engagementDraft', () => {
+  it('maps accepted intake metadata into proposal data without backend-invented values', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-22T10:00:00.000Z'));
+
+    const form = buildEngagementDraftFormFromIntake(acceptedIntake, EMPTY_ENGAGEMENT_DRAFT_FORM);
+    const proposal = buildProposalDataFromDraft(form);
+
+    expect(proposal.client_summary).toMatchObject({
+      client_name: 'Jane Client',
+      matter_summary: 'Custody consultation',
+      location_summary: 'Austin, TX',
+      goals_summary: 'Protect weekday parenting time',
+    });
+    expect(proposal.representation.scope_summary).toBe('Custody consultation');
+    expect(proposal.fees).toMatchObject({
+      billing_type: null,
+      fixed_fee_amount: null,
+      hourly_rate_attorney: null,
+      hourly_rate_admin: null,
+      contingency_percentage: null,
+      retainer_amount: null,
+      payment_frequency: null,
+      fee_notes: null,
+    });
+    expect(proposal.risk_review).toMatchObject({
+      conflict_status: 'unknown',
+      jurisdiction_status: 'unknown',
+      risk_notes: null,
+      open_questions: null,
+    });
+    expect(proposal.source_snapshot).toMatchObject({
+      intake_uuid: 'intake-123',
+      conversation_id: 'conversation-123',
+      matter_id: null,
+      practice_area: 'Family Law',
+      urgency: 'time_sensitive',
+      desired_outcome: 'Protect weekday parenting time',
+      opposing_party: 'John Other',
+      court_date: '2026-06-15',
+    });
+    expect(proposal.draft_meta).toEqual({
+      generated_at: '2026-05-22T10:00:00.000Z',
+      generated_by: 'staff',
+      version: 1,
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('keeps missing optional fields null or empty', () => {
+    const form = buildEngagementDraftFormFromIntake({
+      ...acceptedIntake,
+      conversation_id: null,
+      metadata: undefined,
+      practice_area: null,
+      urgency: null,
+      desired_outcome: null,
+      court_date: null,
+      client_name: undefined,
+    });
+    const proposal = buildProposalDataFromDraft(form);
+
+    expect(proposal.client_summary.client_name).toBeNull();
+    expect(proposal.client_summary.location_summary).toBeNull();
+    expect(proposal.source_snapshot?.conversation_id).toBeNull();
+    expect(proposal.source_snapshot?.practice_area).toBeNull();
+    expect(proposal.source_snapshot?.court_date).toBeNull();
+  });
+
+  it('generates contract body deterministically from current form data', () => {
+    const form = {
+      ...EMPTY_ENGAGEMENT_DRAFT_FORM,
+      clientName: 'Jane Client',
+      matterSummary: 'Custody consultation',
+      scopeSummary: 'Limited-scope advice and drafting.',
+      includedServices: 'Review facts\nDraft agreement',
+      excludedServices: 'Trial representation',
+      feeNotes: 'Fixed fee due before work begins.',
+    };
+
+    expect(buildDeterministicContractBody(form)).toMatchInlineSnapshot(`
+      "Engagement Letter for Jane Client
+
+      This engagement letter confirms the proposed representation for Custody consultation.
+
+      Scope of Representation
+
+      Limited-scope advice and drafting.
+
+      Included services:
+      - Review facts
+      - Draft agreement
+
+      Excluded services:
+      - Trial representation
+
+      Fees and Billing
+
+      Fixed fee due before work begins.
+
+      Client Acknowledgment
+
+      By accepting this engagement, the client confirms they have reviewed the scope, billing terms, and responsibilities described in this agreement.
+
+      No Guarantee
+
+      The practice will provide legal services diligently and professionally, but no outcome is guaranteed."
+    `);
+  });
+});

--- a/tests/unit/engagements/engagementsApi.test.ts
+++ b/tests/unit/engagements/engagementsApi.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApiClient, mockInvalidate } = vi.hoisted(() => ({
+  mockApiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+  mockInvalidate: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({
+  apiClient: mockApiClient,
+  isHttpError: (error: unknown): error is { response: { status: number; data: unknown } } =>
+    typeof error === 'object' && error !== null && 'response' in error,
+}));
+
+vi.mock('@/shared/lib/queryCache', () => ({
+  queryCache: {
+    invalidate: mockInvalidate,
+  },
+}));
+
+import {
+  acceptEngagement,
+  createEngagementContract,
+  patchEngagementContract,
+  sendEngagementToClient,
+} from '@/features/engagements/api/engagementsApi';
+import type { ProposalData } from '@/features/engagements/types/engagement';
+
+const practiceId = 'practice-123';
+const contractId = 'contract-123';
+
+const proposalData: ProposalData = {
+  client_summary: {
+    client_name: 'Jane Client',
+    matter_summary: 'Custody consultation',
+  },
+  representation: {
+    scope_summary: 'Limited scope representation.',
+  },
+  fees: {
+    billing_type: 'fixed',
+    fixed_fee_amount: 1500,
+  },
+  risk_review: {
+    conflict_status: 'unknown',
+    jurisdiction_status: 'unknown',
+  },
+  source_snapshot: {
+    intake_uuid: 'intake-123',
+    conversation_id: 'conversation-123',
+    matter_id: null,
+  },
+  draft_meta: {
+    generated_at: '2026-05-22T10:00:00.000Z',
+    generated_by: 'staff',
+    version: 1,
+  },
+};
+
+const engagementPayload = {
+  id: contractId,
+  intake_id: 'intake-123',
+  matter_id: null,
+  organization_id: practiceId,
+  status: 'draft',
+  contract_body: 'Contract text',
+  billing_snapshot: null,
+  engagement_notes: 'Notes',
+  proposal_data: proposalData,
+  created_at: '2026-05-22T10:00:00.000Z',
+  updated_at: '2026-05-22T10:00:00.000Z',
+};
+
+describe('engagementsApi', () => {
+  beforeEach(() => {
+    mockApiClient.get.mockReset();
+    mockApiClient.post.mockReset();
+    mockApiClient.patch.mockReset();
+    mockInvalidate.mockReset();
+  });
+
+  it('creates an engagement with the documented POST body', async () => {
+    mockApiClient.post.mockResolvedValueOnce({ data: engagementPayload });
+
+    await createEngagementContract(practiceId, {
+      intake_id: 'intake-123',
+      contract_body: 'Contract text',
+      engagement_notes: 'Notes',
+      proposal_data: proposalData,
+    });
+
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      `/api/engagement-contracts/${practiceId}`,
+      {
+        intake_id: 'intake-123',
+        contract_body: 'Contract text',
+        engagement_notes: 'Notes',
+        proposal_data: proposalData,
+      },
+      { signal: undefined },
+    );
+  });
+
+  it('updates a draft with the documented PATCH body', async () => {
+    mockApiClient.patch.mockResolvedValueOnce({ data: engagementPayload });
+
+    await patchEngagementContract(practiceId, contractId, {
+      contract_body: 'Updated contract',
+      engagement_notes: 'Updated notes',
+      proposal_data: proposalData,
+    });
+
+    expect(mockApiClient.patch).toHaveBeenCalledWith(
+      `/api/engagement-contracts/${practiceId}/${contractId}`,
+      {
+        contract_body: 'Updated contract',
+        engagement_notes: 'Updated notes',
+        proposal_data: proposalData,
+      },
+      { signal: undefined },
+    );
+  });
+
+  it('sends via the status endpoint', async () => {
+    mockApiClient.patch
+      .mockResolvedValueOnce({ data: engagementPayload })
+      .mockResolvedValueOnce({ data: { ...engagementPayload, status: 'sent' } });
+
+    await sendEngagementToClient(practiceId, contractId, 'Please review');
+
+    expect(mockApiClient.patch).toHaveBeenNthCalledWith(
+      1,
+      `/api/engagement-contracts/${practiceId}/${contractId}`,
+      { engagement_notes: 'Please review' },
+      { signal: undefined },
+    );
+    expect(mockApiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      `/api/engagement-contracts/${practiceId}/${contractId}/status`,
+      { status: 'sent' },
+      { signal: undefined },
+    );
+  });
+
+  it('accepts via the status endpoint and preserves returned matter_id', async () => {
+    mockApiClient.patch.mockResolvedValueOnce({
+      data: { ...engagementPayload, status: 'accepted', matter_id: 'matter-123' },
+    });
+
+    const accepted = await acceptEngagement(practiceId, contractId);
+
+    expect(mockApiClient.patch).toHaveBeenCalledWith(
+      `/api/engagement-contracts/${practiceId}/${contractId}/status`,
+      { status: 'accepted' },
+      { signal: undefined },
+    );
+    expect(accepted.matter_id).toBe('matter-123');
+  });
+});


### PR DESCRIPTION
## Summary

- **Border token sweep**: Replaced all `border-line-glass/*`, `divide-line-glass/*`, and `ring-line-glass/*` with `border-line-subtle` across 117 files. These tokens emitted white at opacity — invisible in light mode, visible white lines in dark mode. Also fixed `border-line-utility` on structural dividers, hardcoded `border-slate-*` colors, and `border-card-border` misused as internal section dividers. Root cause fixed in shared `Divider` and `SectionDivider` components.
- **Glass class rename**: `glass-card` → `card`, `glass-panel` → `panel`, `glass-input` → `input-surface` across all JSX. The CSS already resolved these to their solid-surface equivalents — purely a naming change. No visual diff.
- **`btn-inverted` removed** from `Button.tsx` type and variant map (zero callers).
- **`index.css`**: Added explicit `@apply` shims for glass aliases, mirrored `isError`/`isSuccess` focus states onto `.input-surface`.
- **`DebugStylesPage`**: Updated to document canonical surface names, removed stale glass framing and hardcoded ring colors.
- **`DESIGN.md`**: Named deprecated tokens (`glass-*`, `border-line-glass`, `btn-inverted`) explicitly with their canonical replacements.

## Test plan

- [ ] Light and dark mode: card, panel, and input surfaces render without unexpected borders or lines
- [ ] Form inputs retain focus ring, error ring, and success ring states
- [ ] Dividers and section headers render as subtle hairlines (not bold white lines in dark mode)
- [ ] Button variants render correctly; no `inverted` variant visible
- [ ] `/debug/styles` page shows `card`, `panel`, `input-surface` documentation correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)