### PR TITLE
fix: add pr-4 to last table column for symmetrical panel padding

### DIFF
--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -231,14 +231,17 @@ export const DataTable = ({
           <tr className={cn('border-b border-line-subtle', stickyHeader && 'sticky top-0 z-10 bg-surface-workspace')}>
             {columns.map((column, index) => {
               const isPrimary = column.id === primaryColumn?.id || (index === 0 && !primaryColumn);
+              const isLast = index === columns.length - 1;
               const baseHeaderClass = isPrimary
                 ? cn(
                   'text-left text-sm font-semibold text-input-text',
-                  density === 'compact' ? 'py-2.5 pr-3 pl-4' : 'py-3.5 pr-3 pl-4'
+                  density === 'compact' ? 'py-2.5 pl-4' : 'py-3.5 pl-4',
+                  isLast ? 'pr-4' : 'pr-3'
                 )
                 : cn(
                   'text-left text-sm font-semibold text-input-text whitespace-nowrap',
-                  density === 'compact' ? 'px-3 py-2.5' : 'px-3 py-3.5'
+                  density === 'compact' ? 'py-2.5' : 'py-3.5',
+                  isLast ? 'pl-3 pr-4' : 'px-3'
                 );
 
               return (
@@ -287,14 +290,17 @@ export const DataTable = ({
                 >
                   {columns.map((column, index) => {
                     const isPrimary = column.id === primaryColumn?.id || (index === 0 && !primaryColumn);
+                    const isLast = index === columns.length - 1;
                     const baseCellClass = isPrimary
                       ? cn(
                         'w-full max-w-0 text-sm font-medium text-input-text sm:w-auto sm:max-w-none',
-                        density === 'compact' ? 'py-2.5 pr-3 pl-4' : 'py-3 pr-3 pl-4'
+                        density === 'compact' ? 'py-2.5 pl-4' : 'py-3 pl-4',
+                        isLast ? 'pr-4' : 'pr-3'
                       )
                       : cn(
                         'text-sm text-input-placeholder',
-                        density === 'compact' ? 'px-3 py-2.5' : 'px-3 py-3'
+                        density === 'compact' ? 'py-2.5' : 'py-3',
+                        isLast ? 'pl-3 pr-4' : 'px-3'
                       );
                     const cellContent = row.isPlaceholder ? '\u00A0' : (row.cells[column.id] ?? '—');
 


### PR DESCRIPTION
## Summary

- Last column in every `DataTable` was using `px-3` (`pr-3` on the right) while the primary column uses `pl-4` on the left — asymmetric and visually cramped against the panel edge
- Now detects the last column (`isLast = index === columns.length - 1`) and applies `pr-4` instead of `pr-3` for both header and cell, in both compact and regular density

Single-file change in `DataTable.tsx` — affects all tables uniformly.

## Test plan

- [ ] Matters, invoices, engagements, reports, intakes, files — last column text has equal breathing room on the right as the first column has on the left

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved DataTable column spacing and alignment, particularly for the last column in the table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->