### PR TITLE
feat(engagements): replace create dialog with dedicated two-column page

### DIFF
--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     /.*intake-invite\.spec\.ts/,
     /.*notifications\.spec\.ts/,
     /.*pricing-gate-membership\.spec\.ts/,
+    /.*engagements-create-page\.spec\.ts/,
     /.*responsive-auth\.spec\.ts/,
     /.*responsive-screenshots\.spec\.ts/,
   ],

--- a/src/features/engagements/pages/CreateEngagementPage.tsx
+++ b/src/features/engagements/pages/CreateEngagementPage.tsx
@@ -1,0 +1,718 @@
+import { FunctionComponent } from 'preact';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { ArrowLeft, RefreshCw, Send } from 'lucide-preact';
+
+import { Button } from '@/shared/ui/Button';
+import { Input, Textarea, Combobox, type ComboboxOption } from '@/shared/ui/input';
+import { CurrencyInput } from '@/shared/ui/input/CurrencyInput';
+import { RadioGroupWithDescriptions } from '@/shared/ui/input/RadioGroupWithDescriptions';
+import type { DescribedRadioOption } from '@/shared/ui/input/RadioGroupWithDescriptions';
+import { FormGrid } from '@/shared/ui/layout/FormGrid';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import { asMajor } from '@/shared/utils/money';
+import type { MajorAmount } from '@/shared/utils/money';
+import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
+import { getPracticeIntake, listIntakes } from '@/features/intake/api/intakesApi';
+import type { IntakeListItem, PracticeIntakeDetail } from '@/features/intake/api/intakesApi';
+import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
+
+import { createEngagementContract } from '../api/engagementsApi';
+import {
+  buildDeterministicContractBody,
+  buildEngagementDraftFormFromIntake,
+  buildProposalDataFromDraft,
+  EMPTY_ENGAGEMENT_DRAFT_FORM,
+  type EngagementDraftForm,
+} from '../utils/engagementDraft';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const BILLING_OPTIONS: DescribedRadioOption[] = [
+  { value: 'hourly',      label: 'Hourly',      description: 'Bill based on time spent on the engagement' },
+  { value: 'fixed',       label: 'Fixed fee',   description: 'One fixed fee for the entire engagement' },
+  { value: 'retainer',    label: 'Retainer',    description: 'Upfront retainer collected before work begins' },
+  { value: 'contingency', label: 'Contingency', description: 'Percentage fee based on the outcome' },
+  { value: 'pro_bono',    label: 'Pro bono',    description: 'Services provided without charge' },
+];
+
+const URGENCY_OPTIONS: ComboboxOption[] = [
+  { value: '',               label: 'Not specified' },
+  { value: 'routine',        label: 'Routine' },
+  { value: 'time_sensitive', label: 'Time sensitive' },
+  { value: 'emergency',      label: 'Emergency' },
+];
+
+const CONFLICT_STATUS_OPTIONS: ComboboxOption[] = [
+  { value: 'unknown',           label: 'Unknown' },
+  { value: 'clear',             label: 'Clear' },
+  { value: 'review_required',   label: 'Review required' },
+  { value: 'conflicted',        label: 'Conflicted' },
+  { value: 'insufficient_data', label: 'Insufficient data' },
+];
+
+const JURISDICTION_STATUS_OPTIONS: ComboboxOption[] = [
+  { value: 'unknown',     label: 'Unknown' },
+  { value: 'supported',   label: 'Supported' },
+  { value: 'unsupported', label: 'Unsupported' },
+];
+
+const PAYMENT_FREQUENCY_OPTIONS: ComboboxOption[] = [
+  { value: '',              label: 'Not specified' },
+  { value: 'one_time',      label: 'One time' },
+  { value: 'monthly',       label: 'Monthly' },
+  { value: 'quarterly',     label: 'Quarterly' },
+  { value: 'on_completion', label: 'On completion' },
+];
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+type FormErrors = Partial<Record<keyof EngagementDraftForm, string>>;
+
+const validateForm = (form: EngagementDraftForm): FormErrors => {
+  const errors: FormErrors = {};
+  if (!form.intakeId) errors.intakeId = 'An accepted intake is required';
+  if (!form.matterSummary.trim()) errors.matterSummary = 'Matter summary is required';
+  if (!form.scopeSummary.trim()) errors.scopeSummary = 'Scope summary is required';
+  if (!form.contractBody.trim()) errors.contractBody = 'Contract body is required';
+  return errors;
+};
+
+// ── Letter preview ───────────────────────────────────────────────────────────
+
+const billingSummaryLine = (form: EngagementDraftForm): string => {
+  switch (form.billingType) {
+    case 'hourly': {
+      const parts: string[] = [];
+      if (form.hourlyRateAttorney) parts.push(`Attorney ${formatCurrency(Number(form.hourlyRateAttorney))}/hr`);
+      if (form.hourlyRateAdmin) parts.push(`Admin ${formatCurrency(Number(form.hourlyRateAdmin))}/hr`);
+      return parts.join(' · ') || 'Hourly';
+    }
+    case 'fixed':
+      return form.fixedFeeAmount ? `Fixed fee: ${formatCurrency(Number(form.fixedFeeAmount))}` : 'Fixed fee';
+    case 'retainer':
+      return form.retainerAmount ? `Retainer: ${formatCurrency(Number(form.retainerAmount))}` : 'Retainer';
+    case 'contingency':
+      return form.contingencyPercentage ? `Contingency: ${form.contingencyPercentage}%` : 'Contingency';
+    case 'pro_bono':
+      return 'Pro bono — no charge';
+    default:
+      return form.billingType || '—';
+  }
+};
+
+const EngagementLetterPreview: FunctionComponent<{
+  form: EngagementDraftForm;
+  practiceName?: string;
+}> = ({ form, practiceName }) => {
+  const clientName = form.clientName.trim() || 'Client Name';
+  const matterSummary = form.matterSummary.trim() || 'Matter description';
+  const contractBody = form.contractBody.trim();
+  const today = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  return (
+    <div className="rounded-xl border border-card-border bg-surface-card text-sm leading-relaxed text-input-text shadow-sm overflow-hidden">
+      {/* Letterhead */}
+      <div className="border-b border-line-subtle bg-surface-overlay/20 px-6 py-4 space-y-0.5">
+        <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+          {practiceName || 'Your Practice'}
+        </p>
+        <p className="text-xs text-input-placeholder">{today}</p>
+      </div>
+
+      <div className="px-6 py-5 space-y-5">
+        {/* Addressee */}
+        <div className="space-y-0.5">
+          <p className="font-semibold text-input-text">{clientName}</p>
+          <p className="text-xs text-input-placeholder">Re: {matterSummary}</p>
+        </div>
+
+        {/* Body */}
+        <div className="border-t border-line-subtle pt-4 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+            Engagement Agreement
+          </p>
+          {contractBody ? (
+            <p className="whitespace-pre-wrap text-xs leading-relaxed">{contractBody}</p>
+          ) : (
+            <p className="text-xs italic text-input-placeholder">
+              Complete the form to generate the engagement letter preview.
+            </p>
+          )}
+        </div>
+
+        {/* Fee summary */}
+        {form.billingType ? (
+          <div className="rounded-lg border border-line-subtle bg-surface-overlay/30 px-4 py-3 space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Fee Summary</p>
+            <p className="text-xs">{billingSummaryLine(form)}</p>
+            {form.feeNotes.trim() && (
+              <p className="text-xs text-input-placeholder">{form.feeNotes.trim()}</p>
+            )}
+          </div>
+        ) : null}
+
+        {/* Signature block */}
+        <div className="border-t border-line-subtle pt-4 space-y-4 text-xs">
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-1">
+              <p className="font-medium text-input-text">Client</p>
+              <div className="h-7 border-b border-dashed border-line-subtle" />
+              <p className="text-input-placeholder">Date ___________</p>
+            </div>
+            <div className="space-y-1">
+              <p className="font-medium text-input-text">Attorney</p>
+              <div className="h-7 border-b border-dashed border-line-subtle" />
+              <p className="text-input-placeholder">Date ___________</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── Selected intake card ─────────────────────────────────────────────────────
+
+const SelectedIntakeCard: FunctionComponent<{
+  intake: IntakeListItem | PracticeIntakeDetail;
+  detailLoading?: boolean;
+  onClear: () => void;
+}> = ({ intake, detailLoading = false, onClear }) => {
+  const name = intake.metadata?.name?.trim() || 'Anonymous lead';
+  const email = intake.metadata?.email?.trim() || '';
+  const subject = resolveIntakeTitle(intake.metadata, '');
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-lg border border-card-border bg-surface-card px-3 py-2.5">
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium text-input-text">{name}</p>
+        {email && <p className="truncate text-sm text-input-placeholder">{email}</p>}
+        {subject && <p className="mt-0.5 truncate text-xs text-input-placeholder">{subject}</p>}
+        {detailLoading && <p className="mt-1 text-xs text-input-placeholder">Loading intake details…</p>}
+      </div>
+      <button
+        type="button"
+        onClick={onClear}
+        className="shrink-0 text-xs font-medium text-accent hover:text-accent/80 focus:outline-none focus-visible:underline"
+      >
+        Change
+      </button>
+    </div>
+  );
+};
+
+// ── Section heading ──────────────────────────────────────────────────────────
+
+const SectionHeading: FunctionComponent<{ title: string }> = ({ title }) => (
+  <h3 className="border-b border-line-subtle pb-2 text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+    {title}
+  </h3>
+);
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+type CreateEngagementPageProps = {
+  practiceId: string | null;
+  basePath?: string;
+  initialIntakeId?: string | null;
+  practiceName?: string;
+  onCreated: (engagementId: string) => void;
+  onCancel: () => void;
+};
+
+export const CreateEngagementPage: FunctionComponent<CreateEngagementPageProps> = ({
+  practiceId,
+  initialIntakeId = null,
+  practiceName,
+  onCreated,
+  onCancel,
+}) => {
+  const [form, setForm] = useState<EngagementDraftForm>({
+    ...EMPTY_ENGAGEMENT_DRAFT_FORM,
+    intakeId: initialIntakeId ?? '',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const [intakes, setIntakes] = useState<IntakeListItem[]>([]);
+  const [selectedIntakeDetail, setSelectedIntakeDetail] = useState<PracticeIntakeDetail | null>(null);
+  const [isLoadingIntakes, setIsLoadingIntakes] = useState(false);
+  const [isLoadingIntakeDetail, setIsLoadingIntakeDetail] = useState(false);
+  const [intakesError, setIntakesError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!practiceId) return;
+    const controller = new AbortController();
+    setIsLoadingIntakes(true);
+    setIntakesError(null);
+
+    listIntakes(practiceId, { page: 1, limit: 100, triage_status: 'accepted' }, { signal: controller.signal })
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setIntakes(result.intakes);
+        if (initialIntakeId) {
+          const match = result.intakes.find((i) => i.uuid === initialIntakeId);
+          if (match) setForm((prev) => buildEngagementDraftFormFromIntake(match, prev));
+        }
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setIntakesError(err instanceof Error ? err.message : 'Failed to load intakes');
+      })
+      .finally(() => { if (!controller.signal.aborted) setIsLoadingIntakes(false); });
+
+    return () => controller.abort();
+  }, [practiceId, initialIntakeId]);
+
+  useEffect(() => {
+    if (!practiceId || !form.intakeId) {
+      setSelectedIntakeDetail(null);
+      return;
+    }
+    const controller = new AbortController();
+    setIsLoadingIntakeDetail(true);
+
+    getPracticeIntake(practiceId, form.intakeId, { signal: controller.signal })
+      .then((detail) => {
+        if (controller.signal.aborted) return;
+        setSelectedIntakeDetail(detail);
+        setForm((prev) => buildEngagementDraftFormFromIntake(detail, prev));
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setSubmitError(err instanceof Error ? err.message : 'Failed to load intake details');
+      })
+      .finally(() => { if (!controller.signal.aborted) setIsLoadingIntakeDetail(false); });
+
+    return () => controller.abort();
+  }, [form.intakeId, practiceId]);
+
+  const selectedIntake = useMemo(
+    () => selectedIntakeDetail ?? intakes.find((i) => i.uuid === form.intakeId) ?? null,
+    [intakes, form.intakeId, selectedIntakeDetail],
+  );
+
+  const intakeOptions = useMemo<ComboboxOption[]>(
+    () => intakes.map((intake) => ({
+      value: intake.uuid,
+      label: intake.metadata?.name?.trim() || 'Anonymous lead',
+      description: resolveIntakeTitle(intake.metadata, '') || intake.metadata?.email || undefined,
+      meta: formatRelativeTime(intake.created_at),
+    })),
+    [intakes],
+  );
+
+  const updateField = useCallback(<K extends keyof EngagementDraftForm>(
+    field: K,
+    value: EngagementDraftForm[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    if (hasAttemptedSubmit) {
+      setErrors((prev) => {
+        if (!prev[field]) return prev;
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    }
+  }, [hasAttemptedSubmit]);
+
+  const handleIntakeChange = useCallback((value: string) => {
+    const intake = intakes.find((i) => i.uuid === value);
+    setSelectedIntakeDetail(null);
+    setForm((prev) =>
+      intake
+        ? buildEngagementDraftFormFromIntake(intake, { ...prev, intakeId: value, contractBody: '' })
+        : { ...prev, intakeId: value },
+    );
+  }, [intakes]);
+
+  const handleRegenerateContract = useCallback(() => {
+    setForm((prev) => ({ ...prev, contractBody: buildDeterministicContractBody(prev) }));
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    setHasAttemptedSubmit(true);
+    setSubmitError(null);
+    const validation = validateForm(form);
+    setErrors(validation);
+    if (Object.keys(validation).length > 0) return;
+
+    if (!practiceId) return;
+    setSubmitting(true);
+    try {
+      const created = await createEngagementContract(practiceId, {
+        intake_id: form.intakeId,
+        contract_body: form.contractBody.trim(),
+        engagement_notes: form.engagementNotes.trim() || undefined,
+        proposal_data: buildProposalDataFromDraft(form),
+      });
+      onCreated(created.id);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to create engagement');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [form, practiceId, onCreated]);
+
+  const currencyValue = (raw: string): MajorAmount | undefined =>
+    raw.trim() ? asMajor(Number(raw)) : undefined;
+
+  const currencyUpdate = (key: keyof EngagementDraftForm) =>
+    (v: number | undefined) => updateField(key, v != null ? String(v) : '');
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-surface-workspace">
+      {/* Sticky page header */}
+      <header className="flex shrink-0 items-center justify-between gap-4 border-b border-line-subtle bg-surface-workspace px-4 py-3 sm:px-6">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={submitting}
+          className="flex items-center gap-1.5 text-sm text-input-placeholder transition-colors hover:text-input-text focus:outline-none focus-visible:underline disabled:opacity-50"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          <span className="hidden sm:inline">Engagements</span>
+        </button>
+        <h1 className="text-base font-semibold text-input-text">New Engagement</h1>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={onCancel} disabled={submitting} className="hidden sm:flex">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            icon={Send}
+            iconPosition="right"
+            onClick={handleSubmit}
+            disabled={submitting || !practiceId}
+          >
+            {submitting ? 'Creating…' : 'Create engagement'}
+          </Button>
+        </div>
+      </header>
+
+      {/* Two-column body */}
+      <div className="flex min-h-0 flex-1">
+
+        {/* ── Left: form ── */}
+        <div className="min-w-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-2xl space-y-8 p-4 pb-20 sm:p-6">
+
+            {submitError && (
+              <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
+                {submitError}
+              </div>
+            )}
+
+            {/* Source intake */}
+            <section className="space-y-3">
+              <SectionHeading title="Source intake" />
+              <p className="text-xs text-input-placeholder">
+                Select an accepted intake — the form will pre-fill from the intake data.
+              </p>
+              {selectedIntake ? (
+                <SelectedIntakeCard
+                  intake={selectedIntake}
+                  detailLoading={isLoadingIntakeDetail}
+                  onClear={() => updateField('intakeId', '')}
+                />
+              ) : (
+                <Combobox
+                  placeholder={isLoadingIntakes ? 'Loading accepted intakes…' : 'Search accepted intakes…'}
+                  options={intakeOptions}
+                  value={form.intakeId}
+                  onChange={handleIntakeChange}
+                  disabled={submitting || isLoadingIntakes}
+                  searchable
+                />
+              )}
+              {errors.intakeId && <p className="text-xs text-rose-400">{errors.intakeId}</p>}
+              {intakesError && <p className="text-sm text-rose-400">{intakesError}</p>}
+            </section>
+
+            {/* Client & matter */}
+            <section className="space-y-4">
+              <SectionHeading title="Client & matter" />
+              <FormGrid>
+                <Input
+                  label="Client name"
+                  value={form.clientName}
+                  onChange={(v) => updateField('clientName', v)}
+                  disabled={submitting}
+                />
+                <Input
+                  label="Practice area"
+                  value={form.practiceArea}
+                  onChange={(v) => updateField('practiceArea', v)}
+                  disabled={submitting}
+                />
+              </FormGrid>
+              <Input
+                label="Matter summary"
+                value={form.matterSummary}
+                onChange={(v) => updateField('matterSummary', v)}
+                disabled={submitting}
+                error={errors.matterSummary}
+              />
+              <FormGrid>
+                <Input
+                  label="Location"
+                  value={form.locationSummary}
+                  onChange={(v) => updateField('locationSummary', v)}
+                  disabled={submitting}
+                />
+                <Combobox
+                  label="Urgency"
+                  options={URGENCY_OPTIONS}
+                  value={form.urgency}
+                  onChange={(v) => updateField('urgency', v)}
+                  disabled={submitting}
+                  searchable={false}
+                />
+              </FormGrid>
+              <FormGrid>
+                <Input
+                  label="Opposing party"
+                  value={form.opposingParty}
+                  onChange={(v) => updateField('opposingParty', v)}
+                  disabled={submitting}
+                />
+                <Input
+                  label="Court date"
+                  type="date"
+                  value={form.courtDate}
+                  onChange={(v) => updateField('courtDate', v)}
+                  disabled={submitting}
+                />
+              </FormGrid>
+              <Textarea
+                label="Goals"
+                value={form.goalsSummary}
+                onChange={(v) => updateField('goalsSummary', v)}
+                rows={2}
+                disabled={submitting}
+              />
+            </section>
+
+            {/* Scope */}
+            <section className="space-y-4">
+              <SectionHeading title="Scope of representation" />
+              <Textarea
+                label="Scope summary"
+                value={form.scopeSummary}
+                onChange={(v) => updateField('scopeSummary', v)}
+                rows={3}
+                disabled={submitting}
+                error={errors.scopeSummary}
+              />
+              <FormGrid>
+                <Textarea
+                  label="Included services (one per line)"
+                  value={form.includedServices}
+                  onChange={(v) => updateField('includedServices', v)}
+                  rows={3}
+                  disabled={submitting}
+                />
+                <Textarea
+                  label="Excluded services (one per line)"
+                  value={form.excludedServices}
+                  onChange={(v) => updateField('excludedServices', v)}
+                  rows={3}
+                  disabled={submitting}
+                />
+              </FormGrid>
+              <FormGrid>
+                <Textarea
+                  label="Client identity notes"
+                  value={form.clientIdentityNotes}
+                  onChange={(v) => updateField('clientIdentityNotes', v)}
+                  rows={2}
+                  disabled={submitting}
+                />
+                <Textarea
+                  label="Jurisdiction notes"
+                  value={form.jurisdictionNotes}
+                  onChange={(v) => updateField('jurisdictionNotes', v)}
+                  rows={2}
+                  disabled={submitting}
+                />
+              </FormGrid>
+            </section>
+
+            {/* Fees */}
+            <section className="space-y-4">
+              <SectionHeading title="Fees" />
+              <RadioGroupWithDescriptions
+                label="Billing type"
+                name="billing-type"
+                value={form.billingType}
+                options={BILLING_OPTIONS}
+                onChange={(v) => updateField('billingType', v)}
+              />
+
+              {form.billingType === 'hourly' && (
+                <FormGrid>
+                  <CurrencyInput
+                    label="Attorney hourly rate"
+                    value={currencyValue(form.hourlyRateAttorney)}
+                    onChange={currencyUpdate('hourlyRateAttorney')}
+                    disabled={submitting}
+                    placeholder="250"
+                  />
+                  <CurrencyInput
+                    label="Admin hourly rate"
+                    value={currencyValue(form.hourlyRateAdmin)}
+                    onChange={currencyUpdate('hourlyRateAdmin')}
+                    disabled={submitting}
+                    placeholder="95"
+                  />
+                </FormGrid>
+              )}
+
+              {form.billingType === 'fixed' && (
+                <CurrencyInput
+                  label="Fixed fee amount"
+                  value={currencyValue(form.fixedFeeAmount)}
+                  onChange={currencyUpdate('fixedFeeAmount')}
+                  disabled={submitting}
+                  placeholder="2500"
+                />
+              )}
+
+              {form.billingType === 'retainer' && (
+                <CurrencyInput
+                  label="Retainer amount"
+                  value={currencyValue(form.retainerAmount)}
+                  onChange={currencyUpdate('retainerAmount')}
+                  disabled={submitting}
+                  placeholder="1500"
+                />
+              )}
+
+              {form.billingType === 'contingency' && (
+                <Input
+                  label="Contingency percentage (%)"
+                  type="number"
+                  value={form.contingencyPercentage}
+                  onChange={(v) => updateField('contingencyPercentage', v)}
+                  disabled={submitting}
+                  placeholder="33"
+                />
+              )}
+
+              {form.billingType && form.billingType !== 'pro_bono' && (
+                <Combobox
+                  label="Payment frequency"
+                  options={PAYMENT_FREQUENCY_OPTIONS}
+                  value={form.paymentFrequency}
+                  onChange={(v) => updateField('paymentFrequency', v)}
+                  disabled={submitting}
+                  searchable={false}
+                />
+              )}
+
+              <Textarea
+                label="Fee notes"
+                value={form.feeNotes}
+                onChange={(v) => updateField('feeNotes', v)}
+                rows={2}
+                disabled={submitting}
+                placeholder="Any additional billing terms for the client…"
+              />
+            </section>
+
+            {/* Risk review */}
+            <section className="space-y-4">
+              <SectionHeading title="Risk review" />
+              <FormGrid>
+                <Combobox
+                  label="Conflict status"
+                  options={CONFLICT_STATUS_OPTIONS}
+                  value={form.conflictStatus}
+                  onChange={(v) => updateField('conflictStatus', v as EngagementDraftForm['conflictStatus'])}
+                  disabled={submitting}
+                  searchable={false}
+                />
+                <Combobox
+                  label="Jurisdiction status"
+                  options={JURISDICTION_STATUS_OPTIONS}
+                  value={form.jurisdictionStatus}
+                  onChange={(v) => updateField('jurisdictionStatus', v as EngagementDraftForm['jurisdictionStatus'])}
+                  disabled={submitting}
+                  searchable={false}
+                />
+              </FormGrid>
+              <FormGrid>
+                <Textarea
+                  label="Risk notes (one per line)"
+                  value={form.riskNotes}
+                  onChange={(v) => updateField('riskNotes', v)}
+                  rows={2}
+                  disabled={submitting}
+                />
+                <Textarea
+                  label="Open questions (one per line)"
+                  value={form.openQuestions}
+                  onChange={(v) => updateField('openQuestions', v)}
+                  rows={2}
+                  disabled={submitting}
+                />
+              </FormGrid>
+            </section>
+
+            {/* Contract */}
+            <section className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <SectionHeading title="Contract body" />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  icon={RefreshCw}
+                  onClick={handleRegenerateContract}
+                  disabled={submitting}
+                >
+                  Regenerate
+                </Button>
+              </div>
+              <Textarea
+                label="Contract body"
+                value={form.contractBody}
+                onChange={(v) => updateField('contractBody', v)}
+                rows={14}
+                disabled={submitting}
+                error={errors.contractBody}
+              />
+              <Textarea
+                label="Internal notes"
+                value={form.engagementNotes}
+                onChange={(v) => updateField('engagementNotes', v)}
+                rows={3}
+                disabled={submitting}
+                placeholder="Notes visible only to your team…"
+              />
+            </section>
+
+          </div>
+        </div>
+
+        {/* ── Right: live preview (xl+) ── */}
+        <aside className="hidden w-[400px] shrink-0 overflow-y-auto border-l border-line-subtle p-6 xl:block">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+              Client preview
+            </p>
+            <p className="text-xs text-input-placeholder">
+              This is what the client will see when they open the engagement.
+            </p>
+            <EngagementLetterPreview form={form} practiceName={practiceName} />
+          </div>
+        </aside>
+
+      </div>
+    </div>
+  );
+};
+
+export default CreateEngagementPage;

--- a/src/features/engagements/pages/CreateEngagementPage.tsx
+++ b/src/features/engagements/pages/CreateEngagementPage.tsx
@@ -212,7 +212,6 @@ const SectionHeading: FunctionComponent<{ title: string }> = ({ title }) => (
 
 type CreateEngagementPageProps = {
   practiceId: string | null;
-  basePath?: string;
   initialIntakeId?: string | null;
   practiceName?: string;
   onCreated: (engagementId: string) => void;

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -261,7 +261,6 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     return (
       <CreateEngagementPage
         practiceId={practiceId}
-        basePath={basePath}
         initialIntakeId={queryIntakeId}
         practiceName={practiceName}
         onCreated={handleEngagementCreated}

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -4,33 +4,24 @@ import { useLocation } from 'preact-iso';
 import { Briefcase, Plus, Search } from 'lucide-preact';
 
 import { Button } from '@/shared/ui/Button';
-import { Input, Textarea, Combobox, type ComboboxOption } from '@/shared/ui/input';
+import { Input } from '@/shared/ui/input';
 import { Tabs, type TabItem } from '@/shared/ui/tabs/Tabs';
 import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
-import { Dialog, DialogBody, DialogFooter, useDialogFormReset } from '@/shared/ui/dialog';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { InfiniteScroll } from '@/shared/ui/layout/InfiniteScroll';
 import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
 import { cn } from '@/shared/utils/cn';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
-import { getPracticeIntake, listIntakes, type IntakeListItem, type PracticeIntakeDetail } from '@/features/intake/api/intakesApi';
-import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
 
-import { createEngagementContract, listEngagements } from '../api/engagementsApi';
+import { listEngagements } from '../api/engagementsApi';
 import type {
   EngagementListItem,
   EngagementStatus,
   ProposalFees,
 } from '../types/engagement';
-import {
-  buildDeterministicContractBody,
-  buildEngagementDraftFormFromIntake,
-  buildProposalDataFromDraft,
-  EMPTY_ENGAGEMENT_DRAFT_FORM,
-  type EngagementDraftForm,
-} from '../utils/engagementDraft';
 import EngagementDetailPage from './EngagementDetailPage';
+import CreateEngagementPage from './CreateEngagementPage';
 
 const PAGE_SIZE = 20;
 
@@ -39,9 +30,9 @@ const PAGE_SIZE = 20;
 type StatusFilter = 'all' | EngagementStatus;
 
 const STATUS_FILTERS: ReadonlyArray<{ id: StatusFilter; label: string }> = [
-  { id: 'all', label: 'All' },
-  { id: 'draft', label: 'Draft' },
-  { id: 'sent', label: 'Sent' },
+  { id: 'all',      label: 'All' },
+  { id: 'draft',    label: 'Draft' },
+  { id: 'sent',     label: 'Sent' },
   { id: 'accepted', label: 'Accepted' },
   { id: 'declined', label: 'Declined' },
 ];
@@ -133,7 +124,7 @@ const EngagementMobileCard: FunctionComponent<{
   const retainer = getRetainerLabel(item.proposal_data?.fees);
 
   const rows: ReadonlyArray<{ label: string; value: ComponentChildren }> = [
-    { label: 'Matter', value: <span className="text-input-placeholder break-words">{matter}</span> },
+    { label: 'Matter',   value: <span className="text-input-placeholder break-words">{matter}</span> },
     { label: 'Retainer', value: <span className="font-medium text-input-text tabular-nums">{retainer}</span> },
   ];
 
@@ -159,427 +150,6 @@ const EngagementMobileCard: FunctionComponent<{
   );
 };
 
-// ── Create Engagement dialog ─────────────────────────────────────────────────
-
-const BILLING_TYPE_OPTIONS: ComboboxOption[] = [
-  { value: 'fixed', label: 'Fixed fee' },
-  { value: 'hourly', label: 'Hourly' },
-  { value: 'contingency', label: 'Contingency' },
-  { value: 'retainer', label: 'Retainer' },
-  { value: 'pro_bono', label: 'Pro bono' },
-];
-
-const RISK_STATUS_OPTIONS: ComboboxOption[] = [
-  { value: 'unknown', label: 'Unknown' },
-  { value: 'clear', label: 'Clear' },
-  { value: 'review_required', label: 'Review required' },
-  { value: 'conflicted', label: 'Conflicted' },
-  { value: 'insufficient_data', label: 'Insufficient data' },
-];
-
-const JURISDICTION_STATUS_OPTIONS: ComboboxOption[] = [
-  { value: 'unknown', label: 'Unknown' },
-  { value: 'supported', label: 'Supported' },
-  { value: 'unsupported', label: 'Unsupported' },
-];
-
-type CreateErrors = Partial<Record<keyof EngagementDraftForm, string>>;
-
-const validateForm = (form: EngagementDraftForm): CreateErrors => {
-  const errors: CreateErrors = {};
-  if (!form.intakeId) errors.intakeId = 'Accepted intake is required';
-  if (!form.matterSummary.trim()) errors.matterSummary = 'Matter summary is required';
-  if (!form.scopeSummary.trim()) errors.scopeSummary = 'Scope summary is required';
-  if (!form.contractBody.trim()) errors.contractBody = 'Contract body is required before creating an engagement';
-  return errors;
-};
-
-interface CreateEngagementDialogProps {
-  practiceId: string;
-  isOpen: boolean;
-  onClose: () => void;
-  onCreated: (engagementId: string) => void;
-  initialIntakeId?: string | null;
-}
-
-const CreateEngagementDialog: FunctionComponent<CreateEngagementDialogProps> = ({
-  practiceId,
-  isOpen,
-  onClose,
-  onCreated,
-  initialIntakeId = null,
-}) => {
-  const [form, setForm] = useState<EngagementDraftForm>(EMPTY_ENGAGEMENT_DRAFT_FORM);
-  const [errors, setErrors] = useState<CreateErrors>({});
-  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  const [intakes, setIntakes] = useState<IntakeListItem[]>([]);
-  const [selectedIntakeDetail, setSelectedIntakeDetail] = useState<PracticeIntakeDetail | null>(null);
-  const [isLoadingIntakes, setIsLoadingIntakes] = useState(false);
-  const [isLoadingIntakeDetail, setIsLoadingIntakeDetail] = useState(false);
-  const [intakesError, setIntakesError] = useState<string | null>(null);
-
-  useDialogFormReset({
-    isOpen,
-    trigger: 'on-open',
-    reason: 'Each open starts a fresh draft; clears any stale submit error or in-flight flag from a previously-interrupted attempt.',
-    reset: () => {
-      setForm({ ...EMPTY_ENGAGEMENT_DRAFT_FORM, intakeId: initialIntakeId ?? '' });
-      setErrors({});
-      setHasAttemptedSubmit(false);
-      setSubmitting(false);
-      setSubmitError(null);
-      setSelectedIntakeDetail(null);
-    },
-  });
-
-  useEffect(() => {
-    if (!isOpen || !practiceId) return;
-    const controller = new AbortController();
-    setIsLoadingIntakes(true);
-    setIntakesError(null);
-    setIntakes([]);
-
-    listIntakes(
-      practiceId,
-      { page: 1, limit: 100, triage_status: 'accepted' },
-      { signal: controller.signal },
-    )
-      .then((result) => {
-        if (controller.signal.aborted) return;
-        setIntakes(result.intakes);
-        if (initialIntakeId) {
-          const selected = result.intakes.find((intake) => intake.uuid === initialIntakeId);
-          if (selected) {
-            setForm((prev) => buildEngagementDraftFormFromIntake(selected, prev));
-          }
-        }
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        setIntakesError(error instanceof Error ? error.message : 'Failed to load clients');
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setIsLoadingIntakes(false);
-      });
-
-    return () => controller.abort();
-  }, [initialIntakeId, isOpen, practiceId]);
-
-  const selectedIntake = useMemo(
-    () => selectedIntakeDetail ?? intakes.find((intake) => intake.uuid === form.intakeId) ?? null,
-    [intakes, form.intakeId, selectedIntakeDetail],
-  );
-
-  const intakeOptions = useMemo<ComboboxOption[]>(
-    () =>
-      intakes.map((intake) => {
-        const name = intake.metadata?.name?.trim() || 'Anonymous lead';
-        const subject = resolveIntakeTitle(intake.metadata, '');
-        return {
-          value: intake.uuid,
-          label: name,
-          description: subject || intake.metadata?.email || undefined,
-          meta: formatRelativeTime(intake.created_at),
-        };
-      }),
-    [intakes],
-  );
-
-  useEffect(() => {
-    if (!isOpen || !practiceId || !form.intakeId) {
-      setSelectedIntakeDetail(null);
-      return;
-    }
-    const controller = new AbortController();
-    setIsLoadingIntakeDetail(true);
-    getPracticeIntake(practiceId, form.intakeId, { signal: controller.signal })
-      .then((detail) => {
-        if (controller.signal.aborted) return;
-        setSelectedIntakeDetail(detail);
-        setForm((prev) => buildEngagementDraftFormFromIntake(detail, prev));
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        setSubmitError(error instanceof Error ? error.message : 'Failed to load intake details');
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setIsLoadingIntakeDetail(false);
-      });
-    return () => controller.abort();
-  }, [form.intakeId, isOpen, practiceId]);
-
-  const updateField = useCallback(<K extends keyof EngagementDraftForm>(field: K, value: EngagementDraftForm[K]) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
-    if (hasAttemptedSubmit) {
-      setErrors((prev) => {
-        if (!prev[field]) return prev;
-        const next = { ...prev };
-        delete next[field];
-        return next;
-      });
-    }
-  }, [hasAttemptedSubmit]);
-
-  const handleIntakeChange = useCallback((value: string) => {
-    const intake = intakes.find((entry) => entry.uuid === value);
-    setSelectedIntakeDetail(null);
-    setForm((prev) => (
-      intake
-        ? buildEngagementDraftFormFromIntake(intake, { ...prev, intakeId: value, contractBody: '' })
-        : { ...prev, intakeId: value }
-    ));
-  }, [intakes]);
-
-  const refreshContractBody = useCallback(() => {
-    setForm((prev) => ({ ...prev, contractBody: buildDeterministicContractBody(prev) }));
-  }, []);
-
-  const handleSubmit = useCallback(async () => {
-    setHasAttemptedSubmit(true);
-    setSubmitError(null);
-    const validation = validateForm(form);
-    setErrors(validation);
-    if (Object.keys(validation).length > 0) return;
-
-    setSubmitting(true);
-    try {
-      const proposalData = buildProposalDataFromDraft(form);
-      const created = await createEngagementContract(practiceId, {
-        intake_id: form.intakeId,
-        contract_body: form.contractBody.trim(),
-        engagement_notes: form.engagementNotes.trim() || undefined,
-        proposal_data: proposalData,
-      });
-
-      onCreated(created.id);
-    } catch (error) {
-      setSubmitError(error instanceof Error ? error.message : 'Failed to create engagement');
-    } finally {
-      setSubmitting(false);
-    }
-  }, [form, practiceId, onCreated]);
-
-  const handleClose = useCallback(() => {
-    if (submitting) return;
-    onClose();
-  }, [onClose, submitting]);
-
-  return (
-    <Dialog
-      isOpen={isOpen}
-      onClose={handleClose}
-      title="Create engagement"
-      description="Draft an engagement contract from an accepted intake before sending it to the client."
-      disableBackdropClick={submitting}
-      contentClassName="max-w-4xl"
-    >
-      <DialogBody className="space-y-5">
-        {submitError && (
-          <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
-            {submitError}
-          </div>
-        )}
-
-        <section className="space-y-2">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Source intake</h3>
-          {selectedIntake ? (
-            <SelectedIntakeCard
-              intake={selectedIntake}
-              detailLoading={isLoadingIntakeDetail}
-              onClear={() => updateField('intakeId', '')}
-            />
-          ) : (
-            <>
-              <Combobox
-                placeholder={isLoadingIntakes ? 'Loading accepted intakes…' : 'Search accepted intakes…'}
-                options={intakeOptions}
-                value={form.intakeId}
-                onChange={handleIntakeChange}
-                disabled={submitting || isLoadingIntakes}
-                searchable
-              />
-              {errors.intakeId && <p className="mt-1 text-xs text-rose-400">{errors.intakeId}</p>}
-            </>
-          )}
-          {intakesError && <p className="text-sm text-rose-400">{intakesError}</p>}
-        </section>
-
-        <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <Input
-            label="Client name"
-            value={form.clientName}
-            onChange={(value) => updateField('clientName', value)}
-            disabled={submitting}
-          />
-          <Input
-            label="Practice area"
-            value={form.practiceArea}
-            onChange={(value) => updateField('practiceArea', value)}
-            disabled={submitting}
-          />
-          <Input
-            label="Matter summary"
-            value={form.matterSummary}
-            onChange={(value) => updateField('matterSummary', value)}
-            disabled={submitting}
-            error={errors.matterSummary}
-          />
-          <Input
-            label="Location summary"
-            value={form.locationSummary}
-            onChange={(value) => updateField('locationSummary', value)}
-            disabled={submitting}
-          />
-        </section>
-
-        <section className="space-y-3">
-          <Textarea
-            label="Goals summary"
-            value={form.goalsSummary}
-            onChange={(value) => updateField('goalsSummary', value)}
-            rows={2}
-            disabled={submitting}
-          />
-          <Textarea
-            label="Scope summary"
-            value={form.scopeSummary}
-            onChange={(value) => updateField('scopeSummary', value)}
-            rows={3}
-            disabled={submitting}
-            error={errors.scopeSummary}
-          />
-          <Textarea
-            label="Included services (one per line)"
-            value={form.includedServices}
-            onChange={(value) => updateField('includedServices', value)}
-            rows={3}
-            disabled={submitting}
-          />
-          <Textarea
-            label="Excluded services (one per line)"
-            value={form.excludedServices}
-            onChange={(value) => updateField('excludedServices', value)}
-            rows={3}
-            disabled={submitting}
-          />
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Textarea
-              label="Client identity notes"
-              value={form.clientIdentityNotes}
-              onChange={(value) => updateField('clientIdentityNotes', value)}
-              rows={2}
-              disabled={submitting}
-            />
-            <Textarea
-              label="Jurisdiction notes"
-              value={form.jurisdictionNotes}
-              onChange={(value) => updateField('jurisdictionNotes', value)}
-              rows={2}
-              disabled={submitting}
-            />
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Fees</h3>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            <Combobox label="Billing type" options={BILLING_TYPE_OPTIONS} value={form.billingType} onChange={(value) => updateField('billingType', value)} disabled={submitting} />
-            <Input label="Fixed fee amount" type="number" value={form.fixedFeeAmount} onChange={(value) => updateField('fixedFeeAmount', value)} disabled={submitting} />
-            <Input label="Retainer amount" type="number" value={form.retainerAmount} onChange={(value) => updateField('retainerAmount', value)} disabled={submitting} />
-            <Input label="Attorney hourly rate" type="number" value={form.hourlyRateAttorney} onChange={(value) => updateField('hourlyRateAttorney', value)} disabled={submitting} />
-            <Input label="Admin hourly rate" type="number" value={form.hourlyRateAdmin} onChange={(value) => updateField('hourlyRateAdmin', value)} disabled={submitting} />
-            <Input label="Contingency percentage" type="number" value={form.contingencyPercentage} onChange={(value) => updateField('contingencyPercentage', value)} disabled={submitting} />
-          </div>
-          <Input label="Payment frequency" value={form.paymentFrequency} onChange={(value) => updateField('paymentFrequency', value)} disabled={submitting} />
-          <Textarea label="Fee notes" value={form.feeNotes} onChange={(value) => updateField('feeNotes', value)} rows={2} disabled={submitting} />
-        </section>
-
-        <section className="space-y-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Risk review</h3>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Combobox label="Conflict status" options={RISK_STATUS_OPTIONS} value={form.conflictStatus} onChange={(value) => updateField('conflictStatus', value as EngagementDraftForm['conflictStatus'])} disabled={submitting} />
-            <Combobox label="Jurisdiction status" options={JURISDICTION_STATUS_OPTIONS} value={form.jurisdictionStatus} onChange={(value) => updateField('jurisdictionStatus', value as EngagementDraftForm['jurisdictionStatus'])} disabled={submitting} />
-          </div>
-          <Textarea label="Risk notes (one per line)" value={form.riskNotes} onChange={(value) => updateField('riskNotes', value)} rows={2} disabled={submitting} />
-          <Textarea label="Open questions (one per line)" value={form.openQuestions} onChange={(value) => updateField('openQuestions', value)} rows={2} disabled={submitting} />
-        </section>
-
-        <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <Input label="Urgency" value={form.urgency} onChange={(value) => updateField('urgency', value)} disabled={submitting} />
-          <Input label="Court date" type="date" value={form.courtDate} onChange={(value) => updateField('courtDate', value)} disabled={submitting} />
-          <Input label="Desired outcome" value={form.desiredOutcome} onChange={(value) => updateField('desiredOutcome', value)} disabled={submitting} />
-          <Input label="Opposing party" value={form.opposingParty} onChange={(value) => updateField('opposingParty', value)} disabled={submitting} />
-        </section>
-
-        <section className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">Contract body</h3>
-            <Button type="button" variant="secondary" size="sm" onClick={refreshContractBody} disabled={submitting}>
-              Regenerate draft
-            </Button>
-          </div>
-          <Textarea
-            label="Contract body"
-            value={form.contractBody}
-            onChange={(value) => updateField('contractBody', value)}
-            rows={12}
-            disabled={submitting}
-            error={errors.contractBody}
-          />
-          <Textarea
-            label="Engagement notes"
-            value={form.engagementNotes}
-            onChange={(value) => updateField('engagementNotes', value)}
-            rows={3}
-            disabled={submitting}
-          />
-        </section>
-      </DialogBody>
-      <DialogFooter>
-        <span className="mr-auto self-center text-xs text-input-placeholder hidden sm:inline">
-          Create the draft first, then review and send from the detail page.
-        </span>
-        <Button variant="secondary" onClick={handleClose} disabled={submitting}>
-          Cancel
-        </Button>
-        <Button variant="primary" onClick={handleSubmit} disabled={submitting} icon={Plus}>
-          {submitting ? 'Creating…' : 'Create engagement'}
-        </Button>
-      </DialogFooter>
-    </Dialog>
-  );
-};
-
-const SelectedIntakeCard: FunctionComponent<{
-  intake: IntakeListItem | PracticeIntakeDetail;
-  detailLoading?: boolean;
-  onClear: () => void;
-}> = ({ intake, detailLoading = false, onClear }) => {
-  const name = intake.metadata?.name?.trim() || 'Anonymous lead';
-  const email = intake.metadata?.email?.trim() || '';
-  const subject = resolveIntakeTitle(intake.metadata, '');
-  return (
-    <div className="flex items-start justify-between gap-3 rounded-lg border border-card-border bg-surface-card px-3 py-2.5">
-      <div className="min-w-0 flex-1">
-        <p className="truncate font-medium text-input-text">{name}</p>
-        <p className="truncate text-sm text-input-placeholder">{email}</p>
-        {subject && <p className="mt-1 truncate text-xs text-input-placeholder">{subject}</p>}
-        {detailLoading ? <p className="mt-1 text-xs text-input-placeholder">Loading intake details…</p> : null}
-      </div>
-      <button
-        type="button"
-        onClick={onClear}
-        className="shrink-0 text-xs font-medium text-accent hover:text-accent/80 focus:outline-none focus-visible:underline"
-      >
-        Change
-      </button>
-    </div>
-  );
-};
-
 // ── Main page ────────────────────────────────────────────────────────────────
 
 type EngagementsPageProps = {
@@ -601,23 +171,16 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
 }) => {
   const location = useLocation();
 
-  // Routing
   const pathSuffix = location.path.startsWith(basePath) ? location.path.slice(basePath.length) : '';
   const pathSegments = pathSuffix.replace(/^\/+/, '').split('/').filter(Boolean);
   const selectedEngagementId = pathSegments[0] ? decodeURIComponent(pathSegments[0]) : null;
   const detailMode: 'view' | 'edit' = pathSegments[1] === 'edit' ? 'edit' : 'view';
-  const queryCreate = resolveQueryValue(location.query?.create);
   const queryIntakeId = resolveQueryValue(location.query?.intakeId);
-  const shouldOpenCreateFromQuery = !selectedEngagementId && (queryCreate === '1' || Boolean(queryIntakeId));
 
-  // Tab state — initialized from sidebar prop, page-internal tabs take over.
   const sidebarTab = normalizeStatusFilter(activeStatusFilter);
   const [activeTab, setActiveTab] = useState<StatusFilter>(sidebarTab);
-  useEffect(() => {
-    setActiveTab(sidebarTab);
-  }, [sidebarTab]);
+  useEffect(() => { setActiveTab(sidebarTab); }, [sidebarTab]);
 
-  // Debounced search
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   useEffect(() => {
@@ -625,15 +188,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  // Create dialog
-  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [refreshCounter, setRefreshCounter] = useState(0);
-
-  useEffect(() => {
-    if (shouldOpenCreateFromQuery) {
-      setIsCreateDialogOpen(true);
-    }
-  }, [shouldOpenCreateFromQuery]);
 
   const {
     items: engagements,
@@ -647,17 +202,10 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
       if (!practiceId) return { items: [], hasMore: false };
       const result = await listEngagements(
         practiceId,
-        {
-          page,
-          limit: PAGE_SIZE,
-          status: activeTab === 'all' ? undefined : [activeTab],
-        },
+        { page, limit: PAGE_SIZE, status: activeTab === 'all' ? undefined : [activeTab] },
         { signal },
       );
-      return {
-        items: result.items,
-        hasMore: result.total > page * PAGE_SIZE,
-      };
+      return { items: result.items, hasMore: result.total > page * PAGE_SIZE };
     },
     deps: [practiceId, activeTab, refreshCounter],
   });
@@ -676,18 +224,10 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
   }, [basePath, location]);
 
   const handleOpenCreate = useCallback(() => {
-    setIsCreateDialogOpen(true);
-  }, []);
-
-  const handleCloseCreate = useCallback(() => {
-    setIsCreateDialogOpen(false);
-    if (shouldOpenCreateFromQuery) {
-      location.route(basePath, true);
-    }
-  }, [basePath, location, shouldOpenCreateFromQuery]);
+    location.route(`${basePath}/new`);
+  }, [basePath, location]);
 
   const handleEngagementCreated = useCallback((engagementId: string) => {
-    setIsCreateDialogOpen(false);
     setRefreshCounter((c) => c + 1);
     location.route(`${basePath}/${encodeURIComponent(engagementId)}`);
   }, [basePath, location]);
@@ -697,7 +237,9 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     handleBack();
   }, [handleBack]);
 
-  if (selectedEngagementId) {
+  // ── Route: detail page ───────────────────────────────────────────────────
+
+  if (selectedEngagementId && selectedEngagementId !== 'new') {
     return (
       <EngagementDetailPage
         practiceId={practiceId}
@@ -713,14 +255,30 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     );
   }
 
+  // ── Route: create page ───────────────────────────────────────────────────
+
+  if (selectedEngagementId === 'new') {
+    return (
+      <CreateEngagementPage
+        practiceId={practiceId}
+        basePath={basePath}
+        initialIntakeId={queryIntakeId}
+        practiceName={practiceName}
+        onCreated={handleEngagementCreated}
+        onCancel={handleBack}
+      />
+    );
+  }
+
   // ── Table column + row construction ────────────────────────────────────────
+
   const headerCellClass = 'text-xs font-semibold uppercase tracking-wide text-input-placeholder';
   const columns: DataTableColumn[] = [
-    { id: 'client', label: 'Client', isPrimary: true, headerClassName: headerCellClass },
-    { id: 'matter', label: 'Matter', headerClassName: headerCellClass },
-    { id: 'billing', label: 'Billing', hideAt: 'md', headerClassName: headerCellClass },
-    { id: 'status', label: 'Status', headerClassName: headerCellClass },
-    { id: 'sent', label: 'Sent', hideAt: 'lg', headerClassName: headerCellClass, align: 'right' },
+    { id: 'client',   label: 'Client',   isPrimary: true, headerClassName: headerCellClass },
+    { id: 'matter',   label: 'Matter',   headerClassName: headerCellClass },
+    { id: 'billing',  label: 'Billing',  hideAt: 'md', headerClassName: headerCellClass },
+    { id: 'status',   label: 'Status',   headerClassName: headerCellClass },
+    { id: 'sent',     label: 'Sent',     hideAt: 'lg', headerClassName: headerCellClass, align: 'right' },
     { id: 'retainer', label: 'Retainer', headerClassName: headerCellClass, align: 'right' },
   ];
 
@@ -728,11 +286,11 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     id: item.id,
     onClick: () => handleSelectEngagement(item),
     cells: {
-      client: <span className="truncate font-medium text-input-text">{item.client_name || 'Unknown Client'}</span>,
-      matter: <span className="truncate text-input-placeholder">{getMatterLabel(item)}</span>,
-      billing: <span className="text-input-placeholder">{getBillingLabel(item.proposal_data?.fees)}</span>,
-      status: <StatusPill status={item.status} />,
-      sent: <span className="text-input-placeholder tabular-nums">{item.sent_at ? formatRelativeTime(item.sent_at) : '—'}</span>,
+      client:   <span className="truncate font-medium text-input-text">{item.client_name || 'Unknown Client'}</span>,
+      matter:   <span className="truncate text-input-placeholder">{getMatterLabel(item)}</span>,
+      billing:  <span className="text-input-placeholder">{getBillingLabel(item.proposal_data?.fees)}</span>,
+      status:   <StatusPill status={item.status} />,
+      sent:     <span className="text-input-placeholder tabular-nums">{item.sent_at ? formatRelativeTime(item.sent_at) : '—'}</span>,
       retainer: <span className="font-medium text-input-text tabular-nums">{getRetainerLabel(item.proposal_data?.fees)}</span>,
     },
   }));
@@ -773,7 +331,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
         </div>
       </header>
 
-      {/* Tab row (desktop + mobile) */}
+      {/* Tab row */}
       <div className="border-b border-line-subtle bg-surface-workspace">
         <Tabs
           items={tabItems}
@@ -865,16 +423,6 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
           </Button>
         </div>
       </div>
-
-      {practiceId && (
-        <CreateEngagementDialog
-          practiceId={practiceId}
-          isOpen={isCreateDialogOpen}
-          onClose={handleCloseCreate}
-          onCreated={handleEngagementCreated}
-          initialIntakeId={queryIntakeId}
-        />
-      )}
     </div>
   );
 };

--- a/src/features/engagements/utils/engagementDraft.ts
+++ b/src/features/engagements/utils/engagementDraft.ts
@@ -145,6 +145,9 @@ export const buildEngagementDraftFormFromIntake = (
   };
 };
 
+const omitNulls = <T extends Record<string, unknown>>(obj: T): { [K in keyof T]: NonNullable<T[K]> } =>
+  Object.fromEntries(Object.entries(obj).filter(([, v]) => v != null)) as { [K in keyof T]: NonNullable<T[K]> };
+
 export const buildProposalDataFromDraft = (form: EngagementDraftForm): ProposalData => {
   const fees: ProposalFees = {
     billing_type: nullableString(form.billingType),
@@ -178,16 +181,15 @@ export const buildProposalDataFromDraft = (form: EngagementDraftForm): ProposalD
       risk_notes: lines(form.riskNotes),
       open_questions: lines(form.openQuestions),
     },
-    source_snapshot: {
+    source_snapshot: omitNulls({
       intake_uuid: nullableString(form.intakeId),
       conversation_id: nullableString(form.conversationId),
-      matter_id: null,
       practice_area: nullableString(form.practiceArea),
       urgency: nullableString(form.urgency),
       desired_outcome: nullableString(form.desiredOutcome),
       opposing_party: nullableString(form.opposingParty),
       court_date: nullableString(form.courtDate),
-    },
+    }),
     draft_meta: {
       generated_at: new Date().toISOString(),
       generated_by: 'staff',

--- a/src/features/engagements/utils/engagementDraft.ts
+++ b/src/features/engagements/utils/engagementDraft.ts
@@ -145,8 +145,8 @@ export const buildEngagementDraftFormFromIntake = (
   };
 };
 
-const omitNulls = <T extends Record<string, unknown>>(obj: T): { [K in keyof T]: NonNullable<T[K]> } =>
-  Object.fromEntries(Object.entries(obj).filter(([, v]) => v != null)) as { [K in keyof T]: NonNullable<T[K]> };
+const omitNulls = <T extends Record<string, unknown>>(obj: T): Partial<{ [K in keyof T]: NonNullable<T[K]> }> =>
+  Object.fromEntries(Object.entries(obj).filter(([, v]) => v != null)) as Partial<{ [K in keyof T]: NonNullable<T[K]> }>;
 
 export const buildProposalDataFromDraft = (form: EngagementDraftForm): ProposalData => {
   const fees: ProposalFees = {

--- a/tests/e2e/engagements-create-page.spec.ts
+++ b/tests/e2e/engagements-create-page.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from './fixtures.auth';
+import { loadE2EConfig } from './helpers/e2eConfig';
+
+const e2eConfig = loadE2EConfig();
+const PRACTICE_SLUG = e2eConfig?.practice.slug ?? process.env.E2E_PRACTICE_SLUG ?? 'demo-owner-local';
+const ENGAGEMENTS_BASE = `/practice/${encodeURIComponent(PRACTICE_SLUG)}/engagements`;
+const CREATE_PATH = `${ENGAGEMENTS_BASE}/new`;
+
+test.describe('engagements create page', () => {
+  test('New Engagement button navigates to /new route', async ({ ownerPage }) => {
+    await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
+
+    // The button may be hidden on small viewports — target either the desktop header
+    // button or the mobile FAB.
+    const newButton = ownerPage.locator('button, a').filter({ hasText: /new engagement/i }).first();
+    await newButton.waitFor({ state: 'visible', timeout: 10000 });
+    await newButton.click();
+
+    await ownerPage.waitForURL(`**${CREATE_PATH}**`, { timeout: 8000 });
+    expect(ownerPage.url()).toContain(CREATE_PATH);
+  });
+
+  test('create page renders required sections', async ({ ownerPage }) => {
+    // Land on the list first so the workspace shell fully initialises, then push to /new.
+    await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
+    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
+    await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
+    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
+
+    // Page heading (h1)
+    await expect(ownerPage.locator('h1').filter({ hasText: 'New Engagement' })).toBeVisible({ timeout: 8000 });
+
+    // Section headings
+    await expect(ownerPage.getByText(/source intake/i).first()).toBeVisible();
+    await expect(ownerPage.getByText(/client & matter/i).first()).toBeVisible();
+    await expect(ownerPage.getByText(/scope of representation/i).first()).toBeVisible();
+    await expect(ownerPage.getByText(/contract body/i).first()).toBeVisible();
+  });
+
+  test('client preview panel visible on desktop viewport', async ({ ownerPage }) => {
+    // Only rendered at xl breakpoint — use a wide viewport
+    await ownerPage.setViewportSize({ width: 1440, height: 900 });
+    await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
+
+    await expect(ownerPage.getByText(/client preview/i)).toBeVisible({ timeout: 8000 });
+    await expect(ownerPage.getByText(/engagement agreement/i)).toBeVisible();
+  });
+
+  test('billing type radio group is present and selectable', async ({ ownerPage }) => {
+    await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
+    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
+    await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
+    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
+
+    // Billing type options rendered by RadioGroupWithDescriptions — use radio role to avoid
+    // matching duplicate text nodes from label + inner span.
+    await expect(ownerPage.getByRole('radio', { name: /hourly/i })).toBeVisible({ timeout: 8000 });
+    await expect(ownerPage.getByRole('radio', { name: /fixed fee/i })).toBeVisible();
+    await expect(ownerPage.getByRole('radio', { name: /contingency/i })).toBeVisible();
+    await expect(ownerPage.getByRole('radio', { name: /retainer/i })).toBeVisible();
+    await expect(ownerPage.getByRole('radio', { name: /pro bono/i })).toBeVisible();
+  });
+
+  test('submit without intake shows validation error', async ({ ownerPage }) => {
+    await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
+
+    const submitButton = ownerPage.getByRole('button', { name: /create engagement/i });
+    await submitButton.waitFor({ state: 'visible', timeout: 8000 });
+    await submitButton.click();
+
+    await expect(ownerPage.getByText(/accepted intake is required/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('cancel button returns to engagements list', async ({ ownerPage }) => {
+    await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
+
+    const cancelButton = ownerPage.getByRole('button', { name: /cancel/i }).first();
+    await cancelButton.waitFor({ state: 'visible', timeout: 8000 });
+    await cancelButton.click();
+
+    await ownerPage.waitForURL(`**${ENGAGEMENTS_BASE}`, { timeout: 8000 });
+    expect(ownerPage.url()).not.toContain('/new');
+  });
+
+  test('no horizontal overflow on create page', async ({ ownerPage }) => {
+    await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
+    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
+
+    const noOverflow = await ownerPage.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth + 1
+    );
+    expect(noOverflow).toBe(true);
+  });
+
+});

--- a/tests/e2e/engagements-create-page.spec.ts
+++ b/tests/e2e/engagements-create-page.spec.ts
@@ -7,30 +7,27 @@ const ENGAGEMENTS_BASE = `/practice/${encodeURIComponent(PRACTICE_SLUG)}/engagem
 const CREATE_PATH = `${ENGAGEMENTS_BASE}/new`;
 
 test.describe('engagements create page', () => {
+  // Raise the per-test budget — staging API responses can be slow.
+  test.setTimeout(60000);
+
   test('New Engagement button navigates to /new route', async ({ ownerPage }) => {
     await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
 
-    // The button may be hidden on small viewports — target either the desktop header
-    // button or the mobile FAB.
+    // Target either the desktop header button or the mobile FAB.
     const newButton = ownerPage.locator('button, a').filter({ hasText: /new engagement/i }).first();
-    await newButton.waitFor({ state: 'visible', timeout: 10000 });
+    await newButton.waitFor({ state: 'visible', timeout: 20000 });
     await newButton.click();
 
-    await ownerPage.waitForURL(`**${CREATE_PATH}**`, { timeout: 8000 });
+    await ownerPage.waitForURL(`**${CREATE_PATH}**`, { timeout: 10000 });
     expect(ownerPage.url()).toContain(CREATE_PATH);
   });
 
   test('create page renders required sections', async ({ ownerPage }) => {
-    // Land on the list first so the workspace shell fully initialises, then push to /new.
-    await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
-    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
     await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
-    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
 
-    // Page heading (h1)
-    await expect(ownerPage.locator('h1').filter({ hasText: 'New Engagement' })).toBeVisible({ timeout: 8000 });
+    // h1 — generous timeout absorbs Preact hydration on cold nav.
+    await expect(ownerPage.locator('h1').filter({ hasText: 'New Engagement' })).toBeVisible({ timeout: 20000 });
 
-    // Section headings
     await expect(ownerPage.getByText(/source intake/i).first()).toBeVisible();
     await expect(ownerPage.getByText(/client & matter/i).first()).toBeVisible();
     await expect(ownerPage.getByText(/scope of representation/i).first()).toBeVisible();
@@ -38,34 +35,42 @@ test.describe('engagements create page', () => {
   });
 
   test('client preview panel visible on desktop viewport', async ({ ownerPage }) => {
-    // Only rendered at xl breakpoint — use a wide viewport
     await ownerPage.setViewportSize({ width: 1440, height: 900 });
     await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
 
-    await expect(ownerPage.getByText(/client preview/i)).toBeVisible({ timeout: 8000 });
+    await expect(ownerPage.getByText(/client preview/i)).toBeVisible({ timeout: 20000 });
     await expect(ownerPage.getByText(/engagement agreement/i)).toBeVisible();
   });
 
   test('billing type radio group is present and selectable', async ({ ownerPage }) => {
-    await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
-    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
     await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
-    await ownerPage.waitForLoadState('networkidle').catch(() => undefined);
 
-    // Billing type options rendered by RadioGroupWithDescriptions — use radio role to avoid
-    // matching duplicate text nodes from label + inner span.
-    await expect(ownerPage.getByRole('radio', { name: /hourly/i })).toBeVisible({ timeout: 8000 });
+    // RadioGroupWithDescriptions renders sr-only radio inputs — use radio role to locate them.
+    const hourly = ownerPage.getByRole('radio', { name: /hourly/i });
+    await expect(hourly).toBeVisible({ timeout: 20000 });
     await expect(ownerPage.getByRole('radio', { name: /fixed fee/i })).toBeVisible();
     await expect(ownerPage.getByRole('radio', { name: /contingency/i })).toBeVisible();
     await expect(ownerPage.getByRole('radio', { name: /retainer/i })).toBeVisible();
     await expect(ownerPage.getByRole('radio', { name: /pro bono/i })).toBeVisible();
+
+    // Clicking uses force:true because the input is sr-only and its label intercepts pointer
+    // events — we want to trigger the input directly, not via the label overlay.
+    const fixedFee = ownerPage.getByRole('radio', { name: /fixed fee/i });
+    await fixedFee.click({ force: true });
+    await expect(fixedFee).toBeChecked();
+    await expect(hourly).not.toBeChecked();
+
+    // Mutual exclusion: switching back unchecks Fixed fee.
+    await hourly.click({ force: true });
+    await expect(hourly).toBeChecked();
+    await expect(fixedFee).not.toBeChecked();
   });
 
   test('submit without intake shows validation error', async ({ ownerPage }) => {
     await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
 
     const submitButton = ownerPage.getByRole('button', { name: /create engagement/i });
-    await submitButton.waitFor({ state: 'visible', timeout: 8000 });
+    await submitButton.waitFor({ state: 'visible', timeout: 20000 });
     await submitButton.click();
 
     await expect(ownerPage.getByText(/accepted intake is required/i)).toBeVisible({ timeout: 5000 });
@@ -75,10 +80,10 @@ test.describe('engagements create page', () => {
     await ownerPage.goto(CREATE_PATH, { waitUntil: 'domcontentloaded' });
 
     const cancelButton = ownerPage.getByRole('button', { name: /cancel/i }).first();
-    await cancelButton.waitFor({ state: 'visible', timeout: 8000 });
+    await cancelButton.waitFor({ state: 'visible', timeout: 20000 });
     await cancelButton.click();
 
-    await ownerPage.waitForURL(`**${ENGAGEMENTS_BASE}`, { timeout: 8000 });
+    await ownerPage.waitForURL(`**${ENGAGEMENTS_BASE}`, { timeout: 10000 });
     expect(ownerPage.url()).not.toContain('/new');
   });
 
@@ -91,5 +96,4 @@ test.describe('engagements create page', () => {
     );
     expect(noOverflow).toBe(true);
   });
-
 });


### PR DESCRIPTION
## Summary

- **New page** `CreateEngagementPage` at `/practice/:slug/engagements/new` replaces the `CreateEngagementDialog`. Two-column layout: scrollable form on the left, live engagement letter preview on the right (visible at `xl` breakpoint). The preview updates as you type and shows exactly what the client will see — letterhead, contract body, fee summary, and signature block.
- **Better inputs** throughout: `RadioGroupWithDescriptions` for billing type (hourly / fixed fee / retainer / contingency / pro bono), `CurrencyInput` for all monetary amounts (conditional per billing type), `Combobox` with fixed options for urgency / conflict status / jurisdiction status / payment frequency, `FormGrid` for paired fields. Matches the patterns used in `MatterForm`.
- **Routing change**: `New Engagement` button now navigates to `/new` instead of opening a dialog. `EngagementsPage` checks `selectedEngagementId === 'new'` and renders `CreateEngagementPage`. ~390 lines of inline dialog code removed.
- **Bug fix**: `source_snapshot` in `buildProposalDataFromDraft` was sending `null` for `matter_id` and nullable string fields. Backend Zod schema expects `string | undefined` — fixed by omitting null values via `omitNulls()`.
- **E2E tests**: 7 new tests covering button navigation, section rendering, desktop preview panel, billing radio group presence, intake validation, cancel behaviour, and horizontal overflow.

## Test plan

- [ ] Navigate to Engagements — "New Engagement" button goes to `/engagements/new`
- [ ] Select an accepted intake from the combobox — fields auto-fill, contract body regenerates
- [ ] Change billing type radio — correct amount input appears (CurrencyInput for fixed/retainer/hourly, % input for contingency, nothing for pro bono)
- [ ] Preview panel updates live on xl viewport as you type
- [ ] Submit with no intake selected — "An accepted intake is required" validation error
- [ ] Cancel returns to the engagements list
- [ ] Create an engagement — navigates to the detail page, engagement appears in the list
- [ ] Previously broken: creating an engagement no longer returns a `source_snapshot` null validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Create Engagement" page enabling intake selection, auto-filled form fields, contract regeneration, and a live client letter preview.

* **Refactor**
  * Engagements list now uses route-based navigation for create/view/edit flows and centralized creation UI.
  * Cleaner draft/proposal data generation that omits null fields.

* **Tests**
  * Added E2E tests for the engagement creation flow and updated test config to include the new spec.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->