### PR TITLE
fix(matters): matter-page bugs from #618 (edit, tasks, engagement, invoice)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,51 +159,7 @@ npx wrangler d1 execute DB --local --config worker/wrangler.toml --env dev --fil
 
 If a feature adds a new Worker-owned `/api/*` prefix, add it to `workerEndpoints` in `vite.config.ts`; otherwise Vite may proxy that path to the backend fallback and produce misleading local 404s.
 
-## 6. Compound Engineering Is The Default Workflow
-
-This project develops with the [Compound Engineering plugin](https://github.com/EveryInc/compound-engineering-plugin) (`ce-*` skills). Use it. Do not invent ad-hoc flows when a `ce-*` skill covers the task.
-
-**Routing is intent-based, not word-matching.** Trigger a `ce-*` skill only when the user is initiating a phase of work that the skill is designed for. A keyword appearing inside an unrelated sentence ("this doesn't work", "I plan to refactor later", "let me review the diff myself") is NOT a trigger.
-
-A request triggers a skill only when ALL three hold:
-
-1. The user is asking *you* to start a new phase of work (not narrating, complaining, or describing).
-2. The request is the imperative form of the skill's purpose (a request to brainstorm, a request to plan, a request to review, etc.) — not the word used in another grammatical role.
-3. No more-specific in-flight task is currently being executed that the skill would interrupt.
-
-If any of the three is in doubt, do not invoke the skill — answer normally and ask whether the user wants the formal workflow.
-
-| Trigger examples | Non-triggers (do NOT route) | Skill |
-|---|---|---|
-| "let's brainstorm X", "brainstorm a feature for…", "help me think through Y" | "I was brainstorming earlier", "we already brainstormed this" | `ce-brainstorm` |
-| "ideate on X", "give me ideas for Y", "what should I improve here", "surprise me" | "that's a good idea", "the idea is to…" | `ce-ideate` |
-| "plan this feature", "create a plan for X", "break this task down" | "I plan to look at this later", "the plan is already written", "what's the deployment plan" | `ce-plan` |
-| "implement the plan", "build this feature now", "execute the plan at docs/…" | "this doesn't work", "make it work", "the test isn't working", "work on it later" | `ce-work` |
-| "debug this", "why is /preferences 404ing", "investigate this stack trace", "fix this bug" (with reproducible failure) | "the debugger config is wrong", "debug output is noisy" | `ce-debug` |
-| "code review my changes", "review this branch / PR", "do a CE code review" | "let me review the diff myself", "I'll review later", "the reviewer said…" | `ce-code-review` |
-| "review the plan doc", "doc review this spec" | "the doc reviewer caught X" | `ce-doc-review` |
-| "commit this", "save my changes as a commit" | "the last commit was bad", "commit history is messy" | `ce-commit` |
-| "resolve the PR feedback", "address the review comments" | "the feedback was useful" | `ce-resolve-pr-feedback` |
-| "compound this learning", "document this as a learning", "save what we learned" | "compound interest", "compound the bug count" | `ce-compound` |
-| "simplify the code I just wrote", "clean up this implementation" | "simple is better", "simplify the design later" | `ce-simplify-code` |
-| "lfg", "run the full pipeline autonomously", "ship it hands-off" | enthusiasm-only "lfg!!" in the middle of a different request | `lfg` |
-
-The canonical loop is **brainstorm → plan → work → code-review → compound**. Reach for `ce-debug` for bug investigation and `lfg` for autonomous end-to-end runs.
-
-**Already inside a skill?** Skill invocations don't recursively re-route. If a skill is in progress and the user says something that *would* be a trigger out of context, continue the current skill — don't switch mid-flight unless the user explicitly asks to (e.g., "stop, let's plan this instead").
-
-**Plugin install check.** Before invoking a `ce-*` skill, confirm `compound-engineering:*` skills appear in the available-skills list. If they don't, tell the user the plugin isn't installed and offer to install it. Install commands (Claude Code):
-
-```text
-/plugin marketplace add EveryInc/compound-engineering-plugin
-/plugin install compound-engineering
-```
-
-After they confirm, the plugin can be installed by running those slash commands in Claude Code. Don't try to install via `npm`, `bun`, or `git clone` — use the plugin marketplace.
-
-The first time the plugin is used in this repo, run `/ce-setup` once to bootstrap project config.
-
-## 7. Browser-Agent And Playwright
+## 6. Browser-Agent And Playwright
 
 Use browser-agent for exploratory smoke tests:
 

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -78,7 +78,9 @@ const buildInvoiceUpdatePayload = ({
   invoiceType: Invoice['invoice_type'];
   lineItems: InvoiceLineItem[];
 }): InvoiceUpdatePayload => ({
-  due_date: dueDate ? new Date(`${dueDate}T00:00:00.000Z`).toISOString() : undefined,
+  // Send the date-only value (YYYY-MM-DD) as-is. The backend validates due_date
+  // as an ISO date and rejects a full datetime string (it was "Invalid ISO date").
+  due_date: dueDate || undefined,
   notes: notes.trim() || undefined,
   memo: memo.trim() || undefined,
   invoice_type: invoiceType,
@@ -251,7 +253,9 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
     matter_id: resolvedMatterId || undefined,
     connected_account_id: accountId,
     invoice_type: invoiceType,
-    due_date: dueDate ? new Date(`${dueDate}T00:00:00.000Z`).toISOString() : undefined,
+    // Send the date-only value (YYYY-MM-DD) as-is. The backend validates due_date
+    // as an ISO date and rejects a full datetime string (it was "Invalid ISO date").
+    due_date: dueDate || undefined,
     notes: notes.trim() || undefined,
     memo: memo.trim() || undefined,
     line_items: lineItems

--- a/src/features/matters/components/MatterDetailHeader.tsx
+++ b/src/features/matters/components/MatterDetailHeader.tsx
@@ -47,9 +47,6 @@ export interface MatterDetailHeaderProps {
   onAddTask: () => void;
   onAddNote: () => void;
   onUploadFile: () => void;
-  engagementActionLabel: string;
-  onEngagementAction: () => void;
-  engagementActionLoading?: boolean;
   moreMenuItems?: MatterMoreMenuItem[];
 }
 
@@ -65,9 +62,6 @@ export const MatterDetailHeader = ({
   onAddTask,
   onAddNote,
   onUploadFile,
-  engagementActionLabel,
-  onEngagementAction,
-  engagementActionLoading = false,
   moreMenuItems
 }: MatterDetailHeaderProps) => {
   const title = detail.title?.trim() || 'Untitled matter';
@@ -123,9 +117,6 @@ export const MatterDetailHeader = ({
         </div>
 
         <div className="flex flex-wrap items-center justify-end gap-2">
-          <Button size="sm" variant="primary" onClick={onEngagementAction} disabled={engagementActionLoading}>
-            {engagementActionLoading ? 'Creating...' : engagementActionLabel}
-          </Button>
           <Button size="sm" variant="secondary" icon={Timer} onClick={onLogTime}>
             Log time
           </Button>

--- a/src/features/matters/components/MatterOverviewTab.tsx
+++ b/src/features/matters/components/MatterOverviewTab.tsx
@@ -54,14 +54,13 @@ export interface MatterOverviewTabProps {
   // Tasks
   tasks: MatterTask[];
 
-  // Engagement
+  // Engagement (view-only — engagements are created from accepted intake
+  // contracts, never from the matter detail, so there is no "create" action here)
   engagement: EngagementDetail | null;
   engagementLoading: boolean;
   engagementError: string | null;
   onEngagementRetry: () => void;
   onViewEngagement: () => void;
-  onCreateEngagement: () => void;
-  engagementActionLoading?: boolean;
 
   // Activity
   timelineItems: TimelineItem[];
@@ -80,6 +79,7 @@ export interface MatterOverviewTabProps {
   onViewTimesheet: () => void;
   onViewAllActivity: () => void;
   onViewTasks: () => void;
+  onAddTask: () => void;
   onTaskClick: () => void;
   onUploadFile: () => void;
   onViewFiles: () => void;
@@ -112,28 +112,24 @@ const OperationalNextStepCard = ({
   engagement,
   engagementLoading,
   engagementError,
-  engagementActionLoading,
-  onCreateEngagement,
   onViewEngagement,
   onEngagementRetry,
-  onViewTasks
+  onAddTask
 }: {
   tasks: MatterTask[];
   engagement: EngagementDetail | null;
   engagementLoading: boolean;
   engagementError: string | null;
-  engagementActionLoading?: boolean;
-  onCreateEngagement: () => void;
   onViewEngagement: () => void;
   onEngagementRetry: () => void;
-  onViewTasks: () => void;
+  onAddTask: () => void;
 }) => {
   const nextTask = [...tasks].filter(isOpenTask).sort(sortByDue)[0] ?? null;
   const hasEngagement = Boolean(engagement);
-  const title = hasEngagement ? 'Review engagement' : 'Create an engagement';
+  const title = hasEngagement ? 'Review engagement' : 'Add your next task';
   const body = hasEngagement
     ? 'Continue from the engagement agreement before advancing client work.'
-    : 'Create and send an engagement agreement before starting work.';
+    : 'Track the work for this matter by adding and assigning tasks.';
 
   return (
     <InfoCard
@@ -158,15 +154,17 @@ const OperationalNextStepCard = ({
         ) : null}
       </div>
       <div className="flex flex-wrap gap-2">
-        <Button
-          size="sm"
-          variant="primary"
-          onClick={hasEngagement ? onViewEngagement : onCreateEngagement}
-          disabled={engagementLoading || engagementActionLoading}
-        >
-          {engagementActionLoading ? 'Creating...' : hasEngagement ? 'View engagement' : 'Create engagement'}
-        </Button>
-        <Button size="sm" variant="secondary" onClick={onViewTasks}>
+        {hasEngagement ? (
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={onViewEngagement}
+            disabled={engagementLoading}
+          >
+            View engagement
+          </Button>
+        ) : null}
+        <Button size="sm" variant={hasEngagement ? 'secondary' : 'primary'} onClick={onAddTask}>
           Add task
         </Button>
       </div>
@@ -180,12 +178,10 @@ const EngagementStatusCard = ({
   engagementLoading,
   engagementError,
   onEngagementRetry,
-  onViewEngagement,
-  onCreateEngagement,
-  engagementActionLoading
+  onViewEngagement
 }: Pick<
   MatterOverviewTabProps,
-  'detail' | 'engagement' | 'engagementLoading' | 'engagementError' | 'onEngagementRetry' | 'onViewEngagement' | 'onCreateEngagement' | 'engagementActionLoading'
+  'detail' | 'engagement' | 'engagementLoading' | 'engagementError' | 'onEngagementRetry' | 'onViewEngagement'
 >) => {
   const billingLabel = BILLING_TYPE_LABEL[detail.billingType];
   const rateLabel = detail.attorneyHourlyRate
@@ -196,15 +192,19 @@ const EngagementStatusCard = ({
   const statusLabel = engagement ? ENGAGEMENT_STATUS_LABEL[engagement.status] : null;
   const summaryParts = [statusLabel, billingLabel, rateLabel].filter((p): p is string => Boolean(p));
 
+  // A matter always has an engagement, so never surface a "missing engagement"
+  // state. Show this card only once an engagement is loaded — or while loading /
+  // on error so the user can retry — and render nothing otherwise.
+  if (!engagement && !engagementLoading && !engagementError) return null;
+
   return (
     <InfoCard icon={Briefcase} title="Engagement" bodyGap="sm">
       {engagementLoading && !engagement ? (
         <LoadingBlock label="Loading engagement" />
       ) : engagementError && !engagement ? (
         <div className="space-y-1">
-          <p className="text-[13px] text-input-text">No engagement yet</p>
+          <p className="text-[13px] text-input-text">Engagement unavailable</p>
           <p className="text-[12px] text-amber-300">
-            Engagement unavailable.{' '}
             <button type="button" className="underline" onClick={onEngagementRetry}>
               Retry
             </button>
@@ -219,24 +219,21 @@ const EngagementStatusCard = ({
             <p className="text-[13px] text-input-placeholder">{summaryParts.join(' · ')}</p>
           ) : null}
         </div>
-      ) : (
-        <div className="space-y-1">
-          <p className="text-[13px] text-input-text">No engagement yet</p>
-          <p className="text-[13px] text-input-placeholder">Create an engagement to get started.</p>
+      ) : null}
+      {engagement ? (
+        <div>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon={ExternalLink}
+            iconPosition="right"
+            onClick={onViewEngagement}
+            disabled={engagementLoading}
+          >
+            View engagement
+          </Button>
         </div>
-      )}
-      <div>
-        <Button
-          size="sm"
-          variant={engagement ? 'secondary' : 'primary'}
-          icon={engagement ? ExternalLink : undefined}
-          iconPosition="right"
-          onClick={engagement ? onViewEngagement : onCreateEngagement}
-          disabled={engagementLoading || engagementActionLoading}
-        >
-          {engagementActionLoading ? 'Creating...' : engagement ? 'View engagement' : 'Create engagement'}
-        </Button>
-      </div>
+      ) : null}
     </InfoCard>
   );
 };
@@ -473,8 +470,6 @@ export const MatterOverviewTab = (props: MatterOverviewTabProps) => {
     engagementError,
     onEngagementRetry,
     onViewEngagement,
-    onCreateEngagement,
-    engagementActionLoading,
     timelineItems,
     activityLoading,
     activityError,
@@ -488,6 +483,7 @@ export const MatterOverviewTab = (props: MatterOverviewTabProps) => {
     onViewTimesheet,
     onViewAllActivity,
     onViewTasks,
+    onAddTask,
     onTaskClick,
     onUploadFile,
     onViewFiles
@@ -502,11 +498,9 @@ export const MatterOverviewTab = (props: MatterOverviewTabProps) => {
             engagement={engagement}
             engagementLoading={engagementLoading}
             engagementError={engagementError}
-            engagementActionLoading={engagementActionLoading}
-            onCreateEngagement={onCreateEngagement}
             onViewEngagement={onViewEngagement}
             onEngagementRetry={onEngagementRetry}
-            onViewTasks={onViewTasks}
+            onAddTask={onAddTask}
           />
           <EngagementStatusCard
             detail={detail}
@@ -515,8 +509,6 @@ export const MatterOverviewTab = (props: MatterOverviewTabProps) => {
             engagementError={engagementError}
             onEngagementRetry={onEngagementRetry}
             onViewEngagement={onViewEngagement}
-            onCreateEngagement={onCreateEngagement}
-            engagementActionLoading={engagementActionLoading}
           />
           {tasks.some(isOpenTask) ? <OpenTasksCard tasks={tasks} onTaskClick={onTaskClick} onViewTasks={onViewTasks} /> : null}
           <RecentActivityCard

--- a/src/features/matters/components/MatterWorkTab.tsx
+++ b/src/features/matters/components/MatterWorkTab.tsx
@@ -10,6 +10,8 @@ import type {
   MatterOption,
   MatterTask
 } from '@/features/matters/data/matterTypes';
+import type { MatterTaskFormValues } from '@/features/matters/components/tasks/MatterTaskForm';
+import type { UpdateMatterTaskPayload } from '@/features/matters/services/mattersApi';
 import type { MajorAmount } from '@/shared/utils/money';
 
 export type WorkSubTab = 'tasks' | 'milestones';
@@ -36,6 +38,14 @@ export interface MatterWorkTabProps {
   tasksError: string | null;
   tasksNotImplemented: boolean;
   assignees: MatterOption[];
+  /** When true, the tasks panel is view-only (e.g. closed matters). */
+  tasksReadOnly?: boolean;
+  onCreateTask?: (values: MatterTaskFormValues) => Promise<void>;
+  onUpdateTask?: (task: MatterTask, patch: UpdateMatterTaskPayload) => Promise<void>;
+  onDeleteTask?: (task: MatterTask) => Promise<void>;
+  /** Open the task-create form on mount (driven by the overview "Add task" CTA). */
+  autoComposeTask?: boolean;
+  onComposeTaskHandled?: () => void;
 
   milestones: MatterDetail['milestones'];
   milestonesLoading: boolean;
@@ -55,6 +65,12 @@ export const MatterWorkTab = ({
   tasksError,
   tasksNotImplemented,
   assignees,
+  tasksReadOnly = false,
+  onCreateTask,
+  onUpdateTask,
+  onDeleteTask,
+  autoComposeTask = false,
+  onComposeTaskHandled,
   milestones,
   milestonesLoading,
   milestonesError,
@@ -88,7 +104,12 @@ export const MatterWorkTab = ({
             loading={tasksLoading}
             error={tasksError}
             assignees={assignees}
-            readOnly
+            readOnly={tasksReadOnly}
+            onCreateTask={onCreateTask}
+            onUpdateTask={onUpdateTask}
+            onDeleteTask={onDeleteTask}
+            autoOpenCreate={autoComposeTask}
+            onAutoOpenHandled={onComposeTaskHandled}
           />
         )
       ) : null}

--- a/src/features/matters/components/tasks/MatterTasksPanel.tsx
+++ b/src/features/matters/components/tasks/MatterTasksPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { MoreVertical, Pencil, Plus, Trash2 } from 'lucide-preact';
 
 import { Icon } from '@/shared/ui/Icon';
@@ -58,6 +58,9 @@ interface MatterTasksPanelProps {
   onCreateTask?: (values: MatterTaskFormValues) => Promise<void>;
   onUpdateTask?: (task: MatterTask, patch: MatterTaskPatch) => Promise<void>;
   onDeleteTask?: (task: MatterTask) => Promise<void>;
+  /** Open the create-task form once on mount (driven by an external CTA). */
+  autoOpenCreate?: boolean;
+  onAutoOpenHandled?: () => void;
 }
 
 const formatDate = (date: string | null) => (date ? formatDateOnlyUtc(date) : 'No due date');
@@ -70,7 +73,9 @@ export const MatterTasksPanel = ({
   readOnly = false,
   onCreateTask,
   onUpdateTask,
-  onDeleteTask
+  onDeleteTask,
+  autoOpenCreate = false,
+  onAutoOpenHandled
 }: MatterTasksPanelProps) => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<MatterTask | null>(null);
@@ -112,6 +117,23 @@ export const MatterTasksPanel = ({
     setRequestError(null);
     setIsFormOpen(false);
   };
+
+  // Open the create form once when an external CTA (e.g. the matter overview
+  // "Add task" button) navigates here with the intent to compose a task.
+  const autoOpenHandledRef = useRef(false);
+  useEffect(() => {
+    // Reset once the compose intent clears so a later "Add task" can reopen.
+    if (!autoOpenCreate) {
+      autoOpenHandledRef.current = false;
+      return;
+    }
+    if (!canCreateTask || autoOpenHandledRef.current) return;
+    autoOpenHandledRef.current = true;
+    setEditingTask(null);
+    setRequestError(null);
+    setIsFormOpen(true);
+    onAutoOpenHandled?.();
+  }, [autoOpenCreate, canCreateTask, onAutoOpenHandled]);
 
   const submitForm = async (values: MatterTaskFormValues) => {
     setRequestError(null);

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/features/matters/data/matterTypes';
 import { MatterEditForm, type MatterFormState } from '@/features/matters/components/MatterForm';
 import { TimeEntryForm, type TimeEntryFormValues } from '@/features/matters/components/time-entries/TimeEntryForm';
+import type { MatterTaskFormValues } from '@/features/matters/components/tasks/MatterTaskForm';
 import {
   MatterDetailPanel,
   type DetailSectionId
@@ -45,6 +46,7 @@ import {
   type BackendMatterActivity,
   type BackendMatterNote,
   type BackendMatterTimeStats,
+  type UpdateMatterTaskPayload,
   createMatterExpense,
   createMatterNote,
   createMatterMilestone,
@@ -57,6 +59,9 @@ import {
   listMatterMilestones,
   listMatterNotes,
   listMatterTasks,
+  createMatterTask,
+  updateMatterTask,
+  deleteMatterTask,
   listMatterTimeEntries,
   reorderMatterMilestones,
   updateMatterExpense,
@@ -334,6 +339,12 @@ export const PracticeMattersPage = ({
   const convertIntakeUuid = useMemo(
     () => resolveQueryValue(location.query?.convertIntake),
     [location.query?.convertIntake]
+  );
+  // The matter overview "Add task" CTA navigates to the Work → Tasks view with
+  // `?compose=task` so the tasks panel auto-opens its create form on arrival.
+  const composeTaskRequested = useMemo(
+    () => resolveQueryValue(location.query?.compose) === 'task',
+    [location.query?.compose]
   );
   const navigate = useCallback((path: string) => location.route(path), [location]);
   const goToList = () => navigate(basePath);
@@ -1382,6 +1393,39 @@ export const PracticeMattersPage = ({
     if (created) setNoteRecords((prev) => [...prev, created]);
   }, [activePracticeId, selectedMatterId]);
 
+  // ── Task handlers ─────────────────────────────────────────────────────────
+  const refreshTasks = useCallback(async () => {
+    if (!activePracticeId || !selectedMatterId) return;
+    const items = await listMatterTasks(activePracticeId, selectedMatterId);
+    setTasks(items.map(toMatterTask));
+  }, [activePracticeId, selectedMatterId]);
+
+  const handleCreateTask = useCallback(async (values: MatterTaskFormValues) => {
+    if (!activePracticeId || !selectedMatterId) throw new Error('IDs required');
+    await createMatterTask(activePracticeId, selectedMatterId, {
+      name: values.name,
+      description: values.description || undefined,
+      assignee_id: values.assigneeId,
+      due_date: values.dueDate,
+      status: values.status,
+      priority: values.priority,
+      stage: values.stage
+    });
+    await refreshTasks();
+  }, [activePracticeId, selectedMatterId, refreshTasks]);
+
+  const handleUpdateTask = useCallback(async (task: MatterTask, patch: UpdateMatterTaskPayload) => {
+    if (!activePracticeId || !selectedMatterId) throw new Error('IDs required');
+    await updateMatterTask(activePracticeId, selectedMatterId, task.id, patch);
+    await refreshTasks();
+  }, [activePracticeId, selectedMatterId, refreshTasks]);
+
+  const handleDeleteTask = useCallback(async (task: MatterTask) => {
+    if (!activePracticeId || !selectedMatterId) throw new Error('IDs required');
+    await deleteMatterTask(activePracticeId, selectedMatterId, task.id);
+    await refreshTasks();
+  }, [activePracticeId, selectedMatterId, refreshTasks]);
+
   // ── Derived list data ─────────────────────────────────────────────────────
   const matterEntries = useMemo(() => matters.map((m) => ({
     summary: toMatterSummary(m, { clientNameById, serviceNameById }),
@@ -1809,12 +1853,9 @@ export const PracticeMattersPage = ({
             responsibleAttorneyLabel,
             assigneeLabel: assigneeLabelComputed,
             onLogTime: () => goToDetail(selectedMatterDetail.id, 'billing', 'time'),
-            onAddTask: () => goToDetail(selectedMatterDetail.id, 'work', 'tasks'),
+            onAddTask: () => navigate(`${basePath}/${encodeURIComponent(selectedMatterDetail.id)}/work?compose=task`),
             onAddNote: () => goToDetail(selectedMatterDetail.id, 'notes'),
             onUploadFile: () => goToDetail(selectedMatterDetail.id, 'files'),
-            engagementActionLabel: engagement ? 'View engagement' : 'Missing engagement',
-            onEngagementAction: () => void handleEngagementPrimaryAction(),
-            engagementActionLoading: engagementCreating,
             moreMenuItems: [
               {
                 label: 'Edit matter',
@@ -1838,8 +1879,6 @@ export const PracticeMattersPage = ({
               setEngagementRetryCount((count) => count + 1);
             },
             onViewEngagement: () => void handleEngagementPrimaryAction(),
-            onCreateEngagement: () => void handleEngagementPrimaryAction(),
-            engagementActionLoading: engagementCreating,
             timelineItems,
             activityLoading,
             activityError,
@@ -1853,6 +1892,7 @@ export const PracticeMattersPage = ({
             onViewTimesheet: () => goToDetail(selectedMatterDetail.id, 'billing', 'time'),
             onViewAllActivity: () => goToDetail(selectedMatterDetail.id, 'activity'),
             onViewTasks: () => goToDetail(selectedMatterDetail.id, 'work', 'tasks'),
+            onAddTask: () => navigate(`${basePath}/${encodeURIComponent(selectedMatterDetail.id)}/work?compose=task`),
             onTaskClick: () => goToDetail(selectedMatterDetail.id, 'work', 'tasks'),
             onUploadFile: () => goToDetail(selectedMatterDetail.id, 'files'),
             onViewFiles: () => goToDetail(selectedMatterDetail.id, 'files')
@@ -1866,6 +1906,12 @@ export const PracticeMattersPage = ({
             tasksError,
             tasksNotImplemented,
             assignees: assigneeOptions,
+            tasksReadOnly: selectedMatterDetail.status === 'closed',
+            onCreateTask: handleCreateTask,
+            onUpdateTask: handleUpdateTask,
+            onDeleteTask: handleDeleteTask,
+            autoComposeTask: composeTaskRequested,
+            onComposeTaskHandled: () => goToDetail(selectedMatterDetail.id, 'work', 'tasks'),
             milestones,
             milestonesLoading,
             milestonesError,

--- a/src/features/matters/services/invoicesApi.ts
+++ b/src/features/matters/services/invoicesApi.ts
@@ -26,6 +26,14 @@ type FetchOptions = {
   signal?: AbortSignal;
 };
 
+// Every invoice mutation must clear the caches that hold invoice status/data so
+// list, detail, and matter-billing views re-fetch instead of rendering a stale
+// status (e.g. a freshly sent invoice still showing as "draft"). Trailing `:`
+// marks a prefix invalidation: `invoice:` covers the practice/client summaries
+// (`invoice:practice:summaries:…`) and detail (`invoice:practice:…` /
+// `invoice:client:…`) caches; `billing:matter:` covers the matter billing tab.
+const INVOICE_CACHE_INVALIDATIONS = ['invoice:', 'billing:matter:'];
+
 // Wire types live in worker/types/wire/invoice.ts (single source of truth).
 // Re-exported here for existing consumers; new code should import from
 // `@/shared/types/wire` directly.
@@ -397,7 +405,7 @@ export const createInvoice = async (
     apiClient.post(
       urls.createInvoice(practiceId),
       normalizeCreatePayload(payload),
-      { signal: options.signal }
+      { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to create invoice'
   );
@@ -415,7 +423,7 @@ export const sendInvoice = async (
     apiClient.post(
       urls.sendInvoice(practiceId, invoiceId),
       {},
-      { signal: options.signal }
+      { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to send invoice'
   );
@@ -445,7 +453,7 @@ export const updateInvoice = async (
     apiClient.patch(
       urls.updateInvoice(practiceId, invoiceId),
       body,
-      { signal: options.signal }
+      { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to update invoice'
   );
@@ -463,7 +471,7 @@ export const voidInvoice = async (
     apiClient.post(
       urls.voidInvoice(practiceId, invoiceId),
       {},
-      { signal: options.signal }
+      { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to void invoice'
   );
@@ -481,7 +489,7 @@ export const syncInvoice = async (
     apiClient.post(
       urls.syncInvoice(practiceId, invoiceId),
       {},
-      { signal: options.signal }
+      { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to sync invoice'
   );
@@ -498,7 +506,7 @@ export const deleteInvoice = async (
   await requestData(
     apiClient.delete(
       urls.deleteInvoice(practiceId, invoiceId),
-      { signal: options.signal }
+      { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to delete invoice'
   );

--- a/src/features/matters/utils/matterUtils.ts
+++ b/src/features/matters/utils/matterUtils.ts
@@ -490,22 +490,26 @@ export const buildUpdatePayload = (
 ): Record<string, unknown> => ({
   title: values.title.trim(),
   billing_type: values.billingType,
-  description: values.description?.trim() ?? null,
-  client_id: values.clientId && values.clientId !== '' ? values.clientId : null,
-  practice_service_id: values.practiceAreaId && values.practiceAreaId !== '' ? values.practiceAreaId : null,
-  case_number: values.caseNumber && values.caseNumber !== '' ? values.caseNumber : null,
-  matter_type: values.matterType && values.matterType !== '' ? values.matterType : null,
-  urgency: values.urgency ? values.urgency : null,
-  responsible_attorney_id: values.responsibleAttorneyId && values.responsibleAttorneyId !== '' ? values.responsibleAttorneyId : null,
-  originating_attorney_id: values.originatingAttorneyId && values.originatingAttorneyId !== '' ? values.originatingAttorneyId : null,
-  court: values.court && values.court !== '' ? values.court : null,
-  judge: values.judge && values.judge !== '' ? values.judge : null,
-  opposing_party: values.opposingParty && values.opposingParty !== '' ? values.opposingParty : null,
-  opposing_counsel: values.opposingCounsel && values.opposingCounsel !== '' ? values.opposingCounsel : null,
-  attorney_hourly_rate: values.attorneyHourlyRate ?? null,
-  admin_hourly_rate: values.adminHourlyRate ?? null,
-  payment_frequency: values.paymentFrequency ?? null,
-  settlement_amount: values.settlementAmount ?? null,
+  // Optional fields are omitted (undefined → stripped by prunePayload) when
+  // empty, never sent as null. The backend update schema rejects null for these
+  // (it expects a string/number/UUID or the field to be absent), so sending
+  // null for an unset field fails validation. Mirrors buildCreatePayload.
+  description: values.description?.trim() || undefined,
+  client_id: values.clientId || undefined,
+  practice_service_id: values.practiceAreaId || undefined,
+  case_number: values.caseNumber || undefined,
+  matter_type: values.matterType || undefined,
+  urgency: values.urgency || undefined,
+  responsible_attorney_id: values.responsibleAttorneyId || undefined,
+  originating_attorney_id: values.originatingAttorneyId || undefined,
+  court: values.court || undefined,
+  judge: values.judge || undefined,
+  opposing_party: values.opposingParty || undefined,
+  opposing_counsel: values.opposingCounsel || undefined,
+  attorney_hourly_rate: values.attorneyHourlyRate ?? undefined,
+  admin_hourly_rate: values.adminHourlyRate ?? undefined,
+  payment_frequency: values.paymentFrequency ?? undefined,
+  settlement_amount: values.settlementAmount ?? undefined,
   // Only send status if it changed
   status: values.status !== currentStatus ? values.status : undefined,
   assignee_ids: Array.isArray(values.assigneeIds) ? values.assigneeIds : []


### PR DESCRIPTION
## Summary

Resolves the matter-page issues reported in #618, plus two follow-ups raised during review.

### Bug fixes (#618)
- **Editing a matter no longer fails.** `buildUpdatePayload` sent `null` for empty optional fields and `prunePayload` only strips `undefined`, so the backend update validator rejected `matter_type`, hourly rates, attorney IDs, `court`, `judge`, opposing party/counsel, and `settlement_amount`. It now omits empty fields (mirroring `buildCreatePayload`).
- **Send invoice no longer fails on `due_date`.** `InvoiceForm` converted the date-only value to a full ISO datetime via `.toISOString()`, which the backend rejected as "Invalid ISO date". It now sends the date-only `YYYY-MM-DD` value as-is (create + update payloads).
- **"Add task" works.** The practice Work tab rendered the tasks panel read-only with no handlers, so neither the overview card nor the header "Add → Task" could create a task. Wired create/update/delete; both "Add task" entry points now open the create form (`?compose=task`).
- **No more engagement-creation / "Missing engagement" prompts.** A matter always has an engagement (created from an accepted intake contract), so the overview "Create engagement" cards, the header "View/Missing engagement" button, and the "No engagement linked" empty state are removed. "View engagement" shows only when one exists.

### Follow-ups (review)
- **Invoice status stuck on "draft" after send.** The send succeeds (backend → `sent`) but list/Billing views read cached summaries that no mutation invalidated. Every invoice mutation now invalidates the `invoice:` and `billing:matter:` caches, so the UI reflects "Sent" without a manual refresh.
- **Docs:** removed the Compound Engineering workflow section from `CLAUDE.md` (the `ce-*` skills remain installed; the doc just no longer mandates them).

## Testing
- `npm run type-check` (app) ✅
- ESLint on changed files ✅ — one **pre-existing** unused-var (`PracticeMattersPage.tsx:317` `showSuccess`) left untouched per the repo's "don't delete pre-existing dead code" convention.
- Unit/component tests for matters tasks + invoices ✅

> Not yet verified in the browser against staging. Worth confirming: matter edit save, send-invoice from a matter, the invoices list / Billing tab flipping to "Sent", and the Work-tab "Add task" flow.

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)