### PR TITLE
ds: PR-12 — delete .card-surface alias (8.4a)

### DIFF
--- a/docs/design-system-commit-8-audit.md
+++ b/docs/design-system-commit-8-audit.md
@@ -198,7 +198,7 @@ Rides 8.1d.
 
 In dependency order (each can be its own PR):
 
-1. **PR-12** (this one is fast): `chore(ds): delete .card-surface alias (8.4a)` — single-file edit, zero risk.
+1. ~~**PR-12** (this one is fast): `chore(ds): delete .card-surface alias (8.4a)` — single-file edit, zero risk.~~ ✅ **landed in PR #655 (commit `99171487`)**.
 2. **PR-13**: `chore(ds): replace text-input-* family (8.1a)` — big mechanical PR, may be split further by directory.
 3. **PR-14**: `chore(ds): replace bg-surface-* + bg-accent-N + font-display + rounded-xl (8.1b/c/d combined)` — second mechanical sweep.
 4. **PR-15**: `refactor(ds): DataTable → CSS grid for 6 non-invoice tables (8.2)`.

--- a/src/index.css
+++ b/src/index.css
@@ -162,10 +162,8 @@
   }
 
 
-  /* Canonical DS card. .card-surface kept as alias for legacy callers.
-     Sweep to single .card happens in Commit 8. */
-  .card,
-  .card-surface {
+  /* Canonical DS card. */
+  .card {
     position: relative;
     background: var(--card);
     border: 1px solid var(--rule);
@@ -174,13 +172,11 @@
     box-shadow: var(--shadow-1);
   }
 
-  .card-hover,
-  .card-surface-hover {
+  .card-hover {
     transition: background 0.18s ease, box-shadow 0.18s ease;
   }
 
-  .card-hover:hover,
-  .card-surface-hover:hover {
+  .card-hover:hover {
     background: var(--paper-2);
     box-shadow: var(--shadow-2);
   }


### PR DESCRIPTION
## Summary

First sweep in the Commit 8 ladder. The `.card-surface` and `.card-surface-hover` aliases have had **zero TSX callers** for the entire post-DS-foundation era — only the definitions in `src/index.css` remained. Per the audit (`docs/design-system-commit-8-audit.md` §8.4), this slice is "safe to delete now."

Net diff: **+5 / -9** across 2 files (1 code, 1 doc).

## Commits

1. **`99171487`** — `chore(ds): delete .card-surface alias (8.4a)` — removes 4 occurrences across 3 selectors in `src/index.css`:
   ```diff
   - /* Canonical DS card. .card-surface kept as alias for legacy callers.
   -    Sweep to single .card happens in Commit 8. */
   - .card,
   - .card-surface {
   + /* Canonical DS card. */
   + .card {

   - .card-hover,
   - .card-surface-hover {
   + .card-hover {

   - .card-hover:hover,
   - .card-surface-hover:hover {
   + .card-hover:hover {
   ```

2. **`df3377d4`** — `docs(ds): mark 8.4a complete in audit ladder` — strikes through the PR-12 entry in `design-system-commit-8-audit.md`.

## Why this PR exists separately

This trivial slice ships standalone — not bundled with the bigger mechanical sweeps — for two reasons:

1. **Validates the audit → execute workflow.** Before committing to the 1446-occurrence `text-input-*` sweep or the 308-occurrence `bg-surface-*` sweep, I want a clean signal that the audit's "zero callers" claim survives merge.
2. **Zero risk, zero coordination cost.** Single file, single-purpose, can be merged behind other in-flight work without churn.

## Test plan

- [x] `grep -r "card-surface" src/` returns zero matches
- [x] `npm run build` green
- [x] `npm run type-check` 0 errors
- [x] `npm run lint:src` baseline preserved (1 pre-existing `OAuthConsentPage.tsx:187` error from staging)
- [ ] Visual smoke: no card surfaces appear differently — N/A since the deleted classes had no callers

## What's next

After this lands, PR-13 picks up the largest mechanical sweep: replacing `text-input-*` across ~244 files. Per the audit's hot-files table, 13 files account for ~400 of the 1446 occurrences — those go first.