### PR TITLE
ds: PR-5 — InspectorPanel identity helpers + MatterInspector extract

### DIFF
--- a/docs/design-system-migration.md
+++ b/docs/design-system-migration.md
@@ -39,15 +39,16 @@ From `design_handoff_blawby_chat_first/DESIGN_SYSTEM.md §0`:
 | 5d.1 — Inspector data hooks | `ddbf98b1` | ✅ in PR #647 | `useUserDetail` / `useMatterDetail` / `usePracticeDetail` extracted to `src/shared/hooks/`. Exported `UpdateUserDetailPayload` from apiClient. |
 | 5d.2 — InspectorPanel hook refactor | `fe6d88d3` | ✅ in PR #647 | Replaced 115-line inline fetch useEffect + 3 cache refs with hook calls. Net −109 lines. Module-level cache namespaced by `practiceId:userId`. |
 | 5d.3 — ClientInspector extract | `e02cf663` | ✅ in PR #647 | `src/features/clients/components/ClientInspector.tsx` (283 lines) consumes useUserDetail, owns its editor state + archive dialog. InspectorPanel −232 lines. |
-| 5d.4 — MatterInspector extract | — | **pending — PR-5 scope** | 380-line render block + matter editor state + matter resolved-field computations + identity helpers (renderCompactIdentity, renderIdentityStack, resolveAttorneyIdentity) — last two shared with ConversationInspector |
-| 5d.5 — ConversationInspector extract | — | **pending — PR-5 scope** | ~500-line render block (largest, most coupling); consumes useUserDetail + useMatterDetail + usePracticeDetail; intake editor state; reuses identity helpers from 5d.4 |
-| 5d.6 — Delete InspectorPanel dispatcher | — | **pending — PR-5 scope** | After 5d.4/5d.5, 4 callers dispatch directly |
-| 5e — Shell refactor | — | **pending — PR-5+ scope** | Drop AppShell sidebar props; refactor WorkspacePage/PracticeHomePage/ClientHomePage/WidgetApp to LeftRail; extract ConversationListPanel (340px column per Conversations spec); delete legacy nav + 4 test files |
+| 5d.4a — identityHelpers extract | `5a396373` | ✅ in PR #648 | Shared `inspector/identityHelpers.tsx` (102 lines): InspectorIdentity type + resolveAttorneyLabel + resolveAttorneyIdentity + renderCompactIdentity + renderIdentityStack. InspectorPanel −65 lines. |
+| 5d.4b — MatterInspector extract | `0d4eefab` | ✅ in PR #648 | `src/features/matters/components/MatterInspector.tsx` (717 lines) consumes useMatterDetail + identityHelpers. Owns full matter editor state, ~14 resolvedMatter fields, status/patch handlers, matterStatusOptions/urgencyOptions/matterTeamIdentities memos. InspectorPanel −628 lines. |
+| 5d.5 — ConversationInspector extract | — | **pending — PR-6 scope** | ~500-line block (largest, most coupling); consumes useUserDetail + useMatterDetail + usePracticeDetail; intake editor state; reuses identity helpers from 5d.4a |
+| 5d.6 — Delete InspectorPanel dispatcher | — | **pending — PR-6 scope** | After 5d.5, 4 callers dispatch directly |
+| 5e — Shell refactor | — | **pending — PR-6+ scope** | Drop AppShell sidebar props; refactor WorkspacePage/PracticeHomePage/ClientHomePage/WidgetApp to LeftRail; extract ConversationListPanel (340px column per Conversations spec); delete legacy nav + 4 test files |
 | 6 — Chat patterns | — | pending | AISummary, StagedAction, Citations, Observation, Composer, ToolUseLine, BriefingGrid, MatterChip; IOLTA manual smoke |
 | 7 — Data display | — | pending | StatStrip, JourneyProgress, LetterPaper, Seg; print test |
 | 8 — Feature sweep | — | pending | TSX feature-files swept for the 8 violation patterns; DataTable audit; AA contrast spot; `prefers-reduced-motion` check; final delete of `.status-*` / `.input-surface` / `.card-surface` aliases |
 
-PR series: #644 (foundation, merged) → #645 (Commit 4 + 5a + 5b, merged) → #646 (5c.1–5c.4, merged) → **#647 (this PR — 5d.1–5d.3)** → PR-5 (5d.4 onward + 5e).
+PR series: #644 (foundation, merged) → #645 (Commit 4 + 5a + 5b, merged) → #646 (5c.1–5c.4, merged) → #647 (5d.1–5d.3, merged) → **#648 (this PR — 5d.4a + 5d.4b)** → PR-6 (5d.5 + 5d.6 + 5e).
 
 ---
 
@@ -149,41 +150,35 @@ Cross-reference between the design handoff and the existing app. "Status" tracks
 
 ---
 
-## PR-5 scope — `feat/ds-migration-pt5` (next session)
+## PR #648 (this PR) — landed checklist
 
-The remaining inspector splits (5d.4–5d.6) + the shell refactor (5e).
+- [x] Extract shared `inspector/identityHelpers.tsx` — `5a396373`
+- [x] Extract `MatterInspector` to `src/features/matters/components/MatterInspector.tsx` — `0d4eefab`
 
-### 5d.4 — Extract MatterInspector
+InspectorPanel is now ~1000 lines (down from ~1925 at start of session). All matter-specific state/memos/helpers are gone from the dispatcher.
 
-The matter render block (~380 lines, L1252-1631 in current InspectorPanel post-#647) has more entanglement than ClientInspector did. Plan accordingly:
+---
 
-- [ ] Extract `MatterInspector` to `src/features/matters/components/MatterInspector.tsx`
-  - Consumes `useMatterDetail`
-  - Moves state: `inspectorMatterStatus`, `activeMatterEditor`, `isSavingMatter`, `isSavingMatterStatus`, `isSavingMatterField`
-  - Moves the ~14 `resolvedMatter*` field computations (client name/id, urgency, attorney ids, case number, type, court, judge, opposing party/counsel, created/updated labels, assignee ids/names)
-  - Moves memos: `matterStatusOptions`, `urgencyOptions`, `matterClientOptionsWithNone`, `matterTeamIdentities`
-  - Moves helpers: `handleMatterStatusChange`, `handleMatterPatchChange`, `resolveMatterClientIdentity`, `resolveAttorneyLabel`, `resolveAttorneyIdentity`, `matterUrgencyLabel`
-  - **Shared with conversation block** (need duplication OR pre-extract to shared util):
-    - `renderCompactIdentity` (uses UserCard)
-    - `renderIdentityStack` (uses StackedAvatars + UserCard)
-    - `resolveAttorneyIdentity`
-    - `InspectorIdentity` type
-  - **Recommended approach**: extract these to `src/shared/ui/inspector/identityHelpers.tsx` as a separate sub-commit (5d.4a) so both MatterInspector (5d.4b) and ConversationInspector (5d.5) can consume them
-- [ ] Update InspectorPanel dispatcher: `<MatterInspector practiceId={...} entityId={...} {...matterProps} />` when entityType === 'matter'
+## PR-6 scope — `feat/ds-migration-pt6` (next session)
 
-### 5d.5 — Extract ConversationInspector
+The remaining inspector split (5d.5 + 5d.6) + the shell refactor (5e).
 
-- [ ] Extract `ConversationInspector` to `src/features/chat/components/ConversationInspector.tsx`
-  - Consumes `useUserDetail` + `useMatterDetail` + `usePracticeDetail` (conversation needs all three because it shows client info + linked matter + practice context)
-  - Moves the ~500-line conversation render block (L950-1460 in current file, will have shifted after 5d.4)
-  - Moves state: `activeConversationEditor` + intake editor sub-states, `isSavingAssignment`, `isSavingPriority`, `isSavingTags`, `isSavingMatter`, `localIntakeDraft`
-  - Moves helpers: `handleIntakeFieldChange`, intake-strength rendering, conversation assignment/priority/tag/matter handlers
-  - Consumes identity helpers extracted in 5d.4a
-- [ ] Update InspectorPanel dispatcher
+### 5d.5 — Extract ConversationInspector (biggest single block in the migration)
+
+Genuinely substantial. The conversation render is ~500 lines (L448-957 in current InspectorPanel) and entangles with:
+
+- **3 data hooks**: `useUserDetail` + `useMatterDetail` + `usePracticeDetail` (conversation shows client info + linked matter + practice context, often simultaneously)
+- **3 sub-paths**: PRACTICE_ONBOARDING (renders `<SetupInspectorContent>`), `isClientView` (read-only branded hero + intake status + consultation details), regular (full editor with assignment / priority / tags / matter / intake fields)
+- **State**: `activeConversationEditor` (14-position discriminator including intake sub-editors), `isSavingAssignment` / `isSavingPriority` / `isSavingTags` / `isSavingMatter`, `localIntakeDraft`, `skipBlurRef`
+- **Memos**: `priorityOptions`, `assignedToOptions`, `currentTags`, `tagOptions`, `matterOptions`, `intakeServiceOptions`, `assignedMemberLabel`, `assignedConversationMember`, `currentMatterLabel`, `currentPriorityLabel`, `currentTagsLabel`, `conversationPeople`
+- **Handlers**: `handleConversationAssignmentChange`, `handleConversationPriorityChange`, `handleConversationTagsChange`, `handleConversationMatterChange`, `handleIntakeFieldChange`
+- **Imports it pulls in**: `SetupInspectorContent`, `InspectorHeaderHero` + the existing primitives, intake strength resolvers (`resolveStrengthTier` etc.), `STATE_OPTIONS` for the state combobox, `updateConversationMatter` from apiClient
+
+**Recommended approach for 5d.5**: do it as a single focused PR-6 session. The pattern from 5d.4b (MatterInspector) applies — extract the JSX + state + handlers wholesale, then iteratively clean up the lint-flagged unused vars in the InspectorPanel dispatcher. Allocate ~90 min for the initial extract + ~30 min for the cleanup pass.
 
 ### 5d.6 — Delete InspectorPanel dispatcher
 
-After 5d.4 + 5d.5 land, the dispatcher is just a thin switch. Better to delete it and have the 4 callers dispatch directly:
+After 5d.5 lands, the dispatcher is just a thin switch. Better to delete it and have the 4 callers dispatch directly:
 
 - [ ] Update `WorkspacePage.tsx` — switch on `inspectorTarget.entityType` to render the right per-feature inspector
 - [ ] Update `WidgetApp.tsx`
@@ -307,33 +302,31 @@ Current baseline on `staging` HEAD.
 
 ---
 
-## Session checklist (resume — PR-5 starts here)
+## Session checklist (resume — PR-6 starts here)
 
 ```powershell
 git fetch upstream
 git checkout staging
 git pull upstream staging --ff-only
-git checkout -b feat/ds-migration-pt5
+git checkout -b feat/ds-migration-pt6
 npm install                                       # if dependencies changed
 npm run build                                     # must pass
 npm run lint:src                                  # baseline: 1 pre-existing OAuthConsentPage error
 npm run type-check                                # baseline: 0 errors
 ```
 
-Open `design_handoff_blawby_chat_first/screens/index.html` in a browser for the 21-screen hub, and `design_handoff_blawby_chat_first/screens/Design System.html` for the visual component showcase before writing code. Then start at "PR-5 scope" above.
+Open `design_handoff_blawby_chat_first/screens/index.html` in a browser for the 21-screen hub, and `design_handoff_blawby_chat_first/screens/Conversations.html` for the canonical 4-column chat-first surface that drives the assistant panel relocation in 5e. Then start at "PR-6 scope" above.
 
-### Suggested PR-5 sub-commit cadence
+### Suggested PR-6 sub-commit cadence
 
-1. `5d.4a` — Extract shared `inspector/identityHelpers.tsx`: `renderCompactIdentity`, `renderIdentityStack`, `resolveAttorneyIdentity`, `InspectorIdentity` type. Additive; no callers updated yet. (~30 min)
-2. `5d.4b` — Extract `MatterInspector` to `features/matters/components/`; consume identity helpers from 5d.4a. (~60 min — ~380 line render block + matter state)
-3. `5d.5` — Extract `ConversationInspector` to `features/chat/components/`; consume identity helpers + all 3 data hooks. (~90 min — ~500 line block, most coupling)
-4. `5d.6` — Delete `InspectorPanel.tsx` dispatcher; 4 callers dispatch directly. (~30 min)
-5. `5e.1` — Drop AppShell sidebar props (assess what each shell still needs)
-6. `5e.2` — Refactor `ClientHomePage` (smallest shell, lowest risk; establishes pattern)
-7. `5e.3` — Refactor `PracticeHomePage`
-8. `5e.4` — Refactor `WidgetApp`
-9. `5e.5` — Refactor `WorkspacePage` (largest, riskiest; do last with established patterns)
-10. `5e.6` — Extract `ConversationListPanel` for the 340px Conversations column
-11. `5e.7` — Delete legacy nav files + dead CSS + 4 test files (final cleanup)
+1. `5d.5` — Extract `ConversationInspector` to `features/chat/components/`; consume identity helpers + all 3 data hooks. (~90-120 min — ~500 line block with 3 sub-paths)
+2. `5d.6` — Delete `InspectorPanel.tsx` dispatcher; 4 callers dispatch directly. (~30 min)
+3. `5e.1` — Drop AppShell sidebar props (assess what each shell still needs)
+4. `5e.2` — Refactor `ClientHomePage` (smallest shell, lowest risk; establishes pattern)
+5. `5e.3` — Refactor `PracticeHomePage`
+6. `5e.4` — Refactor `WidgetApp`
+7. `5e.5` — Refactor `WorkspacePage` (largest, riskiest; do last with established patterns)
+8. `5e.6` — Extract `ConversationListPanel` for the 340px Conversations column
+9. `5e.7` — Delete legacy nav files + dead CSS + 4 test files (final cleanup)
 
-Each is independently green; each is a small reviewable diff. The 5d work realistically fits in one focused session; 5e likely needs its own focused session given WorkspacePage's 1666 lines.
+Each is independently green; each is a small reviewable diff. 5d.5 + 5d.6 fit in one session; 5e likely needs its own focused session given WorkspacePage's 1666 lines.

--- a/src/features/matters/components/MatterInspector.tsx
+++ b/src/features/matters/components/MatterInspector.tsx
@@ -1,0 +1,717 @@
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { useMatterDetail } from '@/shared/hooks/useMatterDetail';
+import { Combobox, type ComboboxOption } from '@/shared/ui/input';
+import { InspectorSectionSkeleton } from '@/shared/ui/layout';
+import {
+  InfoRow,
+  InspectorEditableRow,
+  InspectorGroup,
+  InspectorHeaderEntity,
+} from '@/shared/ui/inspector/InspectorPrimitives';
+import {
+  InspectorIdentity,
+  renderCompactIdentity,
+  renderIdentityStack,
+  resolveAttorneyIdentity as resolveAttorneyIdentityHelper,
+  resolveAttorneyLabel as resolveAttorneyLabelHelper,
+} from '@/shared/ui/inspector/identityHelpers';
+import { MATTER_STATUS_LABELS, MATTER_WORKFLOW_STATUSES, isMatterStatus, type MatterStatus } from '@/shared/types/matterStatus';
+import { MatterFilesSection } from '@/shared/ui/inspector/MatterFilesSection';
+
+const isValidMatterStatus = (value: unknown): value is MatterStatus =>
+  typeof value === 'string' && isMatterStatus(value);
+
+const resolveString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+
+export interface MatterInspectorProps {
+  practiceId: string;
+  /** Matter id being inspected. */
+  entityId: string;
+  // Override / pre-resolved data from caller (falls back to matter detail).
+  matterClientName?: string | null;
+  matterAssigneeNames?: string[];
+  matterCreatedLabel?: string | null;
+  matterUpdatedLabel?: string | null;
+  matterClientId?: string | null;
+  matterUrgency?: string | null;
+  matterResponsibleAttorneyId?: string | null;
+  matterOriginatingAttorneyId?: string | null;
+  matterCaseNumber?: string | null;
+  matterType?: string | null;
+  matterCourt?: string | null;
+  matterJudge?: string | null;
+  matterOpposingParty?: string | null;
+  matterOpposingCounsel?: string | null;
+  // Lookups for combobox population.
+  matterClientOptions?: ComboboxOption[];
+  matterClients?: InspectorIdentity[];
+  matterAssigneeOptions?: ComboboxOption[];
+  conversationMembers?: InspectorIdentity[];
+  // Mutation callbacks (when undefined, fields render read-only).
+  onMatterStatusChange?: (status: MatterStatus) => void;
+  onMatterPatchChange?: (patch: Record<string, unknown>) => Promise<void> | void;
+}
+
+/**
+ * MatterInspector — per-feature inspector for the matter entity type.
+ * Extracted from the legacy InspectorPanel (5d.4b). Owns: matter data fetch
+ * (via useMatterDetail), all matter editor state + handlers, identity
+ * resolution via shared inspector/identityHelpers.
+ */
+export const MatterInspector = ({
+  practiceId,
+  entityId,
+  matterClientName,
+  matterAssigneeNames,
+  matterCreatedLabel,
+  matterUpdatedLabel,
+  matterClientId,
+  matterUrgency,
+  matterResponsibleAttorneyId,
+  matterOriginatingAttorneyId,
+  matterCaseNumber,
+  matterType,
+  matterCourt,
+  matterJudge,
+  matterOpposingParty,
+  matterOpposingCounsel,
+  matterClientOptions = [],
+  matterClients = [],
+  matterAssigneeOptions = [],
+  conversationMembers = [],
+  onMatterStatusChange,
+  onMatterPatchChange,
+}: MatterInspectorProps) => {
+  const { data: matterDetail, isLoading, error } = useMatterDetail(practiceId, entityId);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [activeMatterEditor, setActiveMatterEditor] = useState<
+    'status' | 'person' | 'responsible' | 'originating' | 'urgency' | 'caseNumber' | 'matterType' | 'court' | 'judge' | 'opposingParty' | 'opposingCounsel' | 'team' | null
+  >(null);
+  const [isSavingMatterStatus, setIsSavingMatterStatus] = useState(false);
+  const [isSavingMatterField, setIsSavingMatterField] = useState(false);
+
+  // Reset editor state when entity changes.
+  useEffect(() => {
+    setActiveMatterEditor(null);
+    setLocalError(null);
+  }, [entityId]);
+
+  const [inspectorMatterStatus, setInspectorMatterStatus] = useState<MatterStatus | null>(
+    isValidMatterStatus(matterDetail?.status) ? matterDetail.status : null,
+  );
+  useEffect(() => {
+    setInspectorMatterStatus(isValidMatterStatus(matterDetail?.status) ? matterDetail.status : null);
+  }, [entityId, matterDetail?.status]);
+
+  const canEditMatterStatus = Boolean(onMatterStatusChange && matterDetail && !isLoading && inspectorMatterStatus);
+  const canEditMatterFields = Boolean(onMatterPatchChange && matterDetail && !isLoading);
+
+  const matterDetailRecord = matterDetail as Record<string, unknown> | null;
+
+  const resolvedMatterClientName = matterClientName
+    ?? resolveString(matterDetailRecord?.client_name)
+    ?? null;
+  const resolvedMatterClientId = matterClientId
+    ?? resolveString(matterDetailRecord?.client_id)
+    ?? null;
+  const resolvedMatterUrgency = matterUrgency
+    ?? resolveString(matterDetailRecord?.urgency)
+    ?? null;
+  const resolvedMatterResponsibleAttorneyId = matterResponsibleAttorneyId
+    ?? resolveString(matterDetailRecord?.responsible_attorney_id)
+    ?? null;
+  const resolvedMatterOriginatingAttorneyId = matterOriginatingAttorneyId
+    ?? resolveString(matterDetailRecord?.originating_attorney_id)
+    ?? null;
+  const resolvedMatterCaseNumber = matterCaseNumber
+    ?? resolveString(matterDetailRecord?.case_number)
+    ?? null;
+  const resolvedMatterType = matterType
+    ?? resolveString(matterDetailRecord?.matter_type)
+    ?? null;
+  const resolvedMatterCourt = matterCourt
+    ?? resolveString(matterDetailRecord?.court)
+    ?? null;
+  const resolvedMatterJudge = matterJudge
+    ?? resolveString(matterDetailRecord?.judge)
+    ?? null;
+  const resolvedMatterOpposingParty = matterOpposingParty
+    ?? resolveString(matterDetailRecord?.opposing_party)
+    ?? null;
+  const resolvedMatterOpposingCounsel = matterOpposingCounsel
+    ?? resolveString(matterDetailRecord?.opposing_counsel)
+    ?? null;
+  const resolvedMatterCreatedLabel = matterCreatedLabel
+    ?? resolveString(matterDetailRecord?.created_at)
+    ?? null;
+  const resolvedMatterUpdatedLabel = matterUpdatedLabel
+    ?? resolveString(matterDetailRecord?.updated_at)
+    ?? null;
+
+  const resolvedMatterAssigneeIds = useMemo(() => {
+    if (Array.isArray(matterDetailRecord?.assignee_ids) && matterDetailRecord.assignee_ids.length > 0) {
+      return matterDetailRecord.assignee_ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+    }
+    const assignees = Array.isArray(matterDetailRecord?.assignees) ? matterDetailRecord.assignees : [];
+    return assignees
+      .map((assignee) => {
+        if (!assignee || typeof assignee !== 'object') return '';
+        const row = assignee as Record<string, unknown>;
+        return typeof row.id === 'string' ? row.id : '';
+      })
+      .filter((id): id is string => id.length > 0);
+  }, [matterDetailRecord?.assignee_ids, matterDetailRecord?.assignees]);
+
+  const resolvedMatterAssigneeNames = useMemo(() => {
+    if (matterAssigneeNames && matterAssigneeNames.length > 0) return matterAssigneeNames;
+    const assigneesValue = matterDetailRecord?.assignees;
+    const assignees = Array.isArray(assigneesValue) ? assigneesValue : [];
+    const namesFromRows = assignees
+      .map((assignee) => {
+        if (typeof assignee === 'string') return assignee.trim();
+        if (!assignee || typeof assignee !== 'object') return '';
+        const row = assignee as Record<string, unknown>;
+        return resolveString(row.name) ?? resolveString(row.email) ?? '';
+      })
+      .filter((name): name is string => name.length > 0);
+    if (namesFromRows.length > 0) return namesFromRows;
+    const assigneeIds = Array.isArray(matterDetailRecord?.assignee_ids)
+      ? [...matterDetailRecord.assignee_ids].filter((id) => typeof id === 'string' || typeof id === 'number')
+      : [];
+    return assigneeIds
+      .map((id) => String(id).trim())
+      .filter((id) => id.length > 0)
+      .map((id) => `User ${id.slice(0, 6)}`);
+  }, [matterAssigneeNames, matterDetailRecord]);
+
+  const resolvedMatterClientLabel = useMemo(() => {
+    if (resolvedMatterClientName) return resolvedMatterClientName;
+    if (resolvedMatterClientId) {
+      const option = matterClientOptions.find((entry) => entry.value === resolvedMatterClientId);
+      if (option?.label) return option.label;
+      return `Client ${resolvedMatterClientId.slice(0, 6)}`;
+    }
+    return 'Unassigned client';
+  }, [resolvedMatterClientId, resolvedMatterClientName, matterClientOptions]);
+
+  const matterClientOptionsWithNone = useMemo<ComboboxOption[]>(() => {
+    const hasEmptyOption = matterClientOptions.some((option) => option.value === '');
+    return hasEmptyOption
+      ? matterClientOptions
+      : [{ value: '', label: '— none —' }, ...matterClientOptions];
+  }, [matterClientOptions]);
+
+  const resolveMatterClientIdentity = useCallback(() => {
+    if (!resolvedMatterClientId) {
+      return resolvedMatterClientName
+        ? { name: resolvedMatterClientName, image: null }
+        : null;
+    }
+    const client = matterClients.find((entry) => entry.userId === resolvedMatterClientId);
+    if (client) return client;
+    return resolvedMatterClientName
+      ? { userId: resolvedMatterClientId, name: resolvedMatterClientName, image: null, role: 'client' }
+      : { userId: resolvedMatterClientId, name: `Client ${resolvedMatterClientId.slice(0, 6)}`, image: null, role: 'client' };
+  }, [matterClients, resolvedMatterClientId, resolvedMatterClientName]);
+
+  const resolveAttorneyLabel = useCallback(
+    (id: string | null) => resolveAttorneyLabelHelper(id, matterAssigneeOptions),
+    [matterAssigneeOptions],
+  );
+  const resolveAttorneyIdentity = useCallback(
+    (id: string | null) => resolveAttorneyIdentityHelper(id, conversationMembers, matterAssigneeOptions),
+    [conversationMembers, matterAssigneeOptions],
+  );
+
+  const matterTeamIdentities = useMemo(() => {
+    const identities = new Map<string, { id: string; name: string; image?: string | null }>();
+
+    const addIdentity = (identity: Pick<InspectorIdentity, 'userId' | 'name' | 'image'> | null | undefined) => {
+      if (!identity?.userId || !identity.name) return;
+      identities.set(identity.userId, {
+        id: identity.userId,
+        name: identity.name,
+        image: identity.image ?? null,
+      });
+    };
+
+    addIdentity(resolveAttorneyIdentity(resolvedMatterResponsibleAttorneyId));
+    addIdentity(resolveAttorneyIdentity(resolvedMatterOriginatingAttorneyId));
+
+    const assigneeIds = Array.isArray(matterDetailRecord?.assignee_ids)
+      ? matterDetailRecord.assignee_ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+      : [];
+    assigneeIds.forEach((id) => addIdentity(resolveAttorneyIdentity(id)));
+
+    resolvedMatterAssigneeNames.forEach((name, index) => {
+      if (!name.trim()) return;
+      const nameAlreadyExists = [...identities.values()].some((identity) => identity.name === name);
+      if (!nameAlreadyExists) {
+        identities.set(`matter-assignee-${index}`, {
+          id: `matter-assignee-${index}`,
+          name,
+          image: null,
+        });
+      }
+    });
+
+    return [...identities.values()];
+  }, [
+    matterDetailRecord?.assignee_ids,
+    resolveAttorneyIdentity,
+    resolvedMatterAssigneeNames,
+    resolvedMatterOriginatingAttorneyId,
+    resolvedMatterResponsibleAttorneyId,
+  ]);
+
+  const matterUrgencyLabel = useMemo(() => {
+    if (!resolvedMatterUrgency) return 'Not set';
+    return resolvedMatterUrgency.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+  }, [resolvedMatterUrgency]);
+
+  const matterStatusOptions = useMemo<ComboboxOption[]>(
+    () => MATTER_WORKFLOW_STATUSES.map((status) => ({
+      value: status,
+      label: MATTER_STATUS_LABELS[status],
+    })),
+    [],
+  );
+
+  const urgencyOptions = useMemo<ComboboxOption[]>(
+    () => [
+      { value: '', label: 'Not set' },
+      { value: 'routine', label: 'Routine' },
+      { value: 'time_sensitive', label: 'Time Sensitive' },
+      { value: 'emergency', label: 'Emergency' },
+    ],
+    [],
+  );
+
+  const handleMatterStatusChange = async (value: string) => {
+    if (!canEditMatterStatus || !onMatterStatusChange || !isMatterStatus(value)) return;
+    setLocalError(null);
+    setIsSavingMatterStatus(true);
+    try {
+      await Promise.resolve(onMatterStatusChange(value));
+      setInspectorMatterStatus(value);
+      setActiveMatterEditor(null);
+    } catch (err: unknown) {
+      setLocalError(err instanceof Error ? err.message : 'Failed to update matter status');
+    } finally {
+      setIsSavingMatterStatus(false);
+    }
+  };
+
+  const handleMatterPatchChange = async (patch: Record<string, unknown>) => {
+    if (!canEditMatterFields || !onMatterPatchChange) return;
+    setLocalError(null);
+    setIsSavingMatterField(true);
+    try {
+      const keyMap: Record<string, string> = {
+        clientId: 'client_id',
+        responsibleAttorneyId: 'responsible_attorney_id',
+        originatingAttorneyId: 'originating_attorney_id',
+        caseNumber: 'case_number',
+        matterType: 'matter_type',
+        opposingParty: 'opposing_party',
+        opposingCounsel: 'opposing_counsel',
+        assigneeIds: 'assignee_ids',
+      };
+      const normalizedPatch = Object.fromEntries(
+        Object.entries(patch).map(([key, value]) => [keyMap[key] ?? key, value]),
+      );
+      await Promise.resolve(onMatterPatchChange(normalizedPatch));
+      setActiveMatterEditor(null);
+    } catch (err: unknown) {
+      setLocalError(err instanceof Error ? err.message : 'Failed to update matter');
+    } finally {
+      setIsSavingMatterField(false);
+    }
+  };
+
+  const displayError = localError ?? error;
+
+  if (isLoading) {
+    return (
+      <div className="py-3">
+        <InspectorSectionSkeleton wideRows={[true, false, true, false]} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {displayError ? (
+        <p className="px-4 py-3 text-sm text-neg">{displayError}</p>
+      ) : null}
+      <div className="pb-4">
+        <InspectorHeaderEntity
+          chip="MATTER"
+          title={matterDetail?.title ?? 'Matter'}
+          subtitle={undefined}
+          statusBadge={null}
+        />
+        <div>
+          <InspectorGroup
+            label="Status"
+            onToggle={canEditMatterStatus
+              ? () => setActiveMatterEditor((prev) => (prev === 'status' ? null : 'status'))
+              : undefined}
+            isOpen={activeMatterEditor === 'status'}
+            disabled={isSavingMatterStatus}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={inspectorMatterStatus ? MATTER_STATUS_LABELS[inspectorMatterStatus] : '—'}
+              summaryMuted={!inspectorMatterStatus}
+              isOpen={activeMatterEditor === 'status'}
+            >
+              <div className="relative z-40">
+                <Combobox
+                  value={inspectorMatterStatus ?? ''}
+                  onChange={(value) => { void handleMatterStatusChange(value); }}
+                  options={matterStatusOptions}
+                  searchable={false}
+                  defaultOpen
+                  hideTrigger
+                  placeholder="Select status"
+                  disabled={isSavingMatterStatus || !canEditMatterStatus}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Client"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'person' ? null : 'person'))
+              : undefined}
+            isOpen={activeMatterEditor === 'person'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={renderCompactIdentity(resolveMatterClientIdentity()) ?? resolvedMatterClientLabel}
+              summaryMuted={!resolvedMatterClientId && !resolvedMatterClientName}
+              isOpen={activeMatterEditor === 'person'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterClientId ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ clientId: value === '' ? null : value }); }}
+                  options={matterClientOptionsWithNone}
+                  searchable
+                  defaultOpen
+                  hideTrigger
+                  placeholder="Select client"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Team"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'team' ? null : 'team'))
+              : undefined}
+            isOpen={activeMatterEditor === 'team'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={renderIdentityStack(
+                matterTeamIdentities,
+                'No team members assigned',
+                'team member',
+                'team members',
+              )}
+              summaryMuted={matterTeamIdentities.length === 0}
+              isOpen={activeMatterEditor === 'team'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  multiple
+                  value={resolvedMatterAssigneeIds}
+                  onChange={(value) => { void handleMatterPatchChange({ assigneeIds: value }); }}
+                  options={matterAssigneeOptions}
+                  searchable
+                  defaultOpen
+                  hideTrigger
+                  placeholder="Select team members"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Responsible Attorney"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'responsible' ? null : 'responsible'))
+              : undefined}
+            isOpen={activeMatterEditor === 'responsible'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={renderCompactIdentity(resolveAttorneyIdentity(resolvedMatterResponsibleAttorneyId))}
+              summaryMuted={!resolvedMatterResponsibleAttorneyId}
+              isOpen={activeMatterEditor === 'responsible'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterResponsibleAttorneyId ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ responsibleAttorneyId: value === '' ? null : value }); }}
+                  options={[{ value: '', label: 'Not set' }, ...matterAssigneeOptions]}
+                  searchable
+                  defaultOpen
+                  hideTrigger
+                  placeholder="Select attorney"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Originating Attorney"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'originating' ? null : 'originating'))
+              : undefined}
+            isOpen={activeMatterEditor === 'originating'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={renderCompactIdentity(resolveAttorneyIdentity(resolvedMatterOriginatingAttorneyId)) ?? resolveAttorneyLabel(resolvedMatterOriginatingAttorneyId)}
+              summaryMuted={!resolvedMatterOriginatingAttorneyId}
+              isOpen={activeMatterEditor === 'originating'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterOriginatingAttorneyId ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ originatingAttorneyId: value === '' ? null : value }); }}
+                  options={[{ value: '', label: 'Not set' }, ...matterAssigneeOptions]}
+                  searchable
+                  defaultOpen
+                  hideTrigger
+                  placeholder="Select attorney"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Urgency"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'urgency' ? null : 'urgency'))
+              : undefined}
+            isOpen={activeMatterEditor === 'urgency'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={matterUrgencyLabel}
+              summaryMuted={!resolvedMatterUrgency}
+              isOpen={activeMatterEditor === 'urgency'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterUrgency ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ urgency: value === '' ? null : value }); }}
+                  options={urgencyOptions}
+                  searchable={false}
+                  defaultOpen
+                  hideTrigger
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Case Number"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'caseNumber' ? null : 'caseNumber'))
+              : undefined}
+            isOpen={activeMatterEditor === 'caseNumber'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={resolvedMatterCaseNumber ?? 'Not set'}
+              summaryMuted={!resolvedMatterCaseNumber}
+              isOpen={activeMatterEditor === 'caseNumber'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterCaseNumber ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ caseNumber: value }); }}
+                  options={[]}
+                  allowCustomValues
+                  defaultOpen
+                  hideTrigger
+                  addNewLabel="Set case number"
+                  placeholder="Enter case number"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Matter Type"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'matterType' ? null : 'matterType'))
+              : undefined}
+            isOpen={activeMatterEditor === 'matterType'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={resolvedMatterType ?? 'Not set'}
+              summaryMuted={!resolvedMatterType}
+              isOpen={activeMatterEditor === 'matterType'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterType ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ matterType: value }); }}
+                  options={[]}
+                  allowCustomValues
+                  defaultOpen
+                  hideTrigger
+                  addNewLabel="Set matter type"
+                  placeholder="Enter matter type"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Court"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'court' ? null : 'court'))
+              : undefined}
+            isOpen={activeMatterEditor === 'court'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={resolvedMatterCourt ?? 'Not set'}
+              summaryMuted={!resolvedMatterCourt}
+              isOpen={activeMatterEditor === 'court'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterCourt ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ court: value }); }}
+                  options={[]}
+                  allowCustomValues
+                  defaultOpen
+                  hideTrigger
+                  addNewLabel="Set court"
+                  placeholder="Enter court"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Judge"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'judge' ? null : 'judge'))
+              : undefined}
+            isOpen={activeMatterEditor === 'judge'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={resolvedMatterJudge ?? 'Not set'}
+              summaryMuted={!resolvedMatterJudge}
+              isOpen={activeMatterEditor === 'judge'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterJudge ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ judge: value }); }}
+                  options={[]}
+                  allowCustomValues
+                  defaultOpen
+                  hideTrigger
+                  addNewLabel="Set judge"
+                  placeholder="Enter judge"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Opposing Party"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'opposingParty' ? null : 'opposingParty'))
+              : undefined}
+            isOpen={activeMatterEditor === 'opposingParty'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={resolvedMatterOpposingParty ?? 'Not set'}
+              summaryMuted={!resolvedMatterOpposingParty}
+              isOpen={activeMatterEditor === 'opposingParty'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterOpposingParty ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ opposingParty: value }); }}
+                  options={[]}
+                  allowCustomValues
+                  defaultOpen
+                  hideTrigger
+                  addNewLabel="Set opposing party"
+                  placeholder="Enter opposing party"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup
+            label="Opposing Counsel"
+            onToggle={canEditMatterFields
+              ? () => setActiveMatterEditor((prev) => (prev === 'opposingCounsel' ? null : 'opposingCounsel'))
+              : undefined}
+            isOpen={activeMatterEditor === 'opposingCounsel'}
+            disabled={isSavingMatterField}
+          >
+            <InspectorEditableRow
+              label=""
+              summary={resolvedMatterOpposingCounsel ?? 'Not set'}
+              summaryMuted={!resolvedMatterOpposingCounsel}
+              isOpen={activeMatterEditor === 'opposingCounsel'}
+            >
+              <div className="relative z-30">
+                <Combobox
+                  value={resolvedMatterOpposingCounsel ?? ''}
+                  onChange={(value) => { void handleMatterPatchChange({ opposingCounsel: value }); }}
+                  options={[]}
+                  allowCustomValues
+                  defaultOpen
+                  hideTrigger
+                  addNewLabel="Set opposing counsel"
+                  placeholder="Enter opposing counsel"
+                  disabled={isSavingMatterField || !canEditMatterFields}
+                />
+              </div>
+            </InspectorEditableRow>
+          </InspectorGroup>
+          <InspectorGroup label="Files & Media">
+            <MatterFilesSection
+              practiceId={practiceId}
+              matterId={entityId}
+            />
+          </InspectorGroup>
+          <InspectorGroup label="Record">
+            <InfoRow label="Created" value={resolvedMatterCreatedLabel ?? undefined} />
+            <InfoRow label="Updated" value={resolvedMatterUpdatedLabel ?? undefined} />
+          </InspectorGroup>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -1,19 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { Conversation, ConversationMode, SetupFieldsPayload } from '@/shared/types/conversation';
 import { updateConversationMatter, type PracticeDetails } from '@/shared/lib/apiClient';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 import { useUserDetail } from '@/shared/hooks/useUserDetail';
 import { useMatterDetail } from '@/shared/hooks/useMatterDetail';
 import { usePracticeDetail } from '@/shared/hooks/usePracticeDetail';
-import { MATTER_STATUS_LABELS, MATTER_WORKFLOW_STATUSES, isMatterStatus, type MatterStatus } from '@/shared/types/matterStatus';
+import type { MatterStatus } from '@/shared/types/matterStatus';
 import { InvoiceInspector } from '@/features/invoices/components/InvoiceInspector';
 import { ClientInspector } from '@/features/clients/components/ClientInspector';
+import { MatterInspector } from '@/features/matters/components/MatterInspector';
 import { Button } from '@/shared/ui/Button';
 import { Combobox, type ComboboxOption, Input, Textarea } from '@/shared/ui/input';
 import {
   InspectorIdentity,
-  resolveAttorneyLabel as resolveAttorneyLabelHelper,
-  resolveAttorneyIdentity as resolveAttorneyIdentityHelper,
   renderCompactIdentity,
   renderIdentityStack,
 } from './identityHelpers';
@@ -23,7 +22,6 @@ import {
   InfoRow,
   InspectorEditableRow,
   InspectorGroup,
-  InspectorHeaderEntity,
   InspectorHeaderPerson,
   InspectorHeaderHero,
 } from './InspectorPrimitives';
@@ -37,7 +35,6 @@ import { resolveStrengthTier, resolveStrengthLabel, resolveStrengthStyle, resolv
 import type { PracticeSetupStatus } from '@/features/practice-setup/utils/status';
 import type { BusinessOnboardingStatus } from '@/shared/hooks/usePracticeManagement';
 import { SetupInspectorContent } from './SetupInspectorContent';
-import { MatterFilesSection } from './MatterFilesSection';
 
 type InspectorConfig =
   | { type: 'conversation' }
@@ -104,8 +101,6 @@ type InspectorPanelProps = {
   showCloseButton?: boolean;
 };
 
-const isValidMatterStatus = (value: unknown): value is MatterStatus =>
-  typeof value === 'string' && isMatterStatus(value);
 
 export const InspectorPanel = ({
   entityType,
@@ -120,7 +115,7 @@ export const InspectorPanel = ({
   onConversationMatterChange,
   matterClientName,
   matterAssigneeNames,
-  matterBillingLabel,
+  matterBillingLabel: _matterBillingLabel,
   matterCreatedLabel,
   matterUpdatedLabel,
   matterClientId,
@@ -173,11 +168,6 @@ export const InspectorPanel = ({
   const [isSavingTags, setIsSavingTags] = useState(false);
   const [isSavingMatter, setIsSavingMatter] = useState(false);
   const [activeConversationEditor, setActiveConversationEditor] = useState<'assignment' | 'priority' | 'tags' | 'matter' | 'intakePracticeArea' | 'intakeCity' | 'intakeState' | 'intakeOpposingParty' | 'intakeDesiredOutcome' | 'intakeDescription' | 'intakeName' | 'intakeEmail' | 'intakePhone' | null>(null);
-  const [activeMatterEditor, setActiveMatterEditor] = useState<
-    'status' | 'person' | 'responsible' | 'originating' | 'urgency' | 'caseNumber' | 'matterType' | 'court' | 'judge' | 'opposingParty' | 'opposingCounsel' | 'team' | null
-  >(null);
-  const [isSavingMatterStatus, setIsSavingMatterStatus] = useState(false);
-  const [isSavingMatterField, setIsSavingMatterField] = useState(false);
   const [localIntakeDraft, setLocalIntakeDraft] = useState<string | null>(null);
   const skipBlurRef = useRef(false);
 
@@ -234,15 +224,6 @@ export const InspectorPanel = ({
     ],
     [conversationMembers]
   );
-  const matterStatusOptions = useMemo<ComboboxOption[]>(
-    () => MATTER_WORKFLOW_STATUSES.map((status) => ({
-      value: status,
-      label: MATTER_STATUS_LABELS[status],
-    })),
-    []
-  );
-
-
   const currentTags = useMemo(
     () => Array.isArray(conversation?.tags) ? conversation.tags.filter((tag) => typeof tag === 'string' && tag.trim().length > 0) : [],
     [conversation?.tags]
@@ -323,7 +304,6 @@ export const InspectorPanel = ({
   // their data on the new key, but UI editor state is per-entity-instance.
   useEffect(() => {
     setActiveConversationEditor(null);
-    setActiveMatterEditor(null);
     setLocalIntakeDraft(null);
     setLocalError(null);
   }, [conversation?.id, entityId, entityType]);
@@ -332,120 +312,8 @@ export const InspectorPanel = ({
     setLocalIntakeDraft(null);
   }, [activeConversationEditor]);
 
-  const [inspectorMatterStatus, setInspectorMatterStatus] = useState<MatterStatus | null>(
-    isValidMatterStatus(matterDetail?.status) ? matterDetail.status : null
-  );
-  useEffect(() => {
-    setInspectorMatterStatus(isValidMatterStatus(matterDetail?.status) ? matterDetail.status : null);
-  }, [entityId, entityType, matterDetail?.status]);
-  const canEditMatterStatus = Boolean(onMatterStatusChange && matterDetail && !isLoading && inspectorMatterStatus);
-  const canEditMatterFields = Boolean(onMatterPatchChange && matterDetail && !isLoading);
-  const matterDetailRecord = matterDetail as Record<string, unknown> | null;
-  const resolvedMatterClientName = matterClientName
-    ?? resolveString(matterDetailRecord?.client_name)
-    ?? null;
-  const resolvedMatterClientId = matterClientId
-    ?? resolveString(matterDetailRecord?.client_id)
-    ?? null;
-  const resolvedMatterUrgency = matterUrgency
-    ?? resolveString(matterDetailRecord?.urgency)
-    ?? null;
-  const resolvedMatterResponsibleAttorneyId = matterResponsibleAttorneyId
-    ?? resolveString(matterDetailRecord?.responsible_attorney_id)
-    ?? null;
-  const resolvedMatterOriginatingAttorneyId = matterOriginatingAttorneyId
-    ?? resolveString(matterDetailRecord?.originating_attorney_id)
-    ?? null;
-  const resolvedMatterCaseNumber = matterCaseNumber
-    ?? resolveString(matterDetailRecord?.case_number)
-    ?? null;
-  const resolvedMatterType = matterType
-    ?? resolveString(matterDetailRecord?.matter_type)
-    ?? null;
-  const resolvedMatterCourt = matterCourt
-    ?? resolveString(matterDetailRecord?.court)
-    ?? null;
-  const resolvedMatterJudge = matterJudge
-    ?? resolveString(matterDetailRecord?.judge)
-    ?? null;
-  const resolvedMatterOpposingParty = matterOpposingParty
-    ?? resolveString(matterDetailRecord?.opposing_party)
-    ?? null;
-  const resolvedMatterOpposingCounsel = matterOpposingCounsel
-    ?? resolveString(matterDetailRecord?.opposing_counsel)
-    ?? null;
-  const _resolvedMatterBillingLabel = matterBillingLabel
-    ?? resolveString(matterDetailRecord?.billing_type)
-    ?? null;
-  const resolvedMatterCreatedLabel = matterCreatedLabel
-    ?? resolveString(matterDetailRecord?.created_at)
-    ?? null;
-  const resolvedMatterUpdatedLabel = matterUpdatedLabel
-    ?? resolveString(matterDetailRecord?.updated_at)
-    ?? null;
-  const resolvedMatterAssigneeIds = useMemo(() => {
-    // Prefer assignee_ids if present and non-empty
-    if (Array.isArray(matterDetailRecord?.assignee_ids) && matterDetailRecord.assignee_ids.length > 0) {
-      return matterDetailRecord.assignee_ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
-    }
-    // Fallback: extract ids from assignees array if available
-    const assignees = Array.isArray(matterDetailRecord?.assignees) ? matterDetailRecord.assignees : [];
-    return assignees
-      .map((assignee) => {
-        if (!assignee || typeof assignee !== 'object') return '';
-        const row = assignee as Record<string, unknown>;
-        return typeof row.id === 'string' ? row.id : '';
-      })
-      .filter((id): id is string => id.length > 0);
-  }, [matterDetailRecord?.assignee_ids, matterDetailRecord?.assignees]);
-  const resolvedMatterAssigneeNames = useMemo(() => {
-    if (matterAssigneeNames && matterAssigneeNames.length > 0) return matterAssigneeNames;
-    const assigneesValue = matterDetailRecord?.assignees;
-    const assignees = Array.isArray(assigneesValue) ? assigneesValue : [];
-    const namesFromRows = assignees
-      .map((assignee) => {
-        if (typeof assignee === 'string') return assignee.trim();
-        if (!assignee || typeof assignee !== 'object') return '';
-        const row = assignee as Record<string, unknown>;
-        return resolveString(row.name) ?? resolveString(row.email) ?? '';
-      })
-      .filter((name): name is string => name.length > 0);
-    if (namesFromRows.length > 0) return namesFromRows;
-    const assigneeIds = Array.isArray(matterDetailRecord?.assignee_ids)
-      ? [...matterDetailRecord.assignee_ids].filter((id) => typeof id === 'string' || typeof id === 'number')
-      : [];
-    return assigneeIds
-      .map((id) => String(id).trim())
-      .filter((id) => id.length > 0)
-      .map((id) => `User ${id.slice(0, 6)}`);
-  }, [matterAssigneeNames, matterDetailRecord]);
-  const resolvedMatterClientLabel = useMemo(() => {
-    if (resolvedMatterClientName) return resolvedMatterClientName;
-    if (resolvedMatterClientId) {
-      const option = matterClientOptions.find((entry) => entry.value === resolvedMatterClientId);
-      if (option?.label) return option.label;
-      return `Client ${resolvedMatterClientId.slice(0, 6)}`;
-    }
-    return 'Unassigned client';
-  }, [resolvedMatterClientId, resolvedMatterClientName, matterClientOptions]);
-  const matterClientOptionsWithNone = useMemo<ComboboxOption[]>(() => {
-    const hasEmptyOption = matterClientOptions.some((option) => option.value === '');
-    return hasEmptyOption
-      ? matterClientOptions
-      : [{ value: '', label: '— none —' }, ...matterClientOptions];
-  }, [matterClientOptions]);
-  const resolveMatterClientIdentity = useCallback(() => {
-    if (!resolvedMatterClientId) {
-      return resolvedMatterClientName
-        ? { name: resolvedMatterClientName, image: null }
-        : null;
-    }
-    const client = matterClients.find((entry) => entry.userId === resolvedMatterClientId);
-    if (client) return client;
-    return resolvedMatterClientName
-      ? { userId: resolvedMatterClientId, name: resolvedMatterClientName, image: null, role: 'client' }
-      : { userId: resolvedMatterClientId, name: `Client ${resolvedMatterClientId.slice(0, 6)}`, image: null, role: 'client' };
-  }, [matterClients, resolvedMatterClientId, resolvedMatterClientName]);
+  // matter-specific resolved fields, identity helpers, and matterTeamIdentities
+  // all live inside MatterInspector now.
   const conversationPeople = useMemo(() => {
     const people = new Map<string, { id: string; name: string; image?: string | null }>();
     const clientId = resolveString(userDetail?.user_id) ?? resolveString(userDetail?.id);
@@ -473,111 +341,9 @@ export const InspectorPanel = ({
     }
     return [...people.values()];
   }, [assignedConversationMember, userDetail, conversation, assignedMemberLabel]);
-  const resolveAttorneyLabel = useCallback(
-    (id: string | null) => resolveAttorneyLabelHelper(id, matterAssigneeOptions),
-    [matterAssigneeOptions],
-  );
-  const resolveAttorneyIdentity = useCallback(
-    (id: string | null) => resolveAttorneyIdentityHelper(id, conversationMembers, matterAssigneeOptions),
-    [conversationMembers, matterAssigneeOptions],
-  );
-  const matterTeamIdentities = useMemo(() => {
-    const identities = new Map<string, { id: string; name: string; image?: string | null }>();
-
-    const addIdentity = (identity: Pick<InspectorIdentity, 'userId' | 'name' | 'image'> | null | undefined) => {
-      if (!identity?.userId || !identity.name) return;
-      identities.set(identity.userId, {
-        id: identity.userId,
-        name: identity.name,
-        image: identity.image ?? null,
-      });
-    };
-
-    addIdentity(resolveAttorneyIdentity(resolvedMatterResponsibleAttorneyId));
-    addIdentity(resolveAttorneyIdentity(resolvedMatterOriginatingAttorneyId));
-
-    const assigneeIds = Array.isArray(matterDetailRecord?.assignee_ids)
-      ? matterDetailRecord.assignee_ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
-      : [];
-    assigneeIds.forEach((id) => addIdentity(resolveAttorneyIdentity(id)));
-
-    // Always add fallback identities for non-empty names that aren't already present
-    resolvedMatterAssigneeNames.forEach((name, index) => {
-      if (!name.trim()) return;
-      
-      // Check if this name is already present in existing identities
-      const nameAlreadyExists = [...identities.values()].some(identity => identity.name === name);
-      if (!nameAlreadyExists) {
-        identities.set(`matter-assignee-${index}`, {
-          id: `matter-assignee-${index}`,
-          name,
-          image: null,
-        });
-      }
-    });
-
-    return [...identities.values()];
-  }, [
-    matterDetailRecord?.assignee_ids,
-    resolveAttorneyIdentity,
-    resolvedMatterAssigneeNames,
-    resolvedMatterOriginatingAttorneyId,
-    resolvedMatterResponsibleAttorneyId,
-  ]);
-  // renderCompactIdentity and renderIdentityStack now imported from identityHelpers
-  const matterUrgencyLabel = useMemo(() => {
-    if (!resolvedMatterUrgency) return 'Not set';
-    return resolvedMatterUrgency.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
-  }, [resolvedMatterUrgency]);
-  const urgencyOptions = useMemo<ComboboxOption[]>(
-    () => [
-      { value: '', label: 'Not set' },
-      { value: 'routine', label: 'Routine' },
-      { value: 'time_sensitive', label: 'Time Sensitive' },
-      { value: 'emergency', label: 'Emergency' },
-    ],
-    []
-  );
-  const handleMatterStatusChange = async (value: string) => {
-    if (!canEditMatterStatus || !onMatterStatusChange || !isMatterStatus(value)) return;
-    setError(null);
-    setIsSavingMatterStatus(true);
-    try {
-      await Promise.resolve(onMatterStatusChange(value));
-      setInspectorMatterStatus(value);
-      setActiveMatterEditor(null);
-    } catch (nextError: unknown) {
-      setError(nextError instanceof Error ? nextError.message : 'Failed to update matter status');
-    } finally {
-      setIsSavingMatterStatus(false);
-    }
-  };
-  const handleMatterPatchChange = async (patch: Record<string, unknown>) => {
-    if (!canEditMatterFields || !onMatterPatchChange) return;
-    setError(null);
-    setIsSavingMatterField(true);
-    try {
-      const keyMap: Record<string, string> = {
-        clientId: 'client_id',
-        responsibleAttorneyId: 'responsible_attorney_id',
-        originatingAttorneyId: 'originating_attorney_id',
-        caseNumber: 'case_number',
-        matterType: 'matter_type',
-        opposingParty: 'opposing_party',
-        opposingCounsel: 'opposing_counsel',
-        assigneeIds: 'assignee_ids',
-      };
-      const normalizedPatch = Object.fromEntries(
-        Object.entries(patch).map(([key, value]) => [keyMap[key] ?? key, value])
-      );
-      await Promise.resolve(onMatterPatchChange(normalizedPatch));
-      setActiveMatterEditor(null);
-    } catch (nextError: unknown) {
-      setError(nextError instanceof Error ? nextError.message : 'Failed to update matter');
-    } finally {
-      setIsSavingMatterField(false);
-    }
-  };
+  // matterTeamIdentities, matterUrgencyLabel, and the matter-specific resolved
+  // fields live inside MatterInspector now. renderCompactIdentity and
+  // renderIdentityStack are imported from identityHelpers.
   const handleConversationAssignmentChange = async (value: string) => {
     if (!onConversationAssignedToChange) return;
     setError(null);
@@ -676,12 +442,7 @@ export const InspectorPanel = ({
             <InspectorSectionSkeleton wideRows={[true, false, true, false]} />
           </div>
         ) : null}
-        {/* Client loading skeleton is rendered by ClientInspector itself */}
-        {isLoading && entityType === 'matter' ? (
-          <div className="py-3">
-            <InspectorSectionSkeleton wideRows={[true, false, true, false]} />
-          </div>
-        ) : null}
+        {/* Client + matter loading skeletons are rendered by their per-feature inspectors */}
         {error ? <p className="px-4 py-3 text-sm text-red-400">{error}</p> : null}
 
         {entityType === 'conversation' && !isLoading ? (
@@ -1195,386 +956,33 @@ export const InspectorPanel = ({
           </div>
         ) : null}
 
-        {entityType === 'matter' && !isLoading ? (
-          <div className="pb-4">
-            <InspectorHeaderEntity
-              chip="MATTER"
-              title={matterDetail?.title ?? 'Matter'}
-              subtitle={undefined}
-              statusBadge={null}
-            />
-            <div className="">
-              <InspectorGroup
-                label="Status"
-                onToggle={canEditMatterStatus
-                  ? () => setActiveMatterEditor((prev) => (prev === 'status' ? null : 'status'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'status'}
-                disabled={isSavingMatterStatus}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={inspectorMatterStatus ? MATTER_STATUS_LABELS[inspectorMatterStatus] : '—'}
-                  summaryMuted={!inspectorMatterStatus}
-                  isOpen={activeMatterEditor === 'status'}
-                >
-                  <div className="relative z-40">
-                    <Combobox
-                      value={inspectorMatterStatus ?? ''}
-                      onChange={(value) => { void handleMatterStatusChange(value); }}
-                      options={matterStatusOptions}
-                      searchable={false}
-                      
-                      defaultOpen
-                      hideTrigger
-                      placeholder="Select status"
-                      disabled={isSavingMatterStatus || !canEditMatterStatus}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Client"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'person' ? null : 'person'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'person'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={renderCompactIdentity(resolveMatterClientIdentity()) ?? resolvedMatterClientLabel}
-                  summaryMuted={!resolvedMatterClientId && !resolvedMatterClientName}
-                  isOpen={activeMatterEditor === 'person'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterClientId ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ clientId: value === '' ? null : value }); }}
-                      options={matterClientOptionsWithNone}
-                      searchable
-                      
-                      defaultOpen
-                      hideTrigger
-                      placeholder="Select client"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Team"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'team' ? null : 'team'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'team'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={renderIdentityStack(
-                    matterTeamIdentities,
-                    'No team members assigned',
-                    'team member',
-                    'team members',
-                  )}
-                  summaryMuted={matterTeamIdentities.length === 0}
-                  isOpen={activeMatterEditor === 'team'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      multiple
-                      value={resolvedMatterAssigneeIds}
-                      onChange={(value) => { void handleMatterPatchChange({ assigneeIds: value }); }}
-                      options={matterAssigneeOptions}
-                      searchable
-                      defaultOpen
-                      hideTrigger
-                      placeholder="Select team members"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Responsible Attorney"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'responsible' ? null : 'responsible'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'responsible'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={renderCompactIdentity(resolveAttorneyIdentity(resolvedMatterResponsibleAttorneyId))}
-                  summaryMuted={!resolvedMatterResponsibleAttorneyId}
-                  isOpen={activeMatterEditor === 'responsible'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterResponsibleAttorneyId ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ responsibleAttorneyId: value === '' ? null : value }); }}
-                      options={[{ value: '', label: 'Not set' }, ...matterAssigneeOptions]}
-                      searchable
-                      
-                      defaultOpen
-                      hideTrigger
-                      placeholder="Select attorney"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Originating Attorney"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'originating' ? null : 'originating'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'originating'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={renderCompactIdentity(resolveAttorneyIdentity(resolvedMatterOriginatingAttorneyId)) ?? resolveAttorneyLabel(resolvedMatterOriginatingAttorneyId)}
-                  summaryMuted={!resolvedMatterOriginatingAttorneyId}
-                  isOpen={activeMatterEditor === 'originating'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterOriginatingAttorneyId ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ originatingAttorneyId: value === '' ? null : value }); }}
-                      options={[{ value: '', label: 'Not set' }, ...matterAssigneeOptions]}
-                      searchable
-                      
-                      defaultOpen
-                      hideTrigger
-                      placeholder="Select attorney"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Urgency"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'urgency' ? null : 'urgency'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'urgency'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={matterUrgencyLabel}
-                  summaryMuted={!resolvedMatterUrgency}
-                  isOpen={activeMatterEditor === 'urgency'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterUrgency ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ urgency: value === '' ? null : value }); }}
-                      options={urgencyOptions}
-                      searchable={false}
-                      
-                      defaultOpen
-                      hideTrigger
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Case Number"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'caseNumber' ? null : 'caseNumber'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'caseNumber'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={resolvedMatterCaseNumber ?? 'Not set'}
-                  summaryMuted={!resolvedMatterCaseNumber}
-                  isOpen={activeMatterEditor === 'caseNumber'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterCaseNumber ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ caseNumber: value }); }}
-                      options={[]}
-                      allowCustomValues
-                      
-                      defaultOpen
-                      hideTrigger
-                      addNewLabel="Set case number"
-                      placeholder="Enter case number"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Matter Type"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'matterType' ? null : 'matterType'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'matterType'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={resolvedMatterType ?? 'Not set'}
-                  summaryMuted={!resolvedMatterType}
-                  isOpen={activeMatterEditor === 'matterType'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterType ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ matterType: value }); }}
-                      options={[]}
-                      allowCustomValues
-                      
-                      defaultOpen
-                      hideTrigger
-                      addNewLabel="Set matter type"
-                      placeholder="Enter matter type"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Court"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'court' ? null : 'court'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'court'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={resolvedMatterCourt ?? 'Not set'}
-                  summaryMuted={!resolvedMatterCourt}
-                  isOpen={activeMatterEditor === 'court'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterCourt ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ court: value }); }}
-                      options={[]}
-                      allowCustomValues
-                      
-                      defaultOpen
-                      hideTrigger
-                      addNewLabel="Set court"
-                      placeholder="Enter court"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Judge"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'judge' ? null : 'judge'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'judge'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={resolvedMatterJudge ?? 'Not set'}
-                  summaryMuted={!resolvedMatterJudge}
-                  isOpen={activeMatterEditor === 'judge'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterJudge ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ judge: value }); }}
-                      options={[]}
-                      allowCustomValues
-                      
-                      defaultOpen
-                      hideTrigger
-                      addNewLabel="Set judge"
-                      placeholder="Enter judge"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Opposing Party"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'opposingParty' ? null : 'opposingParty'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'opposingParty'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={resolvedMatterOpposingParty ?? 'Not set'}
-                  summaryMuted={!resolvedMatterOpposingParty}
-                  isOpen={activeMatterEditor === 'opposingParty'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterOpposingParty ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ opposingParty: value }); }}
-                      options={[]}
-                      allowCustomValues
-                      
-                      defaultOpen
-                      hideTrigger
-                      addNewLabel="Set opposing party"
-                      placeholder="Enter opposing party"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup
-                label="Opposing Counsel"
-                onToggle={canEditMatterFields
-                  ? () => setActiveMatterEditor((prev) => (prev === 'opposingCounsel' ? null : 'opposingCounsel'))
-                  : undefined}
-                isOpen={activeMatterEditor === 'opposingCounsel'}
-                disabled={isSavingMatterField}
-              >
-                <InspectorEditableRow
-                  label=""
-                  summary={resolvedMatterOpposingCounsel ?? 'Not set'}
-                  summaryMuted={!resolvedMatterOpposingCounsel}
-                  isOpen={activeMatterEditor === 'opposingCounsel'}
-                >
-                  <div className="relative z-30">
-                    <Combobox
-                      value={resolvedMatterOpposingCounsel ?? ''}
-                      onChange={(value) => { void handleMatterPatchChange({ opposingCounsel: value }); }}
-                      options={[]}
-                      allowCustomValues
-                      
-                      defaultOpen
-                      hideTrigger
-                      addNewLabel="Set opposing counsel"
-                      placeholder="Enter opposing counsel"
-                      disabled={isSavingMatterField || !canEditMatterFields}
-                    />
-                  </div>
-                </InspectorEditableRow>
-              </InspectorGroup>
-              <InspectorGroup label="Files & Media">
-                <MatterFilesSection
-                  practiceId={practiceId}
-                  matterId={entityId}
-                />
-              </InspectorGroup>
-              <InspectorGroup label="Record">
-                <InfoRow label="Created" value={resolvedMatterCreatedLabel ?? undefined} />
-                <InfoRow label="Updated" value={resolvedMatterUpdatedLabel ?? undefined} />
-              </InspectorGroup>
-            </div>
-          </div>
+        {entityType === 'matter' && practiceId && entityId ? (
+          <MatterInspector
+            practiceId={practiceId}
+            entityId={entityId}
+            matterClientName={matterClientName}
+            matterAssigneeNames={matterAssigneeNames}
+            matterCreatedLabel={matterCreatedLabel}
+            matterUpdatedLabel={matterUpdatedLabel}
+            matterClientId={matterClientId}
+            matterUrgency={matterUrgency}
+            matterResponsibleAttorneyId={matterResponsibleAttorneyId}
+            matterOriginatingAttorneyId={matterOriginatingAttorneyId}
+            matterCaseNumber={matterCaseNumber}
+            matterType={matterType}
+            matterCourt={matterCourt}
+            matterJudge={matterJudge}
+            matterOpposingParty={matterOpposingParty}
+            matterOpposingCounsel={matterOpposingCounsel}
+            matterClientOptions={matterClientOptions}
+            matterClients={matterClients}
+            matterAssigneeOptions={matterAssigneeOptions}
+            conversationMembers={conversationMembers}
+            onMatterStatusChange={onMatterStatusChange}
+            onMatterPatchChange={onMatterPatchChange}
+          />
         ) : null}
+
 
         {entityType === 'client' && practiceId && entityId ? (
           <ClientInspector practiceId={practiceId} entityId={entityId} />

--- a/src/shared/ui/inspector/InspectorPanel.tsx
+++ b/src/shared/ui/inspector/InspectorPanel.tsx
@@ -10,7 +10,13 @@ import { InvoiceInspector } from '@/features/invoices/components/InvoiceInspecto
 import { ClientInspector } from '@/features/clients/components/ClientInspector';
 import { Button } from '@/shared/ui/Button';
 import { Combobox, type ComboboxOption, Input, Textarea } from '@/shared/ui/input';
-import { StackedAvatars, UserCard } from '@/shared/ui/profile';
+import {
+  InspectorIdentity,
+  resolveAttorneyLabel as resolveAttorneyLabelHelper,
+  resolveAttorneyIdentity as resolveAttorneyIdentityHelper,
+  renderCompactIdentity,
+  renderIdentityStack,
+} from './identityHelpers';
 import { STATE_OPTIONS } from '@/shared/ui/address/AddressFields';
 import { InspectorSectionSkeleton } from '@/shared/ui/layout';
 import {
@@ -40,14 +46,6 @@ type InspectorConfig =
   | { type: 'invoice' };
 
 type InspectorEntityType = InspectorConfig['type'];
-
-type InspectorIdentity = {
-  userId: string;
-  name: string;
-  email?: string;
-  image?: string | null;
-  role: string;
-};
 
 type InspectorPanelProps = {
   entityType: InspectorEntityType;
@@ -475,32 +473,14 @@ export const InspectorPanel = ({
     }
     return [...people.values()];
   }, [assignedConversationMember, userDetail, conversation, assignedMemberLabel]);
-  const resolveAttorneyLabel = useCallback((id: string | null) => {
-    if (!id) return 'Not set';
-    const option = matterAssigneeOptions.find((entry) => entry.value === id);
-    return option?.label ?? `User ${id.slice(0, 6)}`;
-  }, [matterAssigneeOptions]);
-  const resolveAttorneyIdentity = useCallback((id: string | null) => {
-    if (!id) return null;
-    const member = conversationMembers.find((entry) => entry.userId === id);
-    if (member) return member;
-    const option = matterAssigneeOptions.find((entry) => entry.value === id);
-    if (option?.label) {
-      return {
-        userId: id,
-        name: option.label,
-        email: option.meta,
-        image: null,
-        role: 'member',
-      };
-    }
-    return {
-      userId: id,
-      name: `User ${id.slice(0, 6)}`,
-      image: null,
-      role: 'member',
-    };
-  }, [conversationMembers, matterAssigneeOptions]);
+  const resolveAttorneyLabel = useCallback(
+    (id: string | null) => resolveAttorneyLabelHelper(id, matterAssigneeOptions),
+    [matterAssigneeOptions],
+  );
+  const resolveAttorneyIdentity = useCallback(
+    (id: string | null) => resolveAttorneyIdentityHelper(id, conversationMembers, matterAssigneeOptions),
+    [conversationMembers, matterAssigneeOptions],
+  );
   const matterTeamIdentities = useMemo(() => {
     const identities = new Map<string, { id: string; name: string; image?: string | null }>();
 
@@ -544,41 +524,7 @@ export const InspectorPanel = ({
     resolvedMatterOriginatingAttorneyId,
     resolvedMatterResponsibleAttorneyId,
   ]);
-  const renderCompactIdentity = useCallback((identity: Pick<InspectorIdentity, 'name' | 'image'> | null) => {
-    if (!identity) return null;
-    return (
-      <UserCard
-        name={identity.name}
-        image={identity.image ?? null}
-        size="sm"
-        className="px-0 py-0"
-      />
-    );
-  }, []);
-  const renderIdentityStack = useCallback((
-    users: Array<{ id: string; name: string; image?: string | null }>,
-    emptyLabel: string,
-    singularLabel: string,
-    pluralLabel: string,
-  ) => {
-    if (users.length === 0) {
-      return <span className="text-input-placeholder">{emptyLabel}</span>;
-    }
-
-    return (
-      <div className="flex items-center gap-3">
-        <StackedAvatars users={users} size="sm" max={4} className="shrink-0" />
-        <div className="min-w-0">
-          <p className="truncate text-[14px] text-input-text">
-            {users.map((user) => user.name).join(', ')}
-          </p>
-          <p className="text-[11px] uppercase tracking-wider text-input-placeholder">
-            {users.length} {users.length === 1 ? singularLabel : pluralLabel}
-          </p>
-        </div>
-      </div>
-    );
-  }, []);
+  // renderCompactIdentity and renderIdentityStack now imported from identityHelpers
   const matterUrgencyLabel = useMemo(() => {
     if (!resolvedMatterUrgency) return 'Not set';
     return resolvedMatterUrgency.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());

--- a/src/shared/ui/inspector/identityHelpers.tsx
+++ b/src/shared/ui/inspector/identityHelpers.tsx
@@ -1,0 +1,102 @@
+import type { ComboboxOption } from '@/shared/ui/input';
+import { UserCard, StackedAvatars } from '@/shared/ui/profile';
+
+export type InspectorIdentity = {
+  userId: string;
+  name: string;
+  email?: string;
+  image?: string | null;
+  role: string;
+};
+
+/**
+ * Look up an attorney's display label by id. Falls back to a truncated user id
+ * (`User abc123`) when no label is known. Used by both MatterInspector and
+ * ConversationInspector for assignee/responsible-attorney rendering.
+ */
+export const resolveAttorneyLabel = (
+  id: string | null,
+  matterAssigneeOptions: ComboboxOption[],
+): string => {
+  if (!id) return 'Not set';
+  const option = matterAssigneeOptions.find((entry) => entry.value === id);
+  return option?.label ?? `User ${id.slice(0, 6)}`;
+};
+
+/**
+ * Resolve an attorney id to a full identity object, looking through
+ * conversation members first, then matter assignee options, then synthesizing
+ * a fallback from the id alone. Returns null when id is null.
+ */
+export const resolveAttorneyIdentity = (
+  id: string | null,
+  conversationMembers: InspectorIdentity[],
+  matterAssigneeOptions: ComboboxOption[],
+): InspectorIdentity | null => {
+  if (!id) return null;
+  const member = conversationMembers.find((entry) => entry.userId === id);
+  if (member) return member;
+  const option = matterAssigneeOptions.find((entry) => entry.value === id);
+  if (option?.label) {
+    return {
+      userId: id,
+      name: option.label,
+      email: option.meta,
+      image: null,
+      role: 'member',
+    };
+  }
+  return {
+    userId: id,
+    name: `User ${id.slice(0, 6)}`,
+    image: null,
+    role: 'member',
+  };
+};
+
+/**
+ * Render a small inline identity (avatar + name) for use in inspector summary
+ * rows. Returns null when identity is null so callers can fall back to text.
+ */
+export const renderCompactIdentity = (
+  identity: Pick<InspectorIdentity, 'name' | 'image'> | null,
+) => {
+  if (!identity) return null;
+  return (
+    <UserCard
+      name={identity.name}
+      image={identity.image ?? null}
+      size="sm"
+      className="px-0 py-0"
+    />
+  );
+};
+
+/**
+ * Render a stacked-avatar row with a "{count} {label}" caption. Used for team
+ * lists (matter assignees, conversation participants).
+ */
+export const renderIdentityStack = (
+  users: Array<{ id: string; name: string; image?: string | null }>,
+  emptyLabel: string,
+  singularLabel: string,
+  pluralLabel: string,
+) => {
+  if (users.length === 0) {
+    return <span className="text-dim">{emptyLabel}</span>;
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <StackedAvatars users={users} size="sm" max={4} className="shrink-0" />
+      <div className="min-w-0">
+        <p className="truncate text-[14px] text-ink">
+          {users.map((user) => user.name).join(', ')}
+        </p>
+        <p className="text-[11px] uppercase tracking-wider text-dim">
+          {users.length} {users.length === 1 ? singularLabel : pluralLabel}
+        </p>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Fifth PR in the design-system migration series. Picks up where [#647](https://github.com/Blawby/blawby-ai-chatbot/pull/647) (5d.1–5d.3, merged) left off. Lands the next two clean inspector splits.

## Landed (3 sub-commits)

| SHA | What |
|---|---|
| `5a396373` | **5d.4a** — Extract shared `inspector/identityHelpers.tsx` (102 lines): `InspectorIdentity` type + `resolveAttorneyLabel` + `resolveAttorneyIdentity` + `renderCompactIdentity` + `renderIdentityStack`. Pre-step so MatterInspector + ConversationInspector both consume these without duplication. InspectorPanel net −65 lines. |
| `0d4eefab` | **5d.4b** — Extract `MatterInspector` to `src/features/matters/components/MatterInspector.tsx` (717 lines). Consumes `useMatterDetail` + identity helpers. Owns full matter editor state (12-position discriminator + 5 saving flags), ~14 `resolvedMatter*` field computations, matter status/patch handlers with snake_case keyMap, `matterTeamIdentities`/`matterStatusOptions`/`urgencyOptions` memos. **InspectorPanel net −628 lines** (1925 → ~1000). |
| `d3b3ed68` | Close PR #648 scope + write PR-6 handoff for ConversationInspector (5d.5). |

## Build / lint / type-check

Baseline preserved at every sub-commit:
- ✅ `npm run build` — passes
- ⚠️ `npm run lint:src` — 1 pre-existing error (`OAuthConsentPage.tsx:187`)
- ✅ `npm run type-check` — 0 errors

## Why pause at 5d.4b

ConversationInspector (5d.5) is the largest single block left:
- ~500 lines of JSX with **3 sub-paths** (PRACTICE_ONBOARDING / isClientView / regular conversation)
- 14-position `activeConversationEditor` discriminator including 8 intake sub-editors
- Consumes all 3 data hooks (useUserDetail + useMatterDetail + usePracticeDetail)
- Pulls in `SetupInspectorContent`, `InspectorHeaderHero`, intake strength resolvers, `STATE_OPTIONS`, `updateConversationMatter`
- ~12 memos/handlers/helpers entangled with outer scope

Realistically a 90-120 min focused extract. Rather than half-do it mid-session, I'm shipping 5d.4a + 5d.4b as a clean reviewable PR and pointing PR-6 at the focused effort. The handoff doc has the full dependency list spelled out so the next session can plan the prop surface upfront.

## What's in the handoff doc for PR-6

- **PR-6 scope** — 5d.5 (ConversationInspector) + 5d.6 (delete dispatcher) + 5e.1-7 (shell refactor)
- **Sub-commit cadence** with realistic time estimates (5d.5 ~90-120 min, 5d.6 ~30 min)
- **Session checklist** with branch-creation commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)