### PR TITLE
ds: PR-4 — InspectorPanel hooks + per-feature splits + shell refactor (in progress)

### DIFF
--- a/docs/design-system-migration.md
+++ b/docs/design-system-migration.md
@@ -36,13 +36,18 @@ From `design_handoff_blawby_chat_first/DESIGN_SYSTEM.md §0`:
 | 5c.2 — FocusDrawer generalize + Drawer delete | `af88f4de` | ✅ in PR #646 | FocusDrawer `position: left/right/bottom`; matching slide-in keyframes; deleted unused Drawer.tsx (zero callers) |
 | 5c.3 — AccentHeroSurface inline + delete | `4a4008b4` | ✅ in PR #646 | Inlined DS-tokenized gradient at PracticeContactsPage 2 sites; deleted primitive + barrel exports |
 | 5c.4 — InvoiceInspector extract | `83598c73` | ✅ in PR #646 | First of the per-feature inspector splits; pure data display; pattern proven |
-| 5d — Inspector hooks + per-feature splits (rest) | — | **pending — PR-4 scope** | useUserDetail / useMatterDetail / usePracticeDetail hooks; ClientInspector / MatterInspector / ConversationInspector extracts using those hooks |
-| 5e — Shell refactor | — | **pending — PR-4 scope** | Drop AppShell sidebar props; refactor WorkspacePage/PracticeHomePage/ClientHomePage/WidgetApp to LeftRail; extract ConversationListPanel (340px column per Conversations spec); delete legacy nav + InspectorPanel dispatcher + 4 test files |
+| 5d.1 — Inspector data hooks | `ddbf98b1` | ✅ in PR #647 | `useUserDetail` / `useMatterDetail` / `usePracticeDetail` extracted to `src/shared/hooks/`. Exported `UpdateUserDetailPayload` from apiClient. |
+| 5d.2 — InspectorPanel hook refactor | `fe6d88d3` | ✅ in PR #647 | Replaced 115-line inline fetch useEffect + 3 cache refs with hook calls. Net −109 lines. Module-level cache namespaced by `practiceId:userId`. |
+| 5d.3 — ClientInspector extract | `e02cf663` | ✅ in PR #647 | `src/features/clients/components/ClientInspector.tsx` (283 lines) consumes useUserDetail, owns its editor state + archive dialog. InspectorPanel −232 lines. |
+| 5d.4 — MatterInspector extract | — | **pending — PR-5 scope** | 380-line render block + matter editor state + matter resolved-field computations + identity helpers (renderCompactIdentity, renderIdentityStack, resolveAttorneyIdentity) — last two shared with ConversationInspector |
+| 5d.5 — ConversationInspector extract | — | **pending — PR-5 scope** | ~500-line render block (largest, most coupling); consumes useUserDetail + useMatterDetail + usePracticeDetail; intake editor state; reuses identity helpers from 5d.4 |
+| 5d.6 — Delete InspectorPanel dispatcher | — | **pending — PR-5 scope** | After 5d.4/5d.5, 4 callers dispatch directly |
+| 5e — Shell refactor | — | **pending — PR-5+ scope** | Drop AppShell sidebar props; refactor WorkspacePage/PracticeHomePage/ClientHomePage/WidgetApp to LeftRail; extract ConversationListPanel (340px column per Conversations spec); delete legacy nav + 4 test files |
 | 6 — Chat patterns | — | pending | AISummary, StagedAction, Citations, Observation, Composer, ToolUseLine, BriefingGrid, MatterChip; IOLTA manual smoke |
 | 7 — Data display | — | pending | StatStrip, JourneyProgress, LetterPaper, Seg; print test |
 | 8 — Feature sweep | — | pending | TSX feature-files swept for the 8 violation patterns; DataTable audit; AA contrast spot; `prefers-reduced-motion` check; final delete of `.status-*` / `.input-surface` / `.card-surface` aliases |
 
-PR series: #644 (foundation, merged) → #645 (Commit 4 + 5a + 5b, merged) → **#646 (this PR — 5c.1–5c.4)** → PR-4 (5d + 5e).
+PR series: #644 (foundation, merged) → #645 (Commit 4 + 5a + 5b, merged) → #646 (5c.1–5c.4, merged) → **#647 (this PR — 5d.1–5d.3)** → PR-5 (5d.4 onward + 5e).
 
 ---
 
@@ -134,43 +139,57 @@ Cross-reference between the design handoff and the existing app. "Status" tracks
 
 ---
 
-## PR-4 scope — `feat/ds-migration-pt4` (next session)
+## PR #647 (this PR) — landed checklist
 
-The remaining 5c work, deferred from PR #646 to keep that PR reviewable. Two layers: inspector split (5d) + shell refactor (5e).
+- [x] Extract `useUserDetail(practiceId, userId, { enabled })` hook — `ddbf98b1`
+- [x] Extract `useMatterDetail(practiceId, matterId, { enabled })` hook — `ddbf98b1`
+- [x] Extract `usePracticeDetail(practiceId, { enabled, fallback })` hook — `ddbf98b1`
+- [x] Refactor InspectorPanel's data-fetching useEffect to use the three hooks (−109 lines) — `fe6d88d3`
+- [x] Extract `ClientInspector` to `src/features/clients/components/ClientInspector.tsx` (consumes useUserDetail; owns address editor state + archive flow) — `e02cf663`
 
-### 5d — Inspector hooks + per-feature splits (rest of InspectorPanel)
+---
 
-Per the locked answer to open-item #1, use the hooks-first architecture (cleaner, testable, decouples data from rendering).
+## PR-5 scope — `feat/ds-migration-pt5` (next session)
 
-- [ ] Extract `useUserDetail(practiceId, userId, { enabled })` hook to `src/shared/hooks/useUserDetail.ts`
-  - Encapsulates the `getUserDetail` fetch + cache (`userCacheRef`) + abort controller currently inside InspectorPanel
-  - Returns `{ data, isLoading, error, mutate({ status?, address?, event_name? }), refresh() }`
-  - `mutate` is the per-record patch path; refreshes cache on success
-- [ ] Extract `useMatterDetail(practiceId, matterId, { enabled })` hook to `src/shared/hooks/useMatterDetail.ts`
-  - Same pattern; encapsulates `getMatter` + `matterCacheRef`
-- [ ] Extract `usePracticeDetail(practiceId, { enabled, fallback })` hook to `src/shared/hooks/usePracticeDetail.ts`
-  - Encapsulates `getPracticeDetails` + `practiceCacheRef` + the `propPracticeDetails` fallback path
-- [ ] Refactor `InspectorPanel`'s data-fetching `useEffect` (currently L335–429) to use the three hooks
-- [ ] Extract `ClientInspector` to `src/features/clients/components/ClientInspector.tsx`
-  - Owns the L1838–1939 client render block + the archive confirmation Dialog (L1969–2000)
-  - Consumes `useUserDetail`
-  - Moves `activePersonEditor`, `personAddressDraft`, `isSavingPersonField`, `isArchivingPerson`, `isArchiveConfirmOpen` state into this component
-  - Moves `formatAddressSummary`, `openPersonEditor`, `handlePersonFieldUpdate`, `handlePersonStatusChange` helpers
-- [ ] Extract `ConversationInspector` to `src/features/chat/components/ConversationInspector.tsx`
-  - Owns the L950–1460 conversation render block (largest of the 4)
-  - Consumes `useUserDetail` + `useMatterDetail` + `usePracticeDetail`
-  - Moves `activeConversationEditor`, intake editor state, assignment/priority/tag/matter save flags, etc.
-  - Moves `handleIntakeFieldChange` and related conversation handlers
+The remaining inspector splits (5d.4–5d.6) + the shell refactor (5e).
+
+### 5d.4 — Extract MatterInspector
+
+The matter render block (~380 lines, L1252-1631 in current InspectorPanel post-#647) has more entanglement than ClientInspector did. Plan accordingly:
+
 - [ ] Extract `MatterInspector` to `src/features/matters/components/MatterInspector.tsx`
-  - Owns the L1461–1841 matter render block
   - Consumes `useMatterDetail`
-  - Moves `activeMatterEditor`, `isSavingMatterStatus`, `isSavingMatterField` state and matter field handlers
-- [ ] Delete `src/shared/ui/inspector/InspectorPanel.tsx` (becomes obsolete after split)
-- [ ] Update the 4 callers to dispatch directly:
-  - `WorkspacePage.tsx` — switches based on `inspectorTarget.entityType` to render one of the 4 per-feature inspectors
-  - `WidgetApp.tsx`
-  - `DebugDialogsPage.tsx`
-  - `WorkspaceSetupSection.tsx`
+  - Moves state: `inspectorMatterStatus`, `activeMatterEditor`, `isSavingMatter`, `isSavingMatterStatus`, `isSavingMatterField`
+  - Moves the ~14 `resolvedMatter*` field computations (client name/id, urgency, attorney ids, case number, type, court, judge, opposing party/counsel, created/updated labels, assignee ids/names)
+  - Moves memos: `matterStatusOptions`, `urgencyOptions`, `matterClientOptionsWithNone`, `matterTeamIdentities`
+  - Moves helpers: `handleMatterStatusChange`, `handleMatterPatchChange`, `resolveMatterClientIdentity`, `resolveAttorneyLabel`, `resolveAttorneyIdentity`, `matterUrgencyLabel`
+  - **Shared with conversation block** (need duplication OR pre-extract to shared util):
+    - `renderCompactIdentity` (uses UserCard)
+    - `renderIdentityStack` (uses StackedAvatars + UserCard)
+    - `resolveAttorneyIdentity`
+    - `InspectorIdentity` type
+  - **Recommended approach**: extract these to `src/shared/ui/inspector/identityHelpers.tsx` as a separate sub-commit (5d.4a) so both MatterInspector (5d.4b) and ConversationInspector (5d.5) can consume them
+- [ ] Update InspectorPanel dispatcher: `<MatterInspector practiceId={...} entityId={...} {...matterProps} />` when entityType === 'matter'
+
+### 5d.5 — Extract ConversationInspector
+
+- [ ] Extract `ConversationInspector` to `src/features/chat/components/ConversationInspector.tsx`
+  - Consumes `useUserDetail` + `useMatterDetail` + `usePracticeDetail` (conversation needs all three because it shows client info + linked matter + practice context)
+  - Moves the ~500-line conversation render block (L950-1460 in current file, will have shifted after 5d.4)
+  - Moves state: `activeConversationEditor` + intake editor sub-states, `isSavingAssignment`, `isSavingPriority`, `isSavingTags`, `isSavingMatter`, `localIntakeDraft`
+  - Moves helpers: `handleIntakeFieldChange`, intake-strength rendering, conversation assignment/priority/tag/matter handlers
+  - Consumes identity helpers extracted in 5d.4a
+- [ ] Update InspectorPanel dispatcher
+
+### 5d.6 — Delete InspectorPanel dispatcher
+
+After 5d.4 + 5d.5 land, the dispatcher is just a thin switch. Better to delete it and have the 4 callers dispatch directly:
+
+- [ ] Update `WorkspacePage.tsx` — switch on `inspectorTarget.entityType` to render the right per-feature inspector
+- [ ] Update `WidgetApp.tsx`
+- [ ] Update `DebugDialogsPage.tsx`
+- [ ] Update `WorkspaceSetupSection.tsx`
+- [ ] Delete `src/shared/ui/inspector/InspectorPanel.tsx`
 
 ### 5e — Shell refactor
 
@@ -288,35 +307,33 @@ Current baseline on `staging` HEAD.
 
 ---
 
-## Session checklist (resume — PR-4 starts here)
+## Session checklist (resume — PR-5 starts here)
 
 ```powershell
 git fetch upstream
 git checkout staging
 git pull upstream staging --ff-only
-git checkout -b feat/ds-migration-pt4
+git checkout -b feat/ds-migration-pt5
 npm install                                       # if dependencies changed
 npm run build                                     # must pass
 npm run lint:src                                  # baseline: 1 pre-existing OAuthConsentPage error
 npm run type-check                                # baseline: 0 errors
 ```
 
-Open `design_handoff_blawby_chat_first/screens/index.html` in a browser for the 21-screen hub, and `design_handoff_blawby_chat_first/screens/Design System.html` for the visual component showcase before writing code. Then start at "PR-4 scope" above.
+Open `design_handoff_blawby_chat_first/screens/index.html` in a browser for the 21-screen hub, and `design_handoff_blawby_chat_first/screens/Design System.html` for the visual component showcase before writing code. Then start at "PR-5 scope" above.
 
-### Suggested PR-4 sub-commit cadence
+### Suggested PR-5 sub-commit cadence
 
-1. `5d.1` — Extract `useUserDetail` + `useMatterDetail` + `usePracticeDetail` hooks (additive, no caller changes)
-2. `5d.2` — Refactor `InspectorPanel` data-fetching effect to use the three hooks (verify no regressions; same external behavior)
-3. `5d.3` — Extract `ClientInspector` to `features/clients/components/` (smallest of remaining 3 blocks; pattern proven by 5c.4)
-4. `5d.4` — Extract `MatterInspector` to `features/matters/components/`
-5. `5d.5` — Extract `ConversationInspector` to `features/chat/components/` (largest block, most coupling)
-6. `5d.6` — Delete `InspectorPanel.tsx` dispatcher; 4 callers dispatch directly
-7. `5e.1` — Drop AppShell sidebar props (assess what each shell still needs)
-8. `5e.2` — Refactor `ClientHomePage` (smallest shell, lowest risk; establishes pattern)
-9. `5e.3` — Refactor `PracticeHomePage`
-10. `5e.4` — Refactor `WidgetApp`
-11. `5e.5` — Refactor `WorkspacePage` (largest, riskiest; do last with established patterns)
-12. `5e.6` — Extract `ConversationListPanel` for the 340px Conversations column
-13. `5e.7` — Delete legacy nav files + dead CSS + 4 test files (final cleanup)
+1. `5d.4a` — Extract shared `inspector/identityHelpers.tsx`: `renderCompactIdentity`, `renderIdentityStack`, `resolveAttorneyIdentity`, `InspectorIdentity` type. Additive; no callers updated yet. (~30 min)
+2. `5d.4b` — Extract `MatterInspector` to `features/matters/components/`; consume identity helpers from 5d.4a. (~60 min — ~380 line render block + matter state)
+3. `5d.5` — Extract `ConversationInspector` to `features/chat/components/`; consume identity helpers + all 3 data hooks. (~90 min — ~500 line block, most coupling)
+4. `5d.6` — Delete `InspectorPanel.tsx` dispatcher; 4 callers dispatch directly. (~30 min)
+5. `5e.1` — Drop AppShell sidebar props (assess what each shell still needs)
+6. `5e.2` — Refactor `ClientHomePage` (smallest shell, lowest risk; establishes pattern)
+7. `5e.3` — Refactor `PracticeHomePage`
+8. `5e.4` — Refactor `WidgetApp`
+9. `5e.5` — Refactor `WorkspacePage` (largest, riskiest; do last with established patterns)
+10. `5e.6` — Extract `ConversationListPanel` for the 340px Conversations column
+11. `5e.7` — Delete legacy nav files + dead CSS + 4 test files (final cleanup)
 
-Each is independently green; each is a small reviewable diff.
+Each is independently green; each is a small reviewable diff. The 5d work realistically fits in one focused session; 5e likely needs its own focused session given WorkspacePage's 1666 lines.

--- a/src/features/clients/components/ClientInspector.tsx
+++ b/src/features/clients/components/ClientInspector.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useState } from 'preact/hooks';
+import { useUserDetail } from '@/shared/hooks/useUserDetail';
+import { type UserDetailRecord } from '@/shared/lib/apiClient';
+import type { Address } from '@/shared/types/address';
+import { CONTACT_RELATIONSHIP_STATUS_LABELS } from '@/shared/domain/contacts';
+import { Button } from '@/shared/ui/Button';
+import { Dialog } from '@/shared/ui/dialog';
+import { AddressExperienceForm } from '@/shared/ui/address/AddressExperienceForm';
+import { InspectorSectionSkeleton } from '@/shared/ui/layout';
+import {
+  InfoRow,
+  InspectorEditableRow,
+  InspectorGroup,
+  InspectorHeaderPerson,
+} from '@/shared/ui/inspector/InspectorPrimitives';
+
+export interface ClientInspectorProps {
+  practiceId: string;
+  /** The userId for the client record being inspected. */
+  entityId: string;
+}
+
+const emptyAddress: Address = {
+  address: '',
+  apartment: '',
+  city: '',
+  state: '',
+  postalCode: '',
+  country: 'US',
+};
+
+const readAddressFromDetail = (detail: UserDetailRecord | null): Address => {
+  const record = detail as unknown as Record<string, unknown> | null;
+  const addressValue = record?.address;
+  const address = (addressValue && typeof addressValue === 'object')
+    ? addressValue as Record<string, unknown>
+    : {};
+  const line1 = typeof address.address === 'string'
+    ? address.address
+    : (typeof address.line1 === 'string' ? address.line1 : '');
+  const line2 = typeof address.apartment === 'string'
+    ? address.apartment
+    : (typeof address.line2 === 'string' ? address.line2 : '');
+  const city = typeof address.city === 'string' ? address.city : '';
+  const state = typeof address.state === 'string' ? address.state : '';
+  const postalCode = typeof address.postalCode === 'string'
+    ? address.postalCode
+    : (typeof address.postal_code === 'string' ? address.postal_code : '');
+  const country = typeof address.country === 'string' && address.country.trim().length > 0
+    ? address.country
+    : 'US';
+  return {
+    address: line1,
+    apartment: line2,
+    city,
+    state,
+    postalCode,
+    country,
+  };
+};
+
+const formatAddressSummary = (detail: UserDetailRecord | null): string => {
+  const value = readAddressFromDetail(detail);
+  const parts = [
+    value.address,
+    value.apartment ?? '',
+    [value.city, value.state, value.postalCode].filter(Boolean).join(' '),
+    value.country,
+  ].map((part) => part.trim()).filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : '—';
+};
+
+/**
+ * ClientInspector — per-feature inspector for the client entity type.
+ * Extracted from the legacy InspectorPanel as part of the per-feature split
+ * (5d.3). Owns: user data fetch (via useUserDetail), address editor state,
+ * archive flow + confirmation dialog.
+ *
+ * Outer chrome (header / close button / error banner) currently still lives
+ * in InspectorPanel's dispatcher. The dispatcher disappears in 5d.6 once all
+ * four per-feature inspectors are extracted.
+ */
+export const ClientInspector = ({ practiceId, entityId }: ClientInspectorProps) => {
+  const { data: userDetail, isLoading, error, mutate } = useUserDetail(practiceId, entityId);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [activePersonEditor, setActivePersonEditor] = useState<'address' | null>(null);
+  const [isSavingPersonField, setIsSavingPersonField] = useState(false);
+  const [isArchivingPerson, setIsArchivingPerson] = useState(false);
+  const [isArchiveConfirmOpen, setIsArchiveConfirmOpen] = useState(false);
+  const [personAddressDraft, setPersonAddressDraft] = useState<Address>(emptyAddress);
+
+  // Clear local editor state when the entity changes.
+  useEffect(() => {
+    setActivePersonEditor(null);
+    setLocalError(null);
+  }, [entityId]);
+
+  const openPersonEditor = (editor: 'address') => {
+    setLocalError(null);
+    setPersonAddressDraft(readAddressFromDetail(userDetail));
+    setActivePersonEditor((prev) => (prev === editor ? null : editor));
+  };
+
+  const handlePersonFieldUpdate = async (payload: Partial<{ address: Partial<Address> }>) => {
+    setLocalError(null);
+    setIsSavingPersonField(true);
+    try {
+      await mutate(payload);
+      setActivePersonEditor(null);
+    } catch (err: unknown) {
+      setLocalError(err instanceof Error ? err.message : 'Failed to update contact');
+    } finally {
+      setIsSavingPersonField(false);
+    }
+  };
+
+  const handlePersonStatusChange = async (
+    status: 'archived' | 'active',
+    eventName: 'Archive Contact' | 'Restore Contact',
+  ) => {
+    setLocalError(null);
+    setIsArchivingPerson(true);
+    try {
+      await mutate({ status, event_name: eventName });
+      setActivePersonEditor(null);
+      setIsArchiveConfirmOpen(false);
+    } catch (err: unknown) {
+      setLocalError(err instanceof Error ? err.message : 'Failed to update contact status');
+    } finally {
+      setIsArchivingPerson(false);
+    }
+  };
+
+  const displayError = localError ?? error;
+
+  if (isLoading) {
+    return (
+      <div className="py-3">
+        <InspectorSectionSkeleton wideRows={[true, false, false]} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {displayError ? (
+        <p className="px-4 py-3 text-sm text-neg">{displayError}</p>
+      ) : null}
+      <div className="pb-4">
+        <InspectorHeaderPerson
+          name={userDetail?.user?.name ?? userDetail?.user?.email ?? 'Unknown'}
+          secondaryLine={userDetail?.user?.email ?? undefined}
+        />
+        <div>
+          <InspectorGroup label="Email">
+            <InfoRow label="" value={userDetail?.user?.email ?? undefined} muted={!userDetail?.user?.email} />
+          </InspectorGroup>
+          <InspectorGroup label="Phone">
+            <InfoRow label="" value={userDetail?.user?.phone ?? undefined} muted={!userDetail?.user?.phone} />
+          </InspectorGroup>
+          <InspectorGroup label="Relationship status">
+            <InfoRow
+              label=""
+              value={userDetail?.status ? CONTACT_RELATIONSHIP_STATUS_LABELS[userDetail.status] : undefined}
+              muted={!userDetail?.status}
+            />
+          </InspectorGroup>
+          <InspectorGroup
+            label="Address"
+            onToggle={() => openPersonEditor('address')}
+            isOpen={activePersonEditor === 'address'}
+            disabled={isSavingPersonField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={formatAddressSummary(userDetail)}
+              summaryMuted={formatAddressSummary(userDetail) === '—'}
+              isOpen={activePersonEditor === 'address'}
+            >
+              <div className="space-y-2">
+                <AddressExperienceForm
+                  initialValues={{ address: personAddressDraft }}
+                  fields={['address']}
+                  required={[]}
+                  variant="plain"
+                  showSubmitButton={false}
+                  disabled={isSavingPersonField}
+                  onValuesChange={(updates) => {
+                    const nextAddress = updates.address;
+                    if (!nextAddress || typeof nextAddress !== 'object') return;
+                    setPersonAddressDraft((prev) => ({
+                      ...prev,
+                      ...nextAddress,
+                    }));
+                  }}
+                  addressOptions={{
+                    enableAutocomplete: true,
+                    showCountry: true,
+                    stackedFields: true,
+                  }}
+                />
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setActivePersonEditor(null)}
+                    disabled={isSavingPersonField}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={() => void handlePersonFieldUpdate({ address: personAddressDraft })}
+                    disabled={isSavingPersonField}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup label="Record">
+            <div className="px-5 py-1.5">
+              {userDetail?.status === 'archived' ? (
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-[13px] text-dim">This contact is archived.</p>
+                  <Button
+                    size="sm"
+                    onClick={() => { void handlePersonStatusChange('active', 'Restore Contact'); }}
+                    disabled={isArchivingPerson || isSavingPersonField}
+                  >
+                    {isArchivingPerson ? 'Restoring...' : 'Restore'}
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => setIsArchiveConfirmOpen(true)}
+                  disabled={isArchivingPerson || isSavingPersonField}
+                >
+                  {isArchivingPerson ? 'Archiving...' : 'Archive'}
+                </Button>
+              )}
+            </div>
+          </InspectorGroup>
+        </div>
+      </div>
+      <Dialog
+        isOpen={isArchiveConfirmOpen}
+        onClose={() => {
+          if (isArchivingPerson) return;
+          setIsArchiveConfirmOpen(false);
+        }}
+        title="Archive contact"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-dim">
+            Archive this contact? They will move to the Archived list and can be restored later.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setIsArchiveConfirmOpen(false)}
+              disabled={isArchivingPerson}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => { void handlePersonStatusChange('archived', 'Archive Contact'); }}
+              disabled={isArchivingPerson}
+            >
+              {isArchivingPerson ? 'Archiving...' : 'Archive'}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+};

--- a/src/shared/hooks/useMatterDetail.ts
+++ b/src/shared/hooks/useMatterDetail.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { getMatter, type BackendMatter } from '@/features/matters/services/mattersApi';
+
+export interface UseMatterDetailOptions {
+  /** When false, the hook skips fetching (still returns data: null). */
+  enabled?: boolean;
+}
+
+export interface UseMatterDetailResult {
+  data: BackendMatter | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/** Module-level cache keyed by `practiceId:matterId`. Survives unmount/remount. */
+const matterDetailCache = new Map<string, BackendMatter | null>();
+const cacheKey = (practiceId: string, matterId: string) => `${practiceId}:${matterId}`;
+
+/**
+ * Hook wrapping `getMatter` with abort-safe fetching and module-level caching.
+ *
+ * Matter mutations (status/field updates) flow through `onMatterStatusChange` /
+ * `onMatterPatchChange` props on the inspector components, so this hook is
+ * read-only. Cache invalidation should be triggered via `refresh()` after a
+ * successful mutation completes.
+ */
+export function useMatterDetail(
+  practiceId: string | null,
+  matterId: string | null,
+  options: UseMatterDetailOptions = {},
+): UseMatterDetailResult {
+  const { enabled = true } = options;
+  const [data, setData] = useState<BackendMatter | null>(() => {
+    if (!practiceId || !matterId) return null;
+    return matterDetailCache.get(cacheKey(practiceId, matterId)) ?? null;
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchDetail = useCallback(async (force: boolean): Promise<void> => {
+    if (!practiceId || !matterId || !enabled) {
+      setData(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const key = cacheKey(practiceId, matterId);
+    if (!force && matterDetailCache.has(key)) {
+      setData(matterDetailCache.get(key) ?? null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const detail = await getMatter(practiceId, matterId, { signal: controller.signal });
+      if (controller.signal.aborted) return;
+      matterDetailCache.set(key, detail);
+      setData(detail);
+    } catch (err: unknown) {
+      if ((err as DOMException)?.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load matter detail');
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
+    }
+  }, [practiceId, matterId, enabled]);
+
+  useEffect(() => {
+    void fetchDetail(false);
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [fetchDetail]);
+
+  const refresh = useCallback(() => fetchDetail(true), [fetchDetail]);
+
+  return { data, isLoading, error, refresh };
+}

--- a/src/shared/hooks/usePracticeDetail.ts
+++ b/src/shared/hooks/usePracticeDetail.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { getPracticeDetails, type PracticeDetails } from '@/shared/lib/apiClient';
+
+export interface UsePracticeDetailOptions {
+  /** When false, the hook skips fetching. */
+  enabled?: boolean;
+  /** If provided, used as the initial value and the hook skips its own fetch
+   *  (the caller is providing the source of truth). Matches InspectorPanel's
+   *  `propPracticeDetails` short-circuit behavior. */
+  fallback?: PracticeDetails | null;
+}
+
+export interface UsePracticeDetailResult {
+  data: PracticeDetails | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Hook wrapping `getPracticeDetails`. Note that `getPracticeDetails` already
+ * dedupes/caches via `queryCache.coalesceGet` with a 60s TTL — this hook does
+ * NOT add a second cache layer.
+ *
+ * The `fallback` option mirrors InspectorPanel's `propPracticeDetails` pattern:
+ * when the caller has practice details already (e.g. from a parent shell), the
+ * hook uses them and skips its own fetch.
+ */
+export function usePracticeDetail(
+  practiceId: string | null,
+  options: UsePracticeDetailOptions = {},
+): UsePracticeDetailResult {
+  const { enabled = true, fallback = null } = options;
+  const [data, setData] = useState<PracticeDetails | null>(fallback);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchDetail = useCallback(async (): Promise<void> => {
+    if (!practiceId || !enabled) {
+      setData(fallback);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    if (fallback) {
+      setData(fallback);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const detail = await getPracticeDetails(practiceId, { signal: controller.signal });
+      if (controller.signal.aborted) return;
+      setData(detail);
+    } catch (err: unknown) {
+      if ((err as DOMException)?.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load practice details');
+      // Match InspectorPanel behavior: clear practice detail on real errors
+      setData(null);
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
+    }
+  }, [practiceId, enabled, fallback]);
+
+  useEffect(() => {
+    void fetchDetail();
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [fetchDetail]);
+
+  return { data, isLoading, error, refresh: fetchDetail };
+}

--- a/src/shared/hooks/useUserDetail.ts
+++ b/src/shared/hooks/useUserDetail.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import {
+  getUserDetail,
+  updateUserDetail,
+  type UpdateUserDetailPayload,
+  type UserDetailRecord,
+} from '@/shared/lib/apiClient';
+
+export interface UseUserDetailOptions {
+  /** When false, the hook skips fetching (still returns data: null). */
+  enabled?: boolean;
+}
+
+export interface UseUserDetailResult {
+  data: UserDetailRecord | null;
+  isLoading: boolean;
+  error: string | null;
+  /** Patch the user record. Refreshes local data + cache on success.
+   *  Rejects (throws) on failure so callers can show inline error UX. */
+  mutate: (patch: UpdateUserDetailPayload) => Promise<void>;
+  /** Force a network re-fetch, bypassing the cache. */
+  refresh: () => Promise<void>;
+}
+
+/** Module-level cache keyed by `practiceId:userId`. Survives unmount/remount
+ *  so switching inspectors across navigations reuses already-fetched data. */
+const userDetailCache = new Map<string, UserDetailRecord | null>();
+const cacheKey = (practiceId: string, userId: string) => `${practiceId}:${userId}`;
+
+/**
+ * Hook wrapping `getUserDetail` + `updateUserDetail` with abort-safe
+ * fetching and module-level caching.
+ *
+ * Used by the per-feature inspectors (ClientInspector, ConversationInspector)
+ * after the InspectorPanel split. See `docs/design-system-migration.md` PR-4
+ * scope for context.
+ */
+export function useUserDetail(
+  practiceId: string | null,
+  userId: string | null,
+  options: UseUserDetailOptions = {},
+): UseUserDetailResult {
+  const { enabled = true } = options;
+  const [data, setData] = useState<UserDetailRecord | null>(() => {
+    if (!practiceId || !userId) return null;
+    return userDetailCache.get(cacheKey(practiceId, userId)) ?? null;
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchDetail = useCallback(async (force: boolean): Promise<void> => {
+    if (!practiceId || !userId || !enabled) {
+      setData(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const key = cacheKey(practiceId, userId);
+    if (!force && userDetailCache.has(key)) {
+      setData(userDetailCache.get(key) ?? null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const detail = await getUserDetail(practiceId, userId, { signal: controller.signal });
+      if (controller.signal.aborted) return;
+      userDetailCache.set(key, detail);
+      setData(detail);
+    } catch (err: unknown) {
+      if ((err as DOMException)?.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to load user detail');
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
+    }
+  }, [practiceId, userId, enabled]);
+
+  useEffect(() => {
+    void fetchDetail(false);
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [fetchDetail]);
+
+  const mutate = useCallback(async (patch: UpdateUserDetailPayload): Promise<void> => {
+    if (!practiceId || !userId) return;
+    setError(null);
+    try {
+      await updateUserDetail(practiceId, userId, patch);
+      const key = cacheKey(practiceId, userId);
+      const applyPatch = (record: UserDetailRecord | null): UserDetailRecord | null => {
+        if (!record) return record;
+        const next: UserDetailRecord = { ...record };
+        if (patch.status !== undefined) {
+          (next as Record<string, unknown>).status = patch.status;
+        }
+        if (patch.address !== undefined) {
+          (next as Record<string, unknown>).address = patch.address;
+        }
+        // Other fields (name/email/phone/currency) live on next.user — preserve
+        // the existing nested user object unless the patch explicitly updates
+        // them. The backend always returns the canonical record on success, so
+        // a full refresh is the source of truth for those fields.
+        return next;
+      };
+      setData((prev) => applyPatch(prev));
+      const cached = userDetailCache.get(key);
+      if (cached !== undefined) {
+        userDetailCache.set(key, applyPatch(cached));
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to update user detail';
+      setError(message);
+      throw err;
+    }
+  }, [practiceId, userId]);
+
+  const refresh = useCallback(() => fetchDetail(true), [fetchDetail]);
+
+  return { data, isLoading, error, mutate, refresh };
+}

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -1468,7 +1468,7 @@ type UserDetailBasePayload = {
   event_name?: string;
 };
 
-type UpdateUserDetailPayload = UserDetailBasePayload & Record<string, unknown>;
+export type UpdateUserDetailPayload = UserDetailBasePayload & Record<string, unknown>;
 
 const normalizeOptionalText = (value: unknown): string | undefined => {
   if (typeof value !== 'string') return undefined;

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -1,18 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { Conversation, ConversationMode, SetupFieldsPayload } from '@/shared/types/conversation';
-import { updateConversationMatter, type UserDetailRecord, type PracticeDetails } from '@/shared/lib/apiClient';
+import { updateConversationMatter, type PracticeDetails } from '@/shared/lib/apiClient';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 import { useUserDetail } from '@/shared/hooks/useUserDetail';
 import { useMatterDetail } from '@/shared/hooks/useMatterDetail';
 import { usePracticeDetail } from '@/shared/hooks/usePracticeDetail';
 import { MATTER_STATUS_LABELS, MATTER_WORKFLOW_STATUSES, isMatterStatus, type MatterStatus } from '@/shared/types/matterStatus';
 import { InvoiceInspector } from '@/features/invoices/components/InvoiceInspector';
+import { ClientInspector } from '@/features/clients/components/ClientInspector';
 import { Button } from '@/shared/ui/Button';
 import { Combobox, type ComboboxOption, Input, Textarea } from '@/shared/ui/input';
 import { StackedAvatars, UserCard } from '@/shared/ui/profile';
-import { AddressExperienceForm } from '@/shared/ui/address/AddressExperienceForm';
 import { STATE_OPTIONS } from '@/shared/ui/address/AddressFields';
-import { Dialog } from '@/shared/ui/dialog';
 import { InspectorSectionSkeleton } from '@/shared/ui/layout';
 import {
   InfoRow,
@@ -26,7 +25,6 @@ import { X } from 'lucide-preact';
 
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { CONTACT_RELATIONSHIP_STATUS_LABELS } from '@/shared/domain/contacts';
-import type { Address } from '@/shared/types/address';
 import type { IntakeConversationState, DerivedIntakeStatus } from '@/shared/types/intake';
 import type { PracticeIntakeDetail } from '@/features/intake/api/intakesApi';
 import { resolveStrengthTier, resolveStrengthLabel, resolveStrengthStyle, resolveStrengthDescription } from '@/shared/utils/intakeStrength';
@@ -182,19 +180,7 @@ export const InspectorPanel = ({
   >(null);
   const [isSavingMatterStatus, setIsSavingMatterStatus] = useState(false);
   const [isSavingMatterField, setIsSavingMatterField] = useState(false);
-  const [activePersonEditor, setActivePersonEditor] = useState<'address' | null>(null);
-  const [isSavingPersonField, setIsSavingPersonField] = useState(false);
-  const [isArchivingPerson, setIsArchivingPerson] = useState(false);
-  const [isArchiveConfirmOpen, setIsArchiveConfirmOpen] = useState(false);
   const [localIntakeDraft, setLocalIntakeDraft] = useState<string | null>(null);
-  const [personAddressDraft, setPersonAddressDraft] = useState<Address>({
-    address: '',
-    apartment: '',
-    city: '',
-    state: '',
-    postalCode: '',
-    country: 'US',
-  });
   const skipBlurRef = useRef(false);
 
   const conversationUserId = conversation?.user_id ?? null;
@@ -340,7 +326,6 @@ export const InspectorPanel = ({
   useEffect(() => {
     setActiveConversationEditor(null);
     setActiveMatterEditor(null);
-    setActivePersonEditor(null);
     setLocalIntakeDraft(null);
     setLocalError(null);
   }, [conversation?.id, entityId, entityType]);
@@ -705,66 +690,6 @@ export const InspectorPanel = ({
       setIsSavingMatter(false);
     }
   };
-  const readAddressFromDetail = (detail: UserDetailRecord | null): Address => {
-    const record = detail as unknown as Record<string, unknown> | null;
-    const addressValue = record?.address;
-    const address = (addressValue && typeof addressValue === 'object')
-      ? addressValue as Record<string, unknown>
-      : {};
-    const line1 = typeof address.address === 'string'
-      ? address.address
-      : (typeof address.line1 === 'string' ? address.line1 : '');
-    const line2 = typeof address.apartment === 'string'
-      ? address.apartment
-      : (typeof address.line2 === 'string' ? address.line2 : '');
-    const city = typeof address.city === 'string' ? address.city : '';
-    const state = typeof address.state === 'string' ? address.state : '';
-    const postalCode = typeof address.postalCode === 'string'
-      ? address.postalCode
-      : (typeof address.postal_code === 'string' ? address.postal_code : '');
-    const country = typeof address.country === 'string' && address.country.trim().length > 0
-      ? address.country
-      : 'US';
-    return {
-      address: line1,
-      apartment: line2,
-      city,
-      state,
-      postalCode,
-      country,
-    };
-  };
-  const formatAddressSummary = (detail: UserDetailRecord | null): string => {
-    const value = readAddressFromDetail(detail);
-    const parts = [
-      value.address,
-      value.apartment ?? '',
-      [value.city, value.state, value.postalCode].filter(Boolean).join(' '),
-      value.country
-    ].map((part) => part.trim()).filter(Boolean);
-    return parts.length > 0 ? parts.join(', ') : '—';
-  };
-  const openPersonEditor = (editor: 'address') => {
-    setError(null);
-    setPersonAddressDraft(readAddressFromDetail(userDetail));
-    setActivePersonEditor((prev) => (prev === editor ? null : editor));
-  };
-  const handlePersonFieldUpdate = async (
-    payload: Partial<{ address: Partial<Address> }>
-  ) => {
-    if (!practiceId || !entityId) return;
-    setError(null);
-    setIsSavingPersonField(true);
-    try {
-      await userResult.mutate(payload);
-      setActivePersonEditor(null);
-    } catch (nextError: unknown) {
-      setError(nextError instanceof Error ? nextError.message : 'Failed to update contact');
-    } finally {
-      setIsSavingPersonField(false);
-    }
-  };
-  
   const handleIntakeFieldChange = async (patch: Partial<IntakeConversationState>, shouldClose = true) => {
     if (!onIntakeFieldsChange || !intakeConversationState) return;
     setError(null);
@@ -773,23 +698,6 @@ export const InspectorPanel = ({
       if (shouldClose) setActiveConversationEditor(null);
     } catch (nextError: unknown) {
       setError(nextError instanceof Error ? nextError.message : `Failed to update fields`);
-    }
-  };
-  const handlePersonStatusChange = async (
-    status: 'archived' | 'active',
-    eventName: 'Archive Contact' | 'Restore Contact'
-  ) => {
-    if (!practiceId || !entityId) return;
-    setError(null);
-    setIsArchivingPerson(true);
-    try {
-      await userResult.mutate({ status, event_name: eventName });
-      setActivePersonEditor(null);
-      setIsArchiveConfirmOpen(false);
-    } catch (nextError: unknown) {
-      setError(nextError instanceof Error ? nextError.message : 'Failed to update contact status');
-    } finally {
-      setIsArchivingPerson(false);
     }
   };
 
@@ -822,11 +730,7 @@ export const InspectorPanel = ({
             <InspectorSectionSkeleton wideRows={[true, false, true, false]} />
           </div>
         ) : null}
-        {isLoading && entityType === 'client' ? (
-          <div className="py-3">
-            <InspectorSectionSkeleton wideRows={[true, false, false]} />
-          </div>
-        ) : null}
+        {/* Client loading skeleton is rendered by ClientInspector itself */}
         {isLoading && entityType === 'matter' ? (
           <div className="py-3">
             <InspectorSectionSkeleton wideRows={[true, false, true, false]} />
@@ -1726,107 +1630,8 @@ export const InspectorPanel = ({
           </div>
         ) : null}
 
-        {entityType === 'client' && !isLoading ? (
-          <div className="pb-4">
-            <InspectorHeaderPerson
-              name={userDetail?.user?.name ?? userDetail?.user?.email ?? 'Unknown'}
-              secondaryLine={userDetail?.user?.email ?? undefined}
-            />
-            <div className="">
-              <InspectorGroup label="Email">
-                <InfoRow label="" value={userDetail?.user?.email ?? undefined} muted={!userDetail?.user?.email} />
-              </InspectorGroup>
-              <InspectorGroup label="Phone">
-                <InfoRow label="" value={userDetail?.user?.phone ?? undefined} muted={!userDetail?.user?.phone} />
-              </InspectorGroup>
-              <InspectorGroup label="Relationship status">
-                <InfoRow
-                  label=""
-                  value={userDetail?.status ? CONTACT_RELATIONSHIP_STATUS_LABELS[userDetail.status] : undefined}
-                  muted={!userDetail?.status}
-                />
-              </InspectorGroup>
-              <InspectorGroup
-                label="Address"
-                onToggle={() => openPersonEditor('address')}
-                isOpen={activePersonEditor === 'address'}
-                disabled={isSavingPersonField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={formatAddressSummary(userDetail)}
-                  summaryMuted={formatAddressSummary(userDetail) === '—'}
-                  isOpen={activePersonEditor === 'address'}
-                >
-                  <div className="space-y-2">
-                    <AddressExperienceForm
-                      initialValues={{ address: personAddressDraft }}
-                      fields={['address']}
-                      required={[]}
-                      variant="plain"
-                      showSubmitButton={false}
-                      disabled={isSavingPersonField}
-                      onValuesChange={(updates) => {
-                        const nextAddress = updates.address;
-                        if (!nextAddress || typeof nextAddress !== 'object') return;
-                        setPersonAddressDraft((prev) => ({
-                          ...prev,
-                          ...nextAddress,
-                        }));
-                      }}
-                      addressOptions={{
-                        enableAutocomplete: true,
-                        showCountry: true,
-                        stackedFields: true,
-                      }}
-                    />
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => setActivePersonEditor(null)}
-                        disabled={isSavingPersonField}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        size="sm"
-                        onClick={() => void handlePersonFieldUpdate({ address: personAddressDraft })}
-                        disabled={isSavingPersonField}
-                      >
-                        Save
-                      </Button>
-                    </div>
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup label="Record">
-                <div className="px-5 py-1.5">
-                  {userDetail?.status === 'archived' ? (
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="text-[13px] text-input-placeholder">This contact is archived.</p>
-                      <Button
-                        size="sm"
-                        onClick={() => { void handlePersonStatusChange('active', 'Restore Contact'); }}
-                        disabled={isArchivingPerson || isSavingPersonField}
-                      >
-                        {isArchivingPerson ? 'Restoring...' : 'Restore'}
-                      </Button>
-                    </div>
-                  ) : (
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      onClick={() => setIsArchiveConfirmOpen(true)}
-                      disabled={isArchivingPerson || isSavingPersonField}
-                    >
-                      {isArchivingPerson ? 'Archiving...' : 'Archive'}
-                    </Button>
-                  )}
-                </div>
-              </InspectorGroup>
-            </div>
-          </div>
+        {entityType === 'client' && practiceId && entityId ? (
+          <ClientInspector practiceId={practiceId} entityId={entityId} />
         ) : null}
 
         {entityType === 'invoice' ? (
@@ -1840,38 +1645,6 @@ export const InspectorPanel = ({
           />
         ) : null}
       </div>
-      <Dialog
-        isOpen={isArchiveConfirmOpen}
-        onClose={() => {
-          if (isArchivingPerson) return;
-          setIsArchiveConfirmOpen(false);
-        }}
-        title="Archive contact"
-      >
-        <div className="space-y-4">
-          <p className="text-sm text-input-placeholder">
-            Archive this contact? They will move to the Archived list and can be restored later.
-          </p>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setIsArchiveConfirmOpen(false)}
-              disabled={isArchivingPerson}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="danger"
-              size="sm"
-            onClick={() => { void handlePersonStatusChange('archived', 'Archive Contact'); }}
-              disabled={isArchivingPerson}
-            >
-              {isArchivingPerson ? 'Archiving...' : 'Archive'}
-            </Button>
-          </div>
-        </div>
-      </Dialog>
     </div>
   );
 };

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { Conversation, ConversationMode, SetupFieldsPayload } from '@/shared/types/conversation';
-import { getUserDetail, updateConversationMatter, updateUserDetail, getPracticeDetails, type UserDetailRecord, type PracticeDetails } from '@/shared/lib/apiClient';
-import { getMatter, type BackendMatter } from '@/features/matters/services/mattersApi';
+import { updateConversationMatter, type UserDetailRecord, type PracticeDetails } from '@/shared/lib/apiClient';
+import type { BackendMatter } from '@/features/matters/services/mattersApi';
+import { useUserDetail } from '@/shared/hooks/useUserDetail';
+import { useMatterDetail } from '@/shared/hooks/useMatterDetail';
+import { usePracticeDetail } from '@/shared/hooks/usePracticeDetail';
 import { MATTER_STATUS_LABELS, MATTER_WORKFLOW_STATUSES, isMatterStatus, type MatterStatus } from '@/shared/types/matterStatus';
 import { InvoiceInspector } from '@/features/invoices/components/InvoiceInspector';
 import { Button } from '@/shared/ui/Button';
@@ -167,14 +170,8 @@ export const InspectorPanel = ({
   const resolveString = (value: unknown): string | null =>
     typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
   const { session } = useSessionContext();
-  const userCacheRef = useRef<Map<string, UserDetailRecord | null>>(new Map());
-  const practiceCacheRef = useRef<Map<string, PracticeDetails | null>>(new Map());
-  const matterCacheRef = useRef<Map<string, BackendMatter | null>>(new Map());
-  const [userDetail, setUserDetail] = useState<UserDetailRecord | null>(null);
-  const [practiceDetail, setPracticeDetail] = useState<PracticeDetails | null>(propPracticeDetails ?? null);
-  const [matterDetail, setMatterDetail] = useState<BackendMatter | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const setError = setLocalError;
   const [isSavingAssignment, setIsSavingAssignment] = useState(false);
   const [isSavingPriority, setIsSavingPriority] = useState(false);
   const [isSavingTags, setIsSavingTags] = useState(false);
@@ -199,13 +196,40 @@ export const InspectorPanel = ({
     country: 'US',
   });
   const skipBlurRef = useRef(false);
-  const lastPracticeIdRef = useRef<string | null>(practiceId);
 
   const conversationUserId = conversation?.user_id ?? null;
   const conversationMatterId = conversation?.matter_id ?? null;
   const resolvedConversationMode = conversationMode ?? conversation?.user_info?.mode;
 
-  const makeCacheKey = (pId: string, eId: string) => `${pId}:${eId}`;
+  // Drive the per-entity data hooks from entityType.
+  const targetUserId = entityType === 'conversation'
+    ? conversationUserId
+    : entityType === 'client'
+      ? entityId
+      : null;
+  const targetMatterId = entityType === 'conversation'
+    ? conversationMatterId
+    : entityType === 'matter'
+      ? entityId
+      : null;
+
+  const userResult = useUserDetail(practiceId, targetUserId, {
+    enabled: entityType === 'conversation' || entityType === 'client',
+  });
+  const matterResult = useMatterDetail(practiceId, targetMatterId, {
+    enabled: entityType === 'conversation' || entityType === 'matter',
+  });
+  const practiceResult = usePracticeDetail(practiceId, {
+    enabled: entityType === 'conversation' && !isClientView,
+    fallback: propPracticeDetails ?? null,
+  });
+
+  const userDetail = userResult.data;
+  const matterDetail = matterResult.data;
+  const practiceDetail = practiceResult.data;
+  const isLoading = userResult.isLoading || matterResult.isLoading || practiceResult.isLoading;
+  // Local mutation errors take precedence; fall back to fetch errors from any hook.
+  const error = localError ?? userResult.error ?? matterResult.error ?? practiceResult.error;
   const priorityOptions = useMemo<ComboboxOption[]>(
     () => [
       { value: 'low', label: 'Low' },
@@ -311,122 +335,19 @@ export const InspectorPanel = ({
     [currentTags]
   );
 
-  useEffect(() => {
-    if (lastPracticeIdRef.current !== practiceId) {
-      userCacheRef.current.clear();
-      matterCacheRef.current.clear();
-      practiceCacheRef.current.clear();
-      lastPracticeIdRef.current = practiceId;
-    }
-  }, [practiceId]);
-
+  // Reset editor state when the entity changes — the hooks themselves swap
+  // their data on the new key, but UI editor state is per-entity-instance.
   useEffect(() => {
     setActiveConversationEditor(null);
     setActiveMatterEditor(null);
     setActivePersonEditor(null);
     setLocalIntakeDraft(null);
+    setLocalError(null);
   }, [conversation?.id, entityId, entityType]);
 
   useEffect(() => {
     setLocalIntakeDraft(null);
   }, [activeConversationEditor]);
-
-  useEffect(() => {
-    setUserDetail(null);
-    setPracticeDetail(propPracticeDetails ?? null);
-    setMatterDetail(null);
-    if (!practiceId || !entityId) return;
-    const controller = new AbortController();
-    setError(null);
-    setIsLoading(true);
-
-    const load = async () => {
-      try {
-        if (entityType === 'invoice') {
-          return;
-        }
-
-        if (entityType === 'conversation') {
-          const userId = conversationUserId;
-          const matterId = conversationMatterId;
-
-          // Handle practice details independently from user details
-          if (propPracticeDetails) {
-            setPracticeDetail(propPracticeDetails);
-          } else if (!isClientView) {
-            // Only attempt to load practice details in non-client view
-            try {
-              const practiceDetail = await getPracticeDetails(practiceId, { signal: controller.signal });
-              setPracticeDetail(practiceDetail);
-            } catch (err: unknown) {
-              const error = err as Error;
-              // Only clear state for real errors, not aborted requests
-              if (!controller.signal.aborted && error?.name !== 'AbortError') {
-                setPracticeDetail(null);
-              }
-            }
-          } else {
-            // Client view - set null if no prop details provided
-            setPracticeDetail(null);
-          }
-
-          // Handle user details separately, regardless of practice details
-          if (userId) {
-            const cacheKey = makeCacheKey(practiceId, userId);
-            if (userCacheRef.current.has(cacheKey)) {
-              setUserDetail(userCacheRef.current.get(cacheKey) ?? null);
-            } else {
-              const detail = await getUserDetail(practiceId, userId, { signal: controller.signal });
-              userCacheRef.current.set(cacheKey, detail);
-              setUserDetail(detail);
-            }
-          }
-
-          if (matterId) {
-            const cacheKey = makeCacheKey(practiceId, matterId);
-            if (matterCacheRef.current.has(cacheKey)) {
-              setMatterDetail(matterCacheRef.current.get(cacheKey) ?? null);
-            } else {
-              const detail = await getMatter(practiceId, matterId, { signal: controller.signal });
-              matterCacheRef.current.set(cacheKey, detail);
-              setMatterDetail(detail);
-            }
-          }
-          return;
-        }
-
-        const cacheKey = makeCacheKey(practiceId, entityId);
-        if (entityType === 'matter') {
-          if (matterCacheRef.current.has(cacheKey)) {
-            setMatterDetail(matterCacheRef.current.get(cacheKey) ?? null);
-          } else {
-            const detail = await getMatter(practiceId, entityId, { signal: controller.signal });
-            matterCacheRef.current.set(cacheKey, detail);
-            setMatterDetail(detail);
-          }
-          return;
-        }
-
-        if (userCacheRef.current.has(cacheKey)) {
-          setUserDetail(userCacheRef.current.get(cacheKey) ?? null);
-        } else {
-          const detail = await getUserDetail(practiceId, entityId, { signal: controller.signal });
-          userCacheRef.current.set(cacheKey, detail);
-          setUserDetail(detail);
-        }
-      } catch (nextError: unknown) {
-        if ((nextError as DOMException)?.name === 'AbortError') return;
-        setError(nextError instanceof Error ? nextError.message : 'Failed to load inspector data');
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void load();
-    return () => controller.abort();
-  }, [conversationMatterId, conversationUserId, entityId, entityType, practiceId, isClientView, propPracticeDetails]);
 
   const [inspectorMatterStatus, setInspectorMatterStatus] = useState<MatterStatus | null>(
     isValidMatterStatus(matterDetail?.status) ? matterDetail.status : null
@@ -835,25 +756,7 @@ export const InspectorPanel = ({
     setError(null);
     setIsSavingPersonField(true);
     try {
-      await updateUserDetail(practiceId, entityId, payload);
-      setUserDetail((prev) => {
-        if (!prev) return prev;
-        const previousUser = prev.user;
-        return {
-          ...prev,
-          ...(payload.address ? { address: payload.address } as Record<string, unknown> : {}),
-          user: previousUser
-        };
-      });
-      const cacheKey = makeCacheKey(practiceId, entityId);
-      const cached = userCacheRef.current.get(cacheKey);
-      if (cached) {
-        userCacheRef.current.set(cacheKey, {
-          ...cached,
-          ...(payload.address ? { address: payload.address } as Record<string, unknown> : {}),
-          user: cached.user
-        });
-      }
+      await userResult.mutate(payload);
       setActivePersonEditor(null);
     } catch (nextError: unknown) {
       setError(nextError instanceof Error ? nextError.message : 'Failed to update contact');
@@ -880,19 +783,7 @@ export const InspectorPanel = ({
     setError(null);
     setIsArchivingPerson(true);
     try {
-      await updateUserDetail(practiceId, entityId, { status, event_name: eventName });
-      setUserDetail((prev) => {
-        if (!prev) return prev;
-        return { ...prev, status };
-      });
-      const cacheKey = makeCacheKey(practiceId, entityId);
-      const cached = userCacheRef.current.get(cacheKey);
-      if (cached) {
-        userCacheRef.current.set(cacheKey, {
-          ...cached,
-          status
-        });
-      }
+      await userResult.mutate({ status, event_name: eventName });
       setActivePersonEditor(null);
       setIsArchiveConfirmOpen(false);
     } catch (nextError: unknown) {


### PR DESCRIPTION
Fourth PR in the design-system migration series. Picks up where [#646](https://github.com/Blawby/blawby-ai-chatbot/pull/646) (5c.1–5c.4, merged) left off. Lands the first half of the InspectorPanel split per the [migration doc handoff](https://github.com/Blawby/blawby-ai-chatbot/blob/feat/ds-migration-pt4/docs/design-system-migration.md).

## Landed (4 sub-commits)

| SHA | What |
|---|---|
| `ddbf98b1` | **5d.1** — Extract `useUserDetail` / `useMatterDetail` / `usePracticeDetail` hooks. Additive only; encapsulates the fetch + abort + cache pattern previously inline in InspectorPanel. Exported `UpdateUserDetailPayload` type from apiClient. |
| `fe6d88d3` | **5d.2** — Refactor InspectorPanel to use the 3 hooks. Replaces 115-line inline useEffect + 3 cache refs with hook calls. **Net delete: 109 lines.** Module-level cache namespaced by practiceId — different practices stay isolated. |
| `e02cf663` | **5d.3** — Extract `ClientInspector` to `src/features/clients/components/ClientInspector.tsx` (283 lines). Consumes `useUserDetail`; owns its address editor state + archive confirmation Dialog. InspectorPanel net −232 lines (removed 5 useState slots, 4 helpers, address editor JSX, archive Dialog, loading skeleton). |
| `a23295cd` | Close PR #647 scope + write PR-5 handoff in the migration doc. PR-5 picks up 5d.4 onward. |

## Build / lint / type-check

Baseline preserved at every sub-commit:
- ✅ `npm run build` — passes
- ⚠️ `npm run lint:src` — 1 pre-existing error (`OAuthConsentPage.tsx:187`)
- ✅ `npm run type-check` — 0 errors

## Why split PR-4 from PR-5

I started this PR aiming to land all of 5d (the full inspector hooks-first split) + 5e (shell refactor). Discovered mid-session:

- The MatterInspector extract (~380 line render block) and ConversationInspector extract (~500 line render block) **share helpers** that today live in InspectorPanel: `renderCompactIdentity`, `renderIdentityStack`, `resolveAttorneyIdentity`, plus the `InspectorIdentity` type.
- Doing those splits without first extracting a shared `inspector/identityHelpers.tsx` would either duplicate code or leave the helpers stuck in InspectorPanel.
- Rather than ship a half-done split with messy duplication, I'm stopping after the clean wins (5d.1–5d.3) and writing a detailed PR-5 plan that does the helper extraction as step 1 (5d.4a) before tackling MatterInspector + ConversationInspector.

The handoff doc now has full PR-5 scope with realistic time estimates and the suggested 11-sub-commit cadence.

## What's in the migration doc for PR-5

After this PR merges, `docs/design-system-migration.md` is the single source for resuming:

- **PR-5 scope** — 5d.4a (identityHelpers extract) → 5d.4b (MatterInspector) → 5d.5 (ConversationInspector) → 5d.6 (delete dispatcher, 4 callers dispatch directly) → 5e.1–5e.7 (shell refactor)
- **Sub-commit cadence** with size estimates for each step
- **Session checklist** with the exact branch-creation commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)