### PR TITLE
ds: PR-7 — shell refactor to LeftRail (5e in progress)

### DIFF
--- a/docs/design-system-migration.md
+++ b/docs/design-system-migration.md
@@ -43,12 +43,18 @@ From `design_handoff_blawby_chat_first/DESIGN_SYSTEM.md §0`:
 | 5d.4b — MatterInspector extract | `0d4eefab` | ✅ in PR #648 | `src/features/matters/components/MatterInspector.tsx` (717 lines) consumes useMatterDetail + identityHelpers. Owns full matter editor state, ~14 resolvedMatter fields, status/patch handlers, matterStatusOptions/urgencyOptions/matterTeamIdentities memos. InspectorPanel −628 lines. |
 | 5d.5 — ConversationInspector extract | `d884f792` | ✅ in PR #649 | `src/features/chat/components/ConversationInspector.tsx` (727 lines) — last per-feature inspector. Consumes useUserDetail + useMatterDetail + usePracticeDetail. Owns 3 sub-paths (PRACTICE_ONBOARDING / isClientView / regular), 14-position editor discriminator, intake field handlers. **InspectorPanel −797 lines (1004 → 243).** All per-feature inspector logic now lives in features/*. |
 | 5d.6 — Delete InspectorPanel dispatcher | — | **deferred — see note** | InspectorPanel is now a genuinely thin 243-line facade (type defs + chrome + 4-branch dispatch). Deleting it requires extracting chrome + updating 4 callers (1 of which has dynamic entityType requiring a switch). The dispatcher provides real value as a single entry point with unified prop API. **Recommended: keep as facade unless 5e shell refactor wants the inspector chrome moved closer to the shell.** Revisit when shell work makes the call site obvious. |
-| 5e — Shell refactor | — | **pending — PR-7 scope** | Drop AppShell sidebar props; refactor WorkspacePage/PracticeHomePage/ClientHomePage/WidgetApp to LeftRail; extract ConversationListPanel (340px column per Conversations spec); delete legacy nav + 4 test files |
+| 5e.2 — ClientHomePage to LeftRail | `8246f45c` | ✅ in PR #650 | First shell migrated. Establishes the pattern: build LeftRailItem[] from getXxxNavConfig().rail; LeftRail + main flex composition; drop AppShell entirely for shells that don't need its multi-column grid. |
+| 5e.3 — PracticeHomePage to LeftRail | `b221d125` | ✅ in PR #650 | Same pattern + merges live sidebarCounts into items.badge; OrgSwitcherMenu in brandMark slot. |
+| 5e.4 — WidgetApp to LeftRail mobile + FocusDrawer | `eda94046` | ✅ in PR #650 | NavRail → LeftRail mobile variant; MobileInspectorOverlay → FocusDrawer; hidden prop pattern → conditional render. |
+| 5e.5 — WorkspacePage refactor | — | **pending — PR-8 scope** | Biggest, riskiest (1666 lines). Replaces PracticeSidebar/ClientSidebar/NavRail with LeftRail. Drops isDesktopSidebarCollapsed + `blawby:sidebar:collapsed` localStorage. |
+| 5e.6 — Extract ConversationListPanel | — | **pending — PR-8 scope** | 340px thread-list column per Conversations.html 4-column spec |
+| 5e.1 — Drop AppShell sidebar props | — | **pending — PR-8 scope** | After WorkspacePage migrates, AppShell's sidebar/desktopSidebarCollapsed/mobileSidebar/mobileSidebarOpen/onMobileSidebarClose props become safe to remove |
+| 5e.7 — Delete legacy nav + tests + dead CSS | — | **pending — PR-8 scope** | NavRail, Sidebar, PracticeSidebar, ClientSidebar, MobileInspectorOverlay, WorkspaceShellHeader + `.nav-item-*` / `.workspace-header*` CSS + 4 test files |
 | 6 — Chat patterns | — | pending | AISummary, StagedAction, Citations, Observation, Composer, ToolUseLine, BriefingGrid, MatterChip; IOLTA manual smoke |
 | 7 — Data display | — | pending | StatStrip, JourneyProgress, LetterPaper, Seg; print test |
 | 8 — Feature sweep | — | pending | TSX feature-files swept for the 8 violation patterns; DataTable audit; AA contrast spot; `prefers-reduced-motion` check; final delete of `.status-*` / `.input-surface` / `.card-surface` aliases |
 
-PR series: #644 (foundation, merged) → #645 (Commit 4 + 5a + 5b, merged) → #646 (5c.1–5c.4, merged) → #647 (5d.1–5d.3, merged) → #648 (5d.4a + 5d.4b, merged) → **#649 (this PR — 5d.5)** → PR-7 (5e shell refactor; 5d.6 deferred per facade-is-acceptable note above).
+PR series: #644 (foundation, merged) → #645 (Commit 4 + 5a + 5b, merged) → #646 (5c.1–5c.4, merged) → #647 (5d.1–5d.3, merged) → #648 (5d.4a + 5d.4b, merged) → #649 (5d.5, merged) → **#650 (this PR — 5e.2 + 5e.3 + 5e.4)** → PR-8 (5e.5 WorkspacePage + 5e.6 ConversationListPanel + 5e.1 AppShell prop drop + 5e.7 deletions).
 
 ---
 
@@ -301,31 +307,85 @@ Current baseline on `staging` HEAD.
 
 ---
 
-## Session checklist (resume — PR-7 starts here)
+## PR-7 (this PR) — landed checklist
+
+- [x] **5e.2** — ClientHomePage rewired to LeftRail — `8246f45c`
+- [x] **5e.3** — PracticeHomePage rewired to LeftRail with sidebarCounts → badge merge + OrgSwitcherMenu brandMark — `b221d125`
+- [x] **5e.4** — WidgetApp NavRail → LeftRail mobile + MobileInspectorOverlay → FocusDrawer — `eda94046`
+
+3 of 4 shells migrated. **WorkspacePage (1666L) deferred to PR-8** because of size + risk; do it as its own focused session.
+
+---
+
+## PR-8 scope — `feat/ds-migration-pt8` (next session)
+
+Final shell refactor + cleanup. After PR-8 merges, the legacy nav stack is fully removed.
+
+### 5e.5 — Refactor WorkspacePage
+
+**Biggest single piece in the migration.** 1666 lines. Uses PracticeSidebar + ClientSidebar + NavRail + InspectorPanel + WorkspaceShellHeader. Recipe established by 5e.2/3/4:
+
+1. Drop `PracticeSidebar` / `ClientSidebar` / `NavRail` / `WorkspaceShellHeader` imports
+2. Drop `isDesktopSidebarCollapsed` state + `'blawby:sidebar:collapsed'` localStorage key (locked decision §5)
+3. Drop mobile-sidebar drawer state (`isMobileNavOpen`)
+4. Drop `useCommandPalette`'s top-bar usage (search is now ⌘K only)
+5. Build `railItems` useMemo from `getPracticeNavConfig` (when isPracticeWorkspace) or `getClientNavConfig` (otherwise), merging sidebarCounts into badges
+6. Compose: OrgSwitcherMenu in `brandMark` slot; SidebarProfileMenu in `footer` slot
+7. Replace AppShell composition with the chat-first 4-column layout per Conversations.html spec when in assistant/conversations section: `[LeftRail | ConversationListPanel | main | FocusDrawer]`; simpler `[LeftRail | main | FocusDrawer]` for other sections
+
+The `assistantListPanel` / `conversationListPanel` / `matterListPanel` / `contactsListPanel` / `invoicesListPanel` that WorkspacePage currently passes to AppShell's `listPanel` slot continue to render — they just sit in the second column position rather than being routed through AppShell.
+
+### 5e.6 — Extract ConversationListPanel
+
+Per the Conversations 4-column spec (240 rail | 340 thread list | 1fr active | 400 focus drawer), the assistant/conversations section needs a standalone 340px thread-list column. Currently the conversation list lives inside PracticeSidebar when `workspaceSection === 'assistant'`. Extract as `src/features/chat/components/ConversationListPanel.tsx`:
+
+- Props: `conversations`, `conversationPreviews`, `isLoading`, `error`, `activeConversationId`, `onSelect`, `onNew`
+- 340px wide flex column
+- Currently rendered by PracticeSidebar's `assistantListPanel` block; just lift to standalone
+
+### 5e.1 — Drop AppShell sidebar props
+
+After all 4 shells migrate, no caller passes `sidebar` / `desktopSidebarCollapsed` / `mobileSidebar` / `mobileSidebarOpen` / `onMobileSidebarClose` to AppShell. Drop them from `AppShellProps`, drop all the conditional rendering for sidebar column + mobile drawer + grid template column calculations.
+
+What's left in AppShell becomes: header + listPanel + main + inspector + bottomBar columns. Roughly half the file goes away.
+
+### 5e.7 — Delete legacy nav files + tests + dead CSS
+
+- [ ] `src/shared/ui/nav/NavRail.tsx`
+- [ ] `src/shared/ui/nav/Sidebar.tsx`
+- [ ] `src/shared/ui/nav/PracticeSidebar.tsx`
+- [ ] `src/shared/ui/nav/ClientSidebar.tsx`
+- [ ] `src/shared/ui/inspector/MobileInspectorOverlay.tsx`
+- [ ] `src/shared/ui/layout/WorkspaceShellHeader.tsx`
+- [ ] Dead CSS: `.nav-item-active`, `.nav-item-inactive`, `.workspace-header*`, `.sidebar-scroll`
+- [ ] 4 test files (locked answer #6 — delete; re-add later if equivalents emerge after the rebuild):
+  - `tests/component/nav-rail.test.tsx`
+  - `tests/component/widget-app.test.tsx`
+  - `tests/component/app-shell.test.tsx`
+  - `src/features/invoices/pages/__tests__/InvoicesPages.test.tsx` (or just remove the NavRail import)
+
+---
+
+## Session checklist (resume — PR-8 starts here)
 
 ```powershell
 git fetch upstream
 git checkout staging
 git pull upstream staging --ff-only
-git checkout -b feat/ds-migration-pt7
-npm install                                       # if dependencies changed
+git checkout -b feat/ds-migration-pt8
+npm install
 npm run build                                     # must pass
 npm run lint:src                                  # baseline: 1 pre-existing OAuthConsentPage error
 npm run type-check                                # baseline: 0 errors
 ```
 
-Open `design_handoff_blawby_chat_first/screens/index.html` in a browser for the 21-screen hub, and `design_handoff_blawby_chat_first/screens/Conversations.html` for the canonical 4-column chat-first surface that drives the assistant panel relocation in 5e. Then start at "PR-7 scope" above.
+Open `design_handoff_blawby_chat_first/screens/Conversations.html` for the canonical 4-column layout that drives WorkspacePage's chat/assistant section. The 240 / 340 / 1fr / 400 grid is the spec.
 
-### Suggested PR-7 sub-commit cadence
+### Suggested PR-8 sub-commit cadence
 
-1. `5e.1` — Drop AppShell sidebar props (assess what each shell still needs)
-2. `5e.2` — Refactor `ClientHomePage` (smallest shell, lowest risk; establishes pattern)
-3. `5e.3` — Refactor `PracticeHomePage`
-4. `5e.4` — Refactor `WidgetApp`
-5. `5e.5` — Refactor `WorkspacePage` (largest, riskiest; do last with established patterns)
-6. `5e.6` — Extract `ConversationListPanel` for the 340px Conversations column
-7. `5e.7` — Delete legacy nav files + dead CSS + 4 test files (final cleanup)
+1. `5e.5` — Refactor WorkspacePage (biggest; do in one focused commit with iterative lint cleanup pass)
+2. `5e.6` — Extract ConversationListPanel
+3. `5e.1` — Drop AppShell sidebar props
+4. `5e.7` — Delete legacy nav files + 4 test files + dead CSS
 
-Each is independently green; each is a small reviewable diff. 5e likely needs its own focused session given WorkspacePage's 1666 lines.
-
-If 5e surfaces a natural call site for the inspector chrome (e.g. shell wraps inspector with its own header), revisit 5d.6 at that point: either extract `InspectorChrome` + delete InspectorPanel, or keep InspectorPanel as the facade indefinitely.
+Realistic time estimate: 2-3 hours for WorkspacePage alone, plus ~1 hour for the remaining three combined.

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -22,14 +22,14 @@ import { resolveConversationContactName, resolveConversationDisplayTitle } from 
 import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 import { practiceDetailsStore } from '@/shared/stores/practiceDetailsStore';
 import { useStore } from '@nanostores/preact';
-import { NavRail } from '@/shared/ui/nav/NavRail';
+import { LeftRail, type LeftRailItem } from '@/design-system/layout';
 import type { ConversationMetadata, ConversationMode } from '@/shared/types/conversation';
 import type { UIPracticeConfig } from '@/shared/hooks/usePracticeConfig';
 import DragDropOverlay from '@/shared/ui/DragDropOverlay';
 import { resolveStrengthStyle, resolveStrengthTier } from '@/shared/utils/intakeStrength';
 import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
 import { resolveConsultationState } from '@/shared/utils/consultationState';
-import { MobileInspectorOverlay } from '@/shared/ui/inspector/MobileInspectorOverlay';
+import { FocusDrawer } from '@/design-system/layout';
 import { features } from '@/config/features';
 import { IntakeProvider } from '@/shared/contexts/IntakeContext';
 import type { FileAttachment } from '../../worker/types';
@@ -803,9 +803,10 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
             </div>
 
             {isInspectorOpen && activeConversationId && (
-              <MobileInspectorOverlay
+              <FocusDrawer
                 isOpen={true}
                 onClose={() => setIsInspectorOpen(false)}
+                showCloseButton={false}
               >
                 <InspectorPanel
                   entityType="conversation"
@@ -826,38 +827,39 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
                   }}
                   practiceDetails={cachedPracticeDetails}
                 />
-              </MobileInspectorOverlay>
+              </FocusDrawer>
             )}
           </>
         )}
-        
-        <NavRail
-          variant="bottom"
-          items={[
-            {
-              id: 'home',
-              label: t('nav.home'),
-              icon: Home,
-              href: '#home',
-              isAction: true,
-              isActive: view === 'home',
-              onClick: () => {
-                setConversationMode(null);
-                setView('home');
+
+        {view !== 'chat' && (
+          <LeftRail
+            variant="mobile"
+            items={[
+              {
+                id: 'home',
+                label: t('nav.home'),
+                icon: Home,
+                href: '#home',
+                isAction: true,
+                isActive: view === 'home',
+                onClick: () => {
+                  setConversationMode(null);
+                  setView('home');
+                }
+              },
+              {
+                id: 'list',
+                label: t('nav.messages'),
+                icon: MessagesSquare,
+                href: '#list',
+                isAction: true,
+                isActive: view === 'list',
+                onClick: () => setView('list')
               }
-            },
-            {
-              id: 'list',
-              label: t('nav.messages'),
-              icon: MessagesSquare,
-              href: '#list',
-              isAction: true,
-              isActive: view === 'list',
-              onClick: () => setView('list')
-            }
-          ]}
-          hidden={view === 'chat'}
-        />
+            ] as LeftRailItem[]}
+          />
+        )}
       </div>
       )}
     </>

--- a/src/pages/ClientHomePage.tsx
+++ b/src/pages/ClientHomePage.tsx
@@ -1,16 +1,18 @@
-import { useMemo, useState } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
+import { Sparkles } from 'lucide-preact';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useWorkspace } from '@/shared/hooks/useWorkspace';
 import { useWorkspaceResolver } from '@/shared/hooks/useWorkspaceResolver';
 import { useNavigation } from '@/shared/utils/navigation';
+import { signOut } from '@/shared/utils/auth';
 import { getWorkspaceSettingsPath } from '@/shared/utils/workspace';
 import { Button } from '@/shared/ui/Button';
 import { NextStepsCard, type NextStepsItem } from '@/shared/ui/cards/NextStepsCard';
-import { ClientSidebar } from '@/shared/ui/nav/ClientSidebar';
-import { WorkspaceShellHeader } from '@/shared/ui/layout/WorkspaceShellHeader';
-import { AppShell } from '@/shared/ui/layout/AppShell';
-import { useCommandPalette } from '@/features/search/contexts/CommandPaletteContext';
+import { LeftRail, BrandMark, type LeftRailItem } from '@/design-system/layout';
+import { SidebarProfileMenu } from '@/shared/ui/nav/SidebarProfileMenu';
+import { getClientNavConfig } from '@/shared/config/navConfig';
+import type { IconComponent } from '@/shared/ui/Icon';
 
 const ClientHomePage = () => {
   const { session } = useSessionContext();
@@ -18,8 +20,6 @@ const ClientHomePage = () => {
   const { canAccessPractice } = useWorkspace();
   const { currentPractice } = useWorkspaceResolver();
   const { navigate, navigateToPricing } = useNavigation();
-  const [desktopCollapsed, setDesktopCollapsed] = useState(false);
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   const userName = session?.user?.name || session?.user?.email || 'there';
   const userEmail = session?.user?.email ?? null;
@@ -27,8 +27,6 @@ const ClientHomePage = () => {
   const showUpgrade = !canAccessPractice;
 
   const clientPracticeSlug = currentPractice?.slug ?? null;
-  const orgName = currentPractice?.name?.trim() || userName;
-  const orgInitial = (orgName.charAt(0) || 'B').toUpperCase();
 
   const settingsPath = useMemo(() => {
     const routeMatch = location.path.match(/^\/(client|practice)\/([^/]+)/);
@@ -37,8 +35,8 @@ const ClientHomePage = () => {
       const slug = decodeURIComponent(routeMatch[2]);
       return getWorkspaceSettingsPath(workspace, slug);
     }
-    return currentPractice?.slug ? getWorkspaceSettingsPath('client', currentPractice.slug) : null;
-  }, [currentPractice?.slug, location.path]);
+    return clientPracticeSlug ? getWorkspaceSettingsPath('client', clientPracticeSlug) : null;
+  }, [clientPracticeSlug, location.path]);
 
   const clientNextStepsItems = useMemo<NextStepsItem[]>(() => {
     const items: NextStepsItem[] = [
@@ -68,34 +66,50 @@ const ClientHomePage = () => {
     return items;
   }, [navigateToPricing, showUpgrade]);
 
-  const sidebarUser = { name: userName, email: userEmail, image: userImage };
+  // Build LeftRail items from the canonical client nav config.
+  const railItems = useMemo<LeftRailItem[]>(() => {
+    if (!clientPracticeSlug) return [];
+    const config = getClientNavConfig(
+      { practiceSlug: clientPracticeSlug, role: 'client', canAccessPractice: false },
+      'home',
+    );
+    const items: LeftRailItem[] = config.rail.map((item) => ({
+      id: item.id,
+      label: item.label,
+      icon: item.icon as IconComponent,
+      href: item.href,
+      matchHrefs: item.matchHrefs,
+      badge: item.badge,
+      variant: item.variant,
+      isAction: item.isAction,
+      onClick: item.onClick,
+      prefetch: item.prefetch,
+    }));
 
-  const renderSidebar = (forceExpanded: boolean) =>
-    clientPracticeSlug ? (
-      <ClientSidebar
-        practiceSlug={clientPracticeSlug}
-        org={{ name: orgName, initial: orgInitial }}
-        user={sidebarUser}
-        collapsed={desktopCollapsed}
-        forceExpanded={forceExpanded}
-        onToggleCollapsed={() => setDesktopCollapsed((v) => !v)}
-        onItemActivate={() => setMobileSidebarOpen(false)}
-        activeItemId="home"
-        workspaceSection="home"
-        showUpgradeItem={showUpgrade}
-        onUpgradeClick={() => navigateToPricing()}
-      />
-    ) : null;
+    // "Upgrade to Practice" CTA per locked decision §5 — client-shell may
+    // append a single CTA chip-style action to the rail.
+    if (showUpgrade) {
+      items.push({
+        id: 'upgrade',
+        label: 'Upgrade to Practice',
+        icon: Sparkles as IconComponent,
+        href: '#',
+        isAction: true,
+        onClick: () => navigateToPricing(),
+      });
+    }
 
-  const { open: openCommandPalette } = useCommandPalette();
-  const header = (
-    <WorkspaceShellHeader
-      orgInitial={orgInitial}
-      title="Home"
-      onMenuClick={() => setMobileSidebarOpen(true)}
-      onSearchClick={() => openCommandPalette()}
+    return items;
+  }, [clientPracticeSlug, showUpgrade, navigateToPricing]);
+
+  const profileFooter = session?.user ? (
+    <SidebarProfileMenu
+      user={{ name: userName, email: userEmail, image: userImage }}
+      onAccount={() => clientPracticeSlug && navigate(`/client/${encodeURIComponent(clientPracticeSlug)}/settings/account`)}
+      onSettings={() => settingsPath && navigate(settingsPath)}
+      onSignOut={() => void signOut({ navigate })}
     />
-  );
+  ) : null;
 
   const main = (
     <div className="h-full overflow-y-auto px-6 py-8 md:px-12 md:py-10">
@@ -133,18 +147,23 @@ const ClientHomePage = () => {
   );
 
   return (
-    <AppShell
-      className="bg-transparent h-dvh"
-      accentBackdropVariant="none"
-      header={header}
-      sidebar={renderSidebar(false)}
-      desktopSidebarCollapsed={desktopCollapsed}
-      mobileSidebar={renderSidebar(true)}
-      mobileSidebarOpen={mobileSidebarOpen}
-      onMobileSidebarClose={() => setMobileSidebarOpen(false)}
-      main={main}
-      mainClassName="min-h-0 h-full overflow-hidden"
-    />
+    <div className="flex h-dvh flex-col lg:flex-row">
+      <LeftRail
+        variant="desktop"
+        items={railItems}
+        brandMark={<BrandMark />}
+        footer={profileFooter}
+        className="hidden lg:flex"
+      />
+      <main className="flex-1 min-h-0 overflow-hidden order-first lg:order-none">
+        {main}
+      </main>
+      <LeftRail
+        variant="mobile"
+        items={railItems}
+        className="lg:hidden"
+      />
+    </div>
   );
 };
 

--- a/src/pages/PracticeHomePage.tsx
+++ b/src/pages/PracticeHomePage.tsx
@@ -7,12 +7,14 @@ import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
 import { useSidebarCounts } from '@/shared/hooks/useSidebarCounts';
 import { useClientsData } from '@/shared/hooks/useClientsData';
 import { useNavigation } from '@/shared/utils/navigation';
+import { signOut } from '@/shared/utils/auth';
 import { Button } from '@/shared/ui/Button';
 import { SegmentedToggle, type SegmentedToggleOption } from '@/shared/ui/input/SegmentedToggle';
-import { PracticeSidebar } from '@/shared/ui/nav/PracticeSidebar';
-import { WorkspaceShellHeader } from '@/shared/ui/layout/WorkspaceShellHeader';
-import { AppShell } from '@/shared/ui/layout/AppShell';
-import { useCommandPalette } from '@/features/search/contexts/CommandPaletteContext';
+import { LeftRail, BrandMark, type LeftRailItem } from '@/design-system/layout';
+import { OrgSwitcherMenu } from '@/shared/ui/nav/OrgSwitcherMenu';
+import { SidebarProfileMenu } from '@/shared/ui/nav/SidebarProfileMenu';
+import { getPracticeNavConfig } from '@/shared/config/navConfig';
+import type { IconComponent } from '@/shared/ui/Icon';
 import { usePracticeBillingData } from '@/features/practice-dashboard/hooks/usePracticeBillingData';
 import { listIntakes, type IntakeListItem } from '@/features/intake/api/intakesApi';
 import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
@@ -82,8 +84,6 @@ const PracticeHomePage = () => {
     practiceSlug: urlPracticeSlug,
   });
   const { navigate } = useNavigation();
-  const [desktopCollapsed, setDesktopCollapsed] = useState(false);
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [cashflowRange, setCashflowRange] = useState<CashflowRange>('7d');
   const [setupDismissed, setSetupDismissed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
@@ -212,7 +212,6 @@ const PracticeHomePage = () => {
     return () => controller.abort();
   }, [activePracticeId]);
 
-  const sidebarUser = { name: userName, email: userEmail, image: userImage };
   const invoicesTotal = rawSidebarCounts?.invoices?.total ?? 0;
   const activeClientCount = activeClientsData.items.length;
   const billingComplete = Boolean(
@@ -263,37 +262,50 @@ const PracticeHomePage = () => {
   const hasIntakes = recentIntakes.length > 0;
   const pendingIntakeCount = rawSidebarCounts?.intakes?.pending_review ?? 0;
 
-  const renderSidebar = (forceExpanded: boolean) =>
-    practiceSlug ? (
-      <PracticeSidebar
-        practiceSlug={practiceSlug}
-        org={{
-          id: currentPractice?.id,
-          slug: currentPractice?.slug ?? practiceSlug,
-          name: orgName,
-          initial: orgInitial,
-          logoUrl: currentPractice?.logo ?? null,
-        }}
-        user={sidebarUser}
-        collapsed={desktopCollapsed}
-        forceExpanded={forceExpanded}
-        onToggleCollapsed={() => setDesktopCollapsed((v) => !v)}
-        onItemActivate={() => setMobileSidebarOpen(false)}
-        activeItemId="home"
-        workspaceSection="home"
-        counts={sidebarCounts}
-      />
-    ) : null;
+  // Build LeftRail items from the practice nav config + live sidebar counts.
+  const railItems = useMemo<LeftRailItem[]>(() => {
+    if (!practiceSlug) return [];
+    const config = getPracticeNavConfig(
+      { practiceSlug, role: null, canAccessPractice: true },
+      'home',
+    );
+    return config.rail.map((item) => ({
+      id: item.id,
+      label: item.label,
+      icon: item.icon as IconComponent,
+      href: item.href,
+      matchHrefs: item.matchHrefs,
+      badge: sidebarCounts?.[item.id] ?? item.badge ?? null,
+      variant: item.variant,
+      isAction: item.isAction,
+      onClick: item.onClick,
+      prefetch: item.prefetch,
+    }));
+  }, [practiceSlug, sidebarCounts]);
 
-  const { open: openCommandPalette } = useCommandPalette();
-  const header = (
-    <WorkspaceShellHeader
-      orgInitial={orgInitial}
-      title="Home"
-      onMenuClick={() => setMobileSidebarOpen(true)}
-      onSearchClick={() => openCommandPalette()}
+  const brandMark = currentPractice?.id && practiceSlug ? (
+    <OrgSwitcherMenu
+      org={{
+        id: currentPractice.id,
+        name: orgName,
+        initial: orgInitial,
+        subtitle: 'Practice',
+        logoUrl: currentPractice.logo ?? null,
+      }}
+      collapsed={false}
     />
+  ) : (
+    <BrandMark />
   );
+
+  const profileFooter = session?.user ? (
+    <SidebarProfileMenu
+      user={{ name: userName, email: userEmail, image: userImage }}
+      onAccount={() => practiceBasePath && navigate(`${practiceBasePath}/settings/account`)}
+      onSettings={() => practiceBasePath && navigate(`${practiceBasePath}/settings/general`)}
+      onSignOut={() => void signOut({ navigate })}
+    />
+  ) : null;
 
   const handleNewInvoice = () => {
     if (practiceBasePath) navigate(`${practiceBasePath}/invoices/new`);
@@ -536,18 +548,23 @@ const PracticeHomePage = () => {
   );
 
   return (
-    <AppShell
-      className="bg-transparent h-dvh"
-      accentBackdropVariant="none"
-      header={header}
-      sidebar={renderSidebar(false)}
-      desktopSidebarCollapsed={desktopCollapsed}
-      mobileSidebar={renderSidebar(true)}
-      mobileSidebarOpen={mobileSidebarOpen}
-      onMobileSidebarClose={() => setMobileSidebarOpen(false)}
-      main={main}
-      mainClassName="min-h-0 h-full overflow-hidden"
-    />
+    <div className="flex h-dvh flex-col lg:flex-row">
+      <LeftRail
+        variant="desktop"
+        items={railItems}
+        brandMark={brandMark}
+        footer={profileFooter}
+        className="hidden lg:flex"
+      />
+      <main className="flex-1 min-h-0 overflow-hidden order-first lg:order-none">
+        {main}
+      </main>
+      <LeftRail
+        variant="mobile"
+        items={railItems}
+        className="lg:hidden"
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
Seventh PR in the design-system migration series. Picks up where [#649](https://github.com/Blawby/blawby-ai-chatbot/pull/649) (5d.5, merged) left off. **Begins the 5e shell refactor: 3 of 4 shells migrated to LeftRail.**

## Landed (4 sub-commits)

| SHA | What |
|---|---|
| `8246f45c` | **5e.2** — ClientHomePage rewired to LeftRail. First shell migrated; establishes the pattern. AppShell dropped entirely for this shell (just a flex row of LeftRail + main). |
| `b221d125` | **5e.3** — PracticeHomePage rewired to LeftRail. Same pattern + merges live `sidebarCounts` into items.badge; OrgSwitcherMenu in brandMark slot. |
| `eda94046` | **5e.4** — WidgetApp NavRail → LeftRail mobile + MobileInspectorOverlay → FocusDrawer. Embed-mode widget surface; uses generalized FocusDrawer from 5c.2. |
| `217b33c8` | Close PR #650 scope + write detailed PR-8 handoff (WorkspacePage + ConversationListPanel + AppShell prop drop + legacy file deletions). |

## Pattern established

Each shell refactor follows the same recipe:
1. Drop `ClientSidebar` / `PracticeSidebar` / `NavRail` / `WorkspaceShellHeader` imports
2. Drop `desktopCollapsed` / `mobileSidebarOpen` state (locked decisions §5: no collapse, no top bar)
3. Import `LeftRail` + `BrandMark` from `@/design-system/layout`, `getXxxNavConfig` from `@/shared/config/navConfig`
4. `useMemo` LeftRailItem[] from `config.rail` (NavRailItem maps cleanly to LeftRailItem — just an `icon: ComponentType<unknown>` → `IconComponent` cast)
5. Compose `OrgSwitcherMenu` (or `BrandMark` fallback) in LeftRail's `brandMark` slot, `SidebarProfileMenu` in `footer` slot
6. Replace AppShell with flex row: desktop LeftRail (`hidden lg:flex`) + main + mobile LeftRail (`lg:hidden`, bottom bar)

## Still to land (PR-8 scope)

- [ ] **5e.5** — Refactor WorkspacePage (1666L; the biggest piece — its own focused session)
- [ ] **5e.6** — Extract `ConversationListPanel` (340px column per Conversations 4-column spec)
- [ ] **5e.1** — Drop AppShell sidebar props (safe once WorkspacePage migrates)
- [ ] **5e.7** — Delete legacy nav files (NavRail, Sidebar, PracticeSidebar, ClientSidebar, MobileInspectorOverlay, WorkspaceShellHeader) + 4 test files + dead CSS

The migration doc now has a detailed PR-8 plan with WorkspacePage recipe (drawing from the 3 established shell refactors), Conversations 4-column layout spec for the assistant section, and the suggested sub-commit cadence.

## Build / lint / type-check

Baseline preserved at every sub-commit:
- ✅ `npm run build` — passes
- ⚠️ `npm run lint:src` — 1 pre-existing error (`OAuthConsentPage.tsx:187`)
- ✅ `npm run type-check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)