### PR TITLE
ds: PR-13 — sweep text-input-* family across 244 files (8.1a)

### DIFF
--- a/docs/design-system-commit-8-audit.md
+++ b/docs/design-system-commit-8-audit.md
@@ -199,7 +199,7 @@ Rides 8.1d.
 In dependency order (each can be its own PR):
 
 1. ~~**PR-12** (this one is fast): `chore(ds): delete .card-surface alias (8.4a)` — single-file edit, zero risk.~~ ✅ **landed in PR #655 (commit `99171487`)**.
-2. **PR-13**: `chore(ds): replace text-input-* family (8.1a)` — big mechanical PR, may be split further by directory.
+2. ~~**PR-13**: `chore(ds): replace text-input-* family (8.1a)` — big mechanical PR.~~ ✅ **landed in PR #656 (commit `054c0cf9`).** Net +1446/-1446 across 244 files. Note: `text-input-*` was actually dead (missing from tailwind config); replacement with `text-ink` / `text-dim-2` is a real visual change. CSS bundle grew ~5 kB.
 3. **PR-14**: `chore(ds): replace bg-surface-* + bg-accent-N + font-display + rounded-xl (8.1b/c/d combined)` — second mechanical sweep.
 4. **PR-15**: `refactor(ds): DataTable → CSS grid for 6 non-invoice tables (8.2)`.
 5. **PR-16**: `refactor(ds): migrate SegmentedToggle callers to Seg; delete SegmentedToggle (8.3)`.

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -653,7 +653,7 @@ export function MainApp({
         {conversationHeaderEmail ? (
           <a
             href={`mailto:${conversationHeaderEmail}`}
-            className="inline-flex min-w-0 items-center gap-1.5 truncate hover:text-input-text"
+            className="inline-flex min-w-0 items-center gap-1.5 truncate hover:text-ink"
           >
             <Icon icon={Mail} className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{conversationHeaderEmail}</span>
@@ -662,7 +662,7 @@ export function MainApp({
         {conversationHeaderPhone ? (
           <a
             href={`tel:${conversationHeaderPhone.replace(/[^0-9+]/g, '')}`}
-            className="inline-flex min-w-0 items-center gap-1.5 truncate hover:text-input-text"
+            className="inline-flex min-w-0 items-center gap-1.5 truncate hover:text-ink"
           >
             <Icon icon={Phone} className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{conversationHeaderPhone}</span>
@@ -767,7 +767,7 @@ export function MainApp({
   const chatPanel = chatContent ?? (
     <div className="relative flex min-h-0 flex-1 flex-col">
       {shouldShowChatPlaceholder ? (
-        <div className="flex-1 flex items-center justify-center text-sm text-input-placeholder">
+        <div className="flex-1 flex items-center justify-center text-sm text-dim-2">
           {isPracticeWorkspace
             ? 'Select a conversation to view the thread.'
             : 'Open a practice link to start chatting.'}

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -534,7 +534,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
       size="icon-sm"
       onClick={requestWidgetClose}
       aria-label="Close widget"
-      className="text-input-text/60 hover:text-input-text card backdrop-blur-md border border-line-subtle shadow-lg"
+      className="text-ink/60 hover:text-ink card backdrop-blur-md border border-line-subtle shadow-lg"
     >
       <Icon icon={X} className="h-5 w-5" />
     </Button>

--- a/src/features/chat/components/AIThinkingIndicator.tsx
+++ b/src/features/chat/components/AIThinkingIndicator.tsx
@@ -91,7 +91,7 @@ export function AIThinkingIndicator({
         aria-atomic="true"
       >
         <span className="ai-thinking-indicator__dot" aria-hidden="true" />
-        <span className="text-xs text-input-placeholder">{displayMessage}…</span>
+        <span className="text-xs text-dim-2">{displayMessage}…</span>
       </div>
     );
   }
@@ -108,10 +108,10 @@ export function AIThinkingIndicator({
         <button
           type="button"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-1.5 text-[11px] font-medium text-input-placeholder hover:text-accent-foreground transition-colors outline-none cursor-pointer"
+          className="flex items-center gap-1.5 text-[11px] font-medium text-dim-2 hover:text-accent-foreground transition-colors outline-none cursor-pointer"
           aria-expanded={isExpanded}
         >
-          <Icon icon={Wrench} className="h-3 w-3 text-input-placeholder" />
+          <Icon icon={Wrench} className="h-3 w-3 text-dim-2" />
           <span>{summaryLabel}</span>
           <Icon icon={isExpanded ? ChevronDown : ChevronRight} className="h-3 w-3" />
         </button>
@@ -154,7 +154,7 @@ function ToolProgressRow({
   };
 }) {
   let statusIcon = AlertCircle;
-  let iconClass = 'text-input-placeholder';
+  let iconClass = 'text-dim-2';
   
   if (tool.status === 'completed') {
     statusIcon = Check;
@@ -167,13 +167,13 @@ function ToolProgressRow({
     iconClass = 'text-accent-500 animate-spin';
   } else if (tool.status === 'queued') {
     statusIcon = Loader2;
-    iconClass = 'text-input-placeholder animate-pulse';
+    iconClass = 'text-dim-2 animate-pulse';
   }
 
   return (
     <div className="flex items-center gap-2 text-xs py-0.5" key={tool.toolUseId}>
       <Icon icon={statusIcon} className={`h-3.5 w-3.5 ${iconClass}`} />
-      <span className={tool.status === 'completed' ? 'text-input-placeholder' : 'text-input-text'}>
+      <span className={tool.status === 'completed' ? 'text-dim-2' : 'text-ink'}>
         {tool.label}
       </span>
     </div>

--- a/src/features/chat/components/ChatActionCard.tsx
+++ b/src/features/chat/components/ChatActionCard.tsx
@@ -103,7 +103,7 @@ export const ChatActionCard: FunctionComponent<ChatActionCardProps> = ({
         title={t('chat.card.disclaimer.title')}
         description={disclaimerProps.subtitle || t('chat.card.disclaimer.description')}
       >
-        <div className="max-h-[45vh] overflow-y-auto whitespace-pre-wrap text-sm leading-6 text-input-text">
+        <div className="max-h-[45vh] overflow-y-auto whitespace-pre-wrap text-sm leading-6 text-ink">
           {disclaimerProps.text}
         </div>
         <Button
@@ -140,7 +140,7 @@ export const ChatActionCard: FunctionComponent<ChatActionCardProps> = ({
             />
           </Suspense>
         ) : (
-          <div className="p-4 text-center text-sm text-input-text">
+          <div className="p-4 text-center text-sm text-ink">
             {t('common:chat.paymentDetailsMissing', 'Payment details missing or unavailable.')}
           </div>
         )}

--- a/src/features/chat/components/ChatContainer.tsx
+++ b/src/features/chat/components/ChatContainer.tsx
@@ -582,7 +582,7 @@ const ChatContainer: FunctionComponent<ChatContainerProps> = ({
           >
             {isReconnecting ? (
               <div
-                className="mx-auto flex w-full max-w-3xl items-center gap-2 px-4 py-2 text-xs text-input-placeholder"
+                className="mx-auto flex w-full max-w-3xl items-center gap-2 px-4 py-2 text-xs text-dim-2"
                 role="status"
                 aria-live="polite"
               >

--- a/src/features/chat/components/ChatDockedAction.tsx
+++ b/src/features/chat/components/ChatDockedAction.tsx
@@ -31,7 +31,7 @@ export const ChatDockedAction: FunctionComponent<ChatDockedActionProps> = ({
   return (
     <div
       className={cn(
-        'ui-surface-enter mx-2 mb-4 overflow-hidden shadow-glass card p-6 text-input-text border-none',
+        'ui-surface-enter mx-2 mb-4 overflow-hidden shadow-glass card p-6 text-ink border-none',
         containerClassName
       )}
     >
@@ -39,12 +39,12 @@ export const ChatDockedAction: FunctionComponent<ChatDockedActionProps> = ({
         <div className="mb-4 flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             {title && (
-              <h3 className="truncate text-lg font-bold leading-tight text-input-text">
+              <h3 className="truncate text-lg font-bold leading-tight text-ink">
                 {title}
               </h3>
             )}
             {description && (
-              <p className="mt-1 text-sm text-input-placeholder">
+              <p className="mt-1 text-sm text-dim-2">
                 {description}
               </p>
             )}
@@ -55,7 +55,7 @@ export const ChatDockedAction: FunctionComponent<ChatDockedActionProps> = ({
               size="icon-sm"
               onClick={onClose}
               aria-label="Dismiss"
-              className="shrink-0 text-input-placeholder hover:bg-surface-hover hover:text-input-text"
+              className="shrink-0 text-dim-2 hover:bg-surface-hover hover:text-ink"
             >
               <Icon icon={X} className="h-5 w-5" />
             </Button>

--- a/src/features/chat/components/ConversationContextPanel.tsx
+++ b/src/features/chat/components/ConversationContextPanel.tsx
@@ -14,7 +14,7 @@ import {
 import type { Conversation } from '@/shared/types/conversation';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 
-const sectionTitle = 'text-[11px] font-semibold uppercase tracking-[0.08em] text-input-placeholder';
+const sectionTitle = 'text-[11px] font-semibold uppercase tracking-[0.08em] text-dim-2';
 const sectionDivider = 'border-t border-line-subtle pt-4 mt-4';
 
 interface ActivityEntry {
@@ -66,8 +66,8 @@ const STATUS_TONE: Record<string, string> = {
   discovery: 'text-emerald-400',
   consultation_scheduled: 'text-amber-300',
   intake_pending: 'text-amber-300',
-  closed: 'text-input-placeholder',
-  declined: 'text-input-placeholder',
+  closed: 'text-dim-2',
+  declined: 'text-dim-2',
 };
 
 const formatStatusLabel = (status: string | null | undefined): string => {
@@ -174,7 +174,7 @@ const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps>
 
   const activity = useMemo(() => buildActivityEntries(conversation), [conversation]);
 
-  const statusToneClass = STATUS_TONE[matterStatus] ?? 'text-input-text';
+  const statusToneClass = STATUS_TONE[matterStatus] ?? 'text-ink';
   const statusLabel = formatStatusLabel(matterStatus);
 
   const lastActiveLabel = conversation?.last_message_at
@@ -193,9 +193,9 @@ const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps>
       <div className="flex flex-col items-center gap-3 pb-4 text-center">
         <Avatar src={null} name={contactName || (practiceName ?? 'Contact')} size="lg" />
         <div className="min-w-0">
-          <p className="truncate text-base font-semibold text-input-text">{contactName || '—'}</p>
+          <p className="truncate text-base font-semibold text-ink">{contactName || '—'}</p>
           {lastActiveLabel ? (
-            <p className="mt-0.5 text-xs text-input-placeholder">
+            <p className="mt-0.5 text-xs text-dim-2">
               {t('workspace.conversationContext.lastActive', {
                 defaultValue: 'Active {{relative}}',
                 relative: lastActiveLabel,
@@ -224,7 +224,7 @@ const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps>
               onOpenMatter && matter ? (
                 <button
                   type="button"
-                  className="inline-flex items-center gap-1 text-right text-input-text hover:text-accent-utility focus:outline-none focus-visible:underline"
+                  className="inline-flex items-center gap-1 text-right text-ink hover:text-accent-utility focus:outline-none focus-visible:underline"
                   onClick={() => onOpenMatter(matter.id)}
                 >
                   <span className="truncate">{matterTitle}</span>
@@ -260,7 +260,7 @@ const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps>
           {t('workspace.conversationContext.recentActivity', { defaultValue: 'Recent Activity' })}
         </h3>
         {activity.length === 0 ? (
-          <p className="text-xs text-input-placeholder">
+          <p className="text-xs text-dim-2">
             {t('workspace.conversationContext.noActivity', {
               defaultValue: 'Activity will appear here once the conversation progresses.',
             })}
@@ -270,13 +270,13 @@ const ConversationContextPanel: FunctionComponent<ConversationContextPanelProps>
             {activity.map((entry) => (
               <li key={entry.id} className="flex items-start justify-between gap-3 text-sm">
                 <div className="min-w-0">
-                  <p className="font-medium text-input-text">{entry.title}</p>
+                  <p className="font-medium text-ink">{entry.title}</p>
                   {entry.detail ? (
-                    <p className="mt-0.5 truncate text-xs text-input-placeholder">{entry.detail}</p>
+                    <p className="mt-0.5 truncate text-xs text-dim-2">{entry.detail}</p>
                   ) : null}
                 </div>
                 {entry.timestamp ? (
-                  <span className="flex-shrink-0 text-xs text-input-placeholder">
+                  <span className="flex-shrink-0 text-xs text-dim-2">
                     {formatActivityDate(entry.timestamp)}
                   </span>
                 ) : null}

--- a/src/features/chat/components/ConversationEventRow.tsx
+++ b/src/features/chat/components/ConversationEventRow.tsx
@@ -10,9 +10,9 @@ const ConversationEventRow: FunctionComponent<ConversationEventRowProps> = ({
   className = '',
 }) => (
   <div className={`px-4 py-3 ${className}`.trim()}>
-    <div className="flex items-center gap-3 text-input-placeholder">
+    <div className="flex items-center gap-3 text-dim-2">
       <div className="h-px flex-1 bg-line-glass/30" />
-      <p className="max-w-full shrink text-center text-xs font-medium tracking-wide text-input-placeholder">
+      <p className="max-w-full shrink text-center text-xs font-medium tracking-wide text-dim-2">
         {content}
       </p>
       <div className="h-px flex-1 bg-line-glass/30" />

--- a/src/features/chat/components/DraftConversationView.tsx
+++ b/src/features/chat/components/DraftConversationView.tsx
@@ -160,10 +160,10 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
               : undefined}
           />
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="text-xs uppercase tracking-wide text-input-placeholder">
+            <span className="text-xs uppercase tracking-wide text-dim-2">
               New conversation
             </span>
-            <span className="truncate text-sm font-semibold text-input-text">
+            <span className="truncate text-sm font-semibold text-ink">
               {displayName ?? 'Pick a contact below to begin'}
             </span>
           </div>
@@ -180,7 +180,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
       </header>
 
       <div className="border-b border-line-subtle px-4 py-3 sm:px-6">
-        <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.08em] text-input-placeholder">
+        <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.08em] text-dim-2">
           To
         </span>
         <Combobox
@@ -219,7 +219,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
               }}
               className={cn(
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm',
-                'text-input-text hover:bg-surface-utility/10 focus-visible:bg-surface-utility/10',
+                'text-ink hover:bg-surface-utility/10 focus-visible:bg-surface-utility/10',
               )}
             >
               <span className="text-accent-utility">+ Invite a new contact</span>
@@ -230,7 +230,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
 
       <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">
         <div className="max-w-sm text-center">
-          <p className="text-sm text-input-text">
+          <p className="text-sm text-ink">
             {isPracticeAssistant
               ? 'What would you like to work on?'
               : draftContact?.kind === 'user'
@@ -238,7 +238,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
                 : 'Pick a contact above, then write the first message.'}
           </p>
           {!isPracticeAssistant ? (
-            <p className="mt-1 text-xs text-input-placeholder">
+            <p className="mt-1 text-xs text-dim-2">
               The conversation is created when you send the first message.
             </p>
           ) : null}

--- a/src/features/chat/components/HumanTypingIndicator.tsx
+++ b/src/features/chat/components/HumanTypingIndicator.tsx
@@ -35,7 +35,7 @@ export const HumanTypingIndicator = ({
     >
       <MessageAvatar src={lead.image ?? null} name={lead.name} size="xs" />
       <span className="human-typing-indicator__dot" aria-hidden="true" />
-      <span className="text-xs text-input-placeholder">{label}…</span>
+      <span className="text-xs text-dim-2">{label}…</span>
     </div>
   );
 };

--- a/src/features/chat/components/Message.tsx
+++ b/src/features/chat/components/Message.tsx
@@ -276,8 +276,8 @@ const Message: FunctionComponent<MessageProps> = memo(({
 					<button
 						type="button"
 												className={onReplyPreviewClick
-													? 'relative flex min-w-0 items-center gap-2 pl-7 text-left text-xs text-input-placeholder cursor-pointer transition hover:text-accent-foreground'
-													: 'relative flex min-w-0 items-center gap-2 pl-7 text-left text-xs text-input-placeholder cursor-default pointer-events-none'
+													? 'relative flex min-w-0 items-center gap-2 pl-7 text-left text-xs text-dim-2 cursor-pointer transition hover:text-accent-foreground'
+													: 'relative flex min-w-0 items-center gap-2 pl-7 text-left text-xs text-dim-2 cursor-default pointer-events-none'
 												}
 						onClick={onReplyPreviewClick}
 						disabled={!onReplyPreviewClick}
@@ -293,7 +293,7 @@ const Message: FunctionComponent<MessageProps> = memo(({
 							/>
 						)}
 						<span className="font-semibold text-accent-foreground">{replyPreview.authorName}</span>
-						<span className="truncate text-input-placeholder">
+						<span className="truncate text-dim-2">
 							{replyPreview.isMissing ? 'Original message unavailable' : replyPreview.content}
 						</span>
 					</button>

--- a/src/features/chat/components/MessageActions.tsx
+++ b/src/features/chat/components/MessageActions.tsx
@@ -415,13 +415,13 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 				<div className="my-2">
 					<div className="flex items-center gap-2 p-3 rounded-xl panel">
 						<div className="w-8 h-8 rounded bg-surface-utility/60 dark:bg-surface-utility/10 flex items-center justify-center flex-shrink-0">
-							<Icon icon={FileIcon} className="w-4 h-4 text-input-text"  />
+							<Icon icon={FileIcon} className="w-4 h-4 text-ink"  />
 						</div>
 						<div className="flex-1 min-w-0">
-							<div className="text-sm font-medium text-input-text whitespace-nowrap overflow-hidden text-ellipsis" title={generatedPDF.filename}>
+							<div className="text-sm font-medium text-ink whitespace-nowrap overflow-hidden text-ellipsis" title={generatedPDF.filename}>
 								{generatedPDF.filename.length > 25 ? `${generatedPDF.filename.substring(0, 25)}...` : generatedPDF.filename}
 							</div>
-							<div className="flex items-center gap-2 text-xs text-input-placeholder">
+							<div className="flex items-center gap-2 text-xs text-dim-2">
 								<span>{formatDocumentIconSize(generatedPDF.size)}</span>
 								{generatedPDF.generatedAt && (
 									<span>• {new Date(generatedPDF.generatedAt).toLocaleDateString()}</span>

--- a/src/features/chat/components/MessageAttachments.tsx
+++ b/src/features/chat/components/MessageAttachments.tsx
@@ -115,10 +115,10 @@ const DocumentAttachment: FunctionComponent<DocumentAttachmentProps> = ({ file, 
         {getDocumentIcon(file)}
       </div>
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-input-text whitespace-nowrap overflow-hidden text-ellipsis" title={file.name}>
+        <div className="text-sm font-medium text-ink whitespace-nowrap overflow-hidden text-ellipsis" title={file.name}>
           {file.name.length > 25 ? `${file.name.substring(0, 25)}...` : file.name}
         </div>
-        <div className="text-xs text-input-placeholder">{formatDocumentIconSize(file.size)}</div>
+        <div className="text-xs text-dim-2">{formatDocumentIconSize(file.size)}</div>
       </div>
     </div>
   );

--- a/src/features/chat/components/MessageBubble.tsx
+++ b/src/features/chat/components/MessageBubble.tsx
@@ -37,7 +37,7 @@ export const MessageBubble: FunctionComponent<MessageBubbleProps> = ({
 		variantClasses[variant],
 		messageLayoutClasses,
 		mediaOnlyClasses,
-		'text-input-text',
+		'text-ink',
 		className
 	].filter(Boolean).join(' ');
 

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -319,7 +319,7 @@ const MessageComposer = ({
   const canShowAttachmentMenu = !hideAttachmentControls && !isPublicWorkspace && !isRecording && !isComposerDisabled && Boolean(isReadyToUpload);
   const canShowAudioRecording = features.enableAudioRecording && !isPublicWorkspace && !isComposerDisabled;
 
-  const textareaClasses = "w-full min-h-8 py-2 m-0 text-sm sm:text-base leading-[1.45] text-input-text bg-transparent border-none resize-none outline-none overflow-hidden box-border placeholder:text-input-placeholder transition-all duration-200";
+  const textareaClasses = "w-full min-h-8 py-2 m-0 text-sm sm:text-base leading-[1.45] text-ink bg-transparent border-none resize-none outline-none overflow-hidden box-border placeholder:text-dim-2 transition-all duration-200";
 
   return (
     <div className="px-4 pt-3 pb-3 bg-transparent rounded-none border-0 h-auto flex flex-col w-full">
@@ -343,9 +343,9 @@ const MessageComposer = ({
         )}
         <div className="message-composer-container">
           {replyTo && (
-            <div className="flex items-center justify-between gap-3 rounded-t-2xl bg-surface-utility/40 dark:bg-surface-utility/20 px-4 py-1.5 text-sm text-input-text -mx-2 -mt-1">
+            <div className="flex items-center justify-between gap-3 rounded-t-2xl bg-surface-utility/40 dark:bg-surface-utility/20 px-4 py-1.5 text-sm text-ink -mx-2 -mt-1">
               <div className="flex min-w-0 items-center gap-2">
-                <span className="text-input-text/70">
+                <span className="text-ink/70">
                   <Trans
                     i18nKey="chat.replyingTo"
                     values={{ name: replyTo.authorName }}
@@ -496,7 +496,7 @@ const MessageComposer = ({
                         className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
                           index === mentionFocusIndex
                             ? 'bg-accent-500/15 text-[rgb(var(--accent-foreground))]'
-                            : 'text-input-text hover:bg-surface-utility/40'
+                            : 'text-ink hover:bg-surface-utility/40'
                         }`}
                       >
                         <span className="truncate">{candidate.name}</span>

--- a/src/features/chat/components/MessageContent.tsx
+++ b/src/features/chat/components/MessageContent.tsx
@@ -80,7 +80,7 @@ export const MessageContent: FunctionComponent<MessageContentProps> = ({
   // bottom-left corner. Padding & radius mirror the design components.
   const bubbleClassName = isUser
     ? 'inline-block max-w-full rounded-2xl rounded-br-[4px] bg-accent-500 px-[14px] py-[10px] text-[rgb(var(--accent-foreground))] shadow-sm'
-    : 'inline-block max-w-full rounded-2xl rounded-bl-[4px] bg-[rgb(var(--surface-card-hover))] px-[14px] py-[10px] text-input-text';
+    : 'inline-block max-w-full rounded-2xl rounded-bl-[4px] bg-[rgb(var(--surface-card-hover))] px-[14px] py-[10px] text-ink';
 
   // The outer wrapper is a flex row so the inline-block bubble follows the
   // sender alignment even when the column it sits in (MessageBubble) is wider

--- a/src/features/chat/components/MessagesListPanel.tsx
+++ b/src/features/chat/components/MessagesListPanel.tsx
@@ -91,7 +91,7 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
     <div className="flex h-full min-h-0 flex-col bg-transparent">
       <header className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-base font-semibold text-input-text">
+          <h2 className="text-base font-semibold text-ink">
             {t('workspace.conversationList.title', { defaultValue: 'Messages' })}
           </h2>
           <span
@@ -158,14 +158,14 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
             />
             <div className="min-w-0 flex-1">
               <div className="flex items-start justify-between gap-3">
-                <span className="block truncate text-sm font-semibold text-input-text">
+                <span className="block truncate text-sm font-semibold text-ink">
                   {draftEntry.contactName ?? t('workspace.conversationList.draftPlaceholder', { defaultValue: 'New conversation' })}
                 </span>
                 <span className="rounded-full bg-accent-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent-utility">
                   {t('workspace.conversationList.draftBadge', { defaultValue: 'Draft' })}
                 </span>
               </div>
-              <div className="mt-0.5 truncate text-xs text-input-placeholder">
+              <div className="mt-0.5 truncate text-xs text-dim-2">
                 {draftEntry.contactEmail ?? t('workspace.conversationList.draftHint', { defaultValue: 'Pick a contact and send the first message' })}
               </div>
             </div>

--- a/src/features/chat/components/WorkspaceHomeSection.tsx
+++ b/src/features/chat/components/WorkspaceHomeSection.tsx
@@ -84,7 +84,7 @@ export const WorkspaceHomeSection: FunctionComponent<WorkspaceHomeSectionProps> 
         />
         {practiceBillingError ? (
           <div className="border-b border-line-subtle" role="alert">
-            <div className="mx-auto max-w-7xl px-4 py-3 text-sm text-input-text sm:px-6 lg:px-8">
+            <div className="mx-auto max-w-7xl px-4 py-3 text-sm text-ink sm:px-6 lg:px-8">
               {practiceBillingError}
             </div>
           </div>

--- a/src/features/chat/components/WorkspaceSetupSection.tsx
+++ b/src/features/chat/components/WorkspaceSetupSection.tsx
@@ -367,15 +367,15 @@ export const WorkspaceSetupSection: FunctionComponent<WorkspaceSetupSectionProps
       <div className="relative flex w-full flex-col bg-transparent lg:min-h-0 lg:flex-1 lg:basis-1/2 lg:overflow-hidden">
         <div className="relative z-10 flex min-h-0 flex-1 flex-col lg:overflow-y-auto">
           <Page className="w-full flex-1">
-            <div className="flex h-full min-h-0 flex-col gap-6 text-input-text">
+            <div className="flex h-full min-h-0 flex-col gap-6 text-ink">
               <header className="space-y-2">
-                <p className="text-[10px] font-bold uppercase tracking-[0.45em] text-input-placeholder">
+                <p className="text-[10px] font-bold uppercase tracking-[0.45em] text-dim-2">
                   {setupStatus.needsSetup ? "Let's get started" : 'Practice setup'}
                 </p>
                 <h2 className="text-3xl font-bold tracking-tight">
                   {setupStatus.needsSetup ? 'Almost ready to go' : 'All set'}
                 </h2>
-                {statusText ? <p className="text-xs text-input-placeholder">{statusText}</p> : null}
+                {statusText ? <p className="text-xs text-dim-2">{statusText}</p> : null}
               </header>
 
               <div className="min-h-[500px] lg:min-h-0 lg:flex-1">
@@ -442,7 +442,7 @@ export const WorkspaceSetupSection: FunctionComponent<WorkspaceSetupSectionProps
       <div className="relative flex w-full flex-col items-center gap-5 border-t border-line-subtle bg-transparent px-4 py-6 lg:min-h-0 lg:flex-1 lg:basis-1/2 lg:border-t-0 lg:border-l lg:border-l-line-glass/30">
         <div className="relative flex w-full flex-col items-center gap-5">
           <div className="flex flex-col items-center gap-2">
-            <div className="text-xs font-semibold uppercase tracking-[0.35em] text-input-placeholder">
+            <div className="text-xs font-semibold uppercase tracking-[0.35em] text-dim-2">
               {showSidebarPreview ? t('preview.publicPreview', { defaultValue: 'Public preview' }) : t('preview.setupProgress', { defaultValue: 'Setup progress' })}
             </div>
             {!showSidebarPreview ? (

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -1146,10 +1146,10 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     [mattersStatusFilter, workspacePrefetchData, toggleDetailInspector, detailInspectorOpen, desktopCreate] as const,
     <div className="flex flex-1 flex-col card">
       <div className="mx-6 my-6 panel p-5">
-        <div className="text-sm text-input-placeholder">
+        <div className="text-sm text-dim-2">
           Your active matters will appear here once a practice connects them to your account.
         </div>
-        <div className="mt-2 text-sm text-input-placeholder">
+        <div className="mt-2 text-sm text-dim-2">
           Start a conversation to open a new matter with the practice.
         </div>
       </div>
@@ -1162,7 +1162,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     [contactsStatusFilter, workspacePrefetchData, toggleDetailInspector, detailInspectorOpen, desktopCreate] as const,
     <div className="flex flex-1 flex-col card">
       <div className="mx-6 my-6 panel p-5">
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           Manage contacts and relationship statuses here.
         </p>
       </div>
@@ -1173,7 +1173,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     [invoicesStatusFilter, toggleDetailInspector, detailInspectorOpen, desktopCreate] as const,
     <div className="flex flex-1 flex-col card">
       <div className="mx-6 my-6 panel p-5">
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           Invoice details and payments will appear here.
         </p>
       </div>
@@ -1517,7 +1517,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
         description="This permanently removes the conversation, its messages, reactions, and audit history. This action cannot be undone."
       >
         <div className="flex flex-col gap-4 px-6 pb-6">
-          <p className="text-sm text-input-text">
+          <p className="text-sm text-ink">
             Are you sure you want to delete{' '}
             <span className="font-semibold">
               {conversationPendingDelete

--- a/src/features/chat/styles/chatTypography.ts
+++ b/src/features/chat/styles/chatTypography.ts
@@ -1,12 +1,12 @@
-const conversationName = 'text-xs font-semibold text-input-text';
-const conversationMetaTime = 'text-xs font-normal text-input-placeholder';
+const conversationName = 'text-xs font-semibold text-ink';
+const conversationMetaTime = 'text-xs font-normal text-dim-2';
 
 export const chatTypography = {
   conversationName,
   conversationMetaTime,
   headerName: conversationName,
   headerTime: conversationMetaTime,
-  messageBody: 'text-sm leading-5 text-input-text',
-  previewBody: 'text-sm leading-5 text-input-text',
+  messageBody: 'text-sm leading-5 text-ink',
+  previewBody: 'text-sm leading-5 text-ink',
   previewName: conversationName,
 };

--- a/src/features/chat/utils/fileUtils.tsx
+++ b/src/features/chat/utils/fileUtils.tsx
@@ -21,7 +21,7 @@ export const getDocumentIcon = (file: FileAttachment): VNode => {
 	// PDF icon
 	if (file.type === 'application/pdf' || ext === 'pdf') {
 		return (
-			<Icon icon={File} className="w-4 h-4 text-input-placeholder"  />
+			<Icon icon={File} className="w-4 h-4 text-dim-2"  />
 		);
 	}
 
@@ -30,7 +30,7 @@ export const getDocumentIcon = (file: FileAttachment): VNode => {
 		file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
 		ext === 'doc' || ext === 'docx') {
 		return (
-			<Icon icon={File} className="w-4 h-4 text-input-placeholder"  />
+			<Icon icon={File} className="w-4 h-4 text-dim-2"  />
 		);
 	}
 
@@ -39,27 +39,27 @@ export const getDocumentIcon = (file: FileAttachment): VNode => {
 		file.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
 		ext === 'xls' || ext === 'xlsx' || ext === 'csv') {
 		return (
-			<Icon icon={Table} className="w-4 h-4 text-input-placeholder"  />
+			<Icon icon={Table} className="w-4 h-4 text-dim-2"  />
 		);
 	}
 
 	// Audio file icon
 	if (file.type?.startsWith('audio/')) {
 		return (
-			<Icon icon={Music} className="w-4 h-4 text-input-placeholder"  />
+			<Icon icon={Music} className="w-4 h-4 text-dim-2"  />
 		);
 	}
 
 	// Video file icon
 	if (file.type?.startsWith('video/')) {
 		return (
-			<Icon icon={Video} className="w-4 h-4 text-input-placeholder"  />
+			<Icon icon={Video} className="w-4 h-4 text-dim-2"  />
 		);
 	}
 
 	// Default file icon
 	return (
-		<Icon icon={File} className="w-4 h-4 text-input-placeholder"  />
+		<Icon icon={File} className="w-4 h-4 text-dim-2"  />
 	);
 };
 

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -64,11 +64,11 @@ const ConversationListEmptyState = ({
       <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-subtle">
         <Icon
           icon={MessageSquare}
-          className="h-6 w-6 text-input-placeholder"
+          className="h-6 w-6 text-dim-2"
         />
       </div>
-      <p className="text-sm font-medium text-input-text">{title}</p>
-      <p className="text-xs leading-5 text-input-placeholder">{hint}</p>
+      <p className="text-sm font-medium text-ink">{title}</p>
+      <p className="text-xs leading-5 text-dim-2">{hint}</p>
     </div>
   </div>
 );
@@ -124,7 +124,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
             <span className={cn(
               'block truncate',
               chatTypography.previewName,
-              isUnread ? 'font-bold text-accent-utility' : 'text-input-text'
+              isUnread ? 'font-bold text-accent-utility' : 'text-ink'
             )}>
               {title}
             </span>
@@ -140,7 +140,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
             {timeLabel && (
               <span className={cn(
                 chatTypography.headerTime,
-                isUnread ? 'font-medium text-accent-utility/75' : 'text-input-placeholder'
+                isUnread ? 'font-medium text-accent-utility/75' : 'text-dim-2'
               )}>{timeLabel}</span>
             )}
           </div>
@@ -155,7 +155,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
             'mt-0.5 truncate text-xs leading-5',
             isUnread
               ? 'font-semibold text-accent-utility/85'
-              : 'text-input-placeholder'
+              : 'text-dim-2'
           )}>
             <ChatText text={previewText} className="truncate" />
           </div>

--- a/src/features/chat/views/WidgetConversationListView.tsx
+++ b/src/features/chat/views/WidgetConversationListView.tsx
@@ -51,11 +51,11 @@ const WidgetConversationListEmptyState = ({
       <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-subtle">
         <Icon
           icon={MessageSquare}
-          className="h-6 w-6 text-input-placeholder"
+          className="h-6 w-6 text-dim-2"
         />
       </div>
-      <p className="text-sm font-medium text-input-text">{title}</p>
-      <p className="text-xs leading-5 text-input-placeholder">{hint}</p>
+      <p className="text-sm font-medium text-ink">{title}</p>
+      <p className="text-xs leading-5 text-dim-2">{hint}</p>
     </div>
   </div>
 );
@@ -171,7 +171,7 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
                         <span className={cn(
                           'block truncate',
                           chatTypography.previewName,
-                          isUnread && 'font-bold text-input-text'
+                          isUnread && 'font-bold text-ink'
                         )}>
                           {title}
                         </span>
@@ -202,7 +202,7 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
                     ) : (
                       <div className={cn(
                         'truncate text-sm',
-                        isUnread ? 'font-semibold text-input-text' : 'text-input-placeholder'
+                        isUnread ? 'font-semibold text-ink' : 'text-dim-2'
                       )}>
                         <ChatText text={previewText} className="truncate" />
                       </div>

--- a/src/features/chat/views/WorkspaceHomeView.tsx
+++ b/src/features/chat/views/WorkspaceHomeView.tsx
@@ -60,7 +60,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
 
   return (
     <div className="relative flex flex-1 flex-col rounded-none border-0 bg-transparent shadow-none">
-      <section className="relative z-10 px-6 pb-12 pt-8 text-input-text">
+      <section className="relative z-10 px-6 pb-12 pt-8 text-ink">
         <div className="flex items-center gap-3">
           <Avatar
             src={practiceLogo}
@@ -68,7 +68,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
             size="lg"
             className="ring-2 ring-[rgb(var(--line-glass)/0.24)]"
           />
-          <div className="text-lg font-semibold tracking-wide text-input-text">{resolvedName}</div>
+          <div className="text-lg font-semibold tracking-wide text-ink">{resolvedName}</div>
         </div>
 
         <div className="mt-20 mb-8 space-y-1 text-3xl font-semibold leading-tight">
@@ -86,7 +86,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
             className="card px-5 py-5 text-left transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
             aria-label={t('workspace.home.recentMessage')}
           >
-            <div className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">
+            <div className="text-xs font-semibold uppercase tracking-wide text-dim-2">
               {t('workspace.home.recentMessage')}
             </div>
             <div className="mt-3 flex items-center gap-3">
@@ -105,7 +105,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
                     </span>
                   )}
                 </div>
-                <div className="mt-1 truncate text-sm text-input-text">
+                <div className="mt-1 truncate text-sm text-ink">
                   {recentMessage.preview}
                 </div>
               </div>
@@ -117,7 +117,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
           type="button"
           onClick={onSendMessage}
           disabled={!canSendMessage}
-          className="card flex w-full items-center justify-between px-6 py-5 text-left text-input-text transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+          className="card flex w-full items-center justify-between px-6 py-5 text-left text-ink transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
           aria-label={t('workspace.home.sendMessage')}
         >
           <span className="text-lg font-bold tracking-tight">{t('workspace.home.sendMessage')}</span>
@@ -131,8 +131,8 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
 
         {showConsultationCard && (
           <div className="card px-5 py-6">
-            <h3 className="text-base font-semibold text-input-text">{resolvedConsultationTitle}</h3>
-            <p className="mt-2 text-sm text-input-placeholder">
+            <h3 className="text-base font-semibold text-ink">{resolvedConsultationTitle}</h3>
+            <p className="mt-2 text-sm text-dim-2">
               {resolvedConsultationDescription}
             </p>
             <div className="mt-4">
@@ -147,7 +147,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
                 {resolvedConsultationCta}
               </Button>
             </div>
-            <div className="mt-4 text-center text-xs font-medium text-input-placeholder">
+            <div className="mt-4 text-center text-xs font-medium text-dim-2">
               {t('workspace.home.poweredBy')} {poweredByLink}
             </div>
           </div>

--- a/src/features/client-dashboard/ClientDashboard.tsx
+++ b/src/features/client-dashboard/ClientDashboard.tsx
@@ -47,7 +47,7 @@ export const ClientDashboard = ({
       />
       {error ? (
         <div className="border-b border-line-subtle" role="alert">
-          <div className="mx-auto max-w-7xl px-4 py-3 text-sm text-input-text sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-7xl px-4 py-3 text-sm text-ink sm:px-6 lg:px-8">
             {error}
           </div>
         </div>

--- a/src/features/client-dashboard/components/ClientActionRequiredWidget.tsx
+++ b/src/features/client-dashboard/components/ClientActionRequiredWidget.tsx
@@ -35,8 +35,8 @@ export const ClientActionRequiredWidget = ({
 }: ClientActionRequiredWidgetProps) => (
   <Panel className="flex h-full flex-col">
     <header className="border-b border-line-subtle px-5 py-4">
-      <p className="text-sm font-semibold text-input-text">Action required</p>
-      <p className="text-xs text-input-placeholder">Things waiting on you</p>
+      <p className="text-sm font-semibold text-ink">Action required</p>
+      <p className="text-xs text-dim-2">Things waiting on you</p>
     </header>
     <div className="flex-1 overflow-y-auto px-5 py-4">
       {loading ? (
@@ -44,11 +44,11 @@ export const ClientActionRequiredWidget = ({
           <LoadingSpinner size="md" />
         </div>
       ) : error ? (
-        <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-input-text">
+        <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : items.length === 0 ? (
-        <p className="text-sm text-input-placeholder">You&apos;re all caught up. No actions waiting on you right now.</p>
+        <p className="text-sm text-dim-2">You&apos;re all caught up. No actions waiting on you right now.</p>
       ) : (
         <div className="space-y-3">
           {items.map((item) => {
@@ -64,12 +64,12 @@ export const ClientActionRequiredWidget = ({
                         aria-hidden
                       />
                       <div className="min-w-0">
-                        <p className="truncate font-semibold text-input-text">{item.title}</p>
+                        <p className="truncate font-semibold text-ink">{item.title}</p>
                         {item.subtitle ? (
-                          <p className="truncate text-xs text-input-placeholder">{item.subtitle}</p>
+                          <p className="truncate text-xs text-dim-2">{item.subtitle}</p>
                         ) : null}
                         {item.amount != null && item.amount > 0 ? (
-                          <p className="mt-1 text-sm font-semibold text-input-text">
+                          <p className="mt-1 text-sm font-semibold text-ink">
                             {formatCurrency(item.amount)}
                           </p>
                         ) : null}

--- a/src/features/client-dashboard/components/ClientDashboardHero.tsx
+++ b/src/features/client-dashboard/components/ClientDashboardHero.tsx
@@ -11,7 +11,7 @@ const toneClass: Record<NonNullable<ClientDashboardStat['tone']>, string> = {
   positive: 'text-emerald-300',
   negative: 'text-rose-300',
   attention: 'text-amber-300',
-  neutral: 'text-input-placeholder',
+  neutral: 'text-dim-2',
 };
 
 type ClientDashboardHeroProps = {
@@ -40,8 +40,8 @@ export const ClientDashboardHero = ({
           className="ring-2 ring-line-subtle"
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-xs font-semibold uppercase tracking-[0.16em] text-input-placeholder">Your account</p>
-          <h1 className="truncate text-base font-semibold text-input-text">{name || 'Your account'}</h1>
+          <p className="truncate text-xs font-semibold uppercase tracking-[0.16em] text-dim-2">Your account</p>
+          <h1 className="truncate text-base font-semibold text-ink">{name || 'Your account'}</h1>
         </div>
         <div className="ml-auto shrink-0">
           <Button
@@ -76,13 +76,13 @@ export const ClientDashboardHero = ({
                 'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-line-subtle px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8'
               )}
             >
-              <dt className="text-sm font-medium text-input-placeholder">{stat.label}</dt>
+              <dt className="text-sm font-medium text-dim-2">{stat.label}</dt>
               {stat.helper ? (
-                <dd className={cn(stat.tone ? toneClass[stat.tone] : 'text-input-placeholder', 'text-xs font-medium')}>
+                <dd className={cn(stat.tone ? toneClass[stat.tone] : 'text-dim-2', 'text-xs font-medium')}>
                   {stat.helper}
                 </dd>
               ) : null}
-              <dd className="w-full flex-none text-3xl font-medium tracking-tight text-input-text">
+              <dd className="w-full flex-none text-3xl font-medium tracking-tight text-ink">
                 {stat.value}
               </dd>
             </div>

--- a/src/features/client-dashboard/components/ClientMattersGrid.tsx
+++ b/src/features/client-dashboard/components/ClientMattersGrid.tsx
@@ -24,7 +24,7 @@ export const ClientMattersGrid = ({
   <section className="w-full">
     <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-input-text">Your matters</h2>
+        <h2 className="text-base font-semibold text-ink">Your matters</h2>
         <Button variant="link" size="sm" onClick={() => onViewAll?.()}>
           View all
         </Button>
@@ -40,11 +40,11 @@ export const ClientMattersGrid = ({
           ))}
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-input-text">
+        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : matters.length === 0 ? (
-        <p className="mt-6 text-sm text-input-placeholder">No matters yet. When your firm opens a matter for you, it&apos;ll show up here.</p>
+        <p className="mt-6 text-sm text-dim-2">No matters yet. When your firm opens a matter for you, it&apos;ll show up here.</p>
       ) : (
         <ul className="mt-6 grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-2 lg:grid-cols-3 xl:gap-x-8">
           {matters.map((matter) => (
@@ -59,23 +59,23 @@ export const ClientMattersGrid = ({
               >
                 <div className="flex items-start gap-3 border-b border-line-subtle bg-surface-overlay/70 p-5">
                   <div className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-surface-utility/30">
-                    <Icon icon={Briefcase} className="h-5 w-5 text-input-placeholder" aria-hidden />
+                    <Icon icon={Briefcase} className="h-5 w-5 text-dim-2" aria-hidden />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-semibold text-input-text">{matter.title}</p>
+                    <p className="truncate text-sm font-semibold text-ink">{matter.title}</p>
                     {matter.practiceArea ? (
-                      <p className="truncate text-xs text-input-placeholder">{matter.practiceArea}</p>
+                      <p className="truncate text-xs text-dim-2">{matter.practiceArea}</p>
                     ) : null}
                   </div>
                 </div>
                 <dl className="divide-y divide-line-subtle bg-surface-overlay/60 px-5 py-3 text-sm">
                   <div className="flex justify-between gap-x-4 py-2">
-                    <dt className="text-input-placeholder">Status</dt>
-                    <dd className="text-input-text">{matter.statusLabel ?? '—'}</dd>
+                    <dt className="text-dim-2">Status</dt>
+                    <dd className="text-ink">{matter.statusLabel ?? '—'}</dd>
                   </div>
                   <div className="flex justify-between gap-x-4 py-2">
-                    <dt className="text-input-placeholder">Last update</dt>
-                    <dd className="text-input-text">
+                    <dt className="text-dim-2">Last update</dt>
+                    <dd className="text-ink">
                       {matter.updatedAt ? formatRelativeTime(matter.updatedAt) : '—'}
                     </dd>
                   </div>

--- a/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
+++ b/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
@@ -30,7 +30,7 @@ const statusClass = (status: ClientInvoiceActivityEntry['status']) => {
   const normalized = String(status).toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
+  return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
 };
 
 export const ClientRecentInvoicesTable = ({
@@ -41,7 +41,7 @@ export const ClientRecentInvoicesTable = ({
 }: ClientRecentInvoicesTableProps) => (
   <section>
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <h2 className="mx-auto max-w-2xl text-base font-semibold text-input-text lg:mx-0 lg:max-w-none">
+      <h2 className="mx-auto max-w-2xl text-base font-semibold text-ink lg:mx-0 lg:max-w-none">
         Recent invoices
       </h2>
     </div>
@@ -63,7 +63,7 @@ export const ClientRecentInvoicesTable = ({
       </div>
     ) : error ? (
       <div className="mt-6 border-t border-line-subtle">
-        <div className="mx-auto max-w-7xl px-4 py-5 text-sm text-input-text sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl px-4 py-5 text-sm text-ink sm:px-6 lg:px-8">
           {error}
         </div>
       </div>
@@ -87,7 +87,7 @@ export const ClientRecentInvoicesTable = ({
                   const showEmptyRows = days.length === 0;
                   return displayDays.map((day) => (
                     <Fragment key={day.label}>
-                      <tr className="text-sm text-input-text">
+                      <tr className="text-sm text-ink">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
                           <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
@@ -96,7 +96,7 @@ export const ClientRecentInvoicesTable = ({
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (
                         <tr>
-                          <td colSpan={3} className="relative py-5 text-sm text-input-placeholder">
+                          <td colSpan={3} className="relative py-5 text-sm text-dim-2">
                             No invoice activity yet.
                             <div className="absolute right-full bottom-0 h-px w-screen bg-line-glass/20" />
                             <div className="absolute bottom-0 left-0 h-px w-screen bg-line-glass/20" />
@@ -109,10 +109,10 @@ export const ClientRecentInvoicesTable = ({
                           <tr key={entry.id}>
                             <td className="relative py-5 pr-6">
                               <div className="flex gap-x-6">
-                                <Icon icon={ActivityIcon} className="hidden h-6 w-5 flex-none text-input-placeholder sm:block" aria-hidden />
+                                <Icon icon={ActivityIcon} className="hidden h-6 w-5 flex-none text-dim-2 sm:block" aria-hidden />
                                 <div className="flex-auto">
                                   <div className="flex items-start gap-x-3">
-                                    <div className="text-sm font-medium text-input-text">
+                                    <div className="text-sm font-medium text-ink">
                                       {formatCurrency(entry.amount)} USD
                                     </div>
                                     <div className={cn(statusClass(entry.status), 'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset')}>
@@ -120,7 +120,7 @@ export const ClientRecentInvoicesTable = ({
                                     </div>
                                   </div>
                                   {displayDate ? (
-                                    <div className="mt-1 text-xs text-input-placeholder">{displayDate}</div>
+                                    <div className="mt-1 text-xs text-dim-2">{displayDate}</div>
                                   ) : null}
                                 </div>
                               </div>
@@ -128,8 +128,8 @@ export const ClientRecentInvoicesTable = ({
                               <div className="absolute bottom-0 left-0 h-px w-screen bg-line-glass/20" />
                             </td>
                             <td className="hidden py-5 pr-6 sm:table-cell">
-                              <div className="text-sm text-input-text">{entry.matterTitle ?? 'No matter linked'}</div>
-                              <div className="mt-1 text-xs text-input-placeholder">Invoice #{entry.invoiceNumber}</div>
+                              <div className="text-sm text-ink">{entry.matterTitle ?? 'No matter linked'}</div>
+                              <div className="mt-1 text-xs text-dim-2">Invoice #{entry.invoiceNumber}</div>
                             </td>
                             <td className="py-5 text-right">
                               <div className="flex justify-end">

--- a/src/features/clients/pages/PracticeContactEditorPage.tsx
+++ b/src/features/clients/pages/PracticeContactEditorPage.tsx
@@ -351,7 +351,7 @@ export function PracticeContactEditorPage({
               disabled={saving}
             />
             {resolvedContactId ? (
-              <p className="text-xs text-input-placeholder">
+              <p className="text-xs text-dim-2">
                 Contact record: {resolvedContactId}
               </p>
             ) : null}

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -123,30 +123,30 @@ const PendingInvitationDetailPanel = ({
           <ResponsiveDefinitionGrid>
             <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Email</dt>
-                <dd className="mt-1 text-sm text-input-text">{invitation.email}</dd>
+                <dt className="text-sm font-medium text-dim-2">Email</dt>
+                <dd className="mt-1 text-sm text-ink">{invitation.email}</dd>
               </div>
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Role</dt>
-                <dd className="mt-1 text-sm text-input-text">{roleLabel}</dd>
+                <dt className="text-sm font-medium text-dim-2">Role</dt>
+                <dd className="mt-1 text-sm text-ink">{roleLabel}</dd>
               </div>
             </dl>
             <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Status</dt>
-                <dd className="mt-1 text-sm text-input-text">Pending</dd>
+                <dt className="text-sm font-medium text-dim-2">Status</dt>
+                <dd className="mt-1 text-sm text-ink">Pending</dd>
               </div>
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Expires</dt>
-                <dd className="mt-1 text-sm text-input-text">{formatDate(new Date(invitation.expiresAt))}</dd>
+                <dt className="text-sm font-medium text-dim-2">Expires</dt>
+                <dd className="mt-1 text-sm text-ink">{formatDate(new Date(invitation.expiresAt))}</dd>
               </div>
             </dl>
           </ResponsiveDefinitionGrid>
         </section>
 
         <section className="px-1 py-1">
-          <h3 className="text-sm font-semibold text-input-text">Invite actions</h3>
-          <p className="mt-2 text-sm text-input-placeholder">
+          <h3 className="text-sm font-semibold text-ink">Invite actions</h3>
+          <p className="mt-2 text-sm text-dim-2">
             Copy the invite link or cancel this invitation if it is no longer needed.
           </p>
           {canManage ? (
@@ -242,24 +242,24 @@ const ClientDetailPanel = ({
           <ResponsiveDefinitionGrid>
             <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Email</dt>
-                <dd className="mt-1 text-sm text-input-text">{client.email}</dd>
+                <dt className="text-sm font-medium text-dim-2">Email</dt>
+                <dd className="mt-1 text-sm text-ink">{client.email}</dd>
               </div>
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Phone</dt>
-                <dd className="mt-1 text-sm text-input-text">{isClientRecord ? formatPhoneNumber(client.phone) : 'Not provided'}</dd>
+                <dt className="text-sm font-medium text-dim-2">Phone</dt>
+                <dd className="mt-1 text-sm text-ink">{isClientRecord ? formatPhoneNumber(client.phone) : 'Not provided'}</dd>
               </div>
             </dl>
             <dl className="divide-y divide-line-subtle">
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">Address</dt>
-                <dd className="mt-1 text-sm text-input-text">{client.addressDisplay ?? 'Not provided'}</dd>
+                <dt className="text-sm font-medium text-dim-2">Address</dt>
+                <dd className="mt-1 text-sm text-ink">{client.addressDisplay ?? 'Not provided'}</dd>
               </div>
               <div className="px-5 py-4">
-                <dt className="text-sm font-medium text-input-placeholder">
+                <dt className="text-sm font-medium text-dim-2">
                   {isClientRecord ? 'Relationship status' : 'Team role'}
                 </dt>
-                <dd className="mt-1 text-sm text-input-text">
+                <dd className="mt-1 text-sm text-ink">
                   {isClientRecord ? relationshipLabel : teamRoleLabel}
                 </dd>
               </div>
@@ -268,7 +268,7 @@ const ClientDetailPanel = ({
         </section>
 
         <section className="px-1 py-1">
-          <h3 className="text-sm font-semibold text-input-text">
+          <h3 className="text-sm font-semibold text-ink">
             {isClientRecord ? 'Recent activity' : 'Team access'}
           </h3>
           <div className="mt-4">
@@ -287,7 +287,7 @@ const ClientDetailPanel = ({
                 commentActionsDisabled={memoSubmitting || Boolean(memoActionId)}
               />
             ) : (
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm text-dim-2">
                 Team member access and role changes are managed in Settings &gt; Team.
               </p>
             )}
@@ -863,7 +863,7 @@ export const PracticeContactsPage = ({
         <ul>
           {letters.map((letter) => (
             <li key={letter} data-letter={letter}>
-              <div className="sticky top-0 z-10 bg-surface-collection/80 backdrop-blur-sm px-4 py-1.5 text-xs font-semibold text-input-placeholder border-y border-line-subtle">
+              <div className="sticky top-0 z-10 bg-surface-collection/80 backdrop-blur-sm px-4 py-1.5 text-xs font-semibold text-dim-2 border-y border-line-subtle">
                 {letter}
               </div>
               {groupedClients[letter].map((client) => {
@@ -881,10 +881,10 @@ export const PracticeContactsPage = ({
                     <Avatar
                       name={client.name}
                       size="md"
-                      className="text-input-text"
+                      className="text-ink"
                     />
                     <div className="min-w-0 flex-1 text-left">
-                      <p className="text-sm text-input-text truncate">
+                      <p className="text-sm text-ink truncate">
                         {nameParts.first ? (
                           <>
                             <span>{nameParts.first} </span>
@@ -894,7 +894,7 @@ export const PracticeContactsPage = ({
                           <span className="font-semibold">{nameParts.last}</span>
                         )}
                       </p>
-                      <p className="mt-0.5 text-xs text-input-placeholder truncate">
+                      <p className="mt-0.5 text-xs text-dim-2 truncate">
                         {client.kind === 'team'
                           ? `Team member${normalizedTeamRole ? ` • ${getPracticeRoleLabel(normalizedTeamRole)}` : ''}`
                           : (client.status ? STATUS_LABELS[client.status] : 'Client')}
@@ -906,14 +906,14 @@ export const PracticeContactsPage = ({
             </li>
           ))}
           {prefetchedLoadingMore ? (
-            <li className="px-4 py-3 text-xs text-input-placeholder text-center">
+            <li className="px-4 py-3 text-xs text-dim-2 text-center">
               <LoadingSpinner size="sm" ariaLabel={t('clients.loadingMore', { defaultValue: 'Loading more contacts' })} />
             </li>
           ) : null}
         </ul>
       </div>
           {letters.length > 0 ? (
-        <div className="pointer-events-auto absolute right-1 top-1/2 z-20 -translate-y-1/2 hidden md:flex flex-col items-center gap-1 text-[11px] font-medium text-input-placeholder bg-surface-workspace/80">
+        <div className="pointer-events-auto absolute right-1 top-1/2 z-20 -translate-y-1/2 hidden md:flex flex-col items-center gap-1 text-[11px] font-medium text-dim-2 bg-surface-workspace/80">
           {letters.map((letter) => (
             <Button
               key={letter}
@@ -932,7 +932,7 @@ export const PracticeContactsPage = ({
                 "before:absolute before:-inset-3.5 before:content-['']",
                 activeLetter === letter
                   ? 'text-accent-foreground font-bold bg-accent-500'
-                  : 'text-input-placeholder hover:text-input-text hover:bg-surface-utility/40'
+                  : 'text-dim-2 hover:text-ink hover:bg-surface-utility/40'
               )}
             >
               {letter}
@@ -960,13 +960,13 @@ export const PracticeContactsPage = ({
                   <Avatar
                     name={invitation.email}
                     size="md"
-                    className="text-input-text"
+                    className="text-ink"
                   />
                   <div className="min-w-0 flex-1 text-left">
-                    <p className="truncate text-sm font-medium text-input-text">
+                    <p className="truncate text-sm font-medium text-ink">
                       {invitation.email}
                     </p>
-                    <p className="mt-0.5 truncate text-xs text-input-placeholder">
+                    <p className="mt-0.5 truncate text-xs text-dim-2">
                       {roleLabel} invitation • Expires {formatDate(new Date(invitation.expiresAt))}
                     </p>
                   </div>
@@ -1104,7 +1104,7 @@ export const PracticeContactsPage = ({
   );
 
   const renderErrorState = (message: string | null) => renderCenteredState(
-    <p className="text-sm text-input-placeholder">{message}</p>
+    <p className="text-sm text-dim-2">{message}</p>
   );
 
   const renderListPanel = ({
@@ -1167,7 +1167,7 @@ export const PracticeContactsPage = ({
       }
     : {
         content: sortedClients.length === 0
-          ? <div className="h-full flex-1 items-center justify-center flex"><p className="text-sm text-input-placeholder">No contacts found.</p></div>
+          ? <div className="h-full flex-1 items-center justify-center flex"><p className="text-sm text-dim-2">No contacts found.</p></div>
           : <div className="min-h-0 flex-1">{clientListPane}</div>,
         useEmptyMinHeight: sortedClients.length === 0 || clientsLoading || Boolean(clientsError),
       };

--- a/src/features/engagements/pages/ClientEngagementReviewPage.tsx
+++ b/src/features/engagements/pages/ClientEngagementReviewPage.tsx
@@ -193,7 +193,7 @@ const SignaturePad: FunctionComponent<{
           onTouchEnd={endDraw}
         />
         {!hasStrokeRef.current && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs text-input-placeholder">
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs text-dim-2">
             <Pen className="mr-2 h-4 w-4" />
             Click to draw your signature
           </div>
@@ -229,7 +229,7 @@ const DocumentStatusCard: FunctionComponent<{
   return (
     <section className="card p-5 space-y-3">
       <header className="flex items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-input-text">Document Status</h3>
+        <h3 className="text-sm font-semibold text-ink">Document Status</h3>
         <span className={cn(
           'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset',
           accepted
@@ -242,8 +242,8 @@ const DocumentStatusCard: FunctionComponent<{
       <dl className="space-y-2 text-sm">
         {rows.map(({ label, value }) => (
           <div key={label} className="flex items-start justify-between gap-3">
-            <dt className="text-input-placeholder">{label}</dt>
-            <dd className="text-right text-input-text">{value ?? '—'}</dd>
+            <dt className="text-dim-2">{label}</dt>
+            <dd className="text-right text-ink">{value ?? '—'}</dd>
           </div>
         ))}
       </dl>
@@ -259,7 +259,7 @@ const SignaturePanel: FunctionComponent<{
   disabled: boolean;
 }> = ({ signatureData, agreementChecked, onSignatureChange, onAgreementChange, disabled }) => (
   <section className="card p-5 space-y-3">
-    <h3 className="text-sm font-semibold text-input-text">Your Signature</h3>
+    <h3 className="text-sm font-semibold text-ink">Your Signature</h3>
     <SignaturePad onChange={onSignatureChange} disabled={disabled} />
     <Checkbox
       checked={agreementChecked}
@@ -292,11 +292,11 @@ const EngagementLetter: FunctionComponent<{
   const noGuarantee = proposal?.no_guarantee_language;
 
   return (
-    <article className="rounded-2xl border border-card-border bg-surface-card p-6 sm:p-10 space-y-6 leading-relaxed text-input-text">
+    <article className="rounded-2xl border border-card-border bg-surface-card p-6 sm:p-10 space-y-6 leading-relaxed text-ink">
       <header className="text-center space-y-2 border-b border-line-subtle pb-6">
         <h1 className="text-xl font-bold uppercase tracking-widest">Engagement Letter</h1>
         <p className="text-sm font-medium">{practiceName}</p>
-        <p className="text-xs uppercase tracking-wider text-input-placeholder">
+        <p className="text-xs uppercase tracking-wider text-dim-2">
           Sent {engagement.sent_at ? formatLongDate(engagement.sent_at) : formatLongDate(engagement.created_at)}
         </p>
       </header>
@@ -318,7 +318,7 @@ const EngagementLetter: FunctionComponent<{
         {scope ? (
           <p className="text-sm">{scope}</p>
         ) : (
-          <p className="text-sm italic text-input-placeholder">Scope to be confirmed before commencement of services.</p>
+          <p className="text-sm italic text-dim-2">Scope to be confirmed before commencement of services.</p>
         )}
         {includedServices.length > 0 && (
           <ul className="space-y-1.5 pl-4">
@@ -452,8 +452,8 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
       <div className="min-h-dvh flex flex-col items-center justify-center p-6">
         <div className="card max-w-md w-full p-8 text-center space-y-4">
           <AlertTriangle className="w-10 h-10 text-rose-400 mx-auto" />
-          <h1 className="text-lg font-bold text-input-text">Unable to load engagement</h1>
-          <p className="text-sm text-input-placeholder">{loadError ?? 'This engagement could not be found.'}</p>
+          <h1 className="text-lg font-bold text-ink">Unable to load engagement</h1>
+          <p className="text-sm text-dim-2">{loadError ?? 'This engagement could not be found.'}</p>
         </div>
       </div>
     );
@@ -471,15 +471,15 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
               <button
                 type="button"
                 onClick={onBack}
-                className="rounded-md p-1.5 text-input-placeholder hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                className="rounded-md p-1.5 text-dim-2 hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                 aria-label="Back"
               >
                 <ChevronLeft className="h-5 w-5" />
               </button>
             )}
             <div className="min-w-0">
-              <p className="truncate text-xs font-medium text-input-placeholder">{practiceName}</p>
-              <h1 className="truncate text-base font-semibold text-input-text">Engagement Letter</h1>
+              <p className="truncate text-xs font-medium text-dim-2">{practiceName}</p>
+              <h1 className="truncate text-base font-semibold text-ink">Engagement Letter</h1>
             </div>
           </div>
           <span className={cn(
@@ -516,7 +516,7 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
               <div className="card p-5 space-y-2 text-center">
                 <CheckCircle2 className="mx-auto h-8 w-8 text-emerald-500" />
                 <p className="text-sm font-semibold text-emerald-600 dark:text-emerald-300">Engagement signed</p>
-                <p className="text-xs text-input-placeholder">
+                <p className="text-xs text-dim-2">
                   Thank you. Your attorney will be in touch shortly.
                 </p>
               </div>

--- a/src/features/engagements/pages/CreateEngagementPage.tsx
+++ b/src/features/engagements/pages/CreateEngagementPage.tsx
@@ -200,31 +200,31 @@ const EngagementLetterPreview: FunctionComponent<{
   const today = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
   return (
-    <div className="rounded-xl border border-card-border bg-surface-card text-sm leading-relaxed text-input-text shadow-sm overflow-hidden">
+    <div className="rounded-xl border border-card-border bg-surface-card text-sm leading-relaxed text-ink shadow-sm overflow-hidden">
       {/* Letterhead */}
       <div className="border-b border-line-subtle bg-surface-overlay/20 px-6 py-4 space-y-0.5">
-        <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+        <p className="text-xs font-semibold uppercase tracking-widest text-dim-2">
           {practiceName || 'Your Practice'}
         </p>
-        <p className="text-xs text-input-placeholder">{today}</p>
+        <p className="text-xs text-dim-2">{today}</p>
       </div>
 
       <div className="px-6 py-5 space-y-5">
         {/* Addressee */}
         <div className="space-y-0.5">
-          <p className="font-semibold text-input-text">{clientName}</p>
-          <p className="text-xs text-input-placeholder">Re: {matterSummary}</p>
+          <p className="font-semibold text-ink">{clientName}</p>
+          <p className="text-xs text-dim-2">Re: {matterSummary}</p>
         </div>
 
         {/* Body */}
         <div className="border-t border-line-subtle pt-4 space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+          <p className="text-xs font-semibold uppercase tracking-widest text-dim-2">
             Engagement Agreement
           </p>
           {contractBody ? (
             <p className="whitespace-pre-wrap text-xs leading-relaxed">{contractBody}</p>
           ) : (
-            <p className="text-xs italic text-input-placeholder">
+            <p className="text-xs italic text-dim-2">
               Complete the form to generate the engagement letter preview.
             </p>
           )}
@@ -233,10 +233,10 @@ const EngagementLetterPreview: FunctionComponent<{
         {/* Fee summary */}
         {form.billingType ? (
           <div className="rounded-lg border border-line-subtle bg-surface-overlay/30 px-4 py-3 space-y-1">
-            <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Fee Summary</p>
+            <p className="text-xs font-semibold uppercase tracking-widest text-dim-2">Fee Summary</p>
             <p className="text-xs">{billingSummaryLine(form)}</p>
             {form.feeNotes.trim() && (
-              <p className="text-xs text-input-placeholder">{form.feeNotes.trim()}</p>
+              <p className="text-xs text-dim-2">{form.feeNotes.trim()}</p>
             )}
           </div>
         ) : null}
@@ -245,14 +245,14 @@ const EngagementLetterPreview: FunctionComponent<{
         <div className="border-t border-line-subtle pt-4 space-y-4 text-xs">
           <div className="grid grid-cols-2 gap-6">
             <div className="space-y-1">
-              <p className="font-medium text-input-text">Client</p>
+              <p className="font-medium text-ink">Client</p>
               <div className="h-7 border-b border-dashed border-line-subtle" />
-              <p className="text-input-placeholder">Date ___________</p>
+              <p className="text-dim-2">Date ___________</p>
             </div>
             <div className="space-y-1">
-              <p className="font-medium text-input-text">Attorney</p>
+              <p className="font-medium text-ink">Attorney</p>
               <div className="h-7 border-b border-dashed border-line-subtle" />
-              <p className="text-input-placeholder">Date ___________</p>
+              <p className="text-dim-2">Date ___________</p>
             </div>
           </div>
         </div>
@@ -274,12 +274,12 @@ const SelectedIntakeCard: FunctionComponent<{
   return (
     <div className="flex items-start justify-between gap-3 rounded-lg border border-card-border bg-surface-card px-3 py-2.5">
       <div className="min-w-0 flex-1">
-        <p className="truncate font-medium text-input-text">{name}</p>
-        {email && <p className="truncate text-sm text-input-placeholder">{email}</p>}
-        {subject && <p className="mt-0.5 truncate text-xs text-input-placeholder">{subject}</p>}
+        <p className="truncate font-medium text-ink">{name}</p>
+        {email && <p className="truncate text-sm text-dim-2">{email}</p>}
+        {subject && <p className="mt-0.5 truncate text-xs text-dim-2">{subject}</p>}
         {detailLoading && (
           <div className="mt-1">
-            <LoadingSpinner size="sm" ariaLabel="Loading intake details" className="text-input-placeholder" />
+            <LoadingSpinner size="sm" ariaLabel="Loading intake details" className="text-dim-2" />
           </div>
         )}
       </div>
@@ -297,7 +297,7 @@ const SelectedIntakeCard: FunctionComponent<{
 // ── Section heading ──────────────────────────────────────────────────────────
 
 const SectionHeading: FunctionComponent<{ title: string }> = ({ title }) => (
-  <h3 className="border-b border-line-subtle pb-2 text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+  <h3 className="border-b border-line-subtle pb-2 text-xs font-semibold uppercase tracking-widest text-dim-2">
     {title}
   </h3>
 );
@@ -600,7 +600,7 @@ export const CreateEngagementPage: FunctionComponent<CreateEngagementPageProps> 
             {/* Source intake */}
             <section className="space-y-3">
               <SectionHeading title="Source intake" />
-              <p className="text-xs text-input-placeholder">
+              <p className="text-xs text-dim-2">
                 Select an accepted intake — the form will pre-fill from the intake data.
               </p>
               {selectedIntake ? (
@@ -913,10 +913,10 @@ export const CreateEngagementPage: FunctionComponent<CreateEngagementPageProps> 
         {/* ── Right: live preview (xl+) ── */}
         <aside className="hidden w-[400px] shrink-0 overflow-y-auto border-l border-line-subtle p-6 xl:block">
           <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">
+            <p className="text-xs font-semibold uppercase tracking-widest text-dim-2">
               Client preview
             </p>
-            <p className="text-xs text-input-placeholder">
+            <p className="text-xs text-dim-2">
               This is what the client will see when they open the engagement.
             </p>
             <EngagementLetterPreview form={form} practiceName={practiceName} />

--- a/src/features/engagements/pages/EngagementDetailPage.tsx
+++ b/src/features/engagements/pages/EngagementDetailPage.tsx
@@ -48,7 +48,7 @@ import { useEngagementDetail } from '../hooks/useEngagementDetail';
 
 const STATUS_VARIANTS: Record<EngagementStatus, { label: string; className: string }> = {
   draft:    { label: 'Draft',    className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' },
-  sent:     { label: 'Sent',     className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' },
+  sent:     { label: 'Sent',     className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' },
   accepted: { label: 'Accepted', className: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300' },
   declined: { label: 'Declined', className: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300' },
 };
@@ -66,8 +66,8 @@ const CONFLICT_VARIANTS: Record<ConflictStatus, { label: string; className: stri
   clear:             { label: 'Clear',             className: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300' },
   review_required:   { label: 'Review Required',   className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' },
   conflicted:        { label: 'Conflicted',        className: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300' },
-  unknown:           { label: 'Unknown',           className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' },
-  insufficient_data: { label: 'Insufficient Data', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' },
+  unknown:           { label: 'Unknown',           className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' },
+  insufficient_data: { label: 'Insufficient Data', className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' },
 };
 
 // ── Display helpers ──────────────────────────────────────────────────────────
@@ -110,7 +110,7 @@ const SectionCard: FunctionComponent<{
 }> = ({ title, children, className, action }) => (
   <section className={cn('card p-5 sm:p-6 space-y-4', className)}>
     <header className="flex items-center justify-between gap-2">
-      <h3 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">{title}</h3>
+      <h3 className="text-xs font-semibold uppercase tracking-widest text-dim-2">{title}</h3>
       {action}
     </header>
     {children}
@@ -123,8 +123,8 @@ const InfoRow: FunctionComponent<{
   fallback?: string;
 }> = ({ label, value, fallback = 'Not specified' }) => (
   <div className="grid grid-cols-[120px_minmax(0,1fr)] gap-3 text-sm">
-    <dt className="text-input-placeholder">{label}</dt>
-    <dd className="text-input-text break-words">{value || <span className="text-input-placeholder italic">{fallback}</span>}</dd>
+    <dt className="text-dim-2">{label}</dt>
+    <dd className="text-ink break-words">{value || <span className="text-dim-2 italic">{fallback}</span>}</dd>
   </div>
 );
 
@@ -153,16 +153,16 @@ const ScopeOfRepresentationCard: FunctionComponent<{ proposal: ProposalData | nu
   return (
     <SectionCard title="Scope of representation">
       {scope ? (
-        <p className="text-sm leading-relaxed text-input-text">{scope}</p>
+        <p className="text-sm leading-relaxed text-ink">{scope}</p>
       ) : (
-        <p className="text-sm italic text-input-placeholder">Not yet drafted</p>
+        <p className="text-sm italic text-dim-2">Not yet drafted</p>
       )}
       {included.length > 0 && (
         <div className="space-y-1.5">
-          <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Included</p>
+          <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Included</p>
           <ul className="space-y-1">
             {included.map((service, i) => (
-              <li key={i} className="flex items-start gap-2 text-sm text-input-text">
+              <li key={i} className="flex items-start gap-2 text-sm text-ink">
                 <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
                 <span>{service}</span>
               </li>
@@ -172,10 +172,10 @@ const ScopeOfRepresentationCard: FunctionComponent<{ proposal: ProposalData | nu
       )}
       {excluded.length > 0 && (
         <div className="space-y-1.5">
-          <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Excluded</p>
+          <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Excluded</p>
           <ul className="space-y-1">
             {excluded.map((service, i) => (
-              <li key={i} className="flex items-start gap-2 text-sm text-input-text">
+              <li key={i} className="flex items-start gap-2 text-sm text-ink">
                 <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-rose-500/70" />
                 <span>{service}</span>
               </li>
@@ -192,7 +192,7 @@ const FeeStructureCard: FunctionComponent<{ proposal: ProposalData | null }> = (
   if (!fees) {
     return (
       <SectionCard title="Fee structure">
-        <p className="text-sm italic text-input-placeholder">Not yet drafted</p>
+        <p className="text-sm italic text-dim-2">Not yet drafted</p>
       </SectionCard>
     );
   }
@@ -210,7 +210,7 @@ const FeeStructureCard: FunctionComponent<{ proposal: ProposalData | null }> = (
   if (visible.length === 0) {
     return (
       <SectionCard title="Fee structure">
-        <p className="text-sm italic text-input-placeholder">Not yet drafted</p>
+        <p className="text-sm italic text-dim-2">Not yet drafted</p>
       </SectionCard>
     );
   }
@@ -220,13 +220,13 @@ const FeeStructureCard: FunctionComponent<{ proposal: ProposalData | null }> = (
       <dl className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
         {visible.map(({ label, value }) => (
           <div key={label}>
-            <dt className="text-xs text-input-placeholder">{label}</dt>
-            <dd className="mt-0.5 text-sm font-medium text-input-text">{value}</dd>
+            <dt className="text-xs text-dim-2">{label}</dt>
+            <dd className="mt-0.5 text-sm font-medium text-ink">{value}</dd>
           </div>
         ))}
       </dl>
       {fees.fee_notes && (
-        <p className="border-t border-line-subtle pt-3 text-sm text-input-text">{fees.fee_notes}</p>
+        <p className="border-t border-line-subtle pt-3 text-sm text-ink">{fees.fee_notes}</p>
       )}
     </SectionCard>
   );
@@ -235,11 +235,11 @@ const FeeStructureCard: FunctionComponent<{ proposal: ProposalData | null }> = (
 const ContractBodyCard: FunctionComponent<{ engagement: EngagementDetail }> = ({ engagement }) => (
   <SectionCard title="Contract body">
     {engagement.contract_body?.trim() ? (
-      <div className="max-h-[360px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-line-subtle bg-surface-overlay/30 p-3 text-sm leading-relaxed text-input-text">
+      <div className="max-h-[360px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-line-subtle bg-surface-overlay/30 p-3 text-sm leading-relaxed text-ink">
         {engagement.contract_body}
       </div>
     ) : (
-      <p className="text-sm italic text-input-placeholder">Not yet drafted</p>
+      <p className="text-sm italic text-dim-2">Not yet drafted</p>
     )}
   </SectionCard>
 );
@@ -264,8 +264,8 @@ const TimelineCard: FunctionComponent<{ engagement: EngagementDetail }> = ({ eng
       <dl className="space-y-2.5">
         {rows.map(({ label, value }) => (
           <div key={label} className="flex items-center justify-between gap-3 text-sm">
-            <dt className="text-input-placeholder">{label}</dt>
-            <dd className="text-right text-input-text">{value ?? <span className="italic text-input-placeholder">Pending</span>}</dd>
+            <dt className="text-dim-2">{label}</dt>
+            <dd className="text-right text-ink">{value ?? <span className="italic text-dim-2">Pending</span>}</dd>
           </div>
         ))}
       </dl>
@@ -295,11 +295,11 @@ const RiskReviewCard: FunctionComponent<{ proposal: ProposalData | null }> = ({ 
           {jurisdictionLabel}
         </span>
       </div>
-      {risk?.conflict_note && <p className="text-sm text-input-text">{risk.conflict_note}</p>}
+      {risk?.conflict_note && <p className="text-sm text-ink">{risk.conflict_note}</p>}
       {risk?.open_questions && risk.open_questions.length > 0 && (
         <ul className="space-y-1.5">
           {risk.open_questions.map((q, i) => (
-            <li key={i} className="flex items-start gap-2 text-sm text-input-text">
+            <li key={i} className="flex items-start gap-2 text-sm text-ink">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
               <span>{q}</span>
             </li>
@@ -322,13 +322,13 @@ const SourceInformationCard: FunctionComponent<{ engagement: EngagementDetail }>
   return (
     <SectionCard title="Source information">
       {visible.length === 0 ? (
-        <p className="text-sm italic text-input-placeholder">No source context</p>
+        <p className="text-sm italic text-dim-2">No source context</p>
       ) : (
         <dl className="space-y-2.5">
           {visible.map(({ label, value }) => (
             <div key={label} className="flex items-start justify-between gap-3 text-sm">
-              <dt className="text-input-placeholder">{label}</dt>
-              <dd className="text-right text-input-text capitalize">{value}</dd>
+              <dt className="text-dim-2">{label}</dt>
+              <dd className="text-right text-ink capitalize">{value}</dd>
             </div>
           ))}
         </dl>
@@ -340,9 +340,9 @@ const SourceInformationCard: FunctionComponent<{ engagement: EngagementDetail }>
 const EngagementNotesCard: FunctionComponent<{ engagement: EngagementDetail }> = ({ engagement }) => (
   <SectionCard title="Engagement notes">
     {engagement.engagement_notes ? (
-      <p className="text-sm leading-relaxed text-input-text whitespace-pre-wrap">{engagement.engagement_notes}</p>
+      <p className="text-sm leading-relaxed text-ink whitespace-pre-wrap">{engagement.engagement_notes}</p>
     ) : (
-      <p className="text-sm italic text-input-placeholder">No internal notes yet</p>
+      <p className="text-sm italic text-dim-2">No internal notes yet</p>
     )}
   </SectionCard>
 );
@@ -463,7 +463,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
     return (
       <div className="fixed inset-0 z-40 flex flex-col bg-app-background">
         <header className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
-          <h2 className="text-base font-semibold text-input-text">Messages</h2>
+          <h2 className="text-base font-semibold text-ink">Messages</h2>
           <Button variant="ghost" icon={X} onClick={onToggle} aria-label="Close conversation" />
         </header>
         <div className="min-h-0 flex-1">
@@ -502,15 +502,15 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
         className="flex w-full items-center justify-between gap-3 p-5 text-left transition-colors hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:p-6"
       >
         <div className="flex min-w-0 items-center gap-3">
-          <MessagesSquare className="h-4 w-4 shrink-0 text-input-placeholder" />
-          <h3 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Messages</h3>
+          <MessagesSquare className="h-4 w-4 shrink-0 text-dim-2" />
+          <h3 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Messages</h3>
           {lastActivity && (
-            <span className="truncate text-xs text-input-placeholder">
+            <span className="truncate text-xs text-dim-2">
               · {formatRelativeTime(lastActivity)}
             </span>
           )}
         </div>
-        {isExpanded ? <ChevronUp className="h-4 w-4 text-input-placeholder" /> : <ChevronDown className="h-4 w-4 text-input-placeholder" />}
+        {isExpanded ? <ChevronUp className="h-4 w-4 text-dim-2" /> : <ChevronDown className="h-4 w-4 text-dim-2" />}
       </button>
       {isExpanded && !isMobile && (
         <div className="border-t border-line-subtle">
@@ -1126,9 +1126,9 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
   const statusBanner = (() => {
     if (isSent) {
       return (
-        <div className="rounded-xl border border-line-subtle bg-surface-overlay/40 p-4 text-sm text-input-text">
+        <div className="rounded-xl border border-line-subtle bg-surface-overlay/40 p-4 text-sm text-ink">
           <p className="font-medium">Awaiting client response</p>
-          <p className="mt-1 text-input-placeholder">The client received this engagement and will accept or decline online.</p>
+          <p className="mt-1 text-dim-2">The client received this engagement and will accept or decline online.</p>
         </div>
       );
     }

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -54,9 +54,9 @@ const engagementStatusBadge = (status: EngagementStatus | string | undefined): S
     case 'draft':
       return { label: 'Draft', className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' };
     case 'sent':
-      return { label: 'Sent', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' };
+      return { label: 'Sent', className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' };
     default:
-      return { label: '—', className: 'bg-surface-overlay/60 text-input-placeholder ring-line-subtle' };
+      return { label: '—', className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' };
   }
 };
 
@@ -109,8 +109,8 @@ const EngagementMobileCard: FunctionComponent<{
   const retainer = getRetainerLabel(item.proposal_data?.fees);
 
   const rows: ReadonlyArray<{ label: string; value: ComponentChildren }> = [
-    { label: 'Matter',   value: <span className="text-input-placeholder break-words">{matter}</span> },
-    { label: 'Retainer', value: <span className="font-medium text-input-text tabular-nums">{retainer}</span> },
+    { label: 'Matter',   value: <span className="text-dim-2 break-words">{matter}</span> },
+    { label: 'Retainer', value: <span className="font-medium text-ink tabular-nums">{retainer}</span> },
   ];
 
   return (
@@ -120,13 +120,13 @@ const EngagementMobileCard: FunctionComponent<{
       className="w-full rounded-xl border border-card-border bg-surface-card px-4 py-3 text-left transition-colors hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
     >
       <div className="flex items-start justify-between gap-3 pb-3">
-        <span className="font-semibold text-input-text break-words">{name}</span>
+        <span className="font-semibold text-ink break-words">{name}</span>
         <StatusPill status={item.status} />
       </div>
       <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm">
         {rows.map(({ label, value }) => (
           <div key={label} className="contents">
-            <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">{label}</dt>
+            <dt className="text-xs font-medium uppercase tracking-wide text-dim-2">{label}</dt>
             <dd className="text-right">{value}</dd>
           </div>
         ))}
@@ -261,7 +261,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
 
   // ── Table column + row construction ────────────────────────────────────────
 
-  const headerCellClass = 'text-xs font-semibold uppercase tracking-wide text-input-placeholder';
+  const headerCellClass = 'text-xs font-semibold uppercase tracking-wide text-dim-2';
   const columns: DataTableColumn[] = [
     { id: 'client',   label: 'Client',   isPrimary: true, headerClassName: headerCellClass },
     { id: 'matter',   label: 'Matter',   headerClassName: headerCellClass },
@@ -275,12 +275,12 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     id: item.id,
     onClick: () => handleSelectEngagement(item),
     cells: {
-      client:   <span className="truncate font-medium text-input-text">{item.client_name || 'Unknown Client'}</span>,
-      matter:   <span className="truncate text-input-placeholder">{getMatterLabel(item)}</span>,
-      billing:  <span className="text-input-placeholder">{getBillingLabel(item.proposal_data?.fees)}</span>,
+      client:   <span className="truncate font-medium text-ink">{item.client_name || 'Unknown Client'}</span>,
+      matter:   <span className="truncate text-dim-2">{getMatterLabel(item)}</span>,
+      billing:  <span className="text-dim-2">{getBillingLabel(item.proposal_data?.fees)}</span>,
       status:   <StatusPill status={item.status} />,
-      sent:     <span className="text-input-placeholder tabular-nums">{item.sent_at ? formatRelativeTime(item.sent_at) : '—'}</span>,
-      retainer: <span className="font-medium text-input-text tabular-nums">{getRetainerLabel(item.proposal_data?.fees)}</span>,
+      sent:     <span className="text-dim-2 tabular-nums">{item.sent_at ? formatRelativeTime(item.sent_at) : '—'}</span>,
+      retainer: <span className="font-medium text-ink tabular-nums">{getRetainerLabel(item.proposal_data?.fees)}</span>,
     },
   }));
 

--- a/src/features/files/components/FileDetailDrawer.tsx
+++ b/src/features/files/components/FileDetailDrawer.tsx
@@ -54,30 +54,30 @@ const FileDetailContent = ({ file }: { file: OrgFile }) => {
           <div className="h-full w-full animate-pulse bg-surface-panel" />
         ) : (
           <div className={`flex h-20 w-20 items-center justify-center rounded-2xl ${fileType.color}`}>
-            <Icon icon={fileType.icon} className="h-10 w-10 text-input-text" />
+            <Icon icon={fileType.icon} className="h-10 w-10 text-ink" />
           </div>
         )}
       </div>
 
       <div>
-        <h2 className="break-words text-base font-semibold text-input-text">{file.fileName}</h2>
-        <p className="mt-1 text-xs text-input-placeholder">{fileType.label} · {formatBytes(file.fileSize)}</p>
+        <h2 className="break-words text-base font-semibold text-ink">{file.fileName}</h2>
+        <p className="mt-1 text-xs text-dim-2">{fileType.label} · {formatBytes(file.fileSize)}</p>
       </div>
 
       <dl className="space-y-3 text-sm">
         <div className="flex justify-between gap-4">
-          <dt className="text-input-placeholder">Source</dt>
-          <dd className="text-right text-input-text">{association.kind === 'loose' ? 'Loose file' : association.label}</dd>
+          <dt className="text-dim-2">Source</dt>
+          <dd className="text-right text-ink">{association.kind === 'loose' ? 'Loose file' : association.label}</dd>
         </div>
         <div className="flex justify-between gap-4">
-          <dt className="text-input-placeholder">Added</dt>
-          <dd className="text-right text-input-text">
+          <dt className="text-dim-2">Added</dt>
+          <dd className="text-right text-ink">
             {file.createdAt ? formatRelativeTime(file.createdAt) : '—'}
           </dd>
         </div>
         <div className="flex justify-between gap-4">
-          <dt className="text-input-placeholder">Type</dt>
-          <dd className="text-right text-input-text">{file.mimeType || '—'}</dd>
+          <dt className="text-dim-2">Type</dt>
+          <dd className="text-right text-ink">{file.mimeType || '—'}</dd>
         </div>
       </dl>
     </div>

--- a/src/features/files/components/FilesInspectorPanel.tsx
+++ b/src/features/files/components/FilesInspectorPanel.tsx
@@ -90,12 +90,12 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
       className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-surface-card"
     >
       <header className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
-        <h2 className="text-sm font-semibold text-input-text">Details</h2>
+        <h2 className="text-sm font-semibold text-ink">Details</h2>
         <button
           type="button"
           onClick={onClose}
           aria-label="Close inspector"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-input-placeholder hover:bg-surface-panel hover:text-input-text"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-dim-2 hover:bg-surface-panel hover:text-ink"
         >
           <Icon icon={X} className="h-4 w-4" />
         </button>
@@ -109,22 +109,22 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
             <div className="h-full w-full animate-pulse bg-surface-panel" />
           ) : (
             <div className={`flex h-20 w-20 items-center justify-center rounded-2xl ${fileType.color}`}>
-              <Icon icon={fileType.icon} className="h-10 w-10 text-input-text" />
+              <Icon icon={fileType.icon} className="h-10 w-10 text-ink" />
             </div>
           )}
         </div>
 
         <div>
-          <h3 className="break-words text-base font-semibold text-input-text">{file.fileName}</h3>
-          <p className="mt-1 text-xs text-input-placeholder">
+          <h3 className="break-words text-base font-semibold text-ink">{file.fileName}</h3>
+          <p className="mt-1 text-xs text-dim-2">
             {fileType.label} · {formatBytes(file.fileSize)}
           </p>
         </div>
 
         <dl className="space-y-3 text-sm">
           <div className="flex items-start justify-between gap-4">
-            <dt className="text-input-placeholder">Source</dt>
-            <dd className="text-right text-input-text">
+            <dt className="text-dim-2">Source</dt>
+            <dd className="text-right text-ink">
               {association.kind === 'loose' ? (
                 <span>Loose file</span>
               ) : href ? (
@@ -141,14 +141,14 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
             </dd>
           </div>
           <div className="flex justify-between gap-4">
-            <dt className="text-input-placeholder">Added</dt>
-            <dd className="text-right text-input-text">
+            <dt className="text-dim-2">Added</dt>
+            <dd className="text-right text-ink">
               {file.createdAt ? formatRelativeTime(file.createdAt) : '—'}
             </dd>
           </div>
           <div className="flex justify-between gap-4">
-            <dt className="text-input-placeholder">Type</dt>
-            <dd className="text-right text-input-text">{file.mimeType || '—'}</dd>
+            <dt className="text-dim-2">Type</dt>
+            <dd className="text-right text-ink">{file.mimeType || '—'}</dd>
           </div>
         </dl>
       </div>

--- a/src/features/files/components/FilesList.tsx
+++ b/src/features/files/components/FilesList.tsx
@@ -38,7 +38,7 @@ export const FilesList = ({
       cells: {
         name: (
           <div className="flex min-w-0 items-center gap-3">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-panel text-input-placeholder">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-panel text-dim-2">
               <Icon icon={fileType.icon} className="h-4 w-4" />
             </span>
             <span className="min-w-0 truncate" title={file.fileName}>{file.fileName}</span>

--- a/src/features/files/components/FilesViewToggle.tsx
+++ b/src/features/files/components/FilesViewToggle.tsx
@@ -13,8 +13,8 @@ interface FilesViewToggleProps {
 const buttonClass = (active: boolean) => cn(
   'flex h-7 w-7 items-center justify-center rounded-md transition-colors',
   active
-    ? 'bg-surface-card text-input-text shadow-sm'
-    : 'text-input-placeholder hover:text-input-text'
+    ? 'bg-surface-card text-ink shadow-sm'
+    : 'text-dim-2 hover:text-ink'
 );
 
 export const FilesViewToggle = ({ value, onChange }: FilesViewToggleProps) => (

--- a/src/features/files/components/UploadDestinationDialog.tsx
+++ b/src/features/files/components/UploadDestinationDialog.tsx
@@ -69,13 +69,13 @@ export const UploadDestinationDialog = ({
       value: `matter:${matter.id}`,
       label: matter.title?.trim() || 'Untitled matter',
       meta: 'Matter',
-      icon: <Icon icon={Briefcase} className="h-4 w-4 text-input-placeholder" />,
+      icon: <Icon icon={Briefcase} className="h-4 w-4 text-dim-2" />,
     }));
     const intakeOptions = intakes.map((intake) => ({
       value: `intake:${intake.uuid}`,
       label: resolveIntakeTitle(intake.metadata),
       meta: 'Intake',
-      icon: <Icon icon={Inbox} className="h-4 w-4 text-input-placeholder" />,
+      icon: <Icon icon={Inbox} className="h-4 w-4 text-dim-2" />,
     }));
     return [...matterOptions, ...intakeOptions];
   }, [matters, intakes]);
@@ -192,7 +192,7 @@ export const UploadDestinationDialog = ({
           </div>
         ) : null}
         {!isLoading && options.length === 0 && !error ? (
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-3 text-sm text-input-placeholder">
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-3 text-sm text-dim-2">
             <span className="min-w-0 flex-1">
               {clientUserId
                 ? "You don't have any matters or intakes yet. Open a conversation with the practice to get started."
@@ -213,7 +213,7 @@ export const UploadDestinationDialog = ({
             emptyStateLabel={null}
           />
         ) : options.length > 0 ? (
-          <p className="rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-4 text-sm text-input-placeholder">
+          <p className="rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-4 text-sm text-dim-2">
             Pick a destination above to enable the upload area.
           </p>
         ) : null}

--- a/src/features/intake/components/DocumentChecklist.tsx
+++ b/src/features/intake/components/DocumentChecklist.tsx
@@ -70,7 +70,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
       case 'missing':
         return required ?
           <Icon icon={AlertTriangle} className="w-5 h-5 text-accent-error"  /> :
-          <Icon icon={File} className="w-5 h-5 text-input-placeholder"  />;
+          <Icon icon={File} className="w-5 h-5 text-dim-2"  />;
     }
   };
 
@@ -94,14 +94,14 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
     <div className="card p-6 max-w-2xl">
       {/* Header */}
       <div className="mb-6">
-        <h3 className="text-lg font-semibold text-input-text mb-2">
+        <h3 className="text-lg font-semibold text-ink mb-2">
           Document Checklist for {matterType}
         </h3>
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           Please upload the documents listed below. Required documents are marked with a red icon.
         </p>
         <div className="mt-3 flex items-center gap-4 text-xs font-medium">
-          <span className="text-input-placeholder">
+          <span className="text-dim-2">
             Progress: {completedCount}/{documents.length}
           </span>
           <span className="text-accent-500">
@@ -131,7 +131,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
               {getStatusIcon(doc.status, doc.required)}
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
-                  <h4 className="font-medium text-input-text">
+                  <h4 className="font-medium text-ink">
                     {doc.name}
                   </h4>
                   {doc.required && (
@@ -144,13 +144,13 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                       ? 'bg-emerald-500/10 text-emerald-400'
                       : doc.status === 'pending'
                       ? 'bg-amber-500/10 text-amber-400'
-                      : 'bg-surface-utility/5 text-input-placeholder'
+                      : 'bg-surface-utility/5 text-dim-2'
                   }`}>
                     {getStatusText(doc.status, doc.required)}
                   </span>
                 </div>
                 {doc.description && (
-                  <p className="text-sm text-input-placeholder mb-3">
+                  <p className="text-sm text-dim-2 mb-3">
                     {doc.description}
                   </p>
                 )}
@@ -173,7 +173,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                         Choose Document
                       </Button>
                     </label>
-                    <span className="text-xs text-input-placeholder">
+                    <span className="text-xs text-dim-2">
                       or drag and drop
                     </span>
                   </div>
@@ -183,7 +183,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                 {doc.status === 'uploaded' && doc.file && (
                   <div className="flex items-center gap-2 mt-2">
                     <Icon icon={File} className="w-4 h-4 text-emerald-400"  />
-                    <span className="text-sm text-input-text">
+                    <span className="text-sm text-ink">
                       {doc.file.name}
                     </span>
                     <Button
@@ -213,7 +213,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
         <Button
           variant="ghost"
           onClick={onSkip}
-          className="text-input-placeholder"
+          className="text-dim-2"
         >
           Skip for now
         </Button>

--- a/src/features/intake/components/EmbedCodeBlock.tsx
+++ b/src/features/intake/components/EmbedCodeBlock.tsx
@@ -122,18 +122,18 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
   return (
     <div className="space-y-5">
       <div className="space-y-2">
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           Share the direct link or install the widget script on your site.
         </p>
         <div className="panel rounded-xl px-4 py-3">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
-              <p className="text-xs font-medium uppercase tracking-widest text-input-placeholder">Public link</p>
+              <p className="text-xs font-medium uppercase tracking-widest text-dim-2">Public link</p>
               <a
                 href={publicUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="mt-1 block truncate text-sm font-medium text-input-text underline decoration-line-glass/50 underline-offset-4 hover:decoration-input-text"
+                className="mt-1 block truncate text-sm font-medium text-ink underline decoration-line-glass/50 underline-offset-4 hover:decoration-input-text"
               >
                 {publicUrl}
               </a>
@@ -146,11 +146,11 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
       </div>
 
       <div className="space-y-3">
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code> to load this intake flow.
         </p>
         <div className="relative group">
-          <pre className="bg-elevation-2 overflow-x-auto rounded-xl border border-line-subtle p-4 pr-20 text-sm font-mono text-input-text">
+          <pre className="bg-elevation-2 overflow-x-auto rounded-xl border border-line-subtle p-4 pr-20 text-sm font-mono text-ink">
             {snippet}
           </pre>
           <Button
@@ -171,12 +171,12 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
         description="Copy or inspect the embed snippet for this intake template."
       >
         <DialogBody>
-          <p className="mb-3 text-sm text-input-placeholder">Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code>.</p>
+          <p className="mb-3 text-sm text-dim-2">Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code>.</p>
           <textarea
             ref={textareaRef}
             readOnly
             value={snippet}
-            className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-input-text"
+            className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-ink"
             rows={6}
             aria-label="Embed snippet"
           />
@@ -231,12 +231,12 @@ export function EmbedCodeDialog({ isOpen, onClose, practiceSlug, templateSlug }:
   return (
     <Dialog isOpen={isOpen} onClose={onClose} title="Embed code" description="Copy or inspect the embed snippet for this intake template.">
       <DialogBody>
-        <p className="mb-3 text-sm text-input-placeholder">Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code>.</p>
+        <p className="mb-3 text-sm text-dim-2">Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code>.</p>
         <textarea
           ref={textareaRef}
           readOnly
           value={snippet}
-          className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-input-text"
+          className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-ink"
           rows={6}
           aria-label="Embed snippet"
         />

--- a/src/features/intake/components/IntakeFilesPanel.tsx
+++ b/src/features/intake/components/IntakeFilesPanel.tsx
@@ -117,8 +117,8 @@ export const IntakeFilesPanel: FunctionComponent<IntakeFilesPanelProps> = ({
         showEmptyState={false}
         header={(
           <div className="flex min-w-0 items-center gap-2">
-            <Icon icon={FileText} className="h-4 w-4 text-input-placeholder" />
-            <h3 className="text-sm font-semibold text-input-text">Files</h3>
+            <Icon icon={FileText} className="h-4 w-4 text-dim-2" />
+            <h3 className="text-sm font-semibold text-ink">Files</h3>
           </div>
         )}
       />
@@ -129,7 +129,7 @@ export const IntakeFilesPanel: FunctionComponent<IntakeFilesPanelProps> = ({
             <button
               key={`delete-${file.id}`}
               type="button"
-              className="text-input-placeholder hover:text-red-500"
+              className="text-dim-2 hover:text-red-500"
               onClick={() => setPendingDelete(file)}
             >
               Delete {file.fileName}

--- a/src/features/intake/components/IntakePaymentForm.tsx
+++ b/src/features/intake/components/IntakePaymentForm.tsx
@@ -346,10 +346,10 @@ export const IntakePaymentForm: FunctionComponent<IntakePaymentFormProps> = ({
               </svg>
             </div>
           </div>
-          <h3 className="text-lg font-semibold text-input-text mb-1">
+          <h3 className="text-lg font-semibold text-ink mb-1">
             Payment successful
           </h3>
-          <p className="text-input-placeholder">
+          <p className="text-dim-2">
             Thank you! Your payment was successful and your case details are being processed. A member of our team will contact you at the information you provided.
           </p>
           <div className="mt-4 border-t border-line-subtle pt-4 text-xs text-emerald-700 dark:text-emerald-300">

--- a/src/features/intake/components/PrivacySupportSidebar.tsx
+++ b/src/features/intake/components/PrivacySupportSidebar.tsx
@@ -19,7 +19,7 @@ const PrivacySupportSidebar = ({ className }: PrivacySupportSidebarProps) => {
               href="https://blawby.com/privacy"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-xs sm:text-sm text-input-placeholder hover:text-accent dark:hover:text-accent transition-colors duration-200"
+              className="flex items-center gap-2 text-xs sm:text-sm text-dim-2 hover:text-accent dark:hover:text-accent transition-colors duration-200"
             >
               <Icon icon={ShieldCheck} className="w-4 h-4"  />
               Privacy Policy
@@ -29,7 +29,7 @@ const PrivacySupportSidebar = ({ className }: PrivacySupportSidebarProps) => {
               href="https://blawby.com/help"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-xs sm:text-sm text-input-placeholder hover:text-accent dark:hover:text-accent transition-colors duration-200"
+              className="flex items-center gap-2 text-xs sm:text-sm text-dim-2 hover:text-accent dark:hover:text-accent transition-colors duration-200"
             >
               <Icon icon={HelpCircle} className="w-4 h-4"  />
               Help & Support

--- a/src/features/intake/pages/ClientIntakeStatusPage.tsx
+++ b/src/features/intake/pages/ClientIntakeStatusPage.tsx
@@ -50,7 +50,7 @@ const statusPillClass = (kind: ClientIntakeStatusKind): string => {
       return 'bg-accent-warning/15 text-accent-warning ring-accent-warning/30';
     case 'submitted':
     default:
-      return 'bg-surface-utility/40 text-input-text ring-line-subtle/30';
+      return 'bg-surface-utility/40 text-ink ring-line-subtle/30';
   }
 };
 
@@ -71,7 +71,7 @@ const Card: FunctionComponent<{ children: ComponentChildren; className?: string 
 );
 
 const SectionHeading: FunctionComponent<{ children: ComponentChildren }> = ({ children }) => (
-  <h2 className="text-sm font-semibold text-input-text">{children}</h2>
+  <h2 className="text-sm font-semibold text-ink">{children}</h2>
 );
 
 const TimelineRow: FunctionComponent<{ item: ClientIntakeTimelineItem; isLast: boolean }> = ({
@@ -84,7 +84,7 @@ const TimelineRow: FunctionComponent<{ item: ClientIntakeTimelineItem; isLast: b
       : item.state === 'current'
         ? 'bg-accent-warning'
         : 'bg-input-placeholder/60';
-  const textClass = item.state === 'upcoming' ? 'text-input-placeholder' : 'text-input-text';
+  const textClass = item.state === 'upcoming' ? 'text-dim-2' : 'text-ink';
 
   return (
     <li className="flex gap-3">
@@ -94,7 +94,7 @@ const TimelineRow: FunctionComponent<{ item: ClientIntakeTimelineItem; isLast: b
       </div>
       <div className="flex-1 pb-3">
         <p className={cn('text-sm font-medium', textClass)}>{item.title}</p>
-        <p className="text-xs text-input-placeholder">{item.timestamp}</p>
+        <p className="text-xs text-dim-2">{item.timestamp}</p>
       </div>
     </li>
   );
@@ -110,7 +110,7 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
     return (
       <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
         <DetailHeader title="Intake Forms" showBack={Boolean(onBack)} onBack={onBack} />
-        <div className="p-6 text-sm text-input-placeholder">
+        <div className="p-6 text-sm text-dim-2">
           You have not submitted any intakes yet.
         </div>
       </div>
@@ -126,7 +126,7 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
           {/* Status card */}
           <Card>
             <div className="flex items-center justify-between gap-3">
-              <h1 className="text-base font-semibold text-input-text">{intake.templateName}</h1>
+              <h1 className="text-base font-semibold text-ink">{intake.templateName}</h1>
               <span
                 className={cn(
                   'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ring-1 ring-inset',
@@ -136,14 +136,14 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
                 {intake.statusLabel}
               </span>
             </div>
-            <p className="mt-2 text-xs text-input-placeholder">Submitted {intake.submittedAt}</p>
+            <p className="mt-2 text-xs text-dim-2">Submitted {intake.submittedAt}</p>
           </Card>
 
           {/* Next step */}
           {intake.nextStep ? (
             <Card className="bg-surface-utility/30">
               <SectionHeading>Next Step</SectionHeading>
-              <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-input-text/90">
+              <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-ink/90">
                 {intake.nextStep}
               </p>
             </Card>
@@ -168,8 +168,8 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
               <dl className="mt-3 space-y-3">
                 {intake.responses.map((r) => (
                   <div key={r.id} className="space-y-1">
-                    <dt className="text-xs text-input-placeholder">{r.question}</dt>
-                    <dd className="whitespace-pre-wrap text-sm text-input-text">{r.answer}</dd>
+                    <dt className="text-xs text-dim-2">{r.question}</dt>
+                    <dd className="whitespace-pre-wrap text-sm text-ink">{r.answer}</dd>
                   </div>
                 ))}
               </dl>
@@ -190,7 +190,7 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
           {intake.notes ? (
             <Card>
               <SectionHeading>Notes</SectionHeading>
-              <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-input-text/90">
+              <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-ink/90">
                 {intake.notes}
               </p>
             </Card>

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -236,7 +236,7 @@ function triageBadgeClass(status?: string | null): string {
     case 'rejected':
       return 'bg-error/10 text-error ring-error/20';
     case 'spam':
-      return 'bg-surface-utility/40 text-input-placeholder ring-line-subtle/30';
+      return 'bg-surface-utility/40 text-dim-2 ring-line-subtle/30';
     case 'pending_review':
     default:
       return 'bg-warning/10 text-warning ring-warning/20';
@@ -246,7 +246,7 @@ function triageBadgeClass(status?: string | null): string {
 // ── Sub-components ───────────────────────────────────────────────────────────
 
 const SectionLabel: FunctionComponent<{ children: ComponentChildren; className?: string }> = ({ children, className }) => (
-  <h2 className={cn('text-[10px] font-semibold uppercase tracking-[1px] text-input-placeholder', className)}>
+  <h2 className={cn('text-[10px] font-semibold uppercase tracking-[1px] text-dim-2', className)}>
     {children}
   </h2>
 );
@@ -267,8 +267,8 @@ const DetailField: FunctionComponent<DetailFieldProps> = ({ label, value, emptyT
   const isEmpty = value === null || value === undefined || value === '';
   return (
     <div className="space-y-1">
-      <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">{label}</dt>
-      <dd className={cn('text-sm break-words', isEmpty ? 'text-input-placeholder' : 'text-input-text')}>
+      <dt className="text-xs font-medium uppercase tracking-wide text-dim-2">{label}</dt>
+      <dd className={cn('text-sm break-words', isEmpty ? 'text-dim-2' : 'text-ink')}>
         {isEmpty ? emptyText : value}
       </dd>
     </div>
@@ -278,7 +278,7 @@ const DetailField: FunctionComponent<DetailFieldProps> = ({ label, value, emptyT
 type InfoChipProps = { icon: typeof CheckCircle2; label: string; tone?: 'default' | 'warning' | 'success' | 'error' };
 const InfoChip: FunctionComponent<InfoChipProps> = ({ icon: IconComp, label, tone = 'default' }) => {
   const toneClass = {
-    default: 'text-input-placeholder',
+    default: 'text-dim-2',
     warning: 'text-warning',
     success: 'text-success',
     error: 'text-error',
@@ -974,13 +974,13 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     <Card>
       <div className="space-y-2">
         <SectionLabel>Intake Details</SectionLabel>
-        <h3 className="text-lg font-bold leading-tight text-input-text sm:text-xl">{intakeTitle}</h3>
-        <p className="text-xs text-input-placeholder">
+        <h3 className="text-lg font-bold leading-tight text-ink sm:text-xl">{intakeTitle}</h3>
+        <p className="text-xs text-dim-2">
           Posted {dateLabel}{practiceServiceName ? ` · ${practiceServiceName}` : ''}
         </p>
       </div>
       {description ? (
-        <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-input-text/90">{description}</p>
+        <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-ink/90">{description}</p>
       ) : null}
       <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
         <InfoChip
@@ -1006,8 +1006,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   const formDetailsCard = (
     <Card>
       <div className="mb-4 flex items-center gap-2">
-        <Icon icon={ClipboardList} className="h-4 w-4 text-input-placeholder" />
-        <h3 className="text-sm font-semibold text-input-text">Form Details</h3>
+        <Icon icon={ClipboardList} className="h-4 w-4 text-dim-2" />
+        <h3 className="text-sm font-semibold text-ink">Form Details</h3>
       </div>
       <dl className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
         <DetailField label="Case Type" value={intakeTitle} />
@@ -1030,13 +1030,13 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     <Card>
       <div className="mb-3 flex items-center gap-2">
         <Icon icon={Sparkles} className="h-4 w-4 text-accent" />
-        <h3 className="text-sm font-semibold text-input-text">AI Analysis</h3>
+        <h3 className="text-sm font-semibold text-ink">AI Analysis</h3>
         {enrichedData.confidence < 0.5 ? (
-          <span className="ml-auto text-[10px] text-input-placeholder">Low confidence</span>
+          <span className="ml-auto text-[10px] text-dim-2">Low confidence</span>
         ) : null}
       </div>
       {enrichedData.ai_matter_description ? (
-        <p className="mb-4 text-sm leading-relaxed text-input-text/90">{enrichedData.ai_matter_description}</p>
+        <p className="mb-4 text-sm leading-relaxed text-ink/90">{enrichedData.ai_matter_description}</p>
       ) : null}
       <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
         {enrichedData.practice_area ? (
@@ -1060,14 +1060,14 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
       </dl>
       {enrichedData.conflict_check_names.length > 0 ? (
         <div className="mt-4 space-y-1">
-          <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Conflict Check</dt>
-          <dd className="text-sm text-input-text">{enrichedData.conflict_check_names.join(', ')}</dd>
+          <dt className="text-xs font-medium uppercase tracking-wide text-dim-2">Conflict Check</dt>
+          <dd className="text-sm text-ink">{enrichedData.conflict_check_names.join(', ')}</dd>
         </div>
       ) : null}
       {enrichedData.ai_scope_suggestion ? (
         <div className="mt-4 space-y-1">
-          <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Suggested Scope</dt>
-          <dd className="text-sm text-input-text/90">{enrichedData.ai_scope_suggestion}</dd>
+          <dt className="text-xs font-medium uppercase tracking-wide text-dim-2">Suggested Scope</dt>
+          <dd className="text-sm text-ink/90">{enrichedData.ai_scope_suggestion}</dd>
         </div>
       ) : null}
       <div className="mt-4 flex flex-wrap gap-3">
@@ -1080,7 +1080,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <p className="mt-2 text-xs text-warning">{enrichedData.sol_risk_notes}</p>
       ) : null}
       {enrichedData.multi_state_notes ? (
-        <p className="mt-2 text-xs text-input-placeholder">{enrichedData.multi_state_notes}</p>
+        <p className="mt-2 text-xs text-dim-2">{enrichedData.multi_state_notes}</p>
       ) : null}
     </Card>
   ) : null;
@@ -1092,7 +1092,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           <div className="rounded-lg bg-accent/10 p-2 text-accent">
             <Icon icon={Sparkles} className="h-4 w-4" />
           </div>
-          <p className="text-sm leading-relaxed text-input-text/90">
+          <p className="text-sm leading-relaxed text-ink/90">
             Blawby can ask the client for the missing legal details and add them to this thread.
           </p>
         </div>
@@ -1114,7 +1114,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     <Card className="flex min-h-[420px] flex-col p-0 overflow-hidden">
       <div className="border-b border-line-subtle p-4 sm:px-6 sm:py-5">
         <SectionLabel>Conversation</SectionLabel>
-        <p className="mt-1 text-xs text-input-placeholder">Continue the client thread from this intake.</p>
+        <p className="mt-1 text-xs text-dim-2">Continue the client thread from this intake.</p>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden bg-surface-overlay/20 touch-pan-y">
         {previewLoading && previewMessages.length === 0 ? (
@@ -1125,8 +1125,8 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           </div>
         ) : previewMessages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center p-6 text-center">
-            <Icon icon={MessageSquare} className="mb-2 h-6 w-6 text-input-placeholder" />
-            <p className="text-sm text-input-placeholder">No conversation history yet.</p>
+            <Icon icon={MessageSquare} className="mb-2 h-6 w-6 text-dim-2" />
+            <p className="text-sm text-dim-2">No conversation history yet.</p>
           </div>
         ) : (
           <VirtualMessageList
@@ -1191,22 +1191,22 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
       <dl className="space-y-3 text-sm">
         {email ? (
           <div className="flex items-start gap-3">
-            <Icon icon={Mail} className="mt-0.5 h-4 w-4 shrink-0 text-input-placeholder" />
+            <Icon icon={Mail} className="mt-0.5 h-4 w-4 shrink-0 text-dim-2" />
             <div className="min-w-0 flex-1">
-              <dt className="text-xs text-input-placeholder">Email</dt>
+              <dt className="text-xs text-dim-2">Email</dt>
               <dd className="truncate">
-                <a href={`mailto:${email}`} className="text-input-text hover:text-accent">{email}</a>
+                <a href={`mailto:${email}`} className="text-ink hover:text-accent">{email}</a>
               </dd>
             </div>
           </div>
         ) : null}
         {phone ? (
           <div className="flex items-start gap-3">
-            <Icon icon={Phone} className="mt-0.5 h-4 w-4 shrink-0 text-input-placeholder" />
+            <Icon icon={Phone} className="mt-0.5 h-4 w-4 shrink-0 text-dim-2" />
             <div className="min-w-0 flex-1">
-              <dt className="text-xs text-input-placeholder">Phone</dt>
+              <dt className="text-xs text-dim-2">Phone</dt>
               <dd>
-                <a href={`tel:${phone}`} className="text-input-text hover:text-accent">{phone}</a>
+                <a href={`tel:${phone}`} className="text-ink hover:text-accent">{phone}</a>
               </dd>
             </div>
           </div>
@@ -1247,10 +1247,10 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <Avatar
           name={name ?? ''}
           size="md"
-          className="bg-surface-utility/40 text-input-text ring-1 ring-line-subtle"
+          className="bg-surface-utility/40 text-ink ring-1 ring-line-subtle"
         />
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-input-text">{name ?? 'Unnamed lead'}</p>
+          <p className="truncate text-sm font-semibold text-ink">{name ?? 'Unnamed lead'}</p>
           {intake.payment_verified ? (
             <p className="mt-0.5 inline-flex items-center gap-1 text-xs text-success">
               <Icon icon={CheckCircle2} className="h-3 w-3" />
@@ -1263,17 +1263,17 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <dl className="mt-4 space-y-2 text-sm">
           {email ? (
             <div>
-              <dt className="text-xs text-input-placeholder">Email</dt>
+              <dt className="text-xs text-dim-2">Email</dt>
               <dd className="truncate">
-                <a href={`mailto:${email}`} className="text-input-text hover:text-accent">{email}</a>
+                <a href={`mailto:${email}`} className="text-ink hover:text-accent">{email}</a>
               </dd>
             </div>
           ) : null}
           {phone ? (
             <div>
-              <dt className="text-xs text-input-placeholder">Phone</dt>
+              <dt className="text-xs text-dim-2">Phone</dt>
               <dd>
-                <a href={`tel:${phone}`} className="text-input-text hover:text-accent">{phone}</a>
+                <a href={`tel:${phone}`} className="text-ink hover:text-accent">{phone}</a>
               </dd>
             </div>
           ) : null}
@@ -1399,7 +1399,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <DialogBody className="space-y-4">
           {engagementTemplates.length > 1 ? (
             <div className="space-y-2">
-              <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Select Template</p>
+              <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Select Template</p>
               <div className="flex flex-col gap-1">
                 {engagementTemplates.map((t) => (
                   <button
@@ -1409,12 +1409,12 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                       'flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors',
                       generateTemplateId === t.id
                         ? 'border-accent bg-accent/10 text-[rgb(var(--accent-foreground))]'
-                        : 'border-card-border bg-surface-card text-input-text hover:bg-surface-overlay/40',
+                        : 'border-card-border bg-surface-card text-ink hover:bg-surface-overlay/40',
                     )}
                     onClick={() => setGenerateTemplateId(t.id)}
                   >
                     <span className="flex-1 font-medium">{t.name}</span>
-                    {t.practiceArea ? <span className="text-xs text-input-placeholder">{t.practiceArea}</span> : null}
+                    {t.practiceArea ? <span className="text-xs text-dim-2">{t.practiceArea}</span> : null}
                   </button>
                 ))}
               </div>
@@ -1423,7 +1423,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           {generatedBody ? (
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Generated Letter</p>
+                <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Generated Letter</p>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/src/features/intake/pages/IntakeTemplatesPage.tsx
+++ b/src/features/intake/pages/IntakeTemplatesPage.tsx
@@ -358,8 +358,8 @@ type StatPillProps = {
 function _StatPill({ label, value }: StatPillProps) {
   return (
     <div className="rounded-xl border border-line-subtle bg-surface-card px-3 py-2">
-      <p className="text-lg font-semibold text-input-text">{value}</p>
-      <p className="text-xs text-input-placeholder">{label}</p>
+      <p className="text-lg font-semibold text-ink">{value}</p>
+      <p className="text-xs text-dim-2">{label}</p>
     </div>
   );
 }
@@ -396,7 +396,7 @@ function useIsDesktop(breakpointPx = 768): boolean {
 
 function SectionHeaderLabel({ children }: { children: string }) {
   return (
-    <p className="px-1 text-[11px] font-semibold uppercase tracking-wider text-input-placeholder">
+    <p className="px-1 text-[11px] font-semibold uppercase tracking-wider text-dim-2">
       {children}
     </p>
   );
@@ -434,9 +434,9 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
           }}
           className="flex min-w-0 flex-1 items-center gap-2 text-left"
         >
-          <span className="font-mono text-xs text-input-placeholder">{number}.</span>
-          <span className="text-input-placeholder">{icon}</span>
-          <span className="truncate text-sm font-medium text-input-text">{title}</span>
+          <span className="font-mono text-xs text-dim-2">{number}.</span>
+          <span className="text-dim-2">{icon}</span>
+          <span className="truncate text-sm font-medium text-ink">{title}</span>
         </button>
         {badge ? (
           <span
@@ -444,7 +444,7 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
               'rounded-full px-2 py-0.5 text-[11px] font-medium',
               badge.tone === 'required'
                 ? 'bg-accent-500 text-[rgb(var(--accent-foreground))]'
-                : 'bg-surface-input text-input-placeholder',
+                : 'bg-surface-input text-dim-2',
             )}
           >
             {badge.label}
@@ -456,7 +456,7 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
             onClick={onToggle}
             aria-label={isOpen ? `Collapse ${title}` : `Expand ${title}`}
             aria-expanded={isOpen}
-            className="inline-flex h-6 w-6 items-center justify-center rounded text-input-placeholder hover:text-input-text"
+            className="inline-flex h-6 w-6 items-center justify-center rounded text-dim-2 hover:text-ink"
           >
             <ChevronDown className={cn('h-4 w-4 transition-transform', isOpen && 'rotate-180')} />
           </button>
@@ -515,13 +515,13 @@ function QuestionRow({ label, preview, isSelected, isLocked, badgeLabel, onSelec
       onDragOver={dragHandlers?.onDragOver}
     >
       {isLocked ? (
-        <Lock className="h-3.5 w-3.5 shrink-0 text-input-placeholder" aria-hidden="true" />
+        <Lock className="h-3.5 w-3.5 shrink-0 text-dim-2" aria-hidden="true" />
       ) : (
         <button
           type="button"
           onKeyDown={handleGripKey}
           aria-label={`Reorder ${displayLabel} — Arrow Up or Down to move`}
-          className="inline-flex h-5 w-3.5 shrink-0 cursor-grab items-center justify-center rounded text-input-placeholder hover:text-input-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/45"
+          className="inline-flex h-5 w-3.5 shrink-0 cursor-grab items-center justify-center rounded text-dim-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/45"
         >
           <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
@@ -531,11 +531,11 @@ function QuestionRow({ label, preview, isSelected, isLocked, badgeLabel, onSelec
         onClick={onSelect}
         className="min-w-0 flex-1 text-left focus-visible:outline-none"
       >
-        <span className="block truncate text-input-text">{displayLabel}</span>
-        {previewText ? <span className="block truncate text-xs text-input-placeholder">{previewText}</span> : null}
+        <span className="block truncate text-ink">{displayLabel}</span>
+        {previewText ? <span className="block truncate text-xs text-dim-2">{previewText}</span> : null}
       </button>
       {badgeLabel ? (
-        <span className="shrink-0 text-[11px] font-medium text-input-placeholder">{badgeLabel}</span>
+        <span className="shrink-0 text-[11px] font-medium text-dim-2">{badgeLabel}</span>
       ) : null}
     </div>
   );
@@ -543,7 +543,7 @@ function QuestionRow({ label, preview, isSelected, isLocked, badgeLabel, onSelec
 
 function LockedFieldChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-line-subtle bg-surface-input px-2 py-0.5 text-[11px] font-medium text-input-placeholder">
+    <span className="inline-flex items-center gap-1 rounded-full border border-line-subtle bg-surface-input px-2 py-0.5 text-[11px] font-medium text-dim-2">
       <Lock className="h-3 w-3" />
       {label}
     </span>
@@ -556,7 +556,7 @@ function AddInlineButton({ children, onClick, disabled = false }: { children: st
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="mt-1 flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-line-subtle px-2 py-1.5 text-xs font-medium text-input-placeholder transition-colors hover:border-line-subtle hover:text-input-text disabled:cursor-not-allowed disabled:opacity-50"
+      className="mt-1 flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-line-subtle px-2 py-1.5 text-xs font-medium text-dim-2 transition-colors hover:border-line-subtle hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
     >
       <Plus className="h-3.5 w-3.5" />
       {children}
@@ -575,10 +575,10 @@ function ConfigField({
 }) {
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-sm font-medium text-input-text">{label}</span>
+      <span className="text-sm font-medium text-ink">{label}</span>
       {children}
       {charCount ? (
-        <span className="self-end text-[11px] text-input-placeholder">
+        <span className="self-end text-[11px] text-dim-2">
           {charCount.value.length}/{charCount.max}
         </span>
       ) : null}
@@ -997,7 +997,7 @@ function TemplateEditor({
         onInput={(event) => handleNameChange((event.currentTarget as HTMLInputElement).value)}
         placeholder="New intake form"
         disabled={isSaving}
-        className="w-full min-w-0 rounded-lg border border-transparent bg-transparent px-2 py-1 text-base font-semibold text-input-text outline-none transition-colors placeholder:text-input-placeholder hover:border-line-subtle focus:border-line-subtle focus:bg-surface-utility/10"
+        className="w-full min-w-0 rounded-lg border border-transparent bg-transparent px-2 py-1 text-base font-semibold text-ink outline-none transition-colors placeholder:text-dim-2 hover:border-line-subtle focus:border-line-subtle focus:bg-surface-utility/10"
         aria-label="Form title"
       />
       {slugError ? <p className="mt-1 text-xs text-rose-500">{slugError}</p> : null}
@@ -1074,7 +1074,7 @@ function TemplateEditor({
           hasChanges
             ? 'border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300'
             : hasSavedDraft
-              ? 'border-line-subtle bg-surface-input text-input-placeholder'
+              ? 'border-line-subtle bg-surface-input text-dim-2'
               : 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
         )}
       >
@@ -1118,7 +1118,7 @@ function TemplateEditor({
       <SectionHeaderLabel>FORM STRUCTURE</SectionHeaderLabel>
       {discardPending ? (
         <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 p-3">
-          <p className="text-sm font-semibold text-input-text">Discard draft changes?</p>
+          <p className="text-sm font-semibold text-ink">Discard draft changes?</p>
           <div className="mt-3 flex gap-2">
             <Button
               type="button"
@@ -1338,15 +1338,15 @@ function TemplateEditor({
       <div className="w-full max-w-[380px] overflow-hidden rounded-xl border border-line-subtle bg-surface-card shadow-glass">
         <div className="flex h-11 items-center justify-between border-b border-line-subtle bg-surface-utility/50 px-3">
           <div className="min-w-0">
-            <p className="text-sm font-semibold text-input-text">Widget preview</p>
-            <p className="truncate text-xs text-input-placeholder">{practiceSlug || 'public form'} / {draftTemplate.slug || 'new'}</p>
+            <p className="text-sm font-semibold text-ink">Widget preview</p>
+            <p className="truncate text-xs text-dim-2">{practiceSlug || 'public form'} / {draftTemplate.slug || 'new'}</p>
           </div>
           <a
             href={publicFormUrl}
             target="_blank"
             rel="noreferrer"
             aria-label="Open public form preview"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-input-placeholder transition-colors hover:bg-surface-input hover:text-input-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-dim-2 transition-colors hover:bg-surface-input hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40"
           >
             <ExternalLink className="h-4 w-4" aria-hidden="true" />
           </a>
@@ -1438,10 +1438,10 @@ function TemplateEditor({
             <button
               type="button"
               disabled
-              className="flex items-center justify-between rounded-lg border border-line-subtle bg-surface-input px-3 py-2 text-left text-sm text-input-text"
+              className="flex items-center justify-between rounded-lg border border-line-subtle bg-surface-input px-3 py-2 text-left text-sm text-ink"
             >
               <span>Free text</span>
-              <ChevronDown className="h-4 w-4 text-input-placeholder" />
+              <ChevronDown className="h-4 w-4 text-dim-2" />
             </button>
           </ConfigField>
           <Switch
@@ -1591,14 +1591,14 @@ function TemplateEditor({
       // editable here, so the inspector renders a compact, low-chrome state
       // instead of a full settings panel.
       return (
-        <div className="flex flex-col gap-2 p-4 text-sm text-input-placeholder">
+        <div className="flex flex-col gap-2 p-4 text-sm text-dim-2">
           Name, email, and phone are collected automatically before the conversation starts. These fields cannot be edited from the question builder.
         </div>
       );
     }
 
     return (
-      <div className="flex flex-col gap-2 p-4 text-sm text-input-placeholder">
+      <div className="flex flex-col gap-2 p-4 text-sm text-dim-2">
         Select a section or question to configure.
       </div>
     );
@@ -1624,15 +1624,15 @@ function TemplateEditor({
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-input-text">{inspectorTitle}</p>
-          <p className="truncate text-xs text-input-placeholder">{inspectorBreadcrumb}</p>
+          <p className="text-sm font-semibold text-ink">{inspectorTitle}</p>
+          <p className="truncate text-xs text-dim-2">{inspectorBreadcrumb}</p>
         </div>
         {showCloseButton ? (
           <button
             type="button"
             onClick={closeInspector}
             aria-label="Close panel"
-            className="inline-flex h-6 w-6 items-center justify-center rounded text-input-placeholder hover:text-input-text"
+            className="inline-flex h-6 w-6 items-center justify-center rounded text-dim-2 hover:text-ink"
           >
             <X className="h-4 w-4" />
           </button>
@@ -1659,7 +1659,7 @@ function TemplateEditor({
               aria-label="Back to list"
               onClick={() => setMobileView('list')}
             />
-            <h1 className="flex-1 text-center text-sm font-semibold text-input-text">{mobileTitle}</h1>
+            <h1 className="flex-1 text-center text-sm font-semibold text-ink">{mobileTitle}</h1>
             <span className="w-8" aria-hidden="true" />
           </header>
           <div className="min-h-0 flex-1 overflow-y-auto">{renderConfigBody()}</div>
@@ -1679,7 +1679,7 @@ function TemplateEditor({
               aria-label="Back to list"
               onClick={() => setMobileView('list')}
             />
-            <h1 className="flex-1 text-center text-sm font-semibold text-input-text">Live preview</h1>
+            <h1 className="flex-1 text-center text-sm font-semibold text-ink">Live preview</h1>
             <span className="w-8" aria-hidden="true" />
           </header>
           <div className="flex min-h-0 flex-1 flex-col items-center gap-4 overflow-y-auto p-4">
@@ -1691,7 +1691,7 @@ function TemplateEditor({
               viewportClassName="h-[min(720px,calc(100svh-12rem))] min-h-[480px]"
               initialIntakeStep="conversation"
             />
-            <p className="text-center text-xs text-input-placeholder">
+            <p className="text-center text-xs text-dim-2">
               Try the form like a client would — answers are not saved.
             </p>
           </div>
@@ -1710,7 +1710,7 @@ function TemplateEditor({
             aria-label="Close"
             onClick={onCancel}
           />
-          <h1 className="flex-1 text-center text-sm font-semibold text-input-text">Question Builder</h1>
+          <h1 className="flex-1 text-center text-sm font-semibold text-ink">Question Builder</h1>
           <span className="w-8" aria-hidden="true" />
         </header>
         <div className="flex items-center justify-center gap-2 border-b border-line-subtle px-3 py-2">
@@ -1866,14 +1866,14 @@ function TemplateListView({
         name: (
           <div className="min-w-0">
             <div className="flex min-w-0 items-center gap-2">
-              <p className="truncate font-medium text-input-text">{template.name}</p>
+              <p className="truncate font-medium text-ink">{template.name}</p>
               {hasDraft ? (
                 <span className="shrink-0 rounded-full border border-amber-500/25 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
                   Draft
                 </span>
               ) : null}
             </div>
-            {isDefault ? <p className="text-xs text-input-placeholder">Default form</p> : isDraftOnly ? <p className="text-xs text-input-placeholder">Not published yet</p> : null}
+            {isDefault ? <p className="text-xs text-dim-2">Default form</p> : isDraftOnly ? <p className="text-xs text-dim-2">Not published yet</p> : null}
           </div>
         ),
         questions: <span className="tabular-nums">{template.fields.length}</span>,
@@ -1894,7 +1894,7 @@ function TemplateListView({
                 onClick={(e) => e.stopPropagation()}
                 disabled={isSaving}
                 aria-label={`Actions for ${template.name}`}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-input-placeholder transition-colors hover:bg-surface-utility/10 hover:text-input-text disabled:opacity-60"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-dim-2 transition-colors hover:bg-surface-utility/10 hover:text-ink disabled:opacity-60"
               >
                 <MoreVertical className="h-4 w-4" />
               </button>
@@ -1961,10 +1961,10 @@ function TemplateListView({
         title="Archive form"
       >
         <DialogBody>
-          <p className="text-sm text-input-text">
+          <p className="text-sm text-ink">
             Are you sure you want to archive <strong>{deleteTarget?.name}</strong>?
           </p>
-          <p className="mt-2 text-sm text-input-placeholder">
+          <p className="mt-2 text-sm text-dim-2">
             Links using{' '}
             <code className="rounded bg-surface-utility px-1.5 py-0.5 font-mono text-xs">
               ?template={deleteTarget?.slug}

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -49,7 +49,7 @@ const triageStatusVariant = (status: string | null | undefined): {
     case 'rejected':
       return { label: status === 'rejected' ? 'Rejected' : 'Declined', className: 'text-error' };
     case 'spam':
-      return { label: 'Spam', className: 'text-input-placeholder' };
+      return { label: 'Spam', className: 'text-dim-2' };
     case 'pending_review':
     default:
       return { label: 'Pending Review', className: 'text-warning' };
@@ -220,7 +220,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
     );
   }
 
-  const headerCellClass = 'text-xs font-semibold uppercase tracking-wide text-input-placeholder';
+  const headerCellClass = 'text-xs font-semibold uppercase tracking-wide text-dim-2';
   const columns: DataTableColumn[] = [
     {
       id: 'subject',
@@ -233,7 +233,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
       label: 'Contact',
       hideAt: 'sm',
       headerClassName: headerCellClass,
-      mobileClassName: 'text-input-placeholder',
+      mobileClassName: 'text-dim-2',
     },
     {
       id: 'status',
@@ -257,10 +257,10 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
       id: item.uuid,
       onClick: () => handleSelectIntake(item),
       cells: {
-        subject: <span className="truncate font-medium text-input-text">{subject}</span>,
-        contact: <span className="truncate text-input-placeholder">{contact}</span>,
+        subject: <span className="truncate font-medium text-ink">{subject}</span>,
+        contact: <span className="truncate text-dim-2">{contact}</span>,
         status: <span className={cn('font-medium', triage.className)}>{triage.label}</span>,
-        date: <span className="tabular-nums text-input-placeholder">{formatRelativeTime(item.created_at)}</span>,
+        date: <span className="tabular-nums text-dim-2">{formatRelativeTime(item.created_at)}</span>,
       },
     };
   });
@@ -359,8 +359,8 @@ const IntakeMobileCard: FunctionComponent<IntakeMobileCardProps> = ({ item, onCl
   const email = item.metadata?.email?.trim() || '—';
 
   const rows: ReadonlyArray<{ label: string; value: ComponentChildren }> = [
-    { label: 'Subject', value: <span className="font-medium text-input-text break-words">{subject}</span> },
-    { label: 'Email', value: <span className="text-input-placeholder break-all">{email}</span> },
+    { label: 'Subject', value: <span className="font-medium text-ink break-words">{subject}</span> },
+    { label: 'Email', value: <span className="text-dim-2 break-all">{email}</span> },
     { label: 'Status', value: <span className={cn('font-medium', triage.className)}>{triage.label}</span> },
   ];
 
@@ -373,7 +373,7 @@ const IntakeMobileCard: FunctionComponent<IntakeMobileCardProps> = ({ item, onCl
       <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm">
         {rows.map(({ label, value }) => (
           <div key={label} className="contents">
-            <dt className="text-xs font-medium uppercase tracking-wide text-input-placeholder">{label}</dt>
+            <dt className="text-xs font-medium uppercase tracking-wide text-dim-2">{label}</dt>
             <dd className="text-right">{value}</dd>
           </div>
         ))}

--- a/src/features/invoices/components/InvoiceBuilderSurface.tsx
+++ b/src/features/invoices/components/InvoiceBuilderSurface.tsx
@@ -195,7 +195,7 @@ export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilde
   }
 
   if (mode === 'edit' && !resolvedInvoice && !shouldShowLoading && !displayErrorMessage) {
-    return <div className="p-6 text-sm text-input-placeholder">Invoice not found</div>;
+    return <div className="p-6 text-sm text-dim-2">Invoice not found</div>;
   }
 
   if (mode === 'edit' && displayErrorMessage && !resolvedInvoice) {

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -411,7 +411,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
                   placeholder="Choose a contact"
                   disabled={resolvedReadOnly}
                   footer={!resolvedReadOnly ? () => (
-                    <div className="px-3 py-2 text-sm text-input-placeholder">
+                    <div className="px-3 py-2 text-sm text-dim-2">
                       <button
                         type="button"
                         className="inline-flex items-center gap-2 text-sm text-accent-foreground underline"
@@ -468,12 +468,12 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
               readOnly={resolvedReadOnly}
             />
             <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-input-text">Request payment</h3>
-              <p className="text-xs text-input-placeholder">
+              <h3 className="text-sm font-semibold text-ink">Request payment</h3>
+              <p className="text-xs text-dim-2">
                 Choose when this invoice should be due.
               </p>
               <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm text-input-text">
+                <label className="flex items-center gap-2 text-sm text-ink">
                   <input
                     type="radio"
                     name="due-date-mode"
@@ -486,7 +486,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
                   />
                   <span>Due tomorrow ({defaultDueDate})</span>
                 </label>
-                <label className="flex items-center gap-2 text-sm text-input-text">
+                <label className="flex items-center gap-2 text-sm text-ink">
                   <input
                     type="radio"
                     name="due-date-mode"

--- a/src/features/invoices/components/InvoiceLineItemsForm.tsx
+++ b/src/features/invoices/components/InvoiceLineItemsForm.tsx
@@ -47,7 +47,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-input-text">Line items</h3>
+        <h3 className="text-sm font-semibold text-ink">Line items</h3>
         {!readOnly ? (
           <Button
             size="xs"
@@ -63,7 +63,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
 
       {lineItems.length === 0 ? (
         <div className="rounded-xl border border-dashed border-line-subtle p-8 text-center bg-surface-utility/20">
-           <p className="text-sm text-input-placeholder">No line items added yet.</p>
+           <p className="text-sm text-dim-2">No line items added yet.</p>
            {!readOnly ? (
              <Button
               size="sm"
@@ -86,13 +86,13 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
                 key={item.id}
                 className="group flex items-center gap-3 py-3"
               >
-                <div className="min-w-0 flex-1 text-sm text-input-text">
+                <div className="min-w-0 flex-1 text-sm text-ink">
                   <span className="break-words">
-                    {item.description || <i className="text-input-placeholder">No description</i>}
+                    {item.description || <i className="text-dim-2">No description</i>}
                   </span>
-                  <span className="text-input-placeholder"> × {qtyFormatted}</span>
+                  <span className="text-dim-2"> × {qtyFormatted}</span>
                 </div>
-                <span className="shrink-0 text-sm tabular-nums text-input-text">
+                <span className="shrink-0 text-sm tabular-nums text-ink">
                   {formatCurrency(itemTotal)}
                 </span>
                 {!readOnly ? (
@@ -102,7 +102,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
                       variant="ghost"
                       onClick={() => setEditingItem({ item, index })}
                       icon={SquarePen}
-                      iconClassName="h-4 w-4 text-input-placeholder hover:text-accent-foreground"
+                      iconClassName="h-4 w-4 text-dim-2 hover:text-accent-foreground"
                       aria-label="Edit item"
                       title="Edit item"
                     />
@@ -111,7 +111,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
                       variant="ghost"
                       onClick={() => removeItem(index)}
                       icon={Trash2}
-                      iconClassName="h-4 w-4 text-input-placeholder hover:text-accent-error-light"
+                      iconClassName="h-4 w-4 text-dim-2 hover:text-accent-error-light"
                       aria-label="Delete item"
                       title="Delete item"
                     />

--- a/src/features/invoices/components/InvoicePagination.tsx
+++ b/src/features/invoices/components/InvoicePagination.tsx
@@ -19,7 +19,7 @@ export const InvoicePagination: FunctionComponent<InvoicePaginationProps> = ({
   const currentPage = Math.min(Math.max(1, page), totalPages);
 
   return (
-    <div className="mt-4 flex items-center justify-between text-sm text-input-placeholder">
+    <div className="mt-4 flex items-center justify-between text-sm text-dim-2">
       <span>
         Page {currentPage} of {totalPages} ({total} invoices)
       </span>

--- a/src/features/invoices/components/InvoiceRowParts.tsx
+++ b/src/features/invoices/components/InvoiceRowParts.tsx
@@ -66,7 +66,7 @@ export const InvoiceStatusActions = ({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="rounded-md p-1 text-input-placeholder transition-colors hover:bg-surface-utility/40 hover:text-input-text"
+          className="rounded-md p-1 text-dim-2 transition-colors hover:bg-surface-utility/40 hover:text-ink"
           aria-label="Invoice actions"
           disabled={hasPendingAction}
           onClick={(event) => event.stopPropagation()}

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -93,63 +93,63 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         case 'clientName':
           return { id: key, label: 'Customer name' };
         case 'clientEmail':
-          return { id: key, label: 'Customer email', hideAt: 'md', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Customer email', hideAt: 'md', mobileClassName: 'text-dim-2' };
         case 'dueDate':
-          return { id: key, label: 'Due', hideAt: 'md', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Due', hideAt: 'md', mobileClassName: 'text-dim-2' };
         case 'createdAt':
-          return { id: key, label: 'Created', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Created', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'paidAt':
-          return { id: key, label: 'Paid at', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Paid at', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'subtotal':
-          return { id: key, label: 'Subtotal', align: 'right', hideAt: 'lg', mobileClassName: 'text-input-text' };
+          return { id: key, label: 'Subtotal', align: 'right', hideAt: 'lg', mobileClassName: 'text-ink' };
         case 'taxAmount':
-          return { id: key, label: 'Tax amount', align: 'right', hideAt: 'lg', mobileClassName: 'text-input-text' };
+          return { id: key, label: 'Tax amount', align: 'right', hideAt: 'lg', mobileClassName: 'text-ink' };
         case 'discountAmount':
-          return { id: key, label: 'Discount amount', align: 'right', hideAt: 'lg', mobileClassName: 'text-input-text' };
+          return { id: key, label: 'Discount amount', align: 'right', hideAt: 'lg', mobileClassName: 'text-ink' };
         case 'amountPaid':
-          return { id: key, label: 'Amount paid', align: 'right', hideAt: 'lg', mobileClassName: 'text-input-text' };
+          return { id: key, label: 'Amount paid', align: 'right', hideAt: 'lg', mobileClassName: 'text-ink' };
         case 'amountDue':
-          return { id: key, label: 'Amount due', align: 'right', hideAt: 'lg', mobileClassName: 'text-input-text' };
+          return { id: key, label: 'Amount due', align: 'right', hideAt: 'lg', mobileClassName: 'text-ink' };
         case 'issueDate':
-          return { id: key, label: 'Issue date', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Issue date', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'invoiceType':
-          return { id: key, label: 'Invoice type', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Invoice type', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'notes':
-          return { id: key, label: 'Notes', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Notes', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'memo':
-          return { id: key, label: 'Memo', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Memo', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'fundDestination':
-          return { id: key, label: 'Fund destination', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Fund destination', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'updatedAt':
-          return { id: key, label: 'Updated at', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Updated at', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'clientId':
-          return { id: key, label: 'Client ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Client ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'matterId':
-          return { id: key, label: 'Matter ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Matter ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'connectedAccountId':
-          return { id: key, label: 'Connected account ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Connected account ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'matterTitle':
-          return { id: key, label: 'Matter title', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Matter title', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'matterBillingType':
-          return { id: key, label: 'Billing type', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Billing type', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'clientStatus':
-          return { id: key, label: 'Client status', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Client status', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'stripeInvoiceNumber':
-          return { id: key, label: 'Stripe invoice number', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Stripe invoice number', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'stripeInvoiceId':
-          return { id: key, label: 'Stripe invoice ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Stripe invoice ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'stripeChargeId':
-          return { id: key, label: 'Stripe charge ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Stripe charge ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'stripeTransferId':
-          return { id: key, label: 'Stripe transfer ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Stripe transfer ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'stripePaymentIntentId':
-          return { id: key, label: 'Stripe payment intent ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Stripe payment intent ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'stripeHostedInvoiceUrl':
-          return { id: key, label: 'Hosted invoice URL', hideAt: 'lg', mobileClassName: 'text-input-placeholder', disableCellWrap: true };
+          return { id: key, label: 'Hosted invoice URL', hideAt: 'lg', mobileClassName: 'text-dim-2', disableCellWrap: true };
         case 'connectedAccountEmail':
-          return { id: key, label: 'Connected account email', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Connected account email', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         case 'connectedAccountStripeAccountId':
-          return { id: key, label: 'Stripe account ID', hideAt: 'lg', mobileClassName: 'text-input-placeholder' };
+          return { id: key, label: 'Stripe account ID', hideAt: 'lg', mobileClassName: 'text-dim-2' };
         default:
           return { id: key, label: key };
       }
@@ -173,14 +173,14 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
       cells: {
         total: (
           <div className="flex items-center gap-2">
-            <span className="font-semibold text-input-text">{formatCurrency(invoice.total)}</span>
+            <span className="font-semibold text-ink">{formatCurrency(invoice.total)}</span>
           </div>
         ),
         status: <InvoiceStatusBadge status={invoice.status} />,
         invoiceNumber: (
           <button
             type="button"
-            className="truncate text-left text-sm font-semibold text-input-text hover:underline"
+            className="truncate text-left text-sm font-semibold text-ink hover:underline"
             onClick={(event) => {
               event.stopPropagation();
               onRowClick(invoice);
@@ -194,11 +194,11 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         dueDate: dateValue(invoice.dueDate),
         createdAt: dateValue(invoice.createdAt),
         paidAt: dateValue(invoice.paidAt),
-        subtotal: <span className="text-input-text">{formatCurrency(invoice.subtotal ?? 0)}</span>,
-        taxAmount: <span className="text-input-text">{formatCurrency(invoice.taxAmount ?? 0)}</span>,
-        discountAmount: <span className="text-input-text">{formatCurrency(invoice.discountAmount ?? 0)}</span>,
-        amountPaid: <span className="text-input-text">{formatCurrency(invoice.amountPaid)}</span>,
-        amountDue: <span className="text-input-text">{formatCurrency(invoice.amountDue)}</span>,
+        subtotal: <span className="text-ink">{formatCurrency(invoice.subtotal ?? 0)}</span>,
+        taxAmount: <span className="text-ink">{formatCurrency(invoice.taxAmount ?? 0)}</span>,
+        discountAmount: <span className="text-ink">{formatCurrency(invoice.discountAmount ?? 0)}</span>,
+        amountPaid: <span className="text-ink">{formatCurrency(invoice.amountPaid)}</span>,
+        amountDue: <span className="text-ink">{formatCurrency(invoice.amountDue)}</span>,
         issueDate: dateValue(invoice.issueDate),
         invoiceType: textValue(invoice.invoiceType),
         notes: textValue(invoice.notes),
@@ -304,7 +304,7 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         onLoadMore={onLoadMore}
       />
       {footer ? (
-        <div className="border-t border-line-subtle px-4 py-3 text-sm text-input-placeholder">
+        <div className="border-t border-line-subtle px-4 py-3 text-sm text-dim-2">
           <div>{footer}</div>
         </div>
       ) : null}

--- a/src/features/invoices/components/LineItemEditorDialog.tsx
+++ b/src/features/invoices/components/LineItemEditorDialog.tsx
@@ -108,8 +108,8 @@ export const LineItemEditorDialog = ({
         </div>
 
         <div className="flex items-center justify-between border-t border-line-subtle pt-3">
-          <span className="text-sm text-input-placeholder">Total</span>
-          <span className="text-lg font-semibold text-input-text">
+          <span className="text-sm text-dim-2">Total</span>
+          <span className="text-lg font-semibold text-ink">
             {formatCurrency(formData.line_total ?? asMajor(0))}
           </span>
         </div>

--- a/src/features/invoices/components/SendInvoiceDialog.tsx
+++ b/src/features/invoices/components/SendInvoiceDialog.tsx
@@ -82,16 +82,16 @@ export const SendInvoiceDialog = ({
 
       <DialogBody className="space-y-4">
         <div className="rounded-xl border border-line-subtle bg-surface-utility/40 dark:bg-surface-utility/10 p-4">
-          <p className="text-sm text-input-placeholder">Send this invoice now?</p>
-          <p className="mt-1 text-base font-semibold text-input-text">
+          <p className="text-sm text-dim-2">Send this invoice now?</p>
+          <p className="mt-1 text-base font-semibold text-ink">
             Total due: {formatCurrency(totalAmount)}
           </p>
           {detailMode && resolvedRecipientEmail ? (
-            <p className="mt-2 text-xs text-input-placeholder">
-              Will be sent to <span className="text-input-text">{resolvedRecipientEmail}</span>.
+            <p className="mt-2 text-xs text-dim-2">
+              Will be sent to <span className="text-ink">{resolvedRecipientEmail}</span>.
             </p>
           ) : (
-            <p className="mt-2 text-xs text-input-placeholder">
+            <p className="mt-2 text-xs text-dim-2">
               You can update invoices until they are paid. The client will receive a receipt after payment.
             </p>
           )}

--- a/src/features/invoices/components/detail/InvoiceActivityPanel.tsx
+++ b/src/features/invoices/components/detail/InvoiceActivityPanel.tsx
@@ -14,10 +14,10 @@ export const InvoiceActivityPanel = ({ detail }: InvoiceActivityPanelProps) => {
   return (
     <Panel className="rounded-2xl p-5">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-input-text">Activity</h3>
+        <h3 className="text-sm font-semibold text-ink">Activity</h3>
       </div>
       {items.length === 0 ? (
-        <p className="text-sm text-input-placeholder">No activity yet.</p>
+        <p className="text-sm text-dim-2">No activity yet.</p>
       ) : (
         <ActivityTimeline items={items} />
       )}

--- a/src/features/invoices/components/detail/InvoiceDetailsSidebar.tsx
+++ b/src/features/invoices/components/detail/InvoiceDetailsSidebar.tsx
@@ -34,17 +34,17 @@ const CopyableField = ({ label, value, monospace }: CopyableFieldProps) => {
   if (!value) {
     return (
       <div className="flex items-center justify-between gap-3 text-sm">
-        <span className="text-input-placeholder">{label}</span>
-        <span className="text-input-placeholder">—</span>
+        <span className="text-dim-2">{label}</span>
+        <span className="text-dim-2">—</span>
       </div>
     );
   }
 
   return (
     <div className="flex items-center justify-between gap-3 text-sm">
-      <span className="text-input-placeholder">{label}</span>
+      <span className="text-dim-2">{label}</span>
       <div className="flex min-w-0 items-center gap-1.5">
-        <span className={monospace ? 'truncate font-mono text-xs text-input-text' : 'truncate text-input-text'}>
+        <span className={monospace ? 'truncate font-mono text-xs text-ink' : 'truncate text-ink'}>
           {value}
         </span>
         <Button
@@ -71,25 +71,25 @@ export const InvoiceDetailsSidebar = ({ detail }: InvoiceDetailsSidebarProps) =>
   return (
     <aside className="flex flex-col gap-4">
       <Panel className="rounded-2xl p-5">
-        <h3 className="mb-3 text-sm font-semibold text-input-text">Details</h3>
+        <h3 className="mb-3 text-sm font-semibold text-ink">Details</h3>
         <div className="space-y-2">
           <CopyableField label="Invoice ID" value={detail.id} monospace />
           <div className="flex items-center justify-between gap-3 text-sm">
-            <span className="text-input-placeholder">Created</span>
-            <span className="text-input-text">{dateOrDash(detail.createdAt)}</span>
+            <span className="text-dim-2">Created</span>
+            <span className="text-ink">{dateOrDash(detail.createdAt)}</span>
           </div>
           <div className="flex items-center justify-between gap-3 text-sm">
-            <span className="text-input-placeholder">Issued</span>
-            <span className="text-input-text">{dateOrDash(detail.issueDate)}</span>
+            <span className="text-dim-2">Issued</span>
+            <span className="text-ink">{dateOrDash(detail.issueDate)}</span>
           </div>
           <div className="flex items-center justify-between gap-3 text-sm">
-            <span className="text-input-placeholder">Due</span>
-            <span className="text-input-text">{dateOrDash(detail.dueDate)}</span>
+            <span className="text-dim-2">Due</span>
+            <span className="text-ink">{dateOrDash(detail.dueDate)}</span>
           </div>
           {detail.paidAt ? (
             <div className="flex items-center justify-between gap-3 text-sm">
-              <span className="text-input-placeholder">Paid</span>
-              <span className="text-input-text">{formatLongDate(detail.paidAt)}</span>
+              <span className="text-dim-2">Paid</span>
+              <span className="text-ink">{formatLongDate(detail.paidAt)}</span>
             </div>
           ) : null}
           <CopyableField label="Connected account" value={detail.connectedAccountId ?? null} monospace />
@@ -98,7 +98,7 @@ export const InvoiceDetailsSidebar = ({ detail }: InvoiceDetailsSidebarProps) =>
 
       {hasStripeData ? (
         <Panel className="rounded-2xl p-5">
-          <h3 className="mb-3 text-sm font-semibold text-input-text">Stripe</h3>
+          <h3 className="mb-3 text-sm font-semibold text-ink">Stripe</h3>
           <div className="space-y-2">
             {detail.stripeInvoiceId ? (
               <CopyableField label="Invoice ID" value={detail.stripeInvoiceId} monospace />
@@ -114,7 +114,7 @@ export const InvoiceDetailsSidebar = ({ detail }: InvoiceDetailsSidebarProps) =>
             ) : null}
             {detail.stripeHostedInvoiceUrl ? (
               <div className="flex items-center justify-between gap-3 text-sm">
-                <span className="text-input-placeholder">Hosted URL</span>
+                <span className="text-dim-2">Hosted URL</span>
                 <a
                   href={detail.stripeHostedInvoiceUrl}
                   target="_blank"
@@ -130,18 +130,18 @@ export const InvoiceDetailsSidebar = ({ detail }: InvoiceDetailsSidebarProps) =>
       ) : null}
 
       <Panel className="rounded-2xl p-5">
-        <h3 className="mb-3 text-sm font-semibold text-input-text">Metadata</h3>
+        <h3 className="mb-3 text-sm font-semibold text-ink">Metadata</h3>
         <div className="space-y-3 text-sm">
           <div>
-            <p className="text-xs text-input-placeholder">Memo</p>
-            <p className="mt-1 whitespace-pre-line text-input-text">
-              {detail.memo?.trim() || <span className="text-input-placeholder">No memo</span>}
+            <p className="text-xs text-dim-2">Memo</p>
+            <p className="mt-1 whitespace-pre-line text-ink">
+              {detail.memo?.trim() || <span className="text-dim-2">No memo</span>}
             </p>
           </div>
           <div>
-            <p className="text-xs text-input-placeholder">Notes to client</p>
-            <p className="mt-1 whitespace-pre-line text-input-text">
-              {detail.notes?.trim() || <span className="text-input-placeholder">No notes</span>}
+            <p className="text-xs text-dim-2">Notes to client</p>
+            <p className="mt-1 whitespace-pre-line text-ink">
+              {detail.notes?.trim() || <span className="text-dim-2">No notes</span>}
             </p>
           </div>
         </div>

--- a/src/features/invoices/components/detail/InvoiceLineItemsTable.tsx
+++ b/src/features/invoices/components/detail/InvoiceLineItemsTable.tsx
@@ -16,15 +16,15 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
   return (
     <Panel className="overflow-hidden rounded-2xl">
       <div className="px-5 pt-5">
-        <h3 className="text-sm font-semibold text-input-text">Line items</h3>
+        <h3 className="text-sm font-semibold text-ink">Line items</h3>
       </div>
       {lineItems.length === 0 ? (
-        <div className="px-5 py-8 text-center text-sm text-input-placeholder">No line items.</div>
+        <div className="px-5 py-8 text-center text-sm text-dim-2">No line items.</div>
       ) : (
         <div className="mt-3 overflow-x-auto">
           <table className="min-w-full divide-y divide-line-subtle text-sm">
             <thead>
-              <tr className="text-left text-xs uppercase tracking-wider text-input-placeholder bg-surface-utility/30">
+              <tr className="text-left text-xs uppercase tracking-wider text-dim-2 bg-surface-utility/30">
                 <th className="px-5 py-3 font-medium">Description</th>
                 <th className="px-5 py-3 w-20 text-right font-medium">Qty</th>
                 <th className="px-5 py-3 w-32 text-right font-medium">Unit price</th>
@@ -34,14 +34,14 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
             <tbody className="divide-y divide-line-subtle">
               {lineItems.map((item) => (
                 <tr key={item.id}>
-                  <td className="px-5 py-3 text-input-text">{item.description || <i>No description</i>}</td>
-                  <td className="px-5 py-3 text-right text-input-placeholder tabular-nums">
+                  <td className="px-5 py-3 text-ink">{item.description || <i>No description</i>}</td>
+                  <td className="px-5 py-3 text-right text-dim-2 tabular-nums">
                     {Number(item.quantity ?? 1).toFixed(2)}
                   </td>
-                  <td className="px-5 py-3 text-right text-input-placeholder tabular-nums">
+                  <td className="px-5 py-3 text-right text-dim-2 tabular-nums">
                     {formatCurrency(item.unit_price)}
                   </td>
-                  <td className="px-5 py-3 text-right font-medium text-input-text tabular-nums">
+                  <td className="px-5 py-3 text-right font-medium text-ink tabular-nums">
                     {formatCurrency(item.line_total ?? asMajor(0))}
                   </td>
                 </tr>
@@ -49,40 +49,40 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
             </tbody>
             <tfoot className="bg-surface-utility/10 text-sm">
               <tr>
-                <td colSpan={3} className="px-5 py-2 text-right text-input-placeholder">Subtotal</td>
-                <td className="px-5 py-2 text-right text-input-text tabular-nums">{formatCurrency(subtotal ?? 0)}</td>
+                <td colSpan={3} className="px-5 py-2 text-right text-dim-2">Subtotal</td>
+                <td className="px-5 py-2 text-right text-ink tabular-nums">{formatCurrency(subtotal ?? 0)}</td>
               </tr>
               {showDiscount ? (
                 <tr>
-                  <td colSpan={3} className="px-5 py-2 text-right text-input-placeholder">Discount</td>
-                  <td className="px-5 py-2 text-right text-input-text tabular-nums">
+                  <td colSpan={3} className="px-5 py-2 text-right text-dim-2">Discount</td>
+                  <td className="px-5 py-2 text-right text-ink tabular-nums">
                     -{formatCurrency(discountAmount ?? 0)}
                   </td>
                 </tr>
               ) : null}
               {showTax ? (
                 <tr>
-                  <td colSpan={3} className="px-5 py-2 text-right text-input-placeholder">Tax</td>
-                  <td className="px-5 py-2 text-right text-input-text tabular-nums">{formatCurrency(taxAmount ?? 0)}</td>
+                  <td colSpan={3} className="px-5 py-2 text-right text-dim-2">Tax</td>
+                  <td className="px-5 py-2 text-right text-ink tabular-nums">{formatCurrency(taxAmount ?? 0)}</td>
                 </tr>
               ) : null}
               <tr>
-                <td colSpan={3} className="px-5 py-3 text-right text-sm font-semibold text-input-text">Total</td>
-                <td className="px-5 py-3 text-right text-base font-semibold text-input-text tabular-nums">
+                <td colSpan={3} className="px-5 py-3 text-right text-sm font-semibold text-ink">Total</td>
+                <td className="px-5 py-3 text-right text-base font-semibold text-ink tabular-nums">
                   {formatCurrency(total)}
                 </td>
               </tr>
               {showPaymentBreakdown ? (
                 <>
                   <tr>
-                    <td colSpan={3} className="px-5 py-2 text-right text-input-placeholder">Amount paid</td>
-                    <td className="px-5 py-2 text-right text-input-text tabular-nums">
+                    <td colSpan={3} className="px-5 py-2 text-right text-dim-2">Amount paid</td>
+                    <td className="px-5 py-2 text-right text-ink tabular-nums">
                       -{formatCurrency(amountPaid)}
                     </td>
                   </tr>
                   <tr>
-                    <td colSpan={3} className="px-5 py-2 text-right text-input-placeholder">Amount remaining</td>
-                    <td className="px-5 py-2 text-right text-input-text tabular-nums">
+                    <td colSpan={3} className="px-5 py-2 text-right text-dim-2">Amount remaining</td>
+                    <td className="px-5 py-2 text-right text-ink tabular-nums">
                       {formatCurrency(amountDue)}
                     </td>
                   </tr>

--- a/src/features/invoices/components/detail/InvoicePaymentsSection.tsx
+++ b/src/features/invoices/components/detail/InvoicePaymentsSection.tsx
@@ -22,8 +22,8 @@ export const InvoicePaymentsSection = ({ payments }: InvoicePaymentsSectionProps
   return (
     <Panel className="rounded-2xl p-5">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-input-text">Payments</h3>
-        <span className="text-xs text-input-placeholder">{payments.length} {payments.length === 1 ? 'entry' : 'entries'}</span>
+        <h3 className="text-sm font-semibold text-ink">Payments</h3>
+        <span className="text-xs text-dim-2">{payments.length} {payments.length === 1 ? 'entry' : 'entries'}</span>
       </div>
       <ul className="space-y-3">
         {payments.map((payment) => (
@@ -32,12 +32,12 @@ export const InvoicePaymentsSection = ({ payments }: InvoicePaymentsSectionProps
             className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
           >
             <div className="min-w-0">
-              <p className="text-sm font-medium text-input-text">{formatCurrency(payment.amount)}</p>
-              <p className="text-xs text-input-placeholder">
+              <p className="text-sm font-medium text-ink">{formatCurrency(payment.amount)}</p>
+              <p className="text-xs text-dim-2">
                 {payment.paidAt ? formatLongDate(payment.paidAt) : 'Date unknown'}
               </p>
               {payment.note ? (
-                <p className="mt-1 text-xs text-input-placeholder">{payment.note}</p>
+                <p className="mt-1 text-xs text-dim-2">{payment.note}</p>
               ) : null}
             </div>
             <Pill tone={paymentTone(payment.status)}>{payment.status}</Pill>

--- a/src/features/invoices/components/detail/InvoiceRefundsSection.tsx
+++ b/src/features/invoices/components/detail/InvoiceRefundsSection.tsx
@@ -34,7 +34,7 @@ export const InvoiceRefundsSection = ({
   return (
     <Panel className="rounded-2xl p-5">
       <div className="mb-3">
-        <h3 className="text-sm font-semibold text-input-text">Refunds</h3>
+        <h3 className="text-sm font-semibold text-ink">Refunds</h3>
       </div>
       <div className="space-y-3">
         {refundRequests.map((request) => {
@@ -46,15 +46,15 @@ export const InvoiceRefundsSection = ({
               className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
             >
               <div className="min-w-0">
-                <p className="text-sm font-medium text-input-text">
+                <p className="text-sm font-medium text-ink">
                   {request.amount != null ? formatCurrency(request.amount) : 'Full refund'}
-                  <span className="ml-2 text-xs text-input-placeholder">Request</span>
+                  <span className="ml-2 text-xs text-dim-2">Request</span>
                 </p>
-                <p className="text-xs text-input-placeholder">
+                <p className="text-xs text-dim-2">
                   {eventDate ? formatLongDate(eventDate) : 'Date unknown'}
                 </p>
                 {request.reason ? (
-                  <p className="mt-1 text-xs text-input-placeholder">{request.reason}</p>
+                  <p className="mt-1 text-xs text-dim-2">{request.reason}</p>
                 ) : null}
               </div>
               <div className="flex shrink-0 flex-col items-end gap-2">
@@ -74,12 +74,12 @@ export const InvoiceRefundsSection = ({
             className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
           >
             <div className="min-w-0">
-              <p className="text-sm font-medium text-input-text">{formatCurrency(refund.amount)}</p>
-              <p className="text-xs text-input-placeholder">
+              <p className="text-sm font-medium text-ink">{formatCurrency(refund.amount)}</p>
+              <p className="text-xs text-dim-2">
                 {refund.createdAt ? formatLongDate(refund.createdAt) : 'Date unknown'}
               </p>
               {refund.reason ? (
-                <p className="mt-1 text-xs text-input-placeholder">{refund.reason}</p>
+                <p className="mt-1 text-xs text-dim-2">{refund.reason}</p>
               ) : null}
             </div>
             <Pill tone={refundTone(refund.status)}>{refund.status}</Pill>

--- a/src/features/invoices/components/detail/InvoiceSummaryPanel.tsx
+++ b/src/features/invoices/components/detail/InvoiceSummaryPanel.tsx
@@ -19,9 +19,9 @@ const SummaryField = ({
   const hasValue = Boolean(value && value.trim().length > 0);
   return (
     <div>
-      <p className="text-xs font-medium text-input-placeholder">{label}</p>
+      <p className="text-xs font-medium text-dim-2">{label}</p>
       <p
-        className={`mt-1 text-sm ${hasValue ? 'text-input-text' : 'text-input-placeholder'} ${multiline ? 'whitespace-pre-line' : ''}`}
+        className={`mt-1 text-sm ${hasValue ? 'text-ink' : 'text-dim-2'} ${multiline ? 'whitespace-pre-line' : ''}`}
       >
         {hasValue ? value : emptyText}
       </p>
@@ -33,18 +33,18 @@ export const InvoiceSummaryPanel = ({ detail }: InvoiceSummaryPanelProps) => {
   return (
     <Panel className="rounded-2xl p-5">
       <div className="mb-4">
-        <h3 className="text-sm font-semibold text-input-text">Summary</h3>
+        <h3 className="text-sm font-semibold text-ink">Summary</h3>
       </div>
       <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
         <div className="space-y-1">
-          <p className="text-xs font-medium text-input-placeholder">Billed to</p>
+          <p className="text-xs font-medium text-dim-2">Billed to</p>
           {detail.clientName ? (
-            <p className="text-sm text-input-text">{detail.clientName}</p>
+            <p className="text-sm text-ink">{detail.clientName}</p>
           ) : (
-            <p className="text-sm text-input-placeholder">No contact</p>
+            <p className="text-sm text-dim-2">No contact</p>
           )}
           {detail.clientEmail ? (
-            <p className="text-sm text-input-placeholder">{detail.clientEmail}</p>
+            <p className="text-sm text-dim-2">{detail.clientEmail}</p>
           ) : null}
         </div>
         <SummaryField label="Invoice number" value={detail.invoiceNumber} />

--- a/src/features/invoices/components/dialogs/RefundRequestDialog.tsx
+++ b/src/features/invoices/components/dialogs/RefundRequestDialog.tsx
@@ -74,7 +74,7 @@ export const RefundRequestDialog = ({
           disabled={loading}
           min={0}
         />
-        <p className="text-xs text-input-placeholder">
+        <p className="text-xs text-dim-2">
           Leave blank to request a full refund of {formatCurrency(maxAmount)}.
         </p>
         <Textarea

--- a/src/features/invoices/components/dialogs/VoidInvoiceConfirmDialog.tsx
+++ b/src/features/invoices/components/dialogs/VoidInvoiceConfirmDialog.tsx
@@ -41,7 +41,7 @@ export const VoidInvoiceConfirmDialog = ({
       disableBackdropClick={loading}
     >
       <DialogBody>
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           Once voided, the invoice cannot be sent or paid. You can still view it in the invoice list.
         </p>
       </DialogBody>

--- a/src/features/invoices/components/edit/InvoiceEditHeaderActions.tsx
+++ b/src/features/invoices/components/edit/InvoiceEditHeaderActions.tsx
@@ -46,7 +46,7 @@ export const InvoiceEditHeaderActions = ({ formRef }: InvoiceEditHeaderActionsPr
   return (
     <div className="flex flex-wrap items-center gap-3">
       {lastSavedAt ? (
-        <span className="text-xs text-input-placeholder">
+        <span className="text-xs text-dim-2">
           Draft saved at {formatTime(lastSavedAt)}
         </span>
       ) : null}

--- a/src/features/invoices/components/list/InvoiceFilterChips.tsx
+++ b/src/features/invoices/components/list/InvoiceFilterChips.tsx
@@ -48,7 +48,7 @@ const Chip = ({
     className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${
       active
         ? 'border-accent-foreground/50 bg-accent-foreground/10 text-[rgb(var(--accent-foreground))]'
-        : 'border-line-subtle bg-surface-utility/30 text-input-placeholder hover:text-input-text'
+        : 'border-line-subtle bg-surface-utility/30 text-dim-2 hover:text-ink'
     }`}
   >
     {children}
@@ -59,7 +59,7 @@ const Chip = ({
 const ChipLabel = ({ label, value }: { label: string; value?: string }) => (
   <span>
     {label}
-    {value ? <span className="ml-1 text-input-text">{value}</span> : null}
+    {value ? <span className="ml-1 text-ink">{value}</span> : null}
   </span>
 );
 

--- a/src/features/invoices/components/list/InvoiceListKpiRow.tsx
+++ b/src/features/invoices/components/list/InvoiceListKpiRow.tsx
@@ -8,7 +8,7 @@ interface InvoiceListKpiRowProps {
 
 const SkeletonStat = ({ label }: { label: string }) => (
   <div className="panel rounded-2xl p-4">
-    <p className="text-xs text-input-placeholder">{label}</p>
+    <p className="text-xs text-dim-2">{label}</p>
     <div className="mt-2 h-7 w-24 animate-pulse rounded bg-surface-utility/40" />
     <div className="mt-2 h-3 w-16 animate-pulse rounded bg-surface-utility/30" />
   </div>

--- a/src/features/invoices/components/refunds/RefundRequestReviewDialog.tsx
+++ b/src/features/invoices/components/refunds/RefundRequestReviewDialog.tsx
@@ -104,25 +104,25 @@ export const RefundRequestReviewDialog = ({
       <DialogBody className="space-y-4">
         <div className="rounded-xl border border-line-subtle bg-surface-utility/30 px-4 py-3 text-sm">
           <div className="flex items-center justify-between">
-            <span className="text-input-placeholder">Amount</span>
-            <span className="font-semibold text-input-text">
+            <span className="text-dim-2">Amount</span>
+            <span className="font-semibold text-ink">
               {request.amount != null ? formatCurrency(request.amount) : 'Full refund'}
             </span>
           </div>
           <div className="mt-2 flex items-center justify-between">
-            <span className="text-input-placeholder">Requested</span>
-            <span className="text-input-text">
+            <span className="text-dim-2">Requested</span>
+            <span className="text-ink">
               {request.createdAt ? formatLongDate(request.createdAt) : '—'}
             </span>
           </div>
           <div className="mt-2 flex items-center justify-between">
-            <span className="text-input-placeholder">Status</span>
+            <span className="text-dim-2">Status</span>
             <RefundRequestStatusBadge status={request.status} />
           </div>
           {request.reason ? (
             <div className="mt-3 border-t border-line-subtle pt-3">
-              <p className="text-xs text-input-placeholder">Reason</p>
-              <p className="mt-1 text-input-text">{request.reason}</p>
+              <p className="text-xs text-dim-2">Reason</p>
+              <p className="mt-1 text-ink">{request.reason}</p>
             </div>
           ) : null}
         </div>
@@ -137,7 +137,7 @@ export const RefundRequestReviewDialog = ({
             disabled={loading}
           />
         ) : (
-          <p className="text-sm text-input-placeholder">
+          <p className="text-sm text-dim-2">
             Approve completed. Execute now to issue the refund through Stripe, or close to execute later.
           </p>
         )}

--- a/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
@@ -129,7 +129,7 @@ export function ClientInvoiceDetailPage({
   }
 
   if (!detail) {
-    return <div className="p-6 text-sm text-input-placeholder">Invoice not found.</div>;
+    return <div className="p-6 text-sm text-dim-2">Invoice not found.</div>;
   }
 
   return (
@@ -155,26 +155,26 @@ export function ClientInvoiceDetailPage({
 
           <div className="grid gap-3 sm:grid-cols-3">
           <div className="panel p-4">
-            <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Total</p>
-            <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.total)}</p>
+            <p className="text-xs uppercase tracking-[0.08em] text-dim-2">Total</p>
+            <p className="mt-1 text-lg font-semibold text-ink">{formatCurrency(detail.total)}</p>
           </div>
           <div className="panel p-4">
-            <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Amount paid</p>
-            <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.amountPaid)}</p>
+            <p className="text-xs uppercase tracking-[0.08em] text-dim-2">Amount paid</p>
+            <p className="mt-1 text-lg font-semibold text-ink">{formatCurrency(detail.amountPaid)}</p>
           </div>
           <div className="panel p-4">
-            <p className="text-xs uppercase tracking-[0.08em] text-input-placeholder">Amount due</p>
-            <p className="mt-1 text-lg font-semibold text-input-text">{formatCurrency(detail.amountDue)}</p>
+            <p className="text-xs uppercase tracking-[0.08em] text-dim-2">Amount due</p>
+            <p className="mt-1 text-lg font-semibold text-ink">{formatCurrency(detail.amountDue)}</p>
           </div>
         </div>
 
         <div className="panel overflow-hidden">
           <div className="border-b border-line-subtle px-4 py-3">
-            <h2 className="text-base font-semibold text-input-text">Line items</h2>
+            <h2 className="text-base font-semibold text-ink">Line items</h2>
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
-              <thead className="border-b border-line-subtle text-xs uppercase tracking-[0.08em] text-input-placeholder">
+              <thead className="border-b border-line-subtle text-xs uppercase tracking-[0.08em] text-dim-2">
                 <tr>
                   <th className="px-4 py-3 text-left">Description</th>
                   <th className="px-4 py-3 text-left">Type</th>
@@ -186,11 +186,11 @@ export function ClientInvoiceDetailPage({
               <tbody>
                 {detail.lineItems.map((item) => (
                   <tr key={item.id} className="border-b border-line-subtle last:border-b-0">
-                    <td className="px-4 py-3 text-input-text">{item.description || '—'}</td>
-                    <td className="px-4 py-3 text-input-text">{item.type}</td>
-                    <td className="px-4 py-3 text-right text-input-text">{item.quantity}</td>
-                    <td className="px-4 py-3 text-right text-input-text">{formatCurrency(getMajorAmountValue(item.unit_price))}</td>
-                    <td className="px-4 py-3 text-right font-semibold text-input-text">{formatCurrency(getMajorAmountValue(item.line_total))}</td>
+                    <td className="px-4 py-3 text-ink">{item.description || '—'}</td>
+                    <td className="px-4 py-3 text-ink">{item.type}</td>
+                    <td className="px-4 py-3 text-right text-ink">{item.quantity}</td>
+                    <td className="px-4 py-3 text-right text-ink">{formatCurrency(getMajorAmountValue(item.unit_price))}</td>
+                    <td className="px-4 py-3 text-right font-semibold text-ink">{formatCurrency(getMajorAmountValue(item.line_total))}</td>
                   </tr>
                 ))}
               </tbody>
@@ -200,15 +200,15 @@ export function ClientInvoiceDetailPage({
 
         <div className="grid gap-4 lg:grid-cols-3">
           <div className="panel p-4">
-            <h3 className="text-sm font-semibold text-input-text">Payment history</h3>
+            <h3 className="text-sm font-semibold text-ink">Payment history</h3>
             {detail.payments.length === 0 ? (
-              <p className="mt-2 text-sm text-input-placeholder">No payment history available.</p>
+              <p className="mt-2 text-sm text-dim-2">No payment history available.</p>
             ) : (
               <ul className="mt-2 space-y-2 text-sm">
                 {detail.payments.map((payment) => (
                   <li key={payment.id} className="rounded-xl border border-line-subtle px-3 py-2">
-                    <p className="font-medium text-input-text">{formatCurrency(payment.amount)} • {payment.status}</p>
-                    <p className="text-xs text-input-placeholder">{renderEventDate(payment.paidAt)}</p>
+                    <p className="font-medium text-ink">{formatCurrency(payment.amount)} • {payment.status}</p>
+                    <p className="text-xs text-dim-2">{renderEventDate(payment.paidAt)}</p>
                   </li>
                 ))}
               </ul>
@@ -216,15 +216,15 @@ export function ClientInvoiceDetailPage({
           </div>
 
           <div className="panel p-4">
-            <h3 className="text-sm font-semibold text-input-text">Refund history</h3>
+            <h3 className="text-sm font-semibold text-ink">Refund history</h3>
             {detail.refunds.length === 0 ? (
-              <p className="mt-2 text-sm text-input-placeholder">No refunds for this invoice.</p>
+              <p className="mt-2 text-sm text-dim-2">No refunds for this invoice.</p>
             ) : (
               <ul className="mt-2 space-y-2 text-sm">
                 {detail.refunds.map((refund) => (
                   <li key={refund.id} className="rounded-xl border border-line-subtle px-3 py-2">
-                    <p className="font-medium text-input-text">{formatCurrency(refund.amount)} • {refund.status}</p>
-                    <p className="text-xs text-input-placeholder">{renderEventDate(refund.createdAt)}</p>
+                    <p className="font-medium text-ink">{formatCurrency(refund.amount)} • {refund.status}</p>
+                    <p className="text-xs text-dim-2">{renderEventDate(refund.createdAt)}</p>
                   </li>
                 ))}
               </ul>
@@ -232,7 +232,7 @@ export function ClientInvoiceDetailPage({
           </div>
 
           <div className="panel p-4">
-            <h3 className="text-sm font-semibold text-input-text">Request refund</h3>
+            <h3 className="text-sm font-semibold text-ink">Request refund</h3>
             <div className="mt-3 space-y-3">
               <Input
                 type="number"
@@ -253,7 +253,7 @@ export function ClientInvoiceDetailPage({
               </Button>
             </div>
             {!refundRequestSupported ? (
-              <p className="mt-2 text-xs text-input-placeholder">
+              <p className="mt-2 text-xs text-dim-2">
                 Refund requests are currently unavailable for this workspace.
               </p>
             ) : null}
@@ -261,16 +261,16 @@ export function ClientInvoiceDetailPage({
               <p className="mt-2 text-xs text-accent-error-light">{refundRequestError}</p>
             ) : null}
 
-            <h4 className="mt-5 text-xs font-semibold uppercase tracking-[0.08em] text-input-placeholder">Refund request timeline</h4>
+            <h4 className="mt-5 text-xs font-semibold uppercase tracking-[0.08em] text-dim-2">Refund request timeline</h4>
             {detail.refundRequests.length === 0 ? (
-              <p className="mt-2 text-sm text-input-placeholder">No refund requests yet.</p>
+              <p className="mt-2 text-sm text-dim-2">No refund requests yet.</p>
             ) : (
               <ol className="mt-2 space-y-2 text-sm">
                 {detail.refundRequests.map((request) => (
                   <li key={request.id} className="rounded-xl border border-line-subtle px-3 py-2">
-                    <p className="font-medium text-input-text">{request.status}</p>
-                    <p className="text-xs text-input-placeholder">{renderEventDate(request.createdAt)}</p>
-                    {request.reason ? <p className="mt-1 text-xs text-input-placeholder">{request.reason}</p> : null}
+                    <p className="font-medium text-ink">{request.status}</p>
+                    <p className="text-xs text-dim-2">{renderEventDate(request.createdAt)}</p>
+                    {request.reason ? <p className="mt-1 text-xs text-dim-2">{request.reason}</p> : null}
                   </li>
                 ))}
               </ol>

--- a/src/features/invoices/pages/ClientInvoicesPage.tsx
+++ b/src/features/invoices/pages/ClientInvoicesPage.tsx
@@ -172,15 +172,15 @@ export function ClientInvoicesPage({
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-input-text">{invoice.invoiceNumber || '—'}</p>
-                  <p className="truncate text-xs text-input-placeholder">{invoice.clientName ?? '—'}</p>
-                  <p className="mt-1 text-xs text-input-placeholder">
+                  <p className="truncate text-sm font-semibold text-ink">{invoice.invoiceNumber || '—'}</p>
+                  <p className="truncate text-xs text-dim-2">{invoice.clientName ?? '—'}</p>
+                  <p className="mt-1 text-xs text-dim-2">
                     Due {invoice.dueDate ? formatLongDate(invoice.dueDate) : '—'}
                   </p>
                 </div>
                 <div className="flex shrink-0 flex-col items-end gap-1">
                   <InvoiceStatusBadge status={invoice.status} />
-                  <p className="text-sm font-semibold text-input-text">{formatCurrency(invoice.total)}</p>
+                  <p className="text-sm font-semibold text-ink">{formatCurrency(invoice.total)}</p>
                 </div>
               </div>
             </div>

--- a/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceDetailPage.tsx
@@ -60,7 +60,7 @@ export function PracticeInvoiceDetailPage({
   }
 
   if (!detail) {
-    return <div className="p-6 text-sm text-input-placeholder">Invoice not found.</div>;
+    return <div className="p-6 text-sm text-dim-2">Invoice not found.</div>;
   }
 
   if (!practiceId) {

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -289,15 +289,15 @@ export function PracticeInvoicesPage({
             <div className={cn('w-full px-4 py-3 text-left hover:bg-surface-utility/10')}>
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-input-text">{invoice.invoiceNumber || '—'}</p>
-                  <p className="truncate text-xs text-input-placeholder">{invoice.clientName ?? '—'}</p>
-                  <p className="mt-1 text-xs text-input-placeholder">
+                  <p className="truncate text-sm font-semibold text-ink">{invoice.invoiceNumber || '—'}</p>
+                  <p className="truncate text-xs text-dim-2">{invoice.clientName ?? '—'}</p>
+                  <p className="mt-1 text-xs text-dim-2">
                     Due {invoice.dueDate ? formatLongDate(invoice.dueDate) : '—'}
                   </p>
                 </div>
                 <div className="flex shrink-0 flex-col items-end gap-1">
                   <InvoiceStatusBadge status={invoice.status} />
-                  <p className="text-sm font-semibold text-input-text">{formatCurrency(invoice.total)}</p>
+                  <p className="text-sm font-semibold text-ink">{formatCurrency(invoice.total)}</p>
                 </div>
               </div>
             </div>

--- a/src/features/matters/components/ActivityTimeline.tsx
+++ b/src/features/matters/components/ActivityTimeline.tsx
@@ -106,18 +106,18 @@ const ActivityTimeline: FunctionComponent<ActivityTimelineProps> = ({
                       <div className="absolute left-3 top-8 bottom-0 w-px bg-line-default" />
                     )}
                     <div className="input-surface relative flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center">
-                      <IconComponent className="w-3 h-3 text-input-placeholder" />
+                      <IconComponent className="w-3 h-3 text-dim-2" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center justify-between">
-                        <h5 className="text-xs sm:text-sm font-medium text-input-text">
+                        <h5 className="text-xs sm:text-sm font-medium text-ink">
                           {event.action.replace(/_/g, ' ')}
                         </h5>
-                        <span className="text-xs text-input-placeholder">
+                        <span className="text-xs text-dim-2">
                           {formatRelativeTime(event.created_at)}
                         </span>
                       </div>
-                      <p className="text-xs sm:text-sm text-input-placeholder mt-1">
+                      <p className="text-xs sm:text-sm text-dim-2 mt-1">
                         {event.description}
                       </p>
                     </div>
@@ -127,7 +127,7 @@ const ActivityTimeline: FunctionComponent<ActivityTimelineProps> = ({
 
               {/* Empty state */}
               {!error && events.length === 0 && (
-                <div className="text-center py-6 text-input-placeholder">
+                <div className="text-center py-6 text-dim-2">
                   <Icon icon={Clock} className="w-8 h-8 mx-auto mb-2 opacity-50"  />
                   <p className="text-sm">No activity yet</p>
                   <p className="text-xs mt-1">Activity will appear here as you use the system</p>

--- a/src/features/matters/components/MatterActivityTab.tsx
+++ b/src/features/matters/components/MatterActivityTab.tsx
@@ -70,7 +70,7 @@ export const MatterActivityTab = ({
         {activityLoading && timelineItems.length === 0 ? (
           <LoadingBlock label="Loading activity" />
         ) : activityError && timelineItems.length === 0 ? (
-          <p className="text-sm text-input-placeholder">
+          <p className="text-sm text-dim-2">
             Could not load activity.{' '}
             <button type="button" className="underline" onClick={onActivityRetry}>
               Retry

--- a/src/features/matters/components/MatterCanvas.tsx
+++ b/src/features/matters/components/MatterCanvas.tsx
@@ -48,7 +48,7 @@ const MatterCanvas: FunctionalComponent<MatterCanvasProps> = ({
     <div className="matter-canvas">
       <div className="flex items-center justify-between mb-4">
         <MatterStatusBadge status={effectiveStatus} />
-        <span className="text-sm text-input-placeholder">
+        <span className="text-sm text-dim-2">
           {effectiveStatus === 'lead' ? 'Waiting for review' : effectiveStatus.replaceAll('_', ' ')}
         </span>
       </div>

--- a/src/features/matters/components/MatterDetailHeader.tsx
+++ b/src/features/matters/components/MatterDetailHeader.tsx
@@ -81,17 +81,17 @@ export const MatterDetailHeader = ({
           ) : (
             <div
               aria-hidden="true"
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-surface-card-raised text-lg font-semibold text-input-text"
+              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-surface-card-raised text-lg font-semibold text-ink"
             >
               {heroInitial(clientEmail, clientLabel, title)}
             </div>
           )}
 
           <div className="min-w-0 flex-1">
-            <h2 className="truncate text-xl font-semibold leading-tight tracking-tight text-input-text sm:text-2xl">{title}</h2>
-            {subtitle ? <p className="truncate text-[13px] text-input-placeholder">{subtitle}</p> : null}
+            <h2 className="truncate text-xl font-semibold leading-tight tracking-tight text-ink sm:text-2xl">{title}</h2>
+            {subtitle ? <p className="truncate text-[13px] text-dim-2">{subtitle}</p> : null}
             {teamParts.length > 0 ? (
-              <p className="mt-1 truncate text-xs text-input-placeholder">{teamParts.join(' · ')}</p>
+              <p className="mt-1 truncate text-xs text-dim-2">{teamParts.join(' · ')}</p>
             ) : null}
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <span
@@ -141,9 +141,9 @@ export const MatterDetailHeader = ({
                     <button
                       type="button"
                       onClick={item.onClick}
-                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-input-text transition-colors hover:bg-surface-card-hover"
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-card-hover"
                     >
-                      {Icon ? <Icon className="h-4 w-4 text-input-placeholder" aria-hidden="true" /> : null}
+                      {Icon ? <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" /> : null}
                       {item.label}
                     </button>
                   </li>
@@ -169,9 +169,9 @@ export const MatterDetailHeader = ({
                       <button
                         type="button"
                         onClick={item.onClick}
-                        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-input-text transition-colors hover:bg-surface-card-hover"
+                        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-card-hover"
                       >
-                        {Icon ? <Icon className="h-4 w-4 text-input-placeholder" aria-hidden="true" /> : null}
+                        {Icon ? <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" /> : null}
                         {item.label}
                       </button>
                     </li>

--- a/src/features/matters/components/MatterDetailsPanel.tsx
+++ b/src/features/matters/components/MatterDetailsPanel.tsx
@@ -72,13 +72,13 @@ const ReadField = ({
   if (!display && !forceShow) return null;
   return (
     <div className={className}>
-      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-input-placeholder">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-dim-2">
         {label}
       </p>
       <p className={cn(
         'mt-1.5 text-sm leading-snug',
         numeric && 'tabular-nums',
-        display ? 'text-input-text' : 'text-input-placeholder/50'
+        display ? 'text-ink' : 'text-dim-2/50'
       )}>
         {display ?? '—'}
       </p>
@@ -141,7 +141,7 @@ const InlineCurrencyInput = ({
       onChange={onChange}
       placeholder={placeholder}
       label={label}
-      icon={<span className="text-sm text-input-placeholder">$</span>}
+      icon={<span className="text-sm text-dim-2">$</span>}
       iconPosition="left"
       className="w-full"
       labelKey={undefined}
@@ -167,7 +167,7 @@ const SectionHeader = ({
   onCancel: () => void;
 }) => (
   <div className="mb-4 flex items-center justify-between">
-    <h4 className="font-display text-sm font-semibold tracking-tight text-input-text">
+    <h4 className="font-display text-sm font-semibold tracking-tight text-ink">
       {title}
     </h4>
     {isEditing ? (
@@ -198,8 +198,8 @@ const SectionHeader = ({
         onClick={onEdit}
         icon={Pencil} iconClassName="h-4 w-4"
         className={cn(
-          'text-input-placeholder transition-all',
-          'hover:bg-surface-card-hover hover:text-input-text focus-visible:text-input-text'
+          'text-dim-2 transition-all',
+          'hover:bg-surface-card-hover hover:text-ink focus-visible:text-ink'
         )}
         aria-label={`Edit ${title.toLowerCase()}`}
       />
@@ -382,7 +382,7 @@ export const MatterDetailsPanel = ({
   return (
     <div className="panel divide-y divide-white/[0.06]">
       <div className="flex items-center justify-between px-5 py-4">
-        <h3 className="font-display text-sm font-semibold tracking-tight text-input-text">Matter details</h3>
+        <h3 className="font-display text-sm font-semibold tracking-tight text-ink">Matter details</h3>
         <span aria-hidden="true" className="h-px w-8 bg-gradient-to-r from-accent-500/0 via-accent-500/60 to-accent-500/0" />
       </div>
 
@@ -410,7 +410,7 @@ export const MatterDetailsPanel = ({
                 placeholder="e.g. Contract dispute"
               />
               <div>
-                <p className="block text-xs font-medium text-input-placeholder mb-1.5">
+                <p className="block text-xs font-medium text-dim-2 mb-1.5">
                   Urgency
                 </p>
                 <Combobox
@@ -536,7 +536,7 @@ export const MatterDetailsPanel = ({
           {editing === 'attorneys' ? (
             <div className="grid gap-3 sm:grid-cols-2">
               <div>
-                <p className="block text-xs font-medium text-input-placeholder mb-1.5">
+                <p className="block text-xs font-medium text-dim-2 mb-1.5">
                   Responsible attorney
                 </p>
                 <Combobox
@@ -549,7 +549,7 @@ export const MatterDetailsPanel = ({
                 />
               </div>
               <div>
-                <p className="block text-xs font-medium text-input-placeholder mb-1.5">
+                <p className="block text-xs font-medium text-dim-2 mb-1.5">
                   Originating attorney
                 </p>
                 <Combobox

--- a/src/features/matters/components/MatterForm.tsx
+++ b/src/features/matters/components/MatterForm.tsx
@@ -145,7 +145,7 @@ const buildInitialState = (mode: MatterFormMode, initialValues?: Partial<MatterF
 });
 
 const buildLeadingIcon = (icon: ComponentChildren) => (
-  <div className="w-6 h-6 rounded-full border border-dashed border-line-subtle flex items-center justify-center text-input-placeholder">
+  <div className="w-6 h-6 rounded-full border border-dashed border-line-subtle flex items-center justify-center text-dim-2">
     {icon}
   </div>
 );
@@ -178,10 +178,10 @@ const MatterMilestoneForm = ({
 
   return (
     <div className="border-t border-line-subtle pt-6 space-y-4">
-      <h4 className="text-lg font-medium text-input-text">Enter project milestones</h4>
+      <h4 className="text-lg font-medium text-ink">Enter project milestones</h4>
 
       {milestones.length > 0 && (
-        <ol className="list-decimal pl-4 space-y-2 text-sm text-input-text">
+        <ol className="list-decimal pl-4 space-y-2 text-sm text-ink">
           {milestones.map((milestone, index) => (
             <li
               key={`${milestone.description}-${index}`}
@@ -191,7 +191,7 @@ const MatterMilestoneForm = ({
               <span className="text-left sm:text-right tabular-nums">
                 {milestone.amount ? `$${milestone.amount.toFixed(2)}` : '$0.00'}
               </span>
-              <span className="text-left sm:text-right tabular-nums text-input-placeholder">
+              <span className="text-left sm:text-right tabular-nums text-dim-2">
                 {milestone.dueDate ? formatDateOnlyUtc(milestone.dueDate) : ''}
               </span>
             </li>
@@ -216,7 +216,7 @@ const MatterMilestoneForm = ({
               enforceMaxLength="hard"
               placeholder="Enter a description of your deliverable"
             />
-            <p className="mt-1 text-sm text-input-placeholder">
+            <p className="mt-1 text-sm text-dim-2">
               {draft.description.length}/100
             </p>
           </div>
@@ -389,7 +389,7 @@ const MatterFormInner = ({
       }}
     >
         {unwrapped ? null : (
-          <h2 className="text-xl font-semibold text-input-text">{modalTitle}</h2>
+          <h2 className="text-xl font-semibold text-ink">{modalTitle}</h2>
         )}
 
         <Input
@@ -467,7 +467,7 @@ const MatterFormInner = ({
         </div>
 
         <div className="space-y-4">
-          <h3 className="text-lg font-medium text-input-text">Matter specifics</h3>
+          <h3 className="text-lg font-medium text-ink">Matter specifics</h3>
           <FormGrid>
             <Input
               label="Case number"
@@ -561,7 +561,7 @@ const MatterFormInner = ({
         </div>
 
         <div className="border-t border-line-subtle pt-6 space-y-4">
-          <h3 className="text-lg font-medium text-input-text">Attorney assignments</h3>
+          <h3 className="text-lg font-medium text-ink">Attorney assignments</h3>
           <FormGrid>
             <Combobox
               label="Responsible attorney"
@@ -691,7 +691,7 @@ const MatterFormInner = ({
                 max={100}
                 step={0.1}
                 inputMode="decimal"
-                icon={<span className="text-xs font-semibold text-input-placeholder">%</span>}
+                icon={<span className="text-xs font-semibold text-dim-2">%</span>}
                 iconPosition="right"
               />
             </div>
@@ -702,8 +702,8 @@ const MatterFormInner = ({
           <p className="text-sm text-red-400">{submitError}</p>
         ) : null}
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="flex items-center gap-2 text-xs text-input-placeholder">
-            <Icon icon={ShieldCheck} className="h-4 w-4 text-input-placeholder"  />
+          <p className="flex items-center gap-2 text-xs text-dim-2">
+            <Icon icon={ShieldCheck} className="h-4 w-4 text-dim-2"  />
             <span>
               Payments are built for securing IOLTA compliance.{' '}
               <a

--- a/src/features/matters/components/MatterListItem.tsx
+++ b/src/features/matters/components/MatterListItem.tsx
@@ -35,7 +35,7 @@ export const MatterListItem = ({ matter, onSelect, isSelected = false }: MatterL
         <Avatar
           name={matter.clientName}
           size="sm"
-          className="bg-surface-card-raised text-input-text ring-1 ring-line-subtle"
+          className="bg-surface-card-raised text-ink ring-1 ring-line-subtle"
         />
         <MatterStatusDot
           status={matter.status}
@@ -45,16 +45,16 @@ export const MatterListItem = ({ matter, onSelect, isSelected = false }: MatterL
       <div className="min-w-0 flex-1">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <h2 className="min-w-0 truncate text-[14px] font-semibold leading-5 tracking-tight text-input-text">
+            <h2 className="min-w-0 truncate text-[14px] font-semibold leading-5 tracking-tight text-ink">
               {matter.title}
             </h2>
-            <p className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-input-placeholder">
+            <p className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-dim-2">
               <span className="truncate">{matter.clientName}</span>
-              <span aria-hidden="true" className="text-input-placeholder/30">·</span>
+              <span aria-hidden="true" className="text-dim-2/30">·</span>
               <span className="truncate">{statusLabel}</span>
             </p>
           </div>
-          <span className="shrink-0 text-[11px] tabular-nums text-input-placeholder/80">
+          <span className="shrink-0 text-[11px] tabular-nums text-dim-2/80">
             {updatedLabel}
           </span>
         </div>

--- a/src/features/matters/components/MatterNotesTab.tsx
+++ b/src/features/matters/components/MatterNotesTab.tsx
@@ -31,7 +31,7 @@ export const MatterNotesTab = ({
     {noteLoading && noteItems.length === 0 ? (
       <LoadingBlock label="Loading notes" />
     ) : noteError && noteItems.length === 0 ? (
-      <p className="text-sm text-input-placeholder">
+      <p className="text-sm text-dim-2">
         Could not load notes.{' '}
         <button type="button" className="underline" onClick={onNoteRetry}>
           Retry

--- a/src/features/matters/components/MatterOverviewTab.tsx
+++ b/src/features/matters/components/MatterOverviewTab.tsx
@@ -138,8 +138,8 @@ const OperationalNextStepCard = ({
       bodyGap="sm"
     >
       <div className="space-y-2">
-        <p className="text-sm font-semibold text-input-text">{title}</p>
-        <p className="text-[13px] leading-5 text-input-placeholder">{body}</p>
+        <p className="text-sm font-semibold text-ink">{title}</p>
+        <p className="text-[13px] leading-5 text-dim-2">{body}</p>
         {engagementError && !engagement ? (
           <p className="text-xs text-amber-300">
             Engagement unavailable.{' '}
@@ -148,9 +148,9 @@ const OperationalNextStepCard = ({
             </button>
           </p>
         ) : null}
-        {engagementLoading && !engagement ? <p className="text-xs text-input-placeholder">Checking engagement status...</p> : null}
+        {engagementLoading && !engagement ? <p className="text-xs text-dim-2">Checking engagement status...</p> : null}
         {nextTask ? (
-          <p className="text-xs text-input-placeholder">Next open task: <span className="text-input-text">{nextTask.name}</span></p>
+          <p className="text-xs text-dim-2">Next open task: <span className="text-ink">{nextTask.name}</span></p>
         ) : null}
       </div>
       <div className="flex flex-wrap gap-2">
@@ -203,7 +203,7 @@ const EngagementStatusCard = ({
         <LoadingBlock label="Loading engagement" />
       ) : engagementError && !engagement ? (
         <div className="space-y-1">
-          <p className="text-[13px] text-input-text">Engagement unavailable</p>
+          <p className="text-[13px] text-ink">Engagement unavailable</p>
           <p className="text-[12px] text-amber-300">
             <button type="button" className="underline" onClick={onEngagementRetry}>
               Retry
@@ -212,11 +212,11 @@ const EngagementStatusCard = ({
         </div>
       ) : engagement ? (
         <div className="space-y-1">
-          <p className="text-[13px] text-input-text">
+          <p className="text-[13px] text-ink">
             {engagement?.title?.trim() || 'Standard Legal Services Agreement'}
           </p>
           {summaryParts.length > 0 ? (
-            <p className="text-[13px] text-input-placeholder">{summaryParts.join(' · ')}</p>
+            <p className="text-[13px] text-dim-2">{summaryParts.join(' · ')}</p>
           ) : null}
         </div>
       ) : null}
@@ -256,10 +256,10 @@ const OpenTasksCard = ({
     <InfoCard
       icon={ListChecks}
       title="Open tasks"
-      trailing={<span className="text-[13px] text-input-placeholder">{openTasks.length} {openTasks.length === 1 ? 'task' : 'tasks'}</span>}
+      trailing={<span className="text-[13px] text-dim-2">{openTasks.length} {openTasks.length === 1 ? 'task' : 'tasks'}</span>}
     >
       {visibleTasks.length === 0 ? (
-        <p className="text-[13px] text-input-placeholder">No open tasks.</p>
+        <p className="text-[13px] text-dim-2">No open tasks.</p>
       ) : (
         <ul className="flex flex-col divide-y divide-card-border">
           {visibleTasks.map((task) => (
@@ -273,11 +273,11 @@ const OpenTasksCard = ({
                   {task.status === 'in_progress' ? (
                     <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-400" aria-hidden="true" />
                   ) : (
-                    <Circle className="h-4 w-4 shrink-0 text-input-placeholder" aria-hidden="true" />
+                    <Circle className="h-4 w-4 shrink-0 text-dim-2" aria-hidden="true" />
                   )}
-                  <span className="truncate text-[13px] text-input-text">{task.name}</span>
+                  <span className="truncate text-[13px] text-ink">{task.name}</span>
                 </span>
-                <span className="shrink-0 text-[13px] tabular-nums text-input-placeholder">
+                <span className="shrink-0 text-[13px] tabular-nums text-dim-2">
                   {formatDueDate(task.dueDate)}
                 </span>
               </button>
@@ -324,7 +324,7 @@ const RecentActivityCard = ({
       {activityLoading && timelineItems.length === 0 ? (
         <LoadingBlock label="Loading activity" />
       ) : activityError && timelineItems.length === 0 ? (
-        <p className="text-[13px] text-input-placeholder">
+        <p className="text-[13px] text-dim-2">
           Could not load activity.{' '}
           <button type="button" className="underline" onClick={onActivityRetry}>
             Retry
@@ -337,7 +337,7 @@ const RecentActivityCard = ({
         />
       )}
       {timelineItems.length === 0 && !activityLoading && !activityError ? (
-        <p className="text-[13px] text-input-placeholder">No recent activity.</p>
+        <p className="text-[13px] text-dim-2">No recent activity.</p>
       ) : null}
       {hasMore || timelineItems.length > 0 ? (
         <button
@@ -375,7 +375,7 @@ const MatterSummaryCard = ({
     <DetailRow label="Court" value={detail.court} />
     <DetailRow label="Responsible" value={responsibleAttorneyLabel} />
     <DetailRow label="Assigned" value={assigneeLabel} />
-    {clientEmail ? <p className="break-all text-xs text-input-placeholder">{clientEmail}</p> : null}
+    {clientEmail ? <p className="break-all text-xs text-dim-2">{clientEmail}</p> : null}
     {onOpenClient ? (
       <Button
         variant="outline"
@@ -405,10 +405,10 @@ const BillingCard = ({
   const hasBillableTime = !weeklyHoursLabel.startsWith('0:00');
   return (
     <InfoCard icon={DollarSign} title="Billing" bodyGap="sm">
-      <p className="text-[22px] font-bold leading-tight text-input-text">
-        {weeklyHoursLabel} <span className="text-[13px] font-normal text-input-placeholder">this week</span>
+      <p className="text-[22px] font-bold leading-tight text-ink">
+        {weeklyHoursLabel} <span className="text-[13px] font-normal text-dim-2">this week</span>
       </p>
-      <p className="text-[13px] text-input-placeholder">{hasBillableTime ? 'Billable time is ready to review.' : 'No billable time yet.'}</p>
+      <p className="text-[13px] text-dim-2">{hasBillableTime ? 'Billable time is ready to review.' : 'No billable time yet.'}</p>
       <DetailRow label="Attorney" value={attorneyRateLabel} />
       <DetailRow label="Admin" value={adminRateLabel} />
       <Button variant={hasBillableTime ? 'primary' : 'secondary'} size="sm" onClick={hasBillableTime ? onCreateInvoice : onLogTime} className="w-full justify-center">
@@ -433,7 +433,7 @@ const RecentFilesCard = ({
   onViewFiles: () => void;
 }) => (
   <InfoCard icon={FolderIcon} title="Recent files" bodyGap="sm">
-    <p className="text-[13px] text-input-placeholder">No files uploaded yet.</p>
+    <p className="text-[13px] text-dim-2">No files uploaded yet.</p>
     <Button
       variant="outline"
       size="sm"

--- a/src/features/matters/components/MatterSettingsTab.tsx
+++ b/src/features/matters/components/MatterSettingsTab.tsx
@@ -158,8 +158,8 @@ export const MatterSettingsTab = ({
           {onCloseMatter ? (
             <div className="flex items-center justify-between gap-4">
               <div>
-                <p className="text-sm font-medium text-input-text">Close this matter</p>
-                <p className="text-xs text-input-placeholder">
+                <p className="text-sm font-medium text-ink">Close this matter</p>
+                <p className="text-xs text-dim-2">
                   Mark as closed. No new time entries or tasks can be added.
                 </p>
               </div>
@@ -172,8 +172,8 @@ export const MatterSettingsTab = ({
           {onArchiveMatter ? (
             <div className="flex items-center justify-between gap-4">
               <div>
-                <p className="text-sm font-medium text-input-text">Archive this matter</p>
-                <p className="text-xs text-input-placeholder">
+                <p className="text-sm font-medium text-ink">Archive this matter</p>
+                <p className="text-xs text-dim-2">
                   Move this matter out of active workflows while preserving its data.
                 </p>
               </div>
@@ -186,8 +186,8 @@ export const MatterSettingsTab = ({
           {onDeleteMatter ? (
             <div className="flex items-center justify-between gap-4">
               <div>
-                <p className="text-sm font-medium text-input-text">Delete this matter</p>
-                <p className="text-xs text-input-placeholder">
+                <p className="text-sm font-medium text-ink">Delete this matter</p>
+                <p className="text-xs text-dim-2">
                   Permanently delete this matter and all associated data. This cannot be undone.
                 </p>
               </div>

--- a/src/features/matters/components/MatterStatusPopover.tsx
+++ b/src/features/matters/components/MatterStatusPopover.tsx
@@ -171,14 +171,14 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
                   'w-full flex items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors duration-100',
                   isSelected
                     ? cn(MATTER_STATUS_BADGE_CLASS[status], 'ring-1 ring-inset')
-                    : 'text-input-text hover:bg-surface-card-hover'
+                    : 'text-ink hover:bg-surface-card-hover'
                 )}
               >
                 <Icon
                   icon={statusIcon}
                   className={cn(
                     'h-4 w-4 shrink-0',
-                    isSelected ? '' : 'text-input-placeholder'
+                    isSelected ? '' : 'text-dim-2'
                   )}
                 />
                 <span className="flex-1">{MATTER_STATUS_LABELS[status]}</span>

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -38,9 +38,9 @@ interface MatterSummaryCardsProps {
 const summaryItemBase = 'min-w-0 flex flex-col gap-1';
 const gridBase = 'grid grid-cols-1 gap-x-4 gap-y-5 @lg:grid-cols-2 @3xl:grid-cols-4 @3xl:gap-x-6';
 const wrapperBase = 'card relative overflow-hidden rounded-[20px] @container p-5 sm:p-7';
-const labelClass = 'text-[10px] font-semibold uppercase tracking-[0.14em] text-input-placeholder';
-const kpiValueClass = 'font-display text-[28px] font-bold leading-none tracking-tight tabular-nums text-input-text';
-const denseValueClass = 'font-display text-[24px] font-bold leading-none tracking-tight tabular-nums text-input-text';
+const labelClass = 'text-[10px] font-semibold uppercase tracking-[0.14em] text-dim-2';
+const kpiValueClass = 'font-display text-[28px] font-bold leading-none tracking-tight tabular-nums text-ink';
+const denseValueClass = 'font-display text-[24px] font-bold leading-none tracking-tight tabular-nums text-ink';
 const iconSquareClass = 'inline-flex h-7 w-7 items-center justify-center rounded-lg border border-card-border bg-surface-card-raised text-accent-utility';
 const revealClass = 'motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-300';
 
@@ -172,7 +172,7 @@ export const MatterSummaryCards = ({
                   </div>
                   <p className={cn('mt-3 break-words', isFirst ? kpiValueClass : denseValueClass)}>{card.value}</p>
                   {card.helper ? (
-                    <p className="mt-1 text-xs leading-snug text-input-placeholder/80">{card.helper}</p>
+                    <p className="mt-1 text-xs leading-snug text-dim-2/80">{card.helper}</p>
                   ) : null}
                 </div>
               );
@@ -196,7 +196,7 @@ export const MatterSummaryCards = ({
                     View timesheet
                   </button>
                 ) : (
-                  <span className="text-xs font-medium text-input-placeholder/60">View timesheet</span>
+                  <span className="text-xs font-medium text-dim-2/60">View timesheet</span>
                 )}
               </div>
             </div>
@@ -220,7 +220,7 @@ export const MatterSummaryCards = ({
               <p className={cn(labelClass, 'leading-tight')}>Billable time this week</p>
             </div>
             <p className={cn('mt-3 break-words', kpiValueClass)}>{billableDisplay}</p>
-            <p className="mt-1.5 text-xs leading-snug text-input-placeholder/80">
+            <p className="mt-1.5 text-xs leading-snug text-dim-2/80">
               Based on recorded billable entries this week.
             </p>
             {onLearnMore ? (
@@ -232,7 +232,7 @@ export const MatterSummaryCards = ({
                 Learn more
               </button>
             ) : (
-              <span className="mt-1 text-xs font-medium text-input-placeholder/60">
+              <span className="mt-1 text-xs font-medium text-dim-2/60">
                 Learn more (coming soon)
               </span>
             )}
@@ -248,13 +248,13 @@ export const MatterSummaryCards = ({
               <p className={cn(labelClass, 'leading-tight')}>{billingTypeLabel}</p>
             </div>
             {Array.isArray(billingRateLines) ? (
-              <div className="mt-3 space-y-1 font-display text-base font-semibold leading-snug tabular-nums text-input-text">
+              <div className="mt-3 space-y-1 font-display text-base font-semibold leading-snug tabular-nums text-ink">
                 {billingRateLines.map((line) => (
                   <p key={line}>{line}</p>
                 ))}
               </div>
             ) : (
-              <p className="mt-3 font-display text-lg font-semibold leading-snug tabular-nums text-input-text">{billingRateLines}</p>
+              <p className="mt-3 font-display text-lg font-semibold leading-snug tabular-nums text-ink">{billingRateLines}</p>
             )}
           </div>
           <div
@@ -268,7 +268,7 @@ export const MatterSummaryCards = ({
               <p className={cn(labelClass, 'leading-tight')}>This week&apos;s tracked</p>
             </div>
             <p className={cn('mt-3 break-words', kpiValueClass)}>{totalDisplay}</p>
-            <p className="mt-1.5 text-xs leading-snug text-input-placeholder/80">Across all logged entries this week</p>
+            <p className="mt-1.5 text-xs leading-snug text-dim-2/80">Across all logged entries this week</p>
           </div>
           <div className="col-span-1 flex flex-col items-stretch gap-2 self-center @lg:col-span-2 @lg:items-center @3xl:col-span-1 @3xl:items-end">
             <Button
@@ -289,7 +289,7 @@ export const MatterSummaryCards = ({
                   View timesheet
                 </button>
               ) : (
-                <span className="text-sm font-medium text-input-placeholder/60">View timesheet</span>
+                <span className="text-sm font-medium text-dim-2/60">View timesheet</span>
               )}
             </div>
           </div>
@@ -317,7 +317,7 @@ export const MatterSummaryCards = ({
               <p className={cn(labelClass, 'leading-tight')}>{card.label}</p>
               <p className={cn('mt-2 break-words', denseValueClass)}>{card.value}</p>
               {card.helper ? (
-                <p className="mt-1 text-xs leading-snug text-input-placeholder/80">{card.helper}</p>
+                <p className="mt-1 text-xs leading-snug text-dim-2/80">{card.helper}</p>
               ) : null}
             </div>
           ))}

--- a/src/features/matters/components/MatterWorkTab.tsx
+++ b/src/features/matters/components/MatterWorkTab.tsx
@@ -95,8 +95,8 @@ export const MatterWorkTab = ({
       {subTab === 'tasks' ? (
         tasksNotImplemented ? (
           <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 p-8 text-center">
-            <p className="text-sm font-medium text-input-text">Tasks coming soon</p>
-            <p className="text-xs text-input-placeholder">
+            <p className="text-sm font-medium text-ink">Tasks coming soon</p>
+            <p className="text-xs text-dim-2">
               Task management for this matter is not yet available.
             </p>
           </div>
@@ -132,7 +132,7 @@ export const MatterWorkTab = ({
           />
         ) : (
           <InfoCard icon={Inbox} title="Milestones">
-            <p className="text-sm text-input-placeholder">
+            <p className="text-sm text-dim-2">
               Milestones are only available for fixed-fee matters with milestone billing.
             </p>
           </InfoCard>

--- a/src/features/matters/components/billing/UnbilledSummaryCard.tsx
+++ b/src/features/matters/components/billing/UnbilledSummaryCard.tsx
@@ -23,11 +23,11 @@ export const UnbilledSummaryCard = ({
   if (matter.billingType === 'pro_bono') {
     return (
       <Panel className="p-6">
-        <h3 className="text-sm font-semibold text-input-text">Pro Bono Matter</h3>
-        <p className="mt-2 text-sm text-input-placeholder">
+        <h3 className="text-sm font-semibold text-ink">Pro Bono Matter</h3>
+        <p className="mt-2 text-sm text-dim-2">
           Time tracked: {summary.unbilledTime.hours.toFixed(1)} hrs
         </p>
-        <p className="mt-2 text-xs italic text-input-placeholder">
+        <p className="mt-2 text-xs italic text-dim-2">
           This matter is tracked for internal reporting only. No invoices will be generated.
         </p>
       </Panel>
@@ -41,12 +41,12 @@ export const UnbilledSummaryCard = ({
     const fee = (settlementAmount * percent) / 100;
     return (
       <Panel className="p-6">
-        <h3 className="text-sm font-semibold text-input-text">Contingency Billing</h3>
-        <p className="mt-2 text-sm text-input-placeholder">
+        <h3 className="text-sm font-semibold text-ink">Contingency Billing</h3>
+        <p className="mt-2 text-sm text-dim-2">
           Settlement: {hasSettlement ? formatCurrency(settlementAmount) : 'Not entered'}
         </p>
-        <p className="mt-1 text-sm text-input-placeholder">Fee: {percent}%</p>
-        <p className="mt-3 text-base font-semibold text-input-text">
+        <p className="mt-1 text-sm text-dim-2">Fee: {percent}%</p>
+        <p className="mt-3 text-base font-semibold text-ink">
           Potential invoice: {formatCurrency(fee)}
         </p>
         {hasSettlement && settlementAmount > 0 ? (
@@ -65,8 +65,8 @@ export const UnbilledSummaryCard = ({
   if (matter.billingType === 'fixed' && matter.paymentFrequency === 'milestone') {
     return (
       <Panel className="p-6">
-        <h3 className="text-sm font-semibold text-input-text">Milestone Billing</h3>
-        <p className="mt-2 text-sm text-input-placeholder">
+        <h3 className="text-sm font-semibold text-ink">Milestone Billing</h3>
+        <p className="mt-2 text-sm text-dim-2">
           {(matter.milestones ?? []).length} milestones configured for this matter.
         </p>
         <div className="mt-4 space-y-2">
@@ -75,8 +75,8 @@ export const UnbilledSummaryCard = ({
             return (
               <div key={milestone.id} className="flex items-center justify-between rounded-xl border border-line-subtle px-3 py-2">
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-input-text">{milestone.description}</p>
-                  <p className="text-xs text-input-placeholder">{formatCurrency(milestone.amount)}</p>
+                  <p className="truncate text-sm font-medium text-ink">{milestone.description}</p>
+                  <p className="text-xs text-dim-2">{formatCurrency(milestone.amount)}</p>
                 </div>
                 <Button
                   size="xs"
@@ -96,8 +96,8 @@ export const UnbilledSummaryCard = ({
   if (matter.billingType === 'fixed' && matter.paymentFrequency === 'project') {
     return (
       <Panel className="p-6">
-        <h3 className="text-sm font-semibold text-input-text">Project Billing</h3>
-        <p className="mt-2 text-sm text-input-placeholder">
+        <h3 className="text-sm font-semibold text-ink">Project Billing</h3>
+        <p className="mt-2 text-sm text-dim-2">
           Fixed total: {formatCurrency(matter.totalFixedPrice ?? 0)}
         </p>
         <Button className="mt-4" onClick={onCreateInvoice}>
@@ -109,12 +109,12 @@ export const UnbilledSummaryCard = ({
 
   return (
     <Panel className="p-6">
-      <h3 className="text-sm font-semibold text-input-text">Ready to Invoice</h3>
-      <div className="mt-3 space-y-1 text-sm text-input-placeholder">
+      <h3 className="text-sm font-semibold text-ink">Ready to Invoice</h3>
+      <div className="mt-3 space-y-1 text-sm text-dim-2">
         <p>Unbilled time: {summary.unbilledTime.hours.toFixed(1)} hrs</p>
         <p>Unbilled expenses: {formatCurrency(summary.unbilledExpenses.amount)}</p>
       </div>
-      <p className="mt-4 text-base font-semibold text-input-text">
+      <p className="mt-4 text-base font-semibold text-ink">
         Total unbilled: {formatCurrency(summary.totalUnbilled)}
       </p>
       <Button className="mt-4" onClick={onCreateInvoice} disabled={getMajorAmountValue(summary.totalUnbilled) <= 0}>

--- a/src/features/matters/components/expenses/MatterExpensesPanel.tsx
+++ b/src/features/matters/components/expenses/MatterExpensesPanel.tsx
@@ -207,7 +207,7 @@ export const MatterExpensesPanel = ({
                 <div className="min-w-0 flex-1">
                   <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-semibold text-input-text">
+                    <p className="text-sm font-semibold text-ink">
                       {expense.description}
                     </p>
                     <span
@@ -219,7 +219,7 @@ export const MatterExpensesPanel = ({
                       {expense.billable ? 'Billable' : 'Not billable'}
                     </span>
                   </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-x-2 text-xs leading-5 text-input-placeholder">
+                  <div className="mt-1 flex flex-wrap items-center gap-x-2 text-xs leading-5 text-dim-2">
                     <span className="whitespace-nowrap">
                       Date: <time dateTime={expense.date}>{formatExpenseDate(expense.date)}</time>
                     </span>
@@ -285,7 +285,7 @@ export const MatterExpensesPanel = ({
               <p className="mt-3 text-sm text-red-600 dark:text-red-400">{submitError}</p>
             )}
             {isSubmitting && (
-              <p className="mt-3 text-sm text-input-placeholder">Saving expense...</p>
+              <p className="mt-3 text-sm text-dim-2">Saving expense...</p>
             )}
           </DialogBody>
         </Dialog>
@@ -299,7 +299,7 @@ export const MatterExpensesPanel = ({
           contentClassName="max-w-xl"
         >
           <DialogBody className="space-y-4">
-            <p className="text-sm text-input-placeholder">
+            <p className="text-sm text-dim-2">
               Are you sure you want to delete this expense? This action cannot be undone.
             </p>
             {deleteError && (

--- a/src/features/matters/components/messages/MatterMessagesPanel.tsx
+++ b/src/features/matters/components/messages/MatterMessagesPanel.tsx
@@ -70,8 +70,8 @@ export const MatterMessagesPanel = ({ matter, practiceId, conversationBasePath }
     <section className="panel overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3 border-b border-line-subtle px-6 py-4">
         <div>
-          <p className="text-xs font-medium text-input-placeholder">Linked conversations</p>
-          <h3 className="text-base font-semibold text-input-text">{matter.title}</h3>
+          <p className="text-xs font-medium text-dim-2">Linked conversations</p>
+          <h3 className="text-base font-semibold text-ink">{matter.title}</h3>
         </div>
         <Button
           variant="secondary"
@@ -89,7 +89,7 @@ export const MatterMessagesPanel = ({ matter, practiceId, conversationBasePath }
           <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
         )}
         {!loading && !error && sortedConversations.length === 0 && (
-          <div className="text-sm text-input-placeholder">
+          <div className="text-sm text-dim-2">
             No conversations are linked to this matter yet.
           </div>
         )}
@@ -98,17 +98,17 @@ export const MatterMessagesPanel = ({ matter, practiceId, conversationBasePath }
             {sortedConversations.map((conversation) => (
               <div key={conversation.id} className="py-4 flex flex-wrap items-center justify-between gap-4">
                 <div>
-                  <p className="text-sm font-medium text-input-text">
+                  <p className="text-sm font-medium text-ink">
                     Conversation {conversation.id.slice(0, 8)}
                   </p>
-                  <p className="text-xs text-input-placeholder">
+                  <p className="text-xs text-dim-2">
                     {conversation.last_message_at
                       ? `Last message ${formatRelativeTime(conversation.last_message_at)}`
                       : 'No messages yet'}
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-xs uppercase tracking-wide text-input-placeholder">
+                  <span className="text-xs uppercase tracking-wide text-dim-2">
                     {conversation.status ?? 'active'}
                   </span>
                   <Button

--- a/src/features/matters/components/milestones/MatterMilestonesPanel.tsx
+++ b/src/features/matters/components/milestones/MatterMilestonesPanel.tsx
@@ -187,8 +187,8 @@ export const MatterMilestonesPanel = ({
     <section className="panel">
       <header className="flex flex-wrap items-center justify-between gap-3 border-b border-line-subtle px-6 py-4">
         <div>
-          <h3 className="text-sm font-semibold text-input-text">Milestones</h3>
-          <p className="text-xs text-input-placeholder">
+          <h3 className="text-sm font-semibold text-ink">Milestones</h3>
+          <p className="text-xs text-dim-2">
             {resolvedMilestones.length} milestones tracked
           </p>
         </div>
@@ -204,7 +204,7 @@ export const MatterMilestonesPanel = ({
       ) : loading && resolvedMilestones.length === 0 ? (
         <ListRowSkeleton rows={3} avatar={false} className="divide-y divide-line-default" />
       ) : resolvedMilestones.length === 0 ? (
-        <div className="px-6 py-6 text-sm text-input-placeholder">
+        <div className="px-6 py-6 text-sm text-dim-2">
           No milestones yet. Add milestones to track key deliverables for this matter.
         </div>
       ) : (
@@ -213,10 +213,10 @@ export const MatterMilestonesPanel = ({
             <li key={milestone.id ?? `${milestone.description}-${index}`} className="px-6 py-4">
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <p className="text-sm font-semibold text-input-text">
+                  <p className="text-sm font-semibold text-ink">
                     {milestone.description}
                   </p>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-input-placeholder">
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-dim-2">
                     {milestone.dueDate ? (
                       <span>
                         Due <time dateTime={milestone.dueDate}>{formatDateOnlyUtc(milestone.dueDate)}</time>
@@ -227,7 +227,7 @@ export const MatterMilestonesPanel = ({
                   </div>
                 </div>
                 <div className="flex items-center gap-3">
-                  <div className="text-sm font-semibold text-input-text">
+                  <div className="text-sm font-semibold text-ink">
                     {formatCurrency(milestone.amount ?? 0)}
                   </div>
                   <div className="flex items-center gap-1">
@@ -312,7 +312,7 @@ export const MatterMilestonesPanel = ({
               required
             />
             <div>
-              <span className="block text-sm font-medium text-input-text mb-1">Status</span>
+              <span className="block text-sm font-medium text-ink mb-1">Status</span>
               <Combobox
                 value={formState.status}
                 options={statusOptions}
@@ -345,7 +345,7 @@ export const MatterMilestonesPanel = ({
           contentClassName="max-w-xl"
         >
           <DialogBody className="space-y-4">
-            <p className="text-sm text-input-placeholder">
+            <p className="text-sm text-dim-2">
               Are you sure you want to delete this milestone? This action cannot be undone.
             </p>
             {deleteError && (

--- a/src/features/matters/components/notes/MatterNotesPanel.tsx
+++ b/src/features/matters/components/notes/MatterNotesPanel.tsx
@@ -202,22 +202,22 @@ export const MatterNotesPanel = ({
                 <Avatar name={note.author.name} src={note.author.avatarUrl} size="sm" />
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-semibold text-input-text">
+                    <p className="text-sm font-semibold text-ink">
                       {note.author.name}
                     </p>
                     {note.author.role && (
-                      <span className="input-surface rounded-full px-2 py-0.5 text-xs font-medium text-input-placeholder">
+                      <span className="input-surface rounded-full px-2 py-0.5 text-xs font-medium text-dim-2">
                         {note.author.role}
                       </span>
                     )}
-                    <span className="text-xs text-input-placeholder">
+                    <span className="text-xs text-dim-2">
                       {formatNoteDate(note.updatedAt ?? note.createdAt)}
                     </span>
                     {note.updatedAt && (
-                      <span className="text-xs text-input-placeholder">(edited)</span>
+                      <span className="text-xs text-dim-2">(edited)</span>
                     )}
                   </div>
-                  <p className="mt-2 whitespace-pre-wrap text-sm text-input-text opacity-80 decoration-input-placeholder">
+                  <p className="mt-2 whitespace-pre-wrap text-sm text-ink opacity-80 decoration-input-placeholder">
                     {note.content}
                   </p>
                 </div>
@@ -283,7 +283,7 @@ export const MatterNotesPanel = ({
               <p className="mt-3 text-sm text-red-600 dark:text-red-400">{submitError}</p>
             )}
             {isSubmitting && (
-              <p className="mt-3 text-sm text-input-placeholder">Saving note...</p>
+              <p className="mt-3 text-sm text-dim-2">Saving note...</p>
             )}
           </DialogBody>
         </Dialog>
@@ -297,7 +297,7 @@ export const MatterNotesPanel = ({
           contentClassName="max-w-xl"
         >
           <DialogBody className="space-y-4">
-            <p className="text-sm text-input-text opacity-80">
+            <p className="text-sm text-ink opacity-80">
               Are you sure you want to delete this note? This action cannot be undone.
             </p>
             {deleteError && (

--- a/src/features/matters/components/tasks/MatterTaskForm.tsx
+++ b/src/features/matters/components/tasks/MatterTaskForm.tsx
@@ -139,7 +139,7 @@ export const MatterTaskForm = ({
           onChange={(value) => setFormState((prev) => ({ ...prev, dueDate: value }))}
         />
         <div>
-          <span id="matter-task-assignee-label" className="mb-1 block text-sm font-medium text-input-text">
+          <span id="matter-task-assignee-label" className="mb-1 block text-sm font-medium text-ink">
             Assignee
           </span>
           <Combobox
@@ -155,7 +155,7 @@ export const MatterTaskForm = ({
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <span id="matter-task-status-label" className="mb-1 block text-sm font-medium text-input-text">
+          <span id="matter-task-status-label" className="mb-1 block text-sm font-medium text-ink">
             Status
           </span>
           <Combobox
@@ -168,7 +168,7 @@ export const MatterTaskForm = ({
           />
         </div>
         <div>
-          <span id="matter-task-priority-label" className="mb-1 block text-sm font-medium text-input-text">
+          <span id="matter-task-priority-label" className="mb-1 block text-sm font-medium text-ink">
             Priority
           </span>
           <Combobox
@@ -183,7 +183,7 @@ export const MatterTaskForm = ({
       </div>
 
       <div>
-        <span id="matter-task-stage-label" className="mb-1 block text-sm font-medium text-input-text">
+        <span id="matter-task-stage-label" className="mb-1 block text-sm font-medium text-ink">
           Stage
         </span>
         <Combobox

--- a/src/features/matters/components/tasks/MatterTasksPanel.tsx
+++ b/src/features/matters/components/tasks/MatterTasksPanel.tsx
@@ -226,15 +226,15 @@ export const MatterTasksPanel = ({
                 padding="px-4 py-4"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-semibold text-input-text">{task.name}</p>
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-input-placeholder">
+                  <p className="text-sm font-semibold text-ink">{task.name}</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-dim-2">
                       <span className={[STATUS_STYLES[task.status], 'rounded-md px-2 py-0.5 font-medium ring-1 ring-inset'].join(' ')}>{task.status}</span>
                       <span>Priority: {task.priority}</span>
                       <span>Stage: {task.stage}</span>
                       <span>{formatDate(task.dueDate)}</span>
                       <span>{assignee ? `Assigned: ${assignee.name}` : 'Unassigned'}</span>
                     </div>
-                    {task.description ? <p className="mt-2 text-sm text-input-placeholder">{task.description}</p> : null}
+                    {task.description ? <p className="mt-2 text-sm text-dim-2">{task.description}</p> : null}
                   </div>
                   {!readOnly && (canUpdateTask || canDeleteTask) ? (
                     <div className="flex items-center gap-2">
@@ -247,7 +247,7 @@ export const MatterTasksPanel = ({
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end" className="w-64 space-y-3 p-3">
                             <div>
-                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-input-placeholder">Status</span>
+                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-dim-2">Status</span>
                               <Combobox
                                 value={task.status}
                                 options={STATUS_OPTIONS}
@@ -256,7 +256,7 @@ export const MatterTasksPanel = ({
                               />
                             </div>
                             <div>
-                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-input-placeholder">Priority</span>
+                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-dim-2">Priority</span>
                               <Combobox
                                 value={task.priority}
                                 options={PRIORITY_OPTIONS}
@@ -265,7 +265,7 @@ export const MatterTasksPanel = ({
                               />
                             </div>
                             <div>
-                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-input-placeholder">Assignee</span>
+                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-dim-2">Assignee</span>
                               <Combobox
                                 value={task.assigneeId ?? ''}
                                 options={[{ value: '', label: 'Unassigned' }, ...assignees.map((a) => ({ value: a.id, label: a.name }))]}
@@ -274,7 +274,7 @@ export const MatterTasksPanel = ({
                               />
                             </div>
                             <div>
-                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-input-placeholder">Due date</span>
+                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-dim-2">Due date</span>
                               <Input
                                 type="date"
                                 value={task.dueDate ?? ''}
@@ -282,7 +282,7 @@ export const MatterTasksPanel = ({
                               />
                             </div>
                             <div>
-                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-input-placeholder">Stage</span>
+                              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-dim-2">Stage</span>
                               <Combobox
                                 value={task.stage}
                                 options={stageRowOptions}
@@ -366,7 +366,7 @@ export const MatterTasksPanel = ({
           contentClassName="max-w-xl"
         >
           <DialogBody className="space-y-4">
-            <p className="text-sm text-input-text opacity-80">
+            <p className="text-sm text-ink opacity-80">
               Are you sure you want to delete this task? This action cannot be undone.
             </p>
             {requestError ? <p className="text-sm text-red-600 dark:text-red-400">{requestError}</p> : null}

--- a/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
+++ b/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
@@ -165,7 +165,7 @@ export const TimeEntriesPanel = ({
                 onClick={handlePreviousWeek}
               />
               <div className="min-w-[220px] text-center">
-                <p className="text-sm font-semibold text-input-text">{weekRangeLabel}</p>
+                <p className="text-sm font-semibold text-ink">{weekRangeLabel}</p>
               </div>
               <Button
                 variant="ghost"
@@ -195,7 +195,7 @@ export const TimeEntriesPanel = ({
                 className="w-full text-left px-4 py-3 sm:px-6 hover:bg-surface-card-hover transition-colors"
               >
                 <div className="grid gap-2 sm:grid-cols-12 sm:items-center">
-                  <div className="text-sm font-medium text-input-placeholder sm:col-span-3">
+                  <div className="text-sm font-medium text-dim-2 sm:col-span-3">
                     {formatDateLabel(day.date)}
                   </div>
                   <div className="sm:col-span-9">
@@ -206,11 +206,11 @@ export const TimeEntriesPanel = ({
                           style={{ width: `${day.progressPercentage}%` }}
                         />
                       </div>
-                      <div className="text-sm font-semibold text-input-text min-w-[96px] text-right">
+                      <div className="text-sm font-semibold text-ink min-w-[96px] text-right">
                         {formatDuration(day.totalSeconds)}
                       </div>
                     </div>
-                    <p className="mt-1 text-xs text-input-placeholder">
+                    <p className="mt-1 text-xs text-dim-2">
                       {day.entries.length === 1 ? '1 entry' : `${day.entries.length} entries`}
                     </p>
                   </div>
@@ -250,7 +250,7 @@ export const TimeEntriesPanel = ({
           contentClassName="max-w-xl"
         >
           <DialogBody className="space-y-4">
-            <p className="text-sm text-input-placeholder">
+            <p className="text-sm text-dim-2">
               Are you sure you want to delete this time entry? This action cannot be undone.
             </p>
           </DialogBody>

--- a/src/features/matters/components/time-entries/TimeEntryForm.tsx
+++ b/src/features/matters/components/time-entries/TimeEntryForm.tsx
@@ -122,7 +122,7 @@ export const TimeEntryForm = ({ initialEntry, initialDate, lockDate = false, onS
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="w-full">
-          <span className="block text-sm font-medium text-input-text mb-1">Date</span>
+          <span className="block text-sm font-medium text-ink mb-1">Date</span>
           <Combobox
             value={date.value}
             options={dateOptions}
@@ -132,8 +132,8 @@ export const TimeEntryForm = ({ initialEntry, initialDate, lockDate = false, onS
           />
         </div>
         <div>
-          <span className="block text-sm font-medium text-input-text mb-1">Timezone</span>
-          <div className="input-surface rounded-xl px-3 py-2.5 text-sm text-input-placeholder flex items-center">
+          <span className="block text-sm font-medium text-ink mb-1">Timezone</span>
+          <div className="input-surface rounded-xl px-3 py-2.5 text-sm text-dim-2 flex items-center">
             UTC
           </div>
         </div>

--- a/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
+++ b/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
@@ -74,10 +74,10 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
 
   return (
     <div className="panel p-4">
-      <div className="text-sm font-semibold text-input-text text-center">{monthLabel}</div>
+      <div className="text-sm font-semibold text-ink text-center">{monthLabel}</div>
 
       <div
-        className="mt-4 grid gap-2 text-center text-[11px] font-medium text-input-placeholder justify-items-center"
+        className="mt-4 grid gap-2 text-center text-[11px] font-medium text-dim-2 justify-items-center"
         style={{ gridTemplateColumns: 'repeat(7, minmax(0, 1fr))' }}
       >
         {WEEKDAYS.map((day) => (
@@ -100,8 +100,8 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
               onClick={() => onSelectWeek(day)}
               className={[
                 'h-9 w-9 rounded-full text-sm font-medium transition-colors',
-                isCurrentMonth ? 'text-input-text' : 'text-input-placeholder',
-                isSelectedWeek ? 'bg-surface-card-raised text-input-text' : 'hover:bg-surface-card-hover',
+                isCurrentMonth ? 'text-ink' : 'text-dim-2',
+                isSelectedWeek ? 'bg-surface-card-raised text-ink' : 'hover:bg-surface-card-hover',
                 isToday ? 'ring-2 ring-accent-500' : 'ring-1 ring-transparent'
               ].join(' ')}
             >

--- a/src/features/matters/pages/ClientMattersPage.tsx
+++ b/src/features/matters/pages/ClientMattersPage.tsx
@@ -61,7 +61,7 @@ type ClientMattersPageProps = {
 };
 
 const LoadingState = ({ message }: { message: string }) => (
-  <div className="flex h-full items-center justify-center p-8 text-sm text-input-placeholder">{message}</div>
+  <div className="flex h-full items-center justify-center p-8 text-sm text-dim-2">{message}</div>
 );
 
 const ErrorBanner = ({ children }: { children: ComponentChildren }) => (
@@ -438,8 +438,8 @@ export const ClientMattersPage = ({
                     'transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 rounded-t-sm',
                     'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-all after:duration-150',
                     isActive
-                      ? 'text-input-text after:bg-accent-500'
-                      : 'text-input-placeholder hover:text-input-text after:bg-transparent hover:after:bg-line-subtle'
+                      ? 'text-ink after:bg-accent-500'
+                      : 'text-dim-2 hover:text-ink after:bg-transparent hover:after:bg-line-subtle'
                   ].join(' ')}
                 >
                   {tab.label}
@@ -465,39 +465,39 @@ export const ClientMattersPage = ({
                 />
                 <section className="panel overflow-hidden">
                   <header className="border-b border-line-subtle px-6 py-4">
-                    <h3 className="text-sm font-semibold text-input-text">Matter details</h3>
+                    <h3 className="text-sm font-semibold text-ink">Matter details</h3>
                   </header>
                   <div className="grid gap-4 px-6 py-5 text-sm sm:grid-cols-2">
                     <div>
-                      <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Status</p>
-                      <p className="mt-1 text-input-text">{MATTER_STATUS_LABELS[resolvedMatter.status]}</p>
+                      <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Status</p>
+                      <p className="mt-1 text-ink">{MATTER_STATUS_LABELS[resolvedMatter.status]}</p>
                     </div>
                     <div>
-                      <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Client</p>
-                      <p className="mt-1 text-input-text">{resolvedMatter.clientName || 'Not provided'}</p>
+                      <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Client</p>
+                      <p className="mt-1 text-ink">{resolvedMatter.clientName || 'Not provided'}</p>
                     </div>
                     <div>
-                      <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Practice area</p>
-                      <p className="mt-1 text-input-text">{resolvedMatter.practiceArea || 'Not provided'}</p>
+                      <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Practice area</p>
+                      <p className="mt-1 text-ink">{resolvedMatter.practiceArea || 'Not provided'}</p>
                     </div>
                     <div>
-                      <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">Opened</p>
-                      <p className="mt-1 text-input-text">{resolvedMatter.createdAt || 'Not provided'}</p>
+                      <p className="text-xs font-medium uppercase tracking-wide text-dim-2">Opened</p>
+                      <p className="mt-1 text-ink">{resolvedMatter.createdAt || 'Not provided'}</p>
                     </div>
                   </div>
                 </section>
                 <section className="panel overflow-hidden">
                   <header className="border-b border-line-subtle px-6 py-4">
-                    <h3 className="text-sm font-semibold text-input-text">Matter description</h3>
+                    <h3 className="text-sm font-semibold text-ink">Matter description</h3>
                   </header>
                   <div className="px-6 py-5">
-                    <p className="whitespace-pre-wrap text-sm leading-relaxed text-input-placeholder">
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed text-dim-2">
                       {resolvedMatter.description?.trim() || 'No description available.'}
                     </p>
                   </div>
                 </section>
                 <section>
-                  <h3 className="text-sm font-semibold text-input-text">Recent activity</h3>
+                  <h3 className="text-sm font-semibold text-ink">Recent activity</h3>
                   <Panel className="mt-4 p-4">
                     {fetchError ? (
                       <ErrorBanner>{fetchError}</ErrorBanner>
@@ -569,7 +569,7 @@ export const ClientMattersPage = ({
           isLoadingMore={false}
           error={mattersError}
           minMountSkeletonMs={250}
-          emptyState={<div className="p-4 text-sm text-input-placeholder">No matters found.</div>}
+          emptyState={<div className="p-4 text-sm text-dim-2">No matters found.</div>}
         />
       </Panel>
     </>

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -133,7 +133,7 @@ const matterStatusBadgeClass = (status: MatterStatus): string => {
   const base = 'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap';
   if (ACTIVE_STATUSES.has(status)) return `${base} status-success`;
   if (status === 'closed' || DECLINED_STATUSES.has(status)) {
-    return `${base} border border-line-subtle bg-surface-card-hover text-input-placeholder`;
+    return `${base} border border-line-subtle bg-surface-card-hover text-dim-2`;
   }
   return `${base} status-warning`;
 };
@@ -224,8 +224,8 @@ const useDelayedSkeleton = (loading: boolean): boolean => {
 // ---------------------------------------------------------------------------
 const _DetailField = ({ label, value }: { label: string; value: string }) => (
   <div>
-    <p className="text-xs font-medium uppercase tracking-wide text-input-placeholder">{label}</p>
-    <p className="mt-1 text-sm text-input-text">{value || '—'}</p>
+    <p className="text-xs font-medium uppercase tracking-wide text-dim-2">{label}</p>
+    <p className="mt-1 text-sm text-ink">{value || '—'}</p>
   </div>
 );
 
@@ -258,9 +258,9 @@ const MatterNotFound = ({
         actions={<Button size="sm" variant="secondary" onClick={onBack}>Back to matters</Button>}
       />
       <section className="panel p-6">
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           We could not find a matter with the ID{' '}
-          <span className="font-mono text-input-text">{matterId}</span>{' '}
+          <span className="font-mono text-ink">{matterId}</span>{' '}
           in this workspace.
         </p>
       </section>
@@ -2007,7 +2007,7 @@ export const PracticeMattersPage = ({
             contentClassName="max-w-md"
           >
             <DialogBody className="space-y-3">
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm text-dim-2">
                 Closing marks this matter as closed. No new time entries or tasks can be added.
               </p>
             </DialogBody>
@@ -2026,11 +2026,11 @@ export const PracticeMattersPage = ({
             contentClassName="max-w-md"
           >
             <DialogBody className="space-y-4">
-              <p className="text-sm text-input-placeholder">
-                This permanently deletes <strong className="text-input-text">{selectedMatterDetail.title}</strong> and all associated data (time entries, expenses, notes, files, milestones). This cannot be undone.
+              <p className="text-sm text-dim-2">
+                This permanently deletes <strong className="text-ink">{selectedMatterDetail.title}</strong> and all associated data (time entries, expenses, notes, files, milestones). This cannot be undone.
               </p>
               <div className="space-y-2">
-                <label className="block text-xs font-medium text-input-text">
+                <label className="block text-xs font-medium text-ink">
                   Type <span className="font-semibold">{selectedMatterDetail.title}</span> to confirm
                 </label>
                 <Input
@@ -2063,7 +2063,7 @@ export const PracticeMattersPage = ({
             contentClassName="max-w-xl"
           >
             <div className="space-y-4">
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm text-dim-2">
                 Set the settlement amount before generating a contingency invoice.
               </p>
               <CurrencyInput
@@ -2103,7 +2103,7 @@ export const PracticeMattersPage = ({
     ? sortedMatterSummaries
     : sortedMatterSummaries.filter((matter) => matterStatusCategory(matter.status) === matterCategoryFilter);
 
-  const headerCellClassName = 'text-xs font-medium text-input-placeholder';
+  const headerCellClassName = 'text-xs font-medium text-dim-2';
   const tableColumns: DataTableColumn[] = [
     { id: 'title', label: 'Matter Name', isPrimary: true, headerClassName: headerCellClassName },
     { id: 'client', label: 'Client', hideAt: 'sm', headerClassName: headerCellClassName },
@@ -2118,7 +2118,7 @@ export const PracticeMattersPage = ({
       id: matter.id,
       onClick: () => goToDetail(matter.id),
       cells: {
-        title: <span className="truncate font-medium text-input-text">{matter.title}</span>,
+        title: <span className="truncate font-medium text-ink">{matter.title}</span>,
         client: <span className="truncate">{matter.clientName}</span>,
         practiceArea: matter.practiceArea ?? '—',
         status: (
@@ -2176,7 +2176,7 @@ export const PracticeMattersPage = ({
             type="button"
             onClick={() => setIsShortcutsHelpOpen(true)}
             aria-label="Show keyboard shortcuts"
-            className="hidden h-8 w-8 items-center justify-center rounded-full text-input-placeholder transition-colors hover:bg-surface-card-hover hover:text-input-text md:inline-flex"
+            className="hidden h-8 w-8 items-center justify-center rounded-full text-dim-2 transition-colors hover:bg-surface-card-hover hover:text-ink md:inline-flex"
           >
             <span className="text-sm font-semibold">?</span>
           </button>
@@ -2188,7 +2188,7 @@ export const PracticeMattersPage = ({
             disabled={!activePracticeId}
           >
             New Matter
-            <kbd className="ml-2 hidden rounded border border-line-utility bg-surface-card-hover px-1.5 py-0.5 text-[10px] font-medium text-input-placeholder md:inline">
+            <kbd className="ml-2 hidden rounded border border-line-utility bg-surface-card-hover px-1.5 py-0.5 text-[10px] font-medium text-dim-2 md:inline">
               N
             </kbd>
           </Button>
@@ -2199,7 +2199,7 @@ export const PracticeMattersPage = ({
         {showEmpty ? (
           <EmptyState onCreate={handleNewMatter} disableCreate={!activePracticeId} />
         ) : showFilteredEmpty ? (
-          <div className="px-2 py-8 text-sm text-input-placeholder">
+          <div className="px-2 py-8 text-sm text-dim-2">
             {filteredEmptyMessage}
           </div>
         ) : (
@@ -2232,8 +2232,8 @@ export const PracticeMattersPage = ({
                 { key: '⌘ K', desc: 'Open command palette (or Ctrl + K)' },
               ].map((s) => (
                 <li key={s.key} className="flex items-center justify-between gap-4">
-                  <span className="text-sm text-input-text">{s.desc}</span>
-                  <kbd className="rounded border border-line-utility bg-surface-card-hover px-2 py-0.5 text-xs font-medium text-input-placeholder">
+                  <span className="text-sm text-ink">{s.desc}</span>
+                  <kbd className="rounded border border-line-utility bg-surface-card-hover px-2 py-0.5 text-xs font-medium text-dim-2">
                     {s.key}
                   </kbd>
                 </li>

--- a/src/features/media/components/AudioRecordingUI.tsx
+++ b/src/features/media/components/AudioRecordingUI.tsx
@@ -331,7 +331,7 @@ const AudioRecordingUI: FunctionComponent<AudioRecordingUIProps> = ({
                 onClick={onCancel}
                 aria-label="Cancel recording"
                 title="Cancel recording"
-                className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-all duration-200 text-input-placeholder hover:text-red-400 bg-surface-utility/5 hover:bg-red-500/10 animate-zoom-in"
+                className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-all duration-200 text-dim-2 hover:text-red-400 bg-surface-utility/5 hover:bg-red-500/10 animate-zoom-in"
             >
                 <Icon icon={X} className="w-5 h-5" aria-hidden="true"  />
             </Button>

--- a/src/features/media/components/MediaContent.tsx
+++ b/src/features/media/components/MediaContent.tsx
@@ -33,7 +33,7 @@ const MediaContent: FunctionComponent<MediaContentProps> = ({ media }) => {
         }
         if (!renderUrl) {
             return (
-                <div className="flex h-64 w-64 items-center justify-center rounded-xl bg-surface-panel text-sm text-input-placeholder">
+                <div className="flex h-64 w-64 items-center justify-center rounded-xl bg-surface-panel text-sm text-dim-2">
                     Preview unavailable
                 </div>
             );

--- a/src/features/media/components/MediaSidebar.tsx
+++ b/src/features/media/components/MediaSidebar.tsx
@@ -127,7 +127,7 @@ const MediaRow: FunctionComponent<MediaRowProps> = ({ media, onPreview, onError 
         />
         <div className="flex-1 min-w-0">
           <div
-            className="text-xs sm:text-sm font-medium text-input-text whitespace-nowrap overflow-hidden text-ellipsis"
+            className="text-xs sm:text-sm font-medium text-ink whitespace-nowrap overflow-hidden text-ellipsis"
             title={media.name}
           >
             {media.name.length > 20 ? `${media.name.substring(0, 20)}...` : media.name}
@@ -140,7 +140,7 @@ const MediaRow: FunctionComponent<MediaRowProps> = ({ media, onPreview, onError 
               onClick={(e) => { void handleDownload(e); }}
               title="Download file"
               disabled={busy}
-              className="p-1.5 surface-hover rounded-xl text-input-placeholder hover:text-input-text"
+              className="p-1.5 surface-hover rounded-xl text-dim-2 hover:text-ink"
             >
               <Icon icon={Download} className="w-3.5 h-3.5" />
             </Button>
@@ -175,9 +175,9 @@ export default function MediaSidebar({ messages }: MediaSidebarProps) {
           <AccordionTrigger>Media, DocumentIcons, and Links</AccordionTrigger>
           <AccordionContent>
             <div className="flex flex-col items-center justify-center text-center py-6">
-              <Icon icon={Image} className="w-6 h-6 sm:w-8 sm:h-8 text-input-placeholder/50 mb-2" />
-              <p className="text-sm font-medium mb-1 text-input-text">No files shared yet</p>
-              <p className="text-xs text-input-placeholder">Files you share in the conversation will appear here</p>
+              <Icon icon={Image} className="w-6 h-6 sm:w-8 sm:h-8 text-dim-2/50 mb-2" />
+              <p className="text-sm font-medium mb-1 text-ink">No files shared yet</p>
+              <p className="text-xs text-dim-2">Files you share in the conversation will appear here</p>
             </div>
           </AccordionContent>
         </AccordionItem>
@@ -195,7 +195,7 @@ export default function MediaSidebar({ messages }: MediaSidebarProps) {
               <div className="flex flex-col gap-3 pt-2">
                 {mediaGroups.map((group) => (
                   <div key={group.category} className="flex flex-col gap-2">
-                    <h5 className="text-[10px] font-bold text-input-placeholder uppercase tracking-[0.2em]">
+                    <h5 className="text-[10px] font-bold text-dim-2 uppercase tracking-[0.2em]">
                       {categoryLabels[group.category]} ({group.files.length})
                     </h5>
                     <div className="flex flex-col gap-2">

--- a/src/features/modals/components/CameraCaptureButton.tsx
+++ b/src/features/modals/components/CameraCaptureButton.tsx
@@ -19,7 +19,7 @@ const CameraCaptureButton: FunctionComponent<CameraCaptureButtonProps> = ({ onCl
       className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-utility/10 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
       aria-label="Take photo"
     >
-      <Icon icon={Camera} className="w-16 h-16 text-input-text"  />
+      <Icon icon={Camera} className="w-16 h-16 text-ink"  />
     </button>
   );
 };

--- a/src/features/onboarding/components/InfoCard.tsx
+++ b/src/features/onboarding/components/InfoCard.tsx
@@ -47,7 +47,7 @@ export const InfoCard = ({
   };
 
   const variantClasses: Record<InfoCardVariant, string> = {
-    default: 'panel text-input-text',
+    default: 'panel text-ink',
     blue: 'status-info',
     amber: 'status-warning',
     green: 'status-success',

--- a/src/features/onboarding/components/PersonalInfoStep.tsx
+++ b/src/features/onboarding/components/PersonalInfoStep.tsx
@@ -65,10 +65,10 @@ const PersonalInfoStep = ({
           <Logo size="lg" />
         </div>
 
-        <h2 className="mt-6 text-center text-2xl font-semibold tracking-tight text-input-text">
+        <h2 className="mt-6 text-center text-2xl font-semibold tracking-tight text-ink">
           {t('onboarding.step1.title')}
         </h2>
-        <p className="mt-2 text-center text-sm text-input-placeholder">
+        <p className="mt-2 text-center text-sm text-dim-2">
           {t('onboarding.step1.subtitle')}
         </p>
       </div>
@@ -97,7 +97,7 @@ const PersonalInfoStep = ({
                           onChange={(value) => onChange(value)}
                           placeholder={t('onboarding.step1.fullNamePlaceholder')}
                           icon={User}
-                          iconClassName="h-5 w-5 text-input-placeholder"
+                          iconClassName="h-5 w-5 text-dim-2"
                           error={error?.message}
                         />
                       </FormControl>

--- a/src/features/onboarding/components/PracticeNameStep.tsx
+++ b/src/features/onboarding/components/PracticeNameStep.tsx
@@ -88,10 +88,10 @@ const PracticeNameStep = ({
           <Logo size="lg" />
         </div>
 
-        <h2 className="mt-6 text-center text-2xl font-semibold tracking-tight text-input-text">
+        <h2 className="mt-6 text-center text-2xl font-semibold tracking-tight text-ink">
           Name your practice
         </h2>
-        <p className="mt-2 text-center text-sm text-input-placeholder">
+        <p className="mt-2 text-center text-sm text-dim-2">
           This is the workspace your team and clients will see. You can fine-tune the details later.
         </p>
       </div>
@@ -118,7 +118,7 @@ const PracticeNameStep = ({
                         onChange={(next) => onChange(next)}
                         placeholder="Acme Law"
                         icon={Building2}
-                        iconClassName="h-5 w-5 text-input-placeholder"
+                        iconClassName="h-5 w-5 text-dim-2"
                         error={error?.message}
                       />
                     </FormControl>

--- a/src/features/onboarding/steps/StripeOnboardingStep.tsx
+++ b/src/features/onboarding/steps/StripeOnboardingStep.tsx
@@ -47,7 +47,7 @@ export function StripeOnboardingStep({
     <div className="space-y-6">
       {showIntro && (
         <div className="text-center">
-          <p className="text-sm text-input-placeholder">
+          <p className="text-sm text-dim-2">
             Start Stripe onboarding to verify your trust account and enable payouts.
           </p>
         </div>
@@ -69,8 +69,8 @@ export function StripeOnboardingStep({
         <div className="card p-4 space-y-2">
           {statusItems.map((item) => (
             <div key={item.label} className="flex items-center justify-between text-sm">
-              <span className="text-input-placeholder">{item.label}</span>
-              <span className="font-semibold text-input-text">
+              <span className="text-dim-2">{item.label}</span>
+              <span className="font-semibold text-ink">
                 {item.value}
               </span>
             </div>

--- a/src/features/practice-dashboard/components/BillingActionsWidget.tsx
+++ b/src/features/practice-dashboard/components/BillingActionsWidget.tsx
@@ -30,8 +30,8 @@ export const BillingActionsWidget = ({
     <Panel className="flex h-full flex-col">
       <header className="flex items-center justify-between border-b border-line-subtle px-5 py-4">
         <div>
-          <p className="text-sm font-semibold text-input-text">Billing Actions</p>
-          <p className="text-xs text-input-placeholder">Matters that need billing attention</p>
+          <p className="text-sm font-semibold text-ink">Billing Actions</p>
+          <p className="text-xs text-dim-2">Matters that need billing attention</p>
         </div>
         <Button size="xs" variant="secondary" onClick={() => onRefresh?.()} disabled={loading}>
           Refresh
@@ -43,11 +43,11 @@ export const BillingActionsWidget = ({
             <LoadingSpinner size="md" />
           </div>
         ) : error ? (
-          <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-input-text">
+          <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
             {error}
           </div>
         ) : actions.length === 0 ? (
-          <p className="text-sm text-input-placeholder">No billing actions needed right now.</p>
+          <p className="text-sm text-dim-2">No billing actions needed right now.</p>
         ) : (
           <div className="space-y-4">
             {actions.map((action) => (
@@ -57,12 +57,12 @@ export const BillingActionsWidget = ({
                     <div className="flex gap-3">
                       <div className="text-lg" aria-hidden="true">{ICONS[action.reason]}</div>
                       <div>
-                        <p className="font-semibold text-input-text">{action.title}</p>
+                        <p className="font-semibold text-ink">{action.title}</p>
                         {action.subtitle ? (
-                          <p className="text-xs text-input-placeholder">{action.subtitle}</p>
+                          <p className="text-xs text-dim-2">{action.subtitle}</p>
                         ) : null}
                         {action.amount != null ? (
-                          <p className="mt-1 text-sm font-semibold text-input-text">
+                          <p className="mt-1 text-sm font-semibold text-ink">
                             {formatCurrency(action.amount)}
                           </p>
                         ) : null}

--- a/src/features/practice-dashboard/components/DashboardHero.tsx
+++ b/src/features/practice-dashboard/components/DashboardHero.tsx
@@ -27,7 +27,7 @@ export const DashboardHero = ({
 }: DashboardHeroProps) => (
   <section className="border-b border-line-subtle lg:border-t lg:border-t-line-glass/20">
     <div className="mx-auto flex max-w-7xl items-center gap-6 px-4 py-5 sm:px-6 lg:px-8">
-      <h1 className="shrink-0 text-base font-semibold text-input-text">Cashflow</h1>
+      <h1 className="shrink-0 text-base font-semibold text-ink">Cashflow</h1>
       <div role="group" aria-label="Time window" className="flex shrink-0 gap-x-8 border-l border-line-subtle pl-6 text-sm font-semibold">
         {(Object.keys(WINDOW_LABELS) as BillingWindow[]).map((window) => (
           <Button
@@ -68,13 +68,13 @@ export const DashboardHero = ({
               'flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-t border-line-subtle px-4 py-10 sm:px-6 lg:border-t-0 xl:px-8'
             )}
           >
-            <dt className="text-sm font-medium text-input-placeholder">{stat.label}</dt>
+            <dt className="text-sm font-medium text-dim-2">{stat.label}</dt>
             {stat.changeLabel ? (
-              <dd className={cn(stat.changeTone === 'negative' ? 'text-rose-300' : 'text-input-placeholder', 'text-xs font-medium')}>
+              <dd className={cn(stat.changeTone === 'negative' ? 'text-rose-300' : 'text-dim-2', 'text-xs font-medium')}>
                 {stat.changeLabel}
               </dd>
             ) : null}
-            <dd className="w-full flex-none text-3xl font-medium tracking-tight text-input-text">
+            <dd className="w-full flex-none text-3xl font-medium tracking-tight text-ink">
               {formatCurrency(stat.value)}
             </dd>
           </div>

--- a/src/features/practice-dashboard/components/DashboardSummaryCards.tsx
+++ b/src/features/practice-dashboard/components/DashboardSummaryCards.tsx
@@ -5,14 +5,14 @@ import type { DashboardStat } from '@/features/practice-dashboard/hooks/usePract
 
 const toneClass: Record<NonNullable<DashboardStat['tone']>, string> = {
   positive: 'text-accent-300',
-  negative: 'text-input-text',
-  neutral: 'text-input-placeholder'
+  negative: 'text-ink',
+  neutral: 'text-dim-2'
 };
 
 const changeToneClass: Record<NonNullable<DashboardStat['changeTone']>, string> = {
   positive: 'text-accent-300',
-  negative: 'text-input-text',
-  neutral: 'text-input-placeholder'
+  negative: 'text-ink',
+  neutral: 'text-dim-2'
 };
 
 type DashboardSummaryCardsProps = {
@@ -42,12 +42,12 @@ export const DashboardSummaryCards = ({ stats, loading = false }: DashboardSumma
         ].join(' ')}
       >
         <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-input-placeholder">{stat.label}</p>
-          <p className="mt-2 text-3xl font-semibold tracking-tight text-input-text">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-dim-2">{stat.label}</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-ink">
             {formatCurrency(stat.value)}
           </p>
           {stat.helper ? (
-            <p className={`mt-1 text-xs ${stat.tone ? toneClass[stat.tone] : 'text-input-placeholder'}`}>
+            <p className={`mt-1 text-xs ${stat.tone ? toneClass[stat.tone] : 'text-dim-2'}`}>
               {stat.helper}
             </p>
           ) : null}

--- a/src/features/practice-dashboard/components/OutstandingPaymentsWidget.tsx
+++ b/src/features/practice-dashboard/components/OutstandingPaymentsWidget.tsx
@@ -19,8 +19,8 @@ export const OutstandingPaymentsWidget = ({
 }: OutstandingPaymentsWidgetProps) => (
   <Panel className="flex h-full flex-col">
     <header className="border-b border-line-subtle px-5 py-4">
-      <p className="text-sm font-semibold text-input-text">Outstanding Payments</p>
-      <p className="text-xs text-input-placeholder">Invoices awaiting payment</p>
+      <p className="text-sm font-semibold text-ink">Outstanding Payments</p>
+      <p className="text-xs text-dim-2">Invoices awaiting payment</p>
     </header>
     <div className="flex-1 px-5 py-4">
       {loading ? (
@@ -28,28 +28,28 @@ export const OutstandingPaymentsWidget = ({
           <LoadingSpinner size="md" />
         </div>
       ) : error ? (
-        <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-input-text">
+        <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : summary ? (
-        <div className="space-y-4 text-sm text-input-text">
+        <div className="space-y-4 text-sm text-ink">
           <div>
-            <p className="text-xs uppercase tracking-wide text-input-placeholder">Awaiting payment</p>
+            <p className="text-xs uppercase tracking-wide text-dim-2">Awaiting payment</p>
             <p className="mt-1 text-2xl font-semibold">
               {summary.awaitingCount} invoice{summary.awaitingCount === 1 ? '' : 's'}
             </p>
-            <p className="text-input-placeholder">Total {formatCurrency(summary.awaitingTotal)}</p>
+            <p className="text-dim-2">Total {formatCurrency(summary.awaitingTotal)}</p>
           </div>
           <div>
-            <p className="text-xs uppercase tracking-wide text-input-placeholder">Overdue</p>
-            <p className="mt-1 text-2xl font-semibold text-input-text">
+            <p className="text-xs uppercase tracking-wide text-dim-2">Overdue</p>
+            <p className="mt-1 text-2xl font-semibold text-ink">
               {summary.overdueCount} invoice{summary.overdueCount === 1 ? '' : 's'}
             </p>
-            <p className="text-input-placeholder">Total {formatCurrency(summary.overdueTotal)}</p>
+            <p className="text-dim-2">Total {formatCurrency(summary.overdueTotal)}</p>
           </div>
         </div>
       ) : (
-        <p className="text-sm text-input-placeholder">No unpaid invoices.</p>
+        <p className="text-sm text-dim-2">No unpaid invoices.</p>
       )}
     </div>
     <footer className="border-t border-line-subtle px-5 py-4">

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -36,15 +36,15 @@ const statusClass = (status: ActivityEntry['status']) => {
   const normalized = status.toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  if (normalized === 'draft') return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
-  if (normalized === 'sent' || normalized === 'pending') return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
-  return 'bg-surface-overlay/80 text-input-placeholder ring-line-subtle';
+  if (normalized === 'draft') return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
+  if (normalized === 'sent' || normalized === 'pending') return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
+  return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
 };
 
 export const RecentActivityTable = ({ days, loading = false, error = null, onOpenInvoice }: RecentActivityTableProps) => (
   <section>
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <h2 className="mx-auto max-w-2xl text-base font-semibold text-input-text lg:mx-0 lg:max-w-none">
+      <h2 className="mx-auto max-w-2xl text-base font-semibold text-ink lg:mx-0 lg:max-w-none">
         Recent activity
       </h2>
     </div>
@@ -66,7 +66,7 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
       </div>
     ) : error ? (
       <div className="mt-6 border-t border-line-subtle">
-        <div className="mx-auto max-w-7xl px-4 py-5 text-sm text-input-text sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl px-4 py-5 text-sm text-ink sm:px-6 lg:px-8">
           {error}
         </div>
       </div>
@@ -95,7 +95,7 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
 
                   return displayDays.map((day) => (
                     <Fragment key={day.label}>
-                      <tr className="text-sm text-input-text">
+                      <tr className="text-sm text-ink">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
                           <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
@@ -104,7 +104,7 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (
                         <tr>
-                          <td colSpan={3} className="relative py-5 text-sm text-input-placeholder">
+                          <td colSpan={3} className="relative py-5 text-sm text-dim-2">
                             No transactions yet.
                             <div className="absolute right-full bottom-0 h-px w-screen bg-line-glass/20" />
                             <div className="absolute bottom-0 left-0 h-px w-screen bg-line-glass/20" />
@@ -116,11 +116,11 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                             <div className="flex gap-x-6">
                               {(() => {
                                 const activityIcon = statusIcon(entry.status);
-                                return <Icon icon={activityIcon} className="hidden h-6 w-5 flex-none text-input-placeholder sm:block" />;
+                                return <Icon icon={activityIcon} className="hidden h-6 w-5 flex-none text-dim-2 sm:block" />;
                               })()}
                               <div className="flex-auto">
                                 <div className="flex items-start gap-x-3">
-                                  <div className="text-sm font-medium text-input-text">
+                                  <div className="text-sm font-medium text-ink">
                                     {formatAmountLabel(entry.amount)}
                                   </div>
                                   <div className={cn(statusClass(entry.status), 'rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset')}>
@@ -131,7 +131,7 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                                   const displayDate = entry.issuedAt ? formatDate(entry.issuedAt) : '';
                                   if (!displayDate) return null;
                                   return (
-                                    <div className="mt-1 text-xs text-input-placeholder">
+                                    <div className="mt-1 text-xs text-dim-2">
                                       {displayDate}
                                     </div>
                                   );
@@ -142,8 +142,8 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                             <div className="absolute bottom-0 left-0 h-px w-screen bg-line-glass/20" />
                           </td>
                           <td className="hidden py-5 pr-6 sm:table-cell">
-                            <div className="text-sm text-input-text">{entry.clientName}</div>
-                            <div className="mt-1 text-xs text-input-placeholder">{entry.description ?? '-'}</div>
+                            <div className="text-sm text-ink">{entry.clientName}</div>
+                            <div className="mt-1 text-xs text-dim-2">{entry.description ?? '-'}</div>
                           </td>
                           <td className="py-5 text-right">
                             <div className="flex justify-end">
@@ -151,8 +151,8 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                                 View invoice
                               </Button>
                             </div>
-                            <div className="mt-1 text-xs text-input-placeholder">
-                              Invoice <span className="text-input-text">#{entry.invoiceNumber ?? entry.invoiceId?.slice(0, 6)}</span>
+                            <div className="mt-1 text-xs text-dim-2">
+                              Invoice <span className="text-ink">#{entry.invoiceNumber ?? entry.invoiceId?.slice(0, 6)}</span>
                             </div>
                           </td>
                         </tr>

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -9,7 +9,7 @@ import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatDate } from '@/shared/utils/dateTime';
 import type { RecentClient } from '@/features/practice-dashboard/hooks/usePracticeBillingData';
 
-const neutralTone = 'ring-line-subtle bg-surface-overlay/80 text-input-placeholder';
+const neutralTone = 'ring-line-subtle bg-surface-overlay/80 text-dim-2';
 const statusTone: Record<string, string> = {
   paid: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   overdue: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
@@ -36,7 +36,7 @@ export const RecentClientsGrid = ({
   <section className="w-full">
     <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-input-text">Recent clients</h2>
+        <h2 className="text-base font-semibold text-ink">Recent clients</h2>
         <Button variant="link" size="sm" onClick={() => onViewAll?.()}>
           View all
         </Button>
@@ -52,11 +52,11 @@ export const RecentClientsGrid = ({
           ))}
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-input-text">
+        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : clients.length === 0 ? (
-        <p className="mt-6 text-sm text-input-placeholder">No recent invoices.</p>
+        <p className="mt-6 text-sm text-dim-2">No recent invoices.</p>
       ) : (
         <ul className="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
           {clients.map((client) => (
@@ -72,13 +72,13 @@ export const RecentClientsGrid = ({
                   className="h-12 w-12 rounded-xl"
                 />
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-input-text">{client.name}</p>
+                  <p className="text-sm font-medium text-ink">{client.name}</p>
                 </div>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
                       type="button"
-                      className="relative block text-input-placeholder hover:text-input-text"
+                      className="relative block text-dim-2 hover:text-ink"
                       aria-label={`Client actions for ${client.name}`}
                     >
                       <span className="absolute -inset-2.5" />
@@ -95,8 +95,8 @@ export const RecentClientsGrid = ({
               {client.lastInvoice ? (
                 <dl className="-my-3 divide-y divide-line-subtle bg-surface-overlay/60 px-6 py-4 text-sm">
                   <div className="flex justify-between gap-x-4 py-3">
-                    <dt className="text-input-placeholder">Last invoice</dt>
-                    <dd className="text-input-text">
+                    <dt className="text-dim-2">Last invoice</dt>
+                    <dd className="text-ink">
                       {(() => {
                         if (!client.lastInvoice.date) return '-';
                         const display = formatDate(client.lastInvoice.date, {
@@ -114,9 +114,9 @@ export const RecentClientsGrid = ({
                     </dd>
                   </div>
                   <div className="flex justify-between gap-x-4 py-3">
-                    <dt className="text-input-placeholder">Amount</dt>
+                    <dt className="text-dim-2">Amount</dt>
                     <dd className="flex items-start gap-x-2">
-                      <div className="font-medium text-input-text">{formatCurrency(client.lastInvoice.amount)}</div>
+                      <div className="font-medium text-ink">{formatCurrency(client.lastInvoice.amount)}</div>
                       <div className={`rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${statusTone[client.lastInvoice.status?.toLowerCase() || ''] ?? neutralTone}`}>
                         {client.lastInvoice.status ?? '-'}
                       </div>

--- a/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
@@ -11,7 +11,7 @@ import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
 const statusTone: Record<string, string> = {
   accepted: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   declined: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
-  pending_review: 'ring-line-subtle bg-surface-overlay/80 text-input-placeholder',
+  pending_review: 'ring-line-subtle bg-surface-overlay/80 text-dim-2',
 };
 
 type RecentIntakesGridProps = {
@@ -32,7 +32,7 @@ export const RecentIntakesGrid = ({
   <section className="w-full">
     <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-input-text">Recent Intakes</h2>
+        <h2 className="text-base font-semibold text-ink">Recent Intakes</h2>
         {onViewAll ? (
           <Button variant="link" size="sm" onClick={onViewAll}>
             View all
@@ -40,7 +40,7 @@ export const RecentIntakesGrid = ({
         ) : (
           <span
             aria-disabled="true"
-            className="text-sm font-semibold text-input-placeholder opacity-70 cursor-default"
+            className="text-sm font-semibold text-dim-2 opacity-70 cursor-default"
           >
             View all
           </span>
@@ -56,11 +56,11 @@ export const RecentIntakesGrid = ({
           ))}
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-input-text">
+        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : intakes.length === 0 ? (
-        <p className="mt-6 text-sm text-input-placeholder">No recent intakes.</p>
+        <p className="mt-6 text-sm text-dim-2">No recent intakes.</p>
       ) : (
         <ul className="mt-6 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
           {intakes.map((intake) => {
@@ -94,14 +94,14 @@ export const RecentIntakesGrid = ({
                     className="h-12 w-12 rounded-xl"
                   />
                   <div className="flex-1">
-                    <p className="text-sm font-medium text-input-text">{title}</p>
+                    <p className="text-sm font-medium text-ink">{title}</p>
                   </div>
                   {/* actions removed — whole card is clickable */}
                 </button>
                 <dl className="-my-3 divide-y divide-line-subtle px-6 py-4 text-sm">
                   <div className="flex justify-between gap-x-4 py-3">
-                    <dt className="text-input-placeholder">Date Submitted</dt>
-                    <dd className="text-input-text">
+                    <dt className="text-dim-2">Date Submitted</dt>
+                    <dd className="text-ink">
                       {(() => {
                         if (!intake.created_at) return '-';
                         const display = formatDate(intake.created_at, {
@@ -115,15 +115,15 @@ export const RecentIntakesGrid = ({
                     </dd>
                   </div>
                 <div className="flex justify-between gap-x-4 py-3">
-                  <dt className="text-input-placeholder">Amount</dt>
+                  <dt className="text-dim-2">Amount</dt>
                   <dd className="flex items-start gap-x-2">
-                    <div className="font-medium text-input-text">
+                    <div className="font-medium text-ink">
                       {formatCurrency(fromMinorUnits(intake.amount), intake.currency)}
                     </div>
                   </dd>
                 </div>
                 <div className="flex justify-between gap-x-4 py-3">
-                  <dt className="text-input-placeholder">Status</dt>
+                  <dt className="text-dim-2">Status</dt>
                   <dd className="flex items-start gap-x-2">
                     <div className={`rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${statusTone[intake.triage_status] || statusTone.pending_review}`}>
                       {intake.triage_status === 'pending_review' ? 'Pending' :

--- a/src/features/practice-onboarding/components/ConversationalCorrection.tsx
+++ b/src/features/practice-onboarding/components/ConversationalCorrection.tsx
@@ -98,10 +98,10 @@ const ConversationalCorrection: FunctionComponent<ConversationalCorrectionProps>
               <span className="text-accent-600 font-semibold text-sm">{index + 1}</span>
             </div>
             <div className="flex-1">
-              <p className="text-sm text-input-text mb-2">{request.question}</p>
+              <p className="text-sm text-ink mb-2">{request.question}</p>
               
               {request.examples && request.examples.length > 0 && (
-                <div className="text-xs text-input-placeholder mb-3">
+                <div className="text-xs text-dim-2 mb-3">
                   Examples: {request.examples.join(', ')}
                 </div>
               )}

--- a/src/features/practice-onboarding/components/OnboardingActions.tsx
+++ b/src/features/practice-onboarding/components/OnboardingActions.tsx
@@ -82,8 +82,8 @@ const OnboardingActions: FunctionComponent<OnboardingActionsProps> = ({
       <section className="card p-4 sm:p-5">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h3 className="text-lg font-semibold text-input-text">Setup Progress</h3>
-            <p className="text-sm text-input-placeholder mt-1">
+            <h3 className="text-lg font-semibold text-ink">Setup Progress</h3>
+            <p className="text-sm text-dim-2 mt-1">
               Complete your profile to start accepting clients
             </p>
           </div>
@@ -118,7 +118,7 @@ const OnboardingActions: FunctionComponent<OnboardingActionsProps> = ({
 
       {/* Action Buttons */}
       <section className="card p-4 sm:p-5">
-        <h3 className="text-lg font-semibold text-input-text mb-4">Quick Actions</h3>
+        <h3 className="text-lg font-semibold text-ink mb-4">Quick Actions</h3>
         <div className="flex flex-wrap gap-4">
           {onEditBasics && (
             <Button 
@@ -153,7 +153,7 @@ const OnboardingActions: FunctionComponent<OnboardingActionsProps> = ({
 
         {/* Logo Upload */}
         <div className="mt-6">
-          <h4 className="text-sm font-medium text-input-text mb-2">Practice Logo</h4>
+          <h4 className="text-sm font-medium text-ink mb-2">Practice Logo</h4>
           <div className="flex items-center gap-4">
             <input
               type="file"

--- a/src/features/practice-onboarding/components/OnboardingChat.tsx
+++ b/src/features/practice-onboarding/components/OnboardingChat.tsx
@@ -96,7 +96,7 @@ const OnboardingChat: FunctionComponent<OnboardingChatProps> = ({
     <div className="space-y-6">
       {/* Header */}
       <header className="space-y-2">
-        <p className="text-[10px] font-bold uppercase tracking-[0.45em] text-input-placeholder">
+        <p className="text-[10px] font-bold uppercase tracking-[0.45em] text-dim-2">
           {status.needsSetup ? "Let's get started" : 'Practice setup'}
         </p>
         <h2 className="text-3xl font-bold tracking-tight">
@@ -186,12 +186,12 @@ const OnboardingChat: FunctionComponent<OnboardingChatProps> = ({
                   <div>
                     <div className="text-sm font-semibold">Setup assistant</div>
                     {status.needsSetup ? (
-                      <div className="text-[10px] text-input-placeholder">Onboarding</div>
+                      <div className="text-[10px] text-dim-2">Onboarding</div>
                     ) : null}
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-[10px] font-bold uppercase tracking-wider text-input-placeholder">
+                  <div className="text-[10px] font-bold uppercase tracking-wider text-dim-2">
                     Onboarding
                   </div>
                 </div>

--- a/src/features/practice-setup/components/StripeCheckpointCard.tsx
+++ b/src/features/practice-setup/components/StripeCheckpointCard.tsx
@@ -29,19 +29,19 @@ export function StripeCheckpointCard({
   const statusLabel = isInProgress ? 'In progress' : 'Not started';
 
   return (
-    <div className="card mt-4 space-y-4 border border-line-subtle p-4 text-input-text">
+    <div className="card mt-4 space-y-4 border border-line-subtle p-4 text-ink">
       <div className="flex items-start gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-accent-500/12 text-lg text-[rgb(var(--accent-foreground))]">
           $
         </div>
         <div className="min-w-0 space-y-1">
           <div className="text-sm font-semibold">{title}</div>
-          <p className="text-sm text-input-placeholder">{body}</p>
+          <p className="text-sm text-dim-2">{body}</p>
         </div>
       </div>
       <div className="flex items-center justify-between gap-3 rounded-2xl border border-line-subtle bg-surface-utility/10 px-3 py-2">
         <div>
-          <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-input-placeholder">Stripe status</div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-dim-2">Stripe status</div>
           <div className="text-sm font-medium">{statusLabel}</div>
         </div>
         <Button variant="primary" size="sm" onClick={onConnect} disabled={isLoading}>

--- a/src/features/practice/components/PracticeProfile.tsx
+++ b/src/features/practice/components/PracticeProfile.tsx
@@ -35,7 +35,7 @@ export default function PracticeProfile({
 
 			{/* Practice Name with Verified Badge */}
 			<div className="flex items-center justify-center gap-2 w-full">
-				<h3 className="text-base sm:text-lg font-semibold text-center m-0 text-input-text leading-tight truncate min-w-0" title={name}>{name}</h3>
+				<h3 className="text-base sm:text-lg font-semibold text-center m-0 text-ink leading-tight truncate min-w-0" title={name}>{name}</h3>
 				{showVerified && (
 					<Icon icon={BadgeCheck} decorative={false} className="w-4 h-4 sm:w-5 sm:h-5 text-accent-500 flex-shrink-0" aria-label={t('profile.verified')} title={t('profile.verified')}  />
 				)}
@@ -54,7 +54,7 @@ export default function PracticeProfile({
 			{description && (
 				<div className="text-center">
 					<p
-						className="text-input-placeholder text-center leading-relaxed max-w-xs mx-auto line-clamp-3 text-sm"
+						className="text-dim-2 text-center leading-relaxed max-w-xs mx-auto line-clamp-3 text-sm"
 					>
 						{description}
 					</p>

--- a/src/features/practice/components/WorkspacePracticeDetailsError.tsx
+++ b/src/features/practice/components/WorkspacePracticeDetailsError.tsx
@@ -34,10 +34,10 @@ export function WorkspacePracticeDetailsError({
       ref={dialogRef}
     >
     <div className="max-w-lg panel p-6 text-center">
-        <h1 id="workspace-error-heading" className="text-2xl font-semibold text-input-text">
+        <h1 id="workspace-error-heading" className="text-2xl font-semibold text-ink">
           {t('workspace.error.title')}
         </h1>
-        <p id="workspace-error-desc" className="mt-3 text-sm text-input-placeholder">
+        <p id="workspace-error-desc" className="mt-3 text-sm text-dim-2">
           {t('workspace.error.description', { slug: slugLabel })}
         </p>
         {onRetry ? (

--- a/src/features/pricing/components/PricingView.tsx
+++ b/src/features/pricing/components/PricingView.tsx
@@ -70,7 +70,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
       <div className="flex items-center justify-center p-6 text-center">
         <div className="space-y-4">
           <p className="text-lg font-semibold text-red-500">{t('common:errors.tryAgainLater')}</p>
-          <p className="text-sm text-input-placeholder">{t('pricing:errorGeneric')}</p>
+          <p className="text-sm text-dim-2">{t('pricing:errorGeneric')}</p>
         </div>
       </div>
     );
@@ -78,7 +78,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
   if (!plan) {
     return (
       <div className="flex items-center justify-center p-6 text-center">
-        <p className="text-sm text-input-placeholder">{t('pricing:loading')}</p>
+        <p className="text-sm text-dim-2">{t('pricing:loading')}</p>
       </div>
     );
   }
@@ -151,7 +151,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
     { value: 'yearly', label: annuallyLabelWithDiscount, disabled: !hasYearly }
   ];
   return (
-    <div className={`w-full text-input-text ${className ?? ''}`}>
+    <div className={`w-full text-ink ${className ?? ''}`}>
       <div className="mx-auto w-full max-w-xl px-2 pt-2 pb-2 md:px-3 md:pt-3 md:pb-3">
         {showBillingSelector ? (
           <div className="flex justify-center pb-1">
@@ -168,27 +168,27 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
 
         <div className="mt-6 card px-5 py-6 md:px-7 md:py-8">
           <div className="flex flex-col items-start text-left">
-            <h1 data-testid="pricing-page-title" className="text-3xl font-semibold tracking-tight text-input-text md:text-4xl">
+            <h1 data-testid="pricing-page-title" className="text-3xl font-semibold tracking-tight text-ink md:text-4xl">
               {plan.displayName || plan.name}
             </h1>
             {plan.description ? (
-              <p className="mt-4 max-w-xl text-base leading-7 text-input-placeholder">
+              <p className="mt-4 max-w-xl text-base leading-7 text-dim-2">
                 {plan.description}
               </p>
             ) : null}
             {hasDisplayPrice && plan.currency ? (
               <div className="mt-7 flex items-end gap-1.5">
-                <span className="text-5xl font-semibold tracking-tight text-input-text md:text-6xl">
+                <span className="text-5xl font-semibold tracking-tight text-ink md:text-6xl">
                   {formatCurrency(selectedPriceValue, plan.currency, i18n.language)}
                 </span>
-                <span className="pb-1 text-xl font-semibold text-input-placeholder md:pb-2 md:text-2xl">/{periodLabel}</span>
+                <span className="pb-1 text-xl font-semibold text-dim-2 md:pb-2 md:text-2xl">/{periodLabel}</span>
               </div>
             ) : null}
           </div>
 
           <div className="mt-8">
             {features.length > 0 ? (
-              <ul className="space-y-3 text-base text-input-placeholder">
+              <ul className="space-y-3 text-base text-dim-2">
                 {features.map((feature) => (
                   <li key={feature} className="flex items-start gap-2">
                     <Icon icon={Check} className="mt-0.5 h-5 w-5 flex-none text-accent-500"  />
@@ -197,7 +197,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
                 ))}
               </ul>
             ) : (
-              <p className="text-base text-input-placeholder">{t('pricing:noFeatures')}</p>
+              <p className="text-base text-dim-2">{t('pricing:noFeatures')}</p>
             )}
           </div>
 
@@ -222,7 +222,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({ className, onUpgrade
                   : plan.displayName || plan.name}
             </Button>
             {hasDisplayPrice ? (
-              <p className="mt-4 text-center text-sm text-input-placeholder">
+              <p className="mt-4 text-center text-sm text-dim-2">
                 {billingDescription}
               </p>
             ) : null}

--- a/src/features/reports/components/ReportCard.tsx
+++ b/src/features/reports/components/ReportCard.tsx
@@ -46,16 +46,16 @@ export const ReportCard: FunctionComponent<ReportCardProps> = ({ definition, onC
     >
       <div className="flex items-center justify-between">
         <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
-          <Icon className="h-4 w-4 text-input-placeholder" aria-hidden="true" />
+          <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" />
         </div>
         {definition.phase === 3 ? (
-          <span className="rounded-full bg-surface-utility/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-input-placeholder">
+          <span className="rounded-full bg-surface-utility/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-dim-2">
             Coming soon
           </span>
         ) : null}
       </div>
-      <h3 className="text-sm font-semibold text-input-text">{definition.title}</h3>
-      <p className="text-xs text-input-placeholder">{definition.description}</p>
+      <h3 className="text-sm font-semibold text-ink">{definition.title}</h3>
+      <p className="text-xs text-dim-2">{definition.description}</p>
     </button>
   );
 };

--- a/src/features/reports/components/ReportDataTable.tsx
+++ b/src/features/reports/components/ReportDataTable.tsx
@@ -45,7 +45,7 @@ export const ReportDataTable: FunctionComponent<ReportDataTableProps> = ({
     stickyHeader
     className="panel overflow-hidden"
     bodyClassName="bg-transparent"
-    emptyState={emptyState ?? <span className="text-sm text-input-placeholder">No data</span>}
+    emptyState={emptyState ?? <span className="text-sm text-dim-2">No data</span>}
   />
 );
 

--- a/src/features/reports/components/ReportFilters.tsx
+++ b/src/features/reports/components/ReportFilters.tsx
@@ -39,7 +39,7 @@ export const ReportFilters: FunctionComponent<ReportFiltersProps> = ({ filters, 
           const current = (values.period ?? f.defaultValue ?? 'month') as ReportPeriod;
           return (
             <div key={f.id} className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-input-text">{f.label}</label>
+              <label className="text-xs font-medium text-ink">{f.label}</label>
               <SegmentedToggle<ReportPeriod>
                 value={current}
                 options={PERIOD_OPTIONS}
@@ -71,11 +71,11 @@ export const ReportFilters: FunctionComponent<ReportFiltersProps> = ({ filters, 
           const current = ((values[f.id] as string | undefined) ?? f.defaultValue ?? '');
           return (
             <div key={f.id} className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-input-text">{f.label}</label>
+              <label className="text-xs font-medium text-ink">{f.label}</label>
               <select
                 value={current}
                 onChange={(e) => set(f.id, (e.currentTarget as HTMLSelectElement).value)}
-                className="h-9 rounded-md border border-line-subtle bg-surface-utility/5 px-2 text-sm text-input-text"
+                className="h-9 rounded-md border border-line-subtle bg-surface-utility/5 px-2 text-sm text-ink"
               >
                 {f.options.map((o) => (
                   <option key={o.value} value={o.value}>{o.label}</option>

--- a/src/features/reports/components/ReportPageShell.tsx
+++ b/src/features/reports/components/ReportPageShell.tsx
@@ -72,8 +72,8 @@ export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ defin
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
       <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-lg font-semibold text-input-text">{definition.title}</h1>
-          <p className="mt-1 text-sm text-input-placeholder">{definition.description}</p>
+          <h1 className="text-lg font-semibold text-ink">{definition.title}</h1>
+          <p className="mt-1 text-sm text-dim-2">{definition.description}</p>
         </div>
         <ReportToolbar
           definition={definition}

--- a/src/features/reports/components/ScheduleModal.tsx
+++ b/src/features/reports/components/ScheduleModal.tsx
@@ -71,7 +71,7 @@ export const ScheduleModal: FunctionComponent<ScheduleModalProps> = ({
       <DialogBody>
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-input-text">Frequency</span>
+            <span className="text-xs font-medium text-ink">Frequency</span>
             <SegmentedToggle<ReportFrequency>
               value={frequency}
               options={FREQ_OPTIONS}

--- a/src/features/reports/components/SendNowModal.tsx
+++ b/src/features/reports/components/SendNowModal.tsx
@@ -50,7 +50,7 @@ export const SendNowModal: FunctionComponent<SendNowModalProps> = ({
     <Dialog isOpen={isOpen} onClose={onClose} title="Send report now">
       <DialogBody>
         <div className="flex flex-col gap-3">
-          <p className="text-sm text-input-placeholder">
+          <p className="text-sm text-dim-2">
             Generate this report now and store it under Deliveries. Optionally notify recipients.
           </p>
           <Input

--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -21,8 +21,8 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceS
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
       <div>
-        <h1 className="text-lg font-semibold text-input-text">All reports</h1>
-        <p className="mt-1 text-sm text-input-placeholder">Browse the available reports for your practice.</p>
+        <h1 className="text-lg font-semibold text-ink">All reports</h1>
+        <p className="mt-1 text-sm text-dim-2">Browse the available reports for your practice.</p>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
         {REPORT_DEFINITIONS.map((def) => (

--- a/src/features/reports/pages/reports/DeliveriesListView.tsx
+++ b/src/features/reports/pages/reports/DeliveriesListView.tsx
@@ -52,8 +52,8 @@ export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = ({
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
         <div>
-          <h1 className="text-lg font-semibold text-input-text">Deliveries</h1>
-          <p className="mt-1 text-sm text-input-placeholder">Past report deliveries from scheduled jobs and one-off sends.</p>
+          <h1 className="text-lg font-semibold text-ink">Deliveries</h1>
+          <p className="mt-1 text-sm text-dim-2">Past report deliveries from scheduled jobs and one-off sends.</p>
         </div>
         <WorkspacePlaceholderState
           icon={Inbox}
@@ -68,8 +68,8 @@ export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = ({
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-6">
       <div>
-        <h1 className="text-lg font-semibold text-input-text">Deliveries</h1>
-        <p className="mt-1 text-sm text-input-placeholder">Past report deliveries from scheduled jobs and one-off sends.</p>
+        <h1 className="text-lg font-semibold text-ink">Deliveries</h1>
+        <p className="mt-1 text-sm text-dim-2">Past report deliveries from scheduled jobs and one-off sends.</p>
       </div>
       {error ? (
         <div className="rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 text-sm text-red-400">

--- a/src/features/reports/pages/reports/DeliveryDetailView.tsx
+++ b/src/features/reports/pages/reports/DeliveryDetailView.tsx
@@ -76,33 +76,33 @@ export const DeliveryDetailView: FunctionComponent<DeliveryDetailViewProps> = ({
         ) : null}
       </div>
       <div>
-        <h1 className="text-lg font-semibold text-input-text">{reportTitle}</h1>
-        <p className="mt-1 text-sm font-mono text-input-placeholder">{delivery.id}</p>
+        <h1 className="text-lg font-semibold text-ink">{reportTitle}</h1>
+        <p className="mt-1 text-sm font-mono text-dim-2">{delivery.id}</p>
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div className="rounded-2xl border border-line-subtle p-3">
-          <p className="text-xs text-input-placeholder">Status</p>
+          <p className="text-xs text-dim-2">Status</p>
           <p className={`text-sm font-medium ${STATUS_COLOR[delivery.status] ?? ''}`}>{delivery.status}</p>
         </div>
         <div className="rounded-2xl border border-line-subtle p-3">
-          <p className="text-xs text-input-placeholder">Created</p>
-          <p className="text-sm text-input-text">{new Date(delivery.createdAt).toLocaleString()}</p>
+          <p className="text-xs text-dim-2">Created</p>
+          <p className="text-sm text-ink">{new Date(delivery.createdAt).toLocaleString()}</p>
         </div>
         {delivery.completedAt ? (
           <div className="rounded-2xl border border-line-subtle p-3">
-            <p className="text-xs text-input-placeholder">Completed</p>
-            <p className="text-sm text-input-text">{new Date(delivery.completedAt).toLocaleString()}</p>
+            <p className="text-xs text-dim-2">Completed</p>
+            <p className="text-sm text-ink">{new Date(delivery.completedAt).toLocaleString()}</p>
           </div>
         ) : null}
         {typeof delivery.byteSize === 'number' ? (
           <div className="rounded-2xl border border-line-subtle p-3">
-            <p className="text-xs text-input-placeholder">File size</p>
-            <p className="text-sm text-input-text">{delivery.byteSize.toLocaleString()} bytes</p>
+            <p className="text-xs text-dim-2">File size</p>
+            <p className="text-sm text-ink">{delivery.byteSize.toLocaleString()} bytes</p>
           </div>
         ) : null}
         <div className="rounded-2xl border border-line-subtle p-3 sm:col-span-2">
-          <p className="text-xs text-input-placeholder">Recipients</p>
-          <p className="text-sm text-input-text">
+          <p className="text-xs text-dim-2">Recipients</p>
+          <p className="text-sm text-ink">
             {delivery.recipients.length === 0 ? '—' : delivery.recipients.join(', ')}
           </p>
         </div>

--- a/src/features/search/components/CommandPalette.tsx
+++ b/src/features/search/components/CommandPalette.tsx
@@ -154,7 +154,7 @@ export function CommandPalette({
         Global search
       </div>
       <div className="flex items-center gap-2 px-4 border-b border-line-subtle">
-        <Search size={18} className="text-input-text/60" aria-hidden="true" />
+        <Search size={18} className="text-ink/60" aria-hidden="true" />
         {parsed.scopes.length > 0 ? <ScopePills scopes={parsed.scopes} /> : null}
         <input
           ref={inputRef}
@@ -162,7 +162,7 @@ export function CommandPalette({
           value={query}
           onInput={(event) => setQueryAndReset((event.target as HTMLInputElement).value)}
           placeholder="Search clients, matters, invoices, files…"
-          className="flex-1 bg-transparent py-3 outline-none text-base text-input-text placeholder:text-input-text/40"
+          className="flex-1 bg-transparent py-3 outline-none text-base text-ink placeholder:text-ink/40"
           aria-label="Search query"
         />
       </div>
@@ -210,7 +210,7 @@ function ScopePills({ scopes }: { scopes: SearchScope[] }) {
       {scopes.map((scope) => (
         <span
           key={scope}
-          className="text-xs font-medium px-2 py-1 rounded-md bg-surface-card-hover text-input-text"
+          className="text-xs font-medium px-2 py-1 rounded-md bg-surface-card-hover text-ink"
         >
           in:{scope}
         </span>
@@ -233,7 +233,7 @@ function ResultGroups({
     <div className="flex flex-col">
       {envelope.groups.map((group) => (
         <div key={group.id} className="px-2 pb-2">
-          <div className="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-input-text/50 font-medium">
+          <div className="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-ink/50 font-medium">
             {group.label}
           </div>
           {group.items.map((item) => {
@@ -254,22 +254,22 @@ function ResultGroups({
                   item.archived ? 'opacity-60' : '',
                 )}
               >
-                <Icon size={16} className="mt-0.5 shrink-0 text-input-text/60" aria-hidden="true" />
+                <Icon size={16} className="mt-0.5 shrink-0 text-ink/60" aria-hidden="true" />
                 <div className="min-w-0 flex-1">
-                  <div className="text-sm font-medium truncate text-input-text">
+                  <div className="text-sm font-medium truncate text-ink">
                     {item.title}
                     {item.archived ? (
-                      <span className="ml-2 text-[10px] uppercase text-input-text/50">
+                      <span className="ml-2 text-[10px] uppercase text-ink/50">
                         archived
                       </span>
                     ) : null}
                   </div>
                   {item.subtitle ? (
-                    <div className="text-xs text-input-text/60 truncate">{item.subtitle}</div>
+                    <div className="text-xs text-ink/60 truncate">{item.subtitle}</div>
                   ) : null}
                   {item.snippet ? (
                     <div
-                      className="text-xs text-input-text/70 mt-0.5"
+                      className="text-xs text-ink/70 mt-0.5"
                       dangerouslySetInnerHTML={{ __html: item.snippet }}
                     />
                   ) : null}
@@ -292,7 +292,7 @@ function SuggestionsList({
 }) {
   return (
     <div className="px-2 pb-2">
-      <div className="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-input-text/50 font-medium">
+      <div className="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-ink/50 font-medium">
         Suggestions
       </div>
       {suggestions.map((s) => (
@@ -302,9 +302,9 @@ function SuggestionsList({
           onClick={() => onPick(s.query)}
           className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-surface-card-hover/60"
         >
-          <Search size={14} className="text-input-text/40" aria-hidden="true" />
-          <span className="text-sm text-input-text flex-1">{s.query}</span>
-          <span className="text-[10px] uppercase text-input-text/40">
+          <Search size={14} className="text-ink/40" aria-hidden="true" />
+          <span className="text-sm text-ink flex-1">{s.query}</span>
+          <span className="text-[10px] uppercase text-ink/40">
             {s.source === 'user' ? 'recent' : 'popular'}
           </span>
         </button>
@@ -322,12 +322,12 @@ function DidYouMean({
 }) {
   return (
     <div className="px-6 pb-4 text-center">
-      <div className="text-sm text-input-text/70">
+      <div className="text-sm text-ink/70">
         Did you mean{' '}
         <button
           type="button"
           onClick={onPick}
-          className="text-input-text underline hover:no-underline"
+          className="text-ink underline hover:no-underline"
         >
           {title}
         </button>
@@ -346,7 +346,7 @@ function RecentsList({
 }) {
   return (
     <div className="px-2 pb-2">
-      <div className="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-input-text/50 font-medium">
+      <div className="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-ink/50 font-medium">
         Recent searches
       </div>
       {recents.map((q) => (
@@ -356,8 +356,8 @@ function RecentsList({
           onClick={() => onPick(q)}
           className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-surface-card-hover/60"
         >
-          <Search size={14} className="text-input-text/40" aria-hidden="true" />
-          <span className="text-sm text-input-text">{q}</span>
+          <Search size={14} className="text-ink/40" aria-hidden="true" />
+          <span className="text-sm text-ink">{q}</span>
         </button>
       ))}
     </div>
@@ -366,13 +366,13 @@ function RecentsList({
 
 function EmptyState({ message }: { message: string }) {
   return (
-    <div className="px-6 py-10 text-center text-sm text-input-text/60">{message}</div>
+    <div className="px-6 py-10 text-center text-sm text-ink/60">{message}</div>
   );
 }
 
 function Footer() {
   return (
-    <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-line-subtle text-[11px] text-input-text/60">
+    <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-line-subtle text-[11px] text-ink/60">
       <div className="flex gap-3">
         <span>↑↓ navigate</span>
         <span>↵ open</span>

--- a/src/features/services/components/ServicesByStateEditor.tsx
+++ b/src/features/services/components/ServicesByStateEditor.tsx
@@ -29,14 +29,14 @@ export const ServicesByStateEditor = ({ licensedStates, value, onChange, onRemov
   return (
     <div className="space-y-2">
       {licensedStates.length === 0 && (
-          <div className="text-sm text-input-placeholder">{t('settings:practice.servicesByState.empty', { defaultValue: 'No states selected. Add a state to assign services.' })}</div>
+          <div className="text-sm text-dim-2">{t('settings:practice.servicesByState.empty', { defaultValue: 'No states selected. Add a state to assign services.' })}</div>
         )}
       {licensedStates.map((stateCode) => {
         const opt = STATE_OPTIONS.find((s) => s.value === stateCode);
         const label = opt ? opt.label : stateCode;
         return (
           <div key={stateCode} className="flex items-center gap-3 py-2">
-            <div className="w-40 text-sm text-input-text">{label}</div>
+            <div className="w-40 text-sm text-ink">{label}</div>
             <div className="flex-1">
               <Combobox
                 multiple

--- a/src/features/settings/components/EmailSettingsSection.tsx
+++ b/src/features/settings/components/EmailSettingsSection.tsx
@@ -26,8 +26,8 @@ export const EmailSettingsSection = ({
     <SettingSection title={title} className={className}>
       {/* Email Address */}
       <div className="flex items-center gap-3 py-3">
-        <Icon icon={Mail} className="w-4 h-4 text-input-placeholder"  />
-        <span className="text-sm text-input-text">
+        <Icon icon={Mail} className="w-4 h-4 text-dim-2"  />
+        <span className="text-sm text-ink">
           {email}
         </span>
       </div>
@@ -42,7 +42,7 @@ export const EmailSettingsSection = ({
             onChange={(e) => onFeedbackChange(e.currentTarget.checked)}
             className="w-4 h-4 text-accent-500 bg-transparent border-line-subtle rounded focus:ring-accent-500 focus:ring-2"
           />
-          <label htmlFor="feedback-emails" className="text-sm text-input-text cursor-pointer">
+          <label htmlFor="feedback-emails" className="text-sm text-ink cursor-pointer">
             {feedbackLabel}
           </label>
         </div>

--- a/src/features/settings/components/PlanFeaturesList.tsx
+++ b/src/features/settings/components/PlanFeaturesList.tsx
@@ -26,7 +26,7 @@ export const PlanFeaturesList = ({
               ? <Icon icon={feature.icon as ComponentType<JSX.SVGAttributes<SVGSVGElement>>} className="w-5 h-5" />
               : feature.icon}
           </div>
-          <span className="text-sm text-input-text">
+          <span className="text-sm text-ink">
             {feature.text}
           </span>
         </div>

--- a/src/features/settings/components/PracticeServicesSummary.tsx
+++ b/src/features/settings/components/PracticeServicesSummary.tsx
@@ -8,7 +8,7 @@ export const PracticeServicesSummary = ({ services }: PracticeServicesSummaryPro
   }
 
   return (
-    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-input-placeholder">
+    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-dim-2">
       {services.map((service, index) => (
         <li key={index}>{service}</li>
       ))}

--- a/src/features/settings/components/SettingDescription.tsx
+++ b/src/features/settings/components/SettingDescription.tsx
@@ -10,7 +10,7 @@ export const SettingDescription = ({
   className = ''
 }: SettingDescriptionProps) => {
   return (
-    <p className={cn('mt-1 text-xs text-input-placeholder', className)}>
+    <p className={cn('mt-1 text-xs text-dim-2', className)}>
       {text}
     </p>
   );

--- a/src/features/settings/components/SettingRow.tsx
+++ b/src/features/settings/components/SettingRow.tsx
@@ -40,7 +40,7 @@ export const SettingRow = ({
           typeof description === 'string' ? (
             <SettingDescription text={description} />
           ) : (
-            <div className="mt-1 text-xs text-input-placeholder">
+            <div className="mt-1 text-xs text-dim-2">
               {description}
             </div>
           )

--- a/src/features/settings/components/SettingSection.tsx
+++ b/src/features/settings/components/SettingSection.tsx
@@ -17,7 +17,7 @@ export const SettingSection = ({
 }: SettingSectionProps) => {
   return (
     <div className={cn('py-3', className)}>
-      <h3 className="text-sm font-semibold text-input-text">
+      <h3 className="text-sm font-semibold text-ink">
         {title}
       </h3>
       {description && <SettingDescription text={description} className="mb-4" />}

--- a/src/features/settings/components/SettingsHelperText.tsx
+++ b/src/features/settings/components/SettingsHelperText.tsx
@@ -13,7 +13,7 @@ export const SettingsHelperText = ({
   ...rest
 }: SettingsHelperTextProps) => {
   return (
-    <span className={cn('text-xs text-input-placeholder', className)} {...rest}>
+    <span className={cn('text-xs text-dim-2', className)} {...rest}>
       {children}
     </span>
   );

--- a/src/features/settings/components/SettingsNotice.tsx
+++ b/src/features/settings/components/SettingsNotice.tsx
@@ -20,7 +20,7 @@ export const SettingsNotice = ({
   'aria-live': ariaLive
 }: SettingsNoticeProps) => {
   const variantClasses: Record<SettingsNoticeVariant, string> = {
-  info: 'panel text-input-text',
+  info: 'panel text-ink',
     warning: 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200',
     danger: 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200'
   };

--- a/src/features/settings/components/WidgetPreviewFrame.tsx
+++ b/src/features/settings/components/WidgetPreviewFrame.tsx
@@ -69,7 +69,7 @@ export const WidgetPreviewFrame = ({
 
   return (
     <div className="w-full">
-      {showTitle ? <h3 className="mb-3 text-sm font-semibold text-input-text">{title}</h3> : null}
+      {showTitle ? <h3 className="mb-3 text-sm font-semibold text-ink">{title}</h3> : null}
       <div className={cn(
         'mx-auto w-full max-w-[380px] overflow-hidden bg-surface-card',
         framed && 'rounded-xl border border-line-subtle shadow-glass',

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -845,7 +845,7 @@ export const AccountPage = ({
               progress={avatarUploading ? avatarUploadProgress : null}
             />
           </div>
-          <span className="text-sm text-input-text">
+          <span className="text-sm text-ink">
             {displayName}
           </span>
         </div>
@@ -859,10 +859,10 @@ export const AccountPage = ({
       >
         <SettingRow label={t('settings:account.email.title')} className="cursor-pointer">
           <div className="flex items-center gap-2">
-            <span className="text-sm text-input-text">
+            <span className="text-sm text-ink">
               {emailAddress}
             </span>
-            <Icon icon={ChevronRight} className="w-5 h-5 text-input-placeholder" aria-hidden="true"  />
+            <Icon icon={ChevronRight} className="w-5 h-5 text-dim-2" aria-hidden="true"  />
           </div>
         </SettingRow>
       </button>
@@ -874,7 +874,7 @@ export const AccountPage = ({
           {/* Subscription Plan Section */}
           <SettingRow
             label={currentPlanLabel}
-            labelClassName="text-input-text font-semibold"
+            labelClassName="text-ink font-semibold"
             description={subscriptionDescription}
           >
             <div className="flex gap-2">
@@ -947,7 +947,7 @@ export const AccountPage = ({
             labelNode={
               <div className="space-y-3">
                 {hasSubscription && (
-                  <p className="text-sm font-semibold text-input-text">
+                  <p className="text-sm font-semibold text-ink">
                     {planHeading}
                   </p>
                 )}
@@ -1011,7 +1011,7 @@ export const AccountPage = ({
               label={t('settings:account.links.domainLabel')}
               labelNode={
                 <div className="flex items-center gap-3">
-                  <Icon icon={Globe} className="w-5 h-5 text-input-placeholder"  />
+                  <Icon icon={Globe} className="w-5 h-5 text-dim-2"  />
                   <FormLabel>{t('settings:account.links.domainLabel')}</FormLabel>
                 </div>
               }
@@ -1059,7 +1059,7 @@ export const AccountPage = ({
               labelNode={
                 <div className="flex items-center gap-3">
                   <div className="w-4 h-4">
-                    <svg viewBox="0 0 24 24" className="w-4 h-4 text-input-placeholder fill-current">
+                    <svg viewBox="0 0 24 24" className="w-4 h-4 text-dim-2 fill-current">
                       <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                   </div>
@@ -1121,10 +1121,10 @@ export const AccountPage = ({
         {shouldGateEmailManagement ? (
           <div className="space-y-4">
             <div className="space-y-2">
-              <p className="text-lg font-semibold text-input-text">
+              <p className="text-lg font-semibold text-ink">
                 {t('settings:account.email.addPasswordFirst')}
               </p>
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm text-dim-2">
                 {t('settings:account.email.oauthGatingExplanation')}
               </p>
             </div>

--- a/src/features/settings/pages/AppDetailPage.tsx
+++ b/src/features/settings/pages/AppDetailPage.tsx
@@ -106,11 +106,11 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
                     loading="lazy"
                   />
                 ) : (
-                  <Icon icon={Puzzle} className="w-8 h-8 text-input-text/80" aria-hidden="true"  />
+                  <Icon icon={Puzzle} className="w-8 h-8 text-ink/80" aria-hidden="true"  />
                 )}
               </div>
               <div className="flex items-center gap-2">
-                <h2 className="text-2xl font-bold text-input-text">{app.name}</h2>
+                <h2 className="text-2xl font-bold text-ink">{app.name}</h2>
                 {isComingSoon && (
                   <SettingsBadge variant="warning">
                     {t('settings:apps.comingSoon')}
@@ -208,15 +208,15 @@ export const AppDetailPage = ({ app, onBack, onUpdate }: AppDetailPageProps) => 
           <div className="space-y-6">
             {app.actions.map((action) => (
               <div key={action.name} className="space-y-2 w-full">
-                <code className="text-sm font-mono font-semibold text-input-text block w-full">
+                <code className="text-sm font-mono font-semibold text-ink block w-full">
                   {action.name}
                 </code>
                 {action.hasMetadata && (
-                  <span className="text-xs font-medium text-input-placeholder block w-full">
+                  <span className="text-xs font-medium text-dim-2 block w-full">
                     METADATA
                   </span>
                 )}
-                <p className="text-sm text-input-placeholder font-normal w-full">
+                <p className="text-sm text-dim-2 font-normal w-full">
                   {action.description}
                 </p>
                 {action.visibility && (
@@ -254,7 +254,7 @@ interface InfoRowSimpleProps {
 const InfoRowSimple = ({ label, value }: InfoRowSimpleProps) => {
   return (
     <SettingRow label={label}>
-      <span className="text-sm text-input-text text-right break-all">
+      <span className="text-sm text-ink text-right break-all">
         {value}
       </span>
     </SettingRow>

--- a/src/features/settings/pages/AppsPage.tsx
+++ b/src/features/settings/pages/AppsPage.tsx
@@ -18,7 +18,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
 
   return (
     <div className={`space-y-6 ${className}`}>
-      <p className="text-sm text-input-placeholder mb-4">
+      <p className="text-sm text-dim-2 mb-4">
         {t('settings:apps.description')}
       </p>
       {apps.map((app, index) => (
@@ -41,12 +41,12 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
                         loading="lazy"
                       />
                     ) : (
-                      <Icon icon={Puzzle} className="w-6 h-6 text-input-text/70" aria-hidden="true" />
+                      <Icon icon={Puzzle} className="w-6 h-6 text-ink/70" aria-hidden="true" />
                     )}
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <p className="text-base font-medium text-input-text truncate">{app.name}</p>
+                      <p className="text-base font-medium text-ink truncate">{app.name}</p>
                       {app.connected && (
                         <SettingsBadge variant="success">
                           <Icon icon={BadgeCheck} className="w-4 h-4" aria-hidden="true" />
@@ -63,7 +63,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
                 </div>
               )}
             >
-              <Icon icon={ChevronRight} className="w-5 h-5 text-input-placeholder" aria-hidden="true" />
+              <Icon icon={ChevronRight} className="w-5 h-5 text-dim-2" aria-hidden="true" />
             </SettingRow>
           </button>
           {index < apps.length - 1 && <SectionDivider />}

--- a/src/features/settings/pages/EngagementTemplatesPage.tsx
+++ b/src/features/settings/pages/EngagementTemplatesPage.tsx
@@ -160,7 +160,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
         <div className="flex flex-col gap-5">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col gap-1.5">
-              <span className="text-sm font-medium text-input-text">Template name</span>
+              <span className="text-sm font-medium text-ink">Template name</span>
               <Input
                 type="text"
                 value={template.name}
@@ -169,7 +169,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
               />
             </div>
             <div className="flex flex-col gap-1.5">
-              <span className="text-sm font-medium text-input-text">Practice area</span>
+              <span className="text-sm font-medium text-ink">Practice area</span>
               <Combobox
                 options={serviceOptions}
                 value={template.practiceArea}
@@ -183,7 +183,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
 
           {/* Fee configuration */}
           <div className="flex flex-col gap-3 rounded-xl border border-line-subtle bg-surface-card p-4">
-            <p className="text-sm font-semibold text-input-text">Fee arrangement</p>
+            <p className="text-sm font-semibold text-ink">Fee arrangement</p>
             <div className="flex flex-wrap gap-2">
               {(Object.keys(FEE_TYPE_LABELS) as EngagementFeeType[]).map((type) => (
                 <button
@@ -194,7 +194,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                     'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
                     template.feeType === type
                       ? 'border-accent-500 bg-accent-500/10 text-[rgb(var(--accent-foreground))]'
-                      : 'border-line-subtle text-input-placeholder hover:border-line-subtle hover:text-input-text',
+                      : 'border-line-subtle text-dim-2 hover:border-line-subtle hover:text-ink',
                   )}
                 >
                   {FEE_TYPE_LABELS[type]}
@@ -206,7 +206,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
               {template.feeType === 'hourly' ? (
                 <>
                   <div className="flex flex-col gap-1.5">
-                    <span className="text-sm font-medium text-input-text">Attorney rate ($/hr)</span>
+                    <span className="text-sm font-medium text-ink">Attorney rate ($/hr)</span>
                     <Input
                       type="text"
                       value={centsToDisplay(template.hourlyRateCents)}
@@ -215,7 +215,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                     />
                   </div>
                   <div className="flex flex-col gap-1.5">
-                    <span className="text-sm font-medium text-input-text">Retainer ($)</span>
+                    <span className="text-sm font-medium text-ink">Retainer ($)</span>
                     <Input
                       type="text"
                       value={centsToDisplay(template.retainerCents)}
@@ -226,7 +226,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                 </>
               ) : template.feeType === 'flat' ? (
                 <div className="flex flex-col gap-1.5">
-                  <span className="text-sm font-medium text-input-text">Flat fee ($)</span>
+                  <span className="text-sm font-medium text-ink">Flat fee ($)</span>
                   <Input
                     type="text"
                     value={centsToDisplay(template.flatFeeCents)}
@@ -236,7 +236,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                 </div>
               ) : template.feeType === 'contingency' ? (
                 <div className="flex flex-col gap-1.5">
-                  <span className="text-sm font-medium text-input-text">Contingency %</span>
+                  <span className="text-sm font-medium text-ink">Contingency %</span>
                   <Input
                     type="text"
                     value={template.contingencyPct != null ? String(template.contingencyPct) : ''}
@@ -253,8 +253,8 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
 
           {/* Scope template */}
           <div className="flex flex-col gap-1.5">
-            <span className="text-sm font-medium text-input-text">Scope of representation</span>
-            <p className="text-xs text-input-placeholder">
+            <span className="text-sm font-medium text-ink">Scope of representation</span>
+            <p className="text-xs text-dim-2">
               Default scope language for this practice area. The AI will refine this per matter.
             </p>
             <Textarea
@@ -267,8 +267,8 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
 
           {/* Letter body */}
           <div className="flex flex-col gap-1.5">
-            <span className="text-sm font-medium text-input-text">Letter body</span>
-            <p className="text-xs text-input-placeholder">
+            <span className="text-sm font-medium text-ink">Letter body</span>
+            <p className="text-xs text-dim-2">
               Write your engagement letter once. Click placeholders on the right to insert them at the cursor.
             </p>
             <Textarea
@@ -283,8 +283,8 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
 
         {/* Placeholder sidebar */}
         <div className="flex flex-col gap-3">
-          <p className="text-sm font-semibold text-input-text">Available placeholders</p>
-          <p className="text-xs text-input-placeholder">Click to insert at cursor position in the letter body.</p>
+          <p className="text-sm font-semibold text-ink">Available placeholders</p>
+          <p className="text-xs text-dim-2">Click to insert at cursor position in the letter body.</p>
           <div className="flex flex-col gap-1">
             {PLACEHOLDER_DOCS.map(({ key, description }) => (
               <button
@@ -294,7 +294,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                 className="flex flex-col items-start rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-surface-input"
               >
                 <span className="font-mono text-xs text-accent-500">{key}</span>
-                <span className="text-xs text-input-placeholder">{description}</span>
+                <span className="text-xs text-dim-2">{description}</span>
               </button>
             ))}
           </div>
@@ -319,7 +319,7 @@ function TemplateListView({ templates, onNew, onEdit }: ListViewProps) {
     <div className="flex flex-col gap-4 p-6">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm text-input-placeholder">
+          <p className="text-sm text-dim-2">
             Create a template for each practice area. When you generate an engagement letter from an intake, the AI will select the matching template, fill in the client&apos;s details, and produce a ready-to-review draft.
           </p>
         </div>
@@ -328,9 +328,9 @@ function TemplateListView({ templates, onNew, onEdit }: ListViewProps) {
 
       {templates.length === 0 ? (
         <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-line-subtle py-12 text-center">
-          <FileText className="h-8 w-8 text-input-placeholder" />
-          <p className="text-sm font-medium text-input-text">No templates yet</p>
-          <p className="text-xs text-input-placeholder">Create your first engagement letter template to get started.</p>
+          <FileText className="h-8 w-8 text-dim-2" />
+          <p className="text-sm font-medium text-ink">No templates yet</p>
+          <p className="text-xs text-dim-2">Create your first engagement letter template to get started.</p>
           <Button icon={Plus} onClick={onNew} size="sm" variant="secondary">New template</Button>
         </div>
       ) : (
@@ -343,8 +343,8 @@ function TemplateListView({ templates, onNew, onEdit }: ListViewProps) {
               className="flex items-center justify-between gap-4 px-4 py-3.5 text-left transition-colors hover:bg-surface-card"
             >
               <div className="min-w-0">
-                <p className="truncate text-sm font-medium text-input-text">{template.name}</p>
-                <p className="text-xs text-input-placeholder">
+                <p className="truncate text-sm font-medium text-ink">{template.name}</p>
+                <p className="text-xs text-dim-2">
                   {template.practiceArea || 'No practice area'} · {FEE_TYPE_LABELS[template.feeType]}
                 </p>
               </div>

--- a/src/features/settings/pages/MFAEnrollmentPage.tsx
+++ b/src/features/settings/pages/MFAEnrollmentPage.tsx
@@ -225,7 +225,7 @@ export const MFAEnrollmentPage = ({
 
           {/* Instructions */}
           <div className="space-y-2">
-            <p className="text-sm text-input-placeholder">
+            <p className="text-sm text-dim-2">
               {t('settings:mfa.instructions')}
             </p>
           </div>
@@ -272,7 +272,7 @@ export const MFAEnrollmentPage = ({
               <SectionDivider className="w-full" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-surface-base text-input-placeholder">
+              <span className="px-2 bg-surface-base text-dim-2">
                 {t('settings:mfa.then')}
               </span>
             </div>
@@ -324,7 +324,7 @@ export const MFAEnrollmentPage = ({
               >
                 {t('settings:mfa.footer.terms')}
               </Button>
-              <span className="text-input-placeholder">|</span>
+              <span className="text-dim-2">|</span>
               <Button
                 variant="link"
                 size="sm"

--- a/src/features/settings/pages/McpAccessPage.tsx
+++ b/src/features/settings/pages/McpAccessPage.tsx
@@ -37,11 +37,11 @@ export const McpAccessPage = ({ app, onBack }: McpAccessPageProps) => {
                   {app.logo ? (
                     <img src={app.logo} alt={`${app.name} logo`} className="h-full w-full object-cover" loading="lazy" />
                   ) : (
-                    <Icon icon={Plug} className="h-8 w-8 text-input-text/80" aria-hidden="true" />
+                    <Icon icon={Plug} className="h-8 w-8 text-ink/80" aria-hidden="true" />
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <h2 className="text-2xl font-bold text-input-text">{app.name}</h2>
+                  <h2 className="text-2xl font-bold text-ink">{app.name}</h2>
                   <SettingsBadge variant="info">Not connected</SettingsBadge>
                 </div>
               </div>
@@ -69,13 +69,13 @@ export const McpAccessPage = ({ app, onBack }: McpAccessPageProps) => {
             label="Server URL"
             labelNode={(
               <div className="flex items-center gap-3">
-                <Icon icon={Server} className="h-5 w-5 text-input-placeholder" aria-hidden="true" />
-                <span className="text-sm font-medium text-input-text">Server URL</span>
+                <Icon icon={Server} className="h-5 w-5 text-dim-2" aria-hidden="true" />
+                <span className="text-sm font-medium text-ink">Server URL</span>
               </div>
             )}
             description="Provided by the backend once MCP server access is available."
           >
-            <span className="text-sm text-input-placeholder">Not available yet</span>
+            <span className="text-sm text-dim-2">Not available yet</span>
           </SettingRow>
         </SettingSection>
 
@@ -88,19 +88,19 @@ export const McpAccessPage = ({ app, onBack }: McpAccessPageProps) => {
           <div className="space-y-6">
             {scopeGroups.map((group) => (
               <div key={group.category} className="space-y-3">
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-dim-2">
                   {group.label}
                 </h4>
                 <div className="space-y-3">
                   {group.scopes.map((scope) => (
                     <div key={scope.id} className="space-y-1">
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-input-text">{scope.title}</span>
-                        <code className="rounded bg-surface-utility/10 px-1.5 py-0.5 font-mono text-xs text-input-placeholder">
+                        <span className="text-sm font-medium text-ink">{scope.title}</span>
+                        <code className="rounded bg-surface-utility/10 px-1.5 py-0.5 font-mono text-xs text-dim-2">
                           {scope.id}
                         </code>
                       </div>
-                      <p className="text-sm text-input-placeholder">{scope.description}</p>
+                      <p className="text-sm text-dim-2">{scope.description}</p>
                     </div>
                   ))}
                 </div>

--- a/src/features/settings/pages/NotificationsPage.tsx
+++ b/src/features/settings/pages/NotificationsPage.tsx
@@ -294,7 +294,7 @@ export const NotificationsPage = ({
   if (error || !settings) {
     return (
       <div className={`h-full flex items-center justify-center ${className}`}>
-        <p className="text-input-placeholder">
+        <p className="text-dim-2">
           {t('settings:notifications.loadError', { defaultValue: 'Failed to load notification settings' })}
         </p>
       </div>
@@ -328,7 +328,7 @@ export const NotificationsPage = ({
           ? (
             <>
               <span>{baseDescription}</span>
-              <span className="mt-1 block text-[11px] text-input-placeholder">
+              <span className="mt-1 block text-[11px] text-dim-2">
                 {t('settings:notifications.systemRequiredHint', { defaultValue: 'System notifications are required for all members.' })}
               </span>
             </>

--- a/src/features/settings/pages/PayoutsPage.tsx
+++ b/src/features/settings/pages/PayoutsPage.tsx
@@ -261,7 +261,7 @@ export const PayoutsPage = ({
         >
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
             <div className="w-full max-w-[220px]">
-              <label className="mb-2 block text-sm font-medium text-input-text" htmlFor="billing-increment-minutes">
+              <label className="mb-2 block text-sm font-medium text-ink" htmlFor="billing-increment-minutes">
                 Minutes
               </label>
               <Input
@@ -307,7 +307,7 @@ export const PayoutsPage = ({
                     ? 'h-5 w-5 text-amber-600 dark:text-amber-400'
                     : hasStripeAccount && statusSummary
                       ? `h-5 w-5 ${statusSummary.iconClassName}`
-                      : 'h-5 w-5 text-input-placeholder'}
+                      : 'h-5 w-5 text-dim-2'}
                 />
               </span>
               <div className="min-w-0">
@@ -334,7 +334,7 @@ export const PayoutsPage = ({
           description={isReady ? undefined : 'Bank accounts and payout schedules are managed in Stripe after onboarding.'}
         >
           <div className="flex w-full items-center justify-between gap-3 sm:w-auto sm:justify-end">
-            <span className="text-sm font-medium text-input-text">
+            <span className="text-sm font-medium text-ink">
               {maskStripeAccountId(stripeStatus?.stripe_account_id)}
             </span>
             {hasStripeAccount ? (
@@ -356,13 +356,13 @@ export const PayoutsPage = ({
           label="Business email"
           labelNode={(
             <div className="flex items-center gap-3">
-              <Icon icon={User} className="h-5 w-5 text-input-placeholder" />
-              <span className="text-sm font-medium text-input-text">Business email</span>
+              <Icon icon={User} className="h-5 w-5 text-dim-2" />
+              <span className="text-sm font-medium text-ink">Business email</span>
             </div>
           )}
           description={isReady ? undefined : 'Stripe uses this email during onboarding and verification.'}
         >
-          <span className="text-sm font-medium text-input-text">
+          <span className="text-sm font-medium text-ink">
             {businessEmail || 'Not set'}
           </span>
         </SettingRow>
@@ -373,7 +373,7 @@ export const PayoutsPage = ({
           label="Charges"
           description={isReady ? undefined : 'Card payments can be accepted once Stripe finishes verifying the account.'}
         >
-          <span className="text-sm font-medium text-input-text">
+          <span className="text-sm font-medium text-ink">
             {chargesEnabled ? 'Enabled' : 'Pending verification'}
           </span>
         </SettingRow>
@@ -384,13 +384,13 @@ export const PayoutsPage = ({
           label="Payouts"
           labelNode={(
             <div className="flex items-center gap-3">
-              <Icon icon={Lock} className="h-5 w-5 text-input-placeholder" />
-              <span className="text-sm font-medium text-input-text">Payouts</span>
+              <Icon icon={Lock} className="h-5 w-5 text-dim-2" />
+              <span className="text-sm font-medium text-ink">Payouts</span>
             </div>
           )}
           description={isReady ? undefined : 'Payouts unlock after Stripe verifies your business details.'}
         >
-          <span className="text-sm font-medium text-input-text">
+          <span className="text-sm font-medium text-ink">
             {payoutsEnabled ? 'Enabled' : 'Pending verification'}
           </span>
         </SettingRow>
@@ -401,8 +401,8 @@ export const PayoutsPage = ({
           label="Status"
           labelNode={(
             <div className="flex items-center gap-3">
-              <Icon icon={ShieldCheck} className="h-5 w-5 text-input-placeholder" />
-              <span className="text-sm font-medium text-input-text">Status</span>
+              <Icon icon={ShieldCheck} className="h-5 w-5 text-dim-2" />
+              <span className="text-sm font-medium text-ink">Status</span>
             </div>
           )}
           description={isReady
@@ -411,7 +411,7 @@ export const PayoutsPage = ({
               ? 'Review or complete Stripe onboarding to finish setup.'
               : 'Start Stripe onboarding to create your payout account.'}
         >
-          <span className="text-sm font-medium text-input-text">
+          <span className="text-sm font-medium text-ink">
             {statusLabel}
           </span>
         </SettingRow>

--- a/src/features/settings/pages/PracticeCoveragePage.tsx
+++ b/src/features/settings/pages/PracticeCoveragePage.tsx
@@ -206,7 +206,7 @@ export const PracticeCoveragePage = ({ className, onBack }: PracticeCoveragePage
   if (!currentPractice) {
     return (
       <div className="h-full flex items-center justify-center">
-        <p className="text-sm text-input-placeholder">No practice selected.</p>
+        <p className="text-sm text-dim-2">No practice selected.</p>
       </div>
     );
   }
@@ -237,7 +237,7 @@ export const PracticeCoveragePage = ({ className, onBack }: PracticeCoveragePage
 
         <section className="space-y-4">
           <div>
-            <h3 className="text-sm font-semibold text-input-text">Services</h3>
+            <h3 className="text-sm font-semibold text-ink">Services</h3>
             <SettingsHelperText className="mt-1">
               Choose the legal service areas this practice accepts for routing and intake setup.
             </SettingsHelperText>
@@ -252,7 +252,7 @@ export const PracticeCoveragePage = ({ className, onBack }: PracticeCoveragePage
         <SectionDivider />
         <section className="space-y-3">
           <div>
-            <h3 className="text-sm font-semibold text-input-text">Licensed states</h3>
+            <h3 className="text-sm font-semibold text-ink">Licensed states</h3>
             <SettingsHelperText className="mt-1">
               Enter US state codes where this practice is licensed. Used to help the assistant reason about jurisdiction.
             </SettingsHelperText>

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -93,9 +93,9 @@ const SlugField = ({
         placeholder={placeholder}
         description={description}
       />
-      <p className="mt-2 text-xs text-input-placeholder">
+      <p className="mt-2 text-xs text-dim-2">
         <span>{urlLabel}: </span>
-        <span className="font-mono text-input-text">
+        <span className="font-mono text-ink">
           {origin}/practice/<span className="text-accent-500">{previewSlug}</span>
         </span>
       </p>
@@ -420,7 +420,7 @@ export const PracticePage = ({ className, onBack }: PracticePageProps) => {
   if (!currentPractice) {
     return (
       <EditorShell title={practiceText.pageTitle} showBack={Boolean(onBack)} onBack={onBack}>
-        <p className="text-sm text-input-placeholder">{practiceText.noPracticeSelected}</p>
+        <p className="text-sm text-dim-2">{practiceText.noPracticeSelected}</p>
       </EditorShell>
     );
   }
@@ -506,7 +506,7 @@ export const PracticePage = ({ className, onBack }: PracticePageProps) => {
 
             <div className="space-y-3">
               <div>
-                <h3 className="text-sm font-semibold text-input-text">{practiceText.brandColorLabel}</h3>
+                <h3 className="text-sm font-semibold text-ink">{practiceText.brandColorLabel}</h3>
                 <div className="mt-2 flex items-center gap-3">
                   <div
                     role="img"

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -125,7 +125,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
   if (currentPractice && !activeMemberRoleLoading && isMembershipResolved && !isMember) {
     return (
       <div className="h-full flex items-center justify-center">
-        <p className="text-sm text-input-placeholder">You are not a member of this practice.</p>
+        <p className="text-sm text-dim-2">You are not a member of this practice.</p>
       </div>
     );
   }
@@ -234,7 +234,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
   if (!currentPractice) {
     return (
       <div className="h-full flex items-center justify-center">
-        <p className="text-sm text-input-placeholder">No practice selected.</p>
+        <p className="text-sm text-dim-2">No practice selected.</p>
       </div>
     );
   }
@@ -251,7 +251,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
         <div className="pt-2 pb-6">
           <div className="flex items-center justify-between gap-4">
             <div>
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm text-dim-2">
                 Manage access to your practice workspace.
               </p>
               <SettingsHelperText className="mt-2">
@@ -321,7 +321,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
                     }
                     setEditMemberData(member);
                   }}
-                  className="text-input-text hover:text-accent-600 dark:hover:text-accent-400"
+                  className="text-ink hover:text-accent-600 dark:hover:text-accent-400"
                 >
                   {isEditingMember && editMemberData?.userId === member.userId ? 'Cancel' : 'Manage'}
                 </Button>
@@ -373,7 +373,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
         {isEditingMember && editMemberData && (
           <div className="mt-6 space-y-4">
             <div>
-              <p className="text-sm font-medium text-input-text mb-2">
+              <p className="text-sm font-medium text-ink mb-2">
                 {editMemberData.name || editMemberData.email}
               </p>
             <SettingsHelperText>
@@ -414,7 +414,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
 
         <SectionDivider className="mt-8" />
         <div className="pt-6">
-          <h3 className="text-sm font-semibold text-input-text mb-4">
+          <h3 className="text-sm font-semibold text-ink mb-4">
             Pending Invitations
           </h3>
           {invitations.length > 0 ? (
@@ -427,7 +427,7 @@ export const PracticeTeamPage = ({ className, onBack }: PracticeTeamPageProps) =
                       size="md"
                     />
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-input-text">
+                      <p className="truncate text-sm font-medium text-ink">
                       {inv.email}
                       </p>
                       <SettingsHelperText className="truncate">

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -429,7 +429,7 @@ export const SecurityPage = ({
   if (!settings) {
     return (
       <div className={`h-full flex items-center justify-center ${className}`}>
-        <p className="text-input-placeholder">{t('settings:security.fallback')}</p>
+        <p className="text-dim-2">{t('settings:security.fallback')}</p>
       </div>
     );
   }
@@ -561,7 +561,7 @@ export const SecurityPage = ({
                   <Icon icon={AlertTriangle} className="w-6 h-6 text-orange-500"  />
                 </div>
                 <div className="flex-1">
-                  <h3 className="text-lg font-semibold text-input-text mb-2">
+                  <h3 className="text-lg font-semibold text-ink mb-2">
                     {t('settings:security.mfa.disable.heading')}
                   </h3>
                 </div>

--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -160,7 +160,7 @@ const Card = ({ tone = 'default', children }: { tone?: 'default' | 'error'; chil
         "mx-auto max-w-xl rounded-2xl border p-6 text-sm",
         tone === 'error'
           ? "border-accent-error/30 bg-accent-error/5 text-accent-error-foreground backdrop-blur-xl"
-          : "card text-input-text"
+          : "card text-ink"
       )}
     >
       {children}
@@ -431,7 +431,7 @@ export const AcceptInvitationPage = () => {
         <div className="flex justify-center mb-6">
           <Logo size="lg" />
         </div>
-        <h1 className="text-xl font-semibold text-input-text">Unable to load invitation</h1>
+        <h1 className="text-xl font-semibold text-ink">Unable to load invitation</h1>
         <p className="mt-2 text-sm text-accent-error-light">{preAuthError}</p>
         <div className="mt-4 flex flex-wrap gap-3">
           <Button variant="ghost" onClick={() => navigate('/auth', true)}>
@@ -454,10 +454,10 @@ export const AcceptInvitationPage = () => {
           <Logo size="lg" />
         </div>
         <div className="text-center">
-          <h1 className="text-2xl font-semibold text-input-text">
+          <h1 className="text-2xl font-semibold text-ink">
             Accept your invitation to sign up{practiceName ? ` | ${practiceName}` : ''}
           </h1>
-          <p className="mt-2 text-sm text-input-placeholder">
+          <p className="mt-2 text-sm text-dim-2">
             {subtitle}
           </p>
         </div>
@@ -481,20 +481,20 @@ export const AcceptInvitationPage = () => {
         <div className="flex justify-center mb-6">
           <Logo size="lg" />
         </div>
-        <h1 className="text-xl font-semibold text-input-text">You’re signed in</h1>
-        <p className="mt-2 text-sm text-input-placeholder">
+        <h1 className="text-xl font-semibold text-ink">You’re signed in</h1>
+        <p className="mt-2 text-sm text-dim-2">
           Continue to {practiceName || practiceSlug} to finish your intake.
         </p>
-        <div className="mt-4 space-y-2 text-sm text-input-placeholder">
+        <div className="mt-4 space-y-2 text-sm text-dim-2">
           <div>
-            <span className="font-medium text-input-text">Practice:</span> {practiceName || practiceSlug}
+            <span className="font-medium text-ink">Practice:</span> {practiceName || practiceSlug}
           </div>
           <div>
-            <span className="font-medium text-input-text">Email:</span> {invitedEmail}
+            <span className="font-medium text-ink">Email:</span> {invitedEmail}
           </div>
           {sessionEmail && (
             <div>
-              <span className="font-medium text-input-text">Signed in as:</span> {sessionEmail}
+              <span className="font-medium text-ink">Signed in as:</span> {sessionEmail}
             </div>
           )}
         </div>
@@ -534,7 +534,7 @@ export const AcceptInvitationPage = () => {
         <div className="flex justify-center mb-6">
           <Logo size="lg" />
         </div>
-        <h1 className="text-xl font-semibold text-input-text">Unable to load invitation</h1>
+        <h1 className="text-xl font-semibold text-ink">Unable to load invitation</h1>
         <p className="mt-2 text-sm text-accent-error-light">{inviteState.message}</p>
         <div className="mt-4 flex flex-wrap gap-3">
           <Button variant="secondary" onClick={fetchInvitation}>
@@ -569,32 +569,32 @@ export const AcceptInvitationPage = () => {
       <div className="flex justify-center mb-6">
         <Logo size="lg" />
       </div>
-      <h1 className="text-xl font-semibold text-input-text">Accept invitation</h1>
-      <p className="mt-2 text-sm text-input-placeholder">
+      <h1 className="text-xl font-semibold text-ink">Accept invitation</h1>
+      <p className="mt-2 text-sm text-dim-2">
         You&apos;ve been invited to join {invitation.practiceName ?? 'this practice'}.
       </p>
-      <div className="mt-4 space-y-2 text-sm text-input-placeholder">
+      <div className="mt-4 space-y-2 text-sm text-dim-2">
         {invitation.practiceSlug && (
           <div>
-            <span className="font-medium text-input-text">Practice:</span> {invitation.practiceName || invitation.practiceSlug}
+            <span className="font-medium text-ink">Practice:</span> {invitation.practiceName || invitation.practiceSlug}
           </div>
         )}
         {(invitation.inviterName || invitation.inviterEmail) && (
           <div>
-            <span className="font-medium text-input-text">Invited by:</span> {invitation.inviterName ?? invitation.inviterEmail}
+            <span className="font-medium text-ink">Invited by:</span> {invitation.inviterName ?? invitation.inviterEmail}
           </div>
         )}
         <div>
-          <span className="font-medium text-input-text">Role:</span> {roleLabel}
+          <span className="font-medium text-ink">Role:</span> {roleLabel}
         </div>
         {invitation.expiresAt && (
           <div>
-            <span className="font-medium text-input-text">Expires:</span> {isValidDate(invitation.expiresAt) ? new Date(invitation.expiresAt).toLocaleString() : 'Unknown'}
+            <span className="font-medium text-ink">Expires:</span> {isValidDate(invitation.expiresAt) ? new Date(invitation.expiresAt).toLocaleString() : 'Unknown'}
           </div>
         )}
         {effectiveInvitedEmail && (
           <div>
-            <span className="font-medium text-input-text">Invited email:</span> {effectiveInvitedEmail}
+            <span className="font-medium text-ink">Invited email:</span> {effectiveInvitedEmail}
           </div>
         )}
       </div>
@@ -618,7 +618,7 @@ export const AcceptInvitationPage = () => {
         )}
       </div>
       {invitation.status !== 'pending' && (
-        <p className="mt-2 text-xs text-input-placeholder">
+        <p className="mt-2 text-xs text-dim-2">
           This invitation is no longer pending.
         </p>
       )}

--- a/src/pages/AdminIntakeInspectorPage.tsx
+++ b/src/pages/AdminIntakeInspectorPage.tsx
@@ -104,7 +104,7 @@ const AdminIntakeInspectorPage: FunctionComponent<PageProps> = ({ conversationId
     return (
       <div className="mx-auto max-w-2xl p-6">
         <h1 className="text-xl font-semibold">Sign in required</h1>
-        <p className="mt-2 text-sm text-input-text/70">
+        <p className="mt-2 text-sm text-ink/70">
           The intake inspector is engineer-only. Sign in to continue.
         </p>
       </div>
@@ -132,7 +132,7 @@ const SearchEntry: FunctionComponent = () => {
   return (
     <div className="mx-auto max-w-2xl p-6">
       <h1 className="text-xl font-semibold">Intake inspector</h1>
-      <p className="mt-2 text-sm text-input-text/70">
+      <p className="mt-2 text-sm text-ink/70">
         Engineer-only view of the intake event timeline for a conversation. Paste a
         conversation id to load its timeline.
       </p>
@@ -198,7 +198,7 @@ const TimelineView: FunctionComponent<TimelineViewProps> = ({ conversationId }) 
         <h1 className="text-xl font-semibold">
           {isForbidden ? 'Not authorized' : 'Failed to load timeline'}
         </h1>
-        <p className="mt-2 text-sm text-input-text/70">
+        <p className="mt-2 text-sm text-ink/70">
           {isForbidden
             ? 'Your account is not in the intake-inspector engineer allowlist.'
             : error}
@@ -213,7 +213,7 @@ const TimelineView: FunctionComponent<TimelineViewProps> = ({ conversationId }) 
     return (
       <div className="mx-auto max-w-3xl p-6">
         <h1 className="text-xl font-semibold">Conversation not found</h1>
-        <p className="mt-2 text-sm text-input-text/70">
+        <p className="mt-2 text-sm text-ink/70">
           No conversation with id <code>{conversationId}</code> exists.
         </p>
       </div>
@@ -230,7 +230,7 @@ const TimelineView: FunctionComponent<TimelineViewProps> = ({ conversationId }) 
         <div className="flex items-center justify-between gap-4">
           <div>
             <h1 className="text-xl font-semibold">Intake inspector</h1>
-            <p className="mt-1 text-sm text-input-text/70">
+            <p className="mt-1 text-sm text-ink/70">
               <span className="font-mono">{conversationId}</span>
             </p>
           </div>
@@ -259,7 +259,7 @@ const TimelineView: FunctionComponent<TimelineViewProps> = ({ conversationId }) 
       </header>
 
       {turns.length === 0 ? (
-        <p className="text-sm text-input-text/70">No timeline events recorded for this conversation.</p>
+        <p className="text-sm text-ink/70">No timeline events recorded for this conversation.</p>
       ) : (
         <ol className="space-y-2">
           {turns.map((turn) => (
@@ -277,7 +277,7 @@ const SummaryChip: FunctionComponent<{ label: string; value: string; valueClass?
   valueClass,
 }) => (
   <div className="flex flex-col gap-0.5">
-    <span className="text-xs uppercase tracking-wide text-input-text/60">{label}</span>
+    <span className="text-xs uppercase tracking-wide text-ink/60">{label}</span>
     <span className={valueClass ?? 'text-sm font-medium'}>{value}</span>
   </div>
 );
@@ -300,7 +300,7 @@ const IntakeTimelineRow: FunctionComponent<IntakeTimelineRowProps> = ({ turn }) 
         aria-expanded={expanded}
       >
         <span className="flex items-center gap-3">
-          <span className="font-mono text-xs text-input-text/60">#{turn.turn_seq}</span>
+          <span className="font-mono text-xs text-ink/60">#{turn.turn_seq}</span>
           <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${provenanceBadge}`}>
             {provenanceLabel}
           </span>
@@ -308,7 +308,7 @@ const IntakeTimelineRow: FunctionComponent<IntakeTimelineRowProps> = ({ turn }) 
             <span className="text-xs text-red-600 dark:text-red-300">{turn.failure_reason}</span>
           )}
         </span>
-        <span className="text-xs text-input-text/60">{formatTimestamp(turn.created_at)}</span>
+        <span className="text-xs text-ink/60">{formatTimestamp(turn.created_at)}</span>
       </button>
       {expanded && (
         <div className="border-t border-input-border px-3 py-2 text-xs">
@@ -343,7 +343,7 @@ const ExpandedSection: FunctionComponent<{ label: string; children: ComponentChi
   children,
 }) => (
   <details className="mb-2" open>
-    <summary className="cursor-pointer text-xs font-medium text-input-text/70">{label}</summary>
+    <summary className="cursor-pointer text-xs font-medium text-ink/70">{label}</summary>
     <div className="mt-1 rounded bg-surface-utility/40 p-2 dark:bg-surface-utility/20">{children}</div>
   </details>
 );

--- a/src/pages/ApproveActionPage.tsx
+++ b/src/pages/ApproveActionPage.tsx
@@ -21,16 +21,16 @@ export default function ApproveActionPage({ jwt }: { jwt?: string }) {
     <div className="flex min-h-screen w-full items-center justify-center bg-surface-app px-4 py-10">
       <div className="w-full max-w-md rounded-2xl border border-line-subtle bg-surface-card p-6 text-center shadow-sm">
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
-          <Icon icon={ShieldCheck} className="h-6 w-6 text-input-text" aria-hidden="true" />
+          <Icon icon={ShieldCheck} className="h-6 w-6 text-ink" aria-hidden="true" />
         </div>
-        <h1 className="text-lg font-semibold text-input-text">Approval request</h1>
-        <p className="mt-2 text-sm text-input-placeholder">
+        <h1 className="text-lg font-semibold text-ink">Approval request</h1>
+        <p className="mt-2 text-sm text-dim-2">
           Action approvals aren&apos;t available yet. This unlocks once MCP server support and pending-action
           handling are enabled for your practice.
         </p>
 
         {hasToken ? (
-          <p className="mt-3 text-xs text-input-placeholder">An approval token was received.</p>
+          <p className="mt-3 text-xs text-dim-2">An approval token was received.</p>
         ) : (
           <Alert variant="warning" className="mt-4">
             This approval link is missing its token.

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -93,7 +93,7 @@ const AuthPage = ({ mode = 'signin', onSuccess }: AuthPageProps) => {
               variant="ghost"
               size="sm"
               onClick={handleBackToHome}
-              className="text-sm text-input-placeholder hover:text-input-text"
+              className="text-sm text-dim-2 hover:text-ink"
               icon={ArrowLeft} iconClassName="h-4 w-4"
               iconPosition="left"
             >
@@ -104,10 +104,10 @@ const AuthPage = ({ mode = 'signin', onSuccess }: AuthPageProps) => {
           <div className="flex justify-center mb-6">
             <Logo size="lg" />
           </div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-input-text">
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-ink">
             {authMode === 'signup' ? t('signup.title') : t('signin.title')}
           </h2>
-          <p className="mt-2 text-center text-sm text-input-placeholder">
+          <p className="mt-2 text-center text-sm text-dim-2">
             {authMode === 'signup' ? t('signup.subtitle') : t('signin.subtitle')}
           </p>
         </div>

--- a/src/pages/DebugChatPage.tsx
+++ b/src/pages/DebugChatPage.tsx
@@ -192,8 +192,8 @@ export default function DebugChatPage() {
   return (
     <main className="mx-auto max-w-5xl space-y-4 p-6">
       <header className="space-y-1">
-        <h1 className="text-2xl font-semibold text-input-text">Debug Chat Experience</h1>
-        <p className="text-sm text-input-placeholder">
+        <h1 className="text-2xl font-semibold text-ink">Debug Chat Experience</h1>
+        <p className="text-sm text-dim-2">
           Real chat container + composer with mocked LLM streaming and persisted message replacement.
         </p>
       </header>

--- a/src/pages/DebugConversationsPage.tsx
+++ b/src/pages/DebugConversationsPage.tsx
@@ -410,8 +410,8 @@ export default function DebugConversationsPage() {
       <header className="space-y-2">
         <div className="flex flex-wrap items-center gap-2">
           <Icon icon={MessagesSquare} className="h-6 w-6 text-accent-500" aria-hidden="true"  />
-          <h1 className="text-2xl font-semibold text-input-text">Debug Conversations</h1>
-          <span className="rounded-full border border-line-subtle bg-surface-panel/60 px-2.5 py-1 text-xs font-medium text-input-placeholder">
+          <h1 className="text-2xl font-semibold text-ink">Debug Conversations</h1>
+          <span className="rounded-full border border-line-subtle bg-surface-panel/60 px-2.5 py-1 text-xs font-medium text-dim-2">
             No API
           </span>
         </div>
@@ -468,20 +468,20 @@ export default function DebugConversationsPage() {
         title="Conversation details"
         contentClassName={isMobile ? 'max-w-lg' : 'max-w-xl'}
       >
-        <DialogBody className="space-y-4 text-sm text-input-text">
+        <DialogBody className="space-y-4 text-sm text-ink">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="panel rounded-xl p-3">
-              <div className="text-xs uppercase tracking-wide text-input-placeholder">Workspace</div>
+              <div className="text-xs uppercase tracking-wide text-dim-2">Workspace</div>
               <div className="mt-1 font-semibold capitalize">{workspaceKind}</div>
             </div>
             <div className="panel rounded-xl p-3">
-              <div className="text-xs uppercase tracking-wide text-input-placeholder">Conversation ID</div>
+              <div className="text-xs uppercase tracking-wide text-dim-2">Conversation ID</div>
               <div className="mt-1 break-all font-mono text-xs">{activeConversationId}</div>
             </div>
           </div>
           {activeConversation?.user_info?.title ? (
             <div className="panel rounded-xl p-3">
-              <div className="text-xs uppercase tracking-wide text-input-placeholder">Title</div>
+              <div className="text-xs uppercase tracking-wide text-dim-2">Title</div>
               <div className="mt-1 font-semibold">{String(activeConversation.user_info.title)}</div>
             </div>
           ) : null}

--- a/src/pages/DebugDialogsPage.tsx
+++ b/src/pages/DebugDialogsPage.tsx
@@ -803,14 +803,14 @@ function PreviewRenderer({ previewId }: { previewId: PreviewId }) {
   const content = type === 'fullscreen' ? (
     <div className="flex flex-1 items-center justify-center p-8">
       <div className="max-w-xl text-center">
-        <p className="text-lg font-medium text-input-text">Shared fullscreen shell</p>
-        <p className="mt-2 text-sm text-input-placeholder">Used by media and camera flows.</p>
+        <p className="text-lg font-medium text-ink">Shared fullscreen shell</p>
+        <p className="mt-2 text-sm text-dim-2">Used by media and camera flows.</p>
       </div>
     </div>
   ) : (
     <DialogBody className="space-y-3">
-      <p className="text-sm text-input-text">Shared shell preview.</p>
-      <p className="text-sm text-input-placeholder">No additional feature UI injected.</p>
+      <p className="text-sm text-ink">Shared shell preview.</p>
+      <p className="text-sm text-dim-2">No additional feature UI injected.</p>
     </DialogBody>
   );
 
@@ -855,17 +855,17 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
     <article id={`gall-card-${item.previewId}`} className="space-y-4 rounded-3xl panel p-6">
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-bold text-input-text">{item.name}</h2>
+          <h2 className="text-lg font-bold text-ink">{item.name}</h2>
           <span className="rounded-full bg-accent-500/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[rgb(var(--accent-foreground))]">
             {item.section}
           </span>
         </div>
-        <p className="font-mono text-[10px] text-input-placeholder">{item.file}</p>
+        <p className="font-mono text-[10px] text-dim-2">{item.file}</p>
       </div>
 
       <div className="space-y-2 text-sm">
-        <p className="font-semibold text-input-text">Found in</p>
-        <ul className="space-y-1 text-input-placeholder">
+        <p className="font-semibold text-ink">Found in</p>
+        <ul className="space-y-1 text-dim-2">
           {item.usedIn.map((path) => (
             <li key={path} className="break-all font-mono text-[10px]">
               {path}
@@ -877,7 +877,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
       {frameSrcBase ? (
         <div className="grid gap-4 pt-2 md:grid-cols-2 items-start">
           <div className="space-y-2 min-h-[320px]">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-input-placeholder">Light Mode</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-dim-2">Light Mode</p>
             <div 
               className="widget-shell-gradient relative overflow-visible rounded-2xl border border-line-subtle p-4 shadow-glass" 
               style={{ backgroundAttachment: 'scroll', isolation: 'isolate' }}
@@ -899,7 +899,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
             </div>
           </div>
           <div className="space-y-2 min-h-[320px]">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-input-placeholder">Dark Mode</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-dim-2">Dark Mode</p>
             <div 
               className="relative overflow-visible rounded-2xl border border-line-subtle bg-surface-workspace p-4 shadow-glass dark"
               style={{ isolation: 'isolate' }}
@@ -922,7 +922,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
           </div>
         </div>
       ) : (
-        <div className="flex h-32 items-center justify-center rounded-2xl bg-surface-utility/5 text-xs text-input-placeholder italic">
+        <div className="flex h-32 items-center justify-center rounded-2xl bg-surface-utility/5 text-xs text-dim-2 italic">
           No preview available
         </div>
       )}
@@ -943,8 +943,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
       <PreviewSurface onReplay={replayAnimations}>
         <div className="mx-auto flex min-h-screen max-w-2xl items-center justify-center p-8">
           <div className="card w-full p-8 text-center">
-            <p className="text-lg font-semibold text-input-text">Preview not found</p>
-            <p className="mt-2 text-sm text-input-placeholder">
+            <p className="text-lg font-semibold text-ink">Preview not found</p>
+            <p className="mt-2 text-sm text-dim-2">
               The requested dialog preview does not exist.
             </p>
           </div>
@@ -971,8 +971,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
       <header className="space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-semibold text-input-text">Debug Dialogs</h1>
-            <p className="text-sm text-input-placeholder">
+            <h1 className="text-2xl font-semibold text-ink">Debug Dialogs</h1>
+            <p className="text-sm text-dim-2">
               Side-by-side review of actual dialog implementations and launcher patterns.
             </p>
           </div>
@@ -992,8 +992,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
 
       <section className="space-y-4 mt-12 mb-4">
         <div className="space-y-1">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder mb-3 mt-10">Shared Shells</h2>
-          <p className="text-sm text-input-placeholder">Core container patterns. Review these first if the goal is consolidation.</p>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2 mb-3 mt-10">Shared Shells</h2>
+          <p className="text-sm text-dim-2">Core container patterns. Review these first if the goal is consolidation.</p>
         </div>
         <div className="space-y-4">
           {sharedShells.map((item) => <GalleryCard key={item.name} item={item} previewNonce={previewNonce} />)}
@@ -1002,8 +1002,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
 
       <section className="space-y-4 mt-12 mb-4">
         <div className="space-y-1">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder mb-3 mt-10">Feature Dialogs</h2>
-          <p className="text-sm text-input-placeholder">Real feature implementations layered on top of the shared shell.</p>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2 mb-3 mt-10">Feature Dialogs</h2>
+          <p className="text-sm text-dim-2">Real feature implementations layered on top of the shared shell.</p>
         </div>
         <div className="space-y-4">
           {featureDialogs.map((item) => <GalleryCard key={item.name} item={item} previewNonce={previewNonce} />)}
@@ -1012,8 +1012,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
 
       <section className="space-y-4 mt-12 mb-4">
         <div className="space-y-1">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder mb-3 mt-10">Feature Panels</h2>
-          <p className="text-sm text-input-placeholder">Right-side panel patterns that are part of the same transient-surface system.</p>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2 mb-3 mt-10">Feature Panels</h2>
+          <p className="text-sm text-dim-2">Right-side panel patterns that are part of the same transient-surface system.</p>
         </div>
         <div className="space-y-4">
           {featurePanels.map((item) => <GalleryCard key={item.name} item={item} previewNonce={previewNonce} />)}
@@ -1022,8 +1022,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
 
       <section className="space-y-4 mt-12 mb-4">
         <div className="space-y-1">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder mb-3 mt-10">Launcher Patterns</h2>
-          <p className="text-sm text-input-placeholder">Inline components that launch dialog experiences rather than being dialog shells themselves.</p>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2 mb-3 mt-10">Launcher Patterns</h2>
+          <p className="text-sm text-dim-2">Inline components that launch dialog experiences rather than being dialog shells themselves.</p>
         </div>
         <div className="space-y-4">
           {launcherPatterns.map((item) => <GalleryCard key={item.name} item={item} previewNonce={previewNonce} />)}
@@ -1032,8 +1032,8 @@ export default function DebugDialogsPage({ previewId }: DebugDialogsPageProps) {
 
       <section className="space-y-4 mt-12 mb-4">
         <div className="space-y-1">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder mb-3 mt-10">Docked Surfaces</h2>
-          <p className="text-sm text-input-placeholder">Transient UI that is not a portal dialog but should still align with the shared design system.</p>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2 mb-3 mt-10">Docked Surfaces</h2>
+          <p className="text-sm text-dim-2">Transient UI that is not a portal dialog but should still align with the shared design system.</p>
         </div>
         <div className="space-y-4">
           {dockedSurfaces.map((item) => <GalleryCard key={item.name} item={item} previewNonce={previewNonce} />)}

--- a/src/pages/DebugMatterPage.tsx
+++ b/src/pages/DebugMatterPage.tsx
@@ -301,8 +301,8 @@ export default function DebugMatterPage() {
   return (
     <main className="mx-auto max-w-[1400px] space-y-6 p-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-input-text">Debug Matter Playground</h1>
-        <p className="text-sm text-input-placeholder">
+        <h1 className="text-2xl font-semibold text-ink">Debug Matter Playground</h1>
+        <p className="text-sm text-dim-2">
           Dev-only page for iterating on matter UI states without backend calls.
         </p>
       </header>
@@ -310,7 +310,7 @@ export default function DebugMatterPage() {
       <section className="grid gap-6 lg:grid-cols-[360px_minmax(0,1fr)]">
         <aside className="panel overflow-hidden">
           <div className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
-            <h2 className="text-sm font-semibold text-input-text">Matters</h2>
+            <h2 className="text-sm font-semibold text-ink">Matters</h2>
             <Button size="xs" onClick={() => setEditorState('create')}>New</Button>
           </div>
           <ul className="divide-y divide-line-subtle">
@@ -373,8 +373,8 @@ export default function DebugMatterPage() {
                           'transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 rounded-t-sm',
                           'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-all after:duration-150',
                           isActive
-                            ? 'text-input-text after:bg-accent-500'
-                            : 'text-input-placeholder hover:text-input-text after:bg-transparent hover:after:bg-line-glass/20'
+                            ? 'text-ink after:bg-accent-500'
+                            : 'text-dim-2 hover:text-ink after:bg-transparent hover:after:bg-line-glass/20'
                         ].join(' ')}
                       >
                         {tab.label}
@@ -396,7 +396,7 @@ export default function DebugMatterPage() {
                 <div className="space-y-4">
                   <section className="panel overflow-hidden">
                     <div className="border-b border-line-subtle px-6 py-4">
-                      <h3 className="text-sm font-semibold text-input-text">Matter description</h3>
+                      <h3 className="text-sm font-semibold text-ink">Matter description</h3>
                     </div>
                     {isDescriptionEditing ? (
                       <div className="space-y-3 px-6 py-5">
@@ -420,7 +420,7 @@ export default function DebugMatterPage() {
                       </div>
                     ) : (
                       <div className="flex items-start justify-between gap-4 px-6 py-5">
-                        <p className="whitespace-pre-wrap text-sm leading-relaxed text-input-placeholder">
+                        <p className="whitespace-pre-wrap text-sm leading-relaxed text-dim-2">
                           {selectedDetail.description || 'No description yet.'}
                         </p>
                         <Button
@@ -453,7 +453,7 @@ export default function DebugMatterPage() {
               ) : null}
 
               {activeTab === 'messages' ? (
-                <section className="panel p-6 text-sm text-input-placeholder">
+                <section className="panel p-6 text-sm text-dim-2">
                   Message thread preview placeholder for UI layout work.
                 </section>
               ) : null}

--- a/src/pages/DebugStylesPage.tsx
+++ b/src/pages/DebugStylesPage.tsx
@@ -75,50 +75,50 @@ export default function DebugStylesPage() {
   return (
     <main className="mx-auto max-w-6xl space-y-8 p-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-input-text">Debug Style Reference</h1>
-        <p className="text-sm text-input-placeholder">
+        <h1 className="text-2xl font-semibold text-ink">Debug Style Reference</h1>
+        <p className="text-sm text-dim-2">
           Dev-only style inventory for button variants, surfaces, and nav state tokens.
         </p>
       </header>
 
       <section className="space-y-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Surfaces</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Surfaces</h2>
+        <p className="text-sm text-dim-2">
           Use <code>card</code>, <code>panel</code>, or <code>input-surface</code>. The <code>glass-*</code> names are deprecated aliases and must not be used in new code.
         </p>
         <div className="grid gap-4 md:grid-cols-3">
           <div className="card p-4">
-            <p className="font-medium text-input-text">card</p>
-            <p className="text-sm text-input-placeholder">Content cards. <code>bg-surface-card</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
+            <p className="font-medium text-ink">card</p>
+            <p className="text-sm text-dim-2">Content cards. <code>bg-surface-card</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
           </div>
           <div className="panel p-4">
-            <p className="font-medium text-input-text">panel</p>
-            <p className="text-sm text-input-placeholder">Section containers. <code>bg-surface-section</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
+            <p className="font-medium text-ink">panel</p>
+            <p className="text-sm text-dim-2">Section containers. <code>bg-surface-section</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
           </div>
           <div className="input-surface rounded-xl p-4">
-            <p className="font-medium text-input-text">input-surface</p>
-            <p className="text-sm text-input-placeholder">Input backgrounds. <code>bg-surface-input</code>, <code>border-subtle</code>, <code>rounded-xl</code>.</p>
+            <p className="font-medium text-ink">input-surface</p>
+            <p className="text-sm text-dim-2">Input backgrounds. <code>bg-surface-input</code>, <code>border-subtle</code>, <code>rounded-xl</code>.</p>
           </div>
         </div>
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Buttons</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Buttons</h2>
+        <p className="text-sm text-dim-2">
           `menu-item` and `tab` are intentionally subtle and can look similar; use them by behavior/context, not for visual emphasis.
         </p>
         <div className="grid gap-3 md:grid-cols-2">
           {buttonVariants.map((variant) => (
             <div key={variant} className="panel flex items-center gap-3 rounded-xl p-3">
               <Button variant={variant}>{variant}</Button>
-              <code className="text-xs text-input-placeholder">variant=&quot;{variant}&quot;</code>
+              <code className="text-xs text-dim-2">variant=&quot;{variant}&quot;</code>
             </div>
           ))}
         </div>
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Button Sizes</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Button Sizes</h2>
         <div className="panel flex flex-wrap items-center gap-3 rounded-xl p-3">
           {buttonSizes.map((size) => (
             <Button key={size} size={size} variant="secondary">
@@ -130,14 +130,14 @@ export default function DebugStylesPage() {
               <Button size={iconSize} variant="icon" aria-label={`${iconSize} sample`}>
                 +
               </Button>
-              <code className="text-xs text-input-placeholder">{iconSize}</code>
+              <code className="text-xs text-dim-2">{iconSize}</code>
             </div>
           ))}
         </div>
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Nav State Tokens</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Nav State Tokens</h2>
         <div className="grid gap-3 md:grid-cols-2">
           <button type="button" className="nav-item-active rounded-xl px-3 py-2 text-left">
             Active nav item (`nav-item-active`)
@@ -149,8 +149,8 @@ export default function DebugStylesPage() {
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Status Utilities</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Status Utilities</h2>
+        <p className="text-sm text-dim-2">
           Semantic status banners for inline feedback. Uses `rounded-xl`.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
@@ -174,8 +174,8 @@ export default function DebugStylesPage() {
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Dynamic Foreground</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Dynamic Foreground</h2>
+        <p className="text-sm text-dim-2">
           Accent-colored surfaces should use `text-[rgb(var(--accent-foreground))]` for contrast-safe text/icons.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
@@ -191,14 +191,14 @@ export default function DebugStylesPage() {
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Input States</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Input States</h2>
+        <p className="text-sm text-dim-2">
           Status is communicated through colored rings on the <code>input-surface</code> base.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
           <div className="panel rounded-xl p-4 space-y-4">
             <div className="space-y-1">
-              <label htmlFor="defaultInput" className="text-xs font-medium text-input-placeholder">Default / Focus</label>
+              <label htmlFor="defaultInput" className="text-xs font-medium text-dim-2">Default / Focus</label>
               <input
                 id="defaultInput"
                 className="input-surface w-full rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-accent-500/30"
@@ -206,7 +206,7 @@ export default function DebugStylesPage() {
               />
             </div>
             <div className="space-y-1">
-              <label htmlFor="errorInput" className="text-xs font-medium text-input-placeholder">Error</label>
+              <label htmlFor="errorInput" className="text-xs font-medium text-dim-2">Error</label>
               <input
                 id="errorInput"
                 className="input-surface w-full rounded-xl px-3 py-2 text-sm ring-2 ring-accent-error/40 focus:ring-accent-error/60"
@@ -216,7 +216,7 @@ export default function DebugStylesPage() {
           </div>
           <div className="panel rounded-xl p-4 space-y-4">
             <div className="space-y-1">
-              <label htmlFor="successInput" className="text-xs font-medium text-input-placeholder">Success</label>
+              <label htmlFor="successInput" className="text-xs font-medium text-dim-2">Success</label>
               <input
                 id="successInput"
                 className="input-surface w-full rounded-xl px-3 py-2 text-sm ring-2 ring-accent-success/40 focus:ring-accent-success/60"
@@ -224,7 +224,7 @@ export default function DebugStylesPage() {
               />
             </div>
             <div className="space-y-1">
-              <label htmlFor="disabledInput" className="text-xs font-medium text-input-placeholder">Disabled</label>
+              <label htmlFor="disabledInput" className="text-xs font-medium text-dim-2">Disabled</label>
               <input
                 id="disabledInput"
                 disabled
@@ -236,9 +236,9 @@ export default function DebugStylesPage() {
         </div>
       </section>
 
-      <section className="space-y-4 pt-4 text-input-text">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Inputs</h2>
-        <p className="text-sm text-input-placeholder">
+      <section className="space-y-4 pt-4 text-ink">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Inputs</h2>
+        <p className="text-sm text-dim-2">
           Height baseline should align with Combobox for `md` controls.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
@@ -287,8 +287,8 @@ export default function DebugStylesPage() {
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Combobox Modes</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Combobox Modes</h2>
+        <p className="text-sm text-dim-2">
           One component, four modes. `multiple` and `allowCustomValues` toggle behavior; this is not a separate component.
         </p>
         <div className="grid gap-4 md:grid-cols-2 overflow-visible">
@@ -308,7 +308,7 @@ export default function DebugStylesPage() {
               options={comboboxOptions}
               value={comboboxValue}
               onChange={setComboboxValue}
-              leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-input-placeholder')}
+              leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-dim-2')}
             />
           </div>
           <div className="panel relative z-30 rounded-xl p-4 overflow-visible">
@@ -320,7 +320,7 @@ export default function DebugStylesPage() {
               onChange={setComboboxMultiOnlyValue}
               multiple
               searchable={false}
-              leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-input-placeholder')}
+              leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-dim-2')}
             />
           </div>
           <div className="panel relative z-30 rounded-xl p-4 overflow-visible">
@@ -332,15 +332,15 @@ export default function DebugStylesPage() {
               onChange={setComboboxMultiValue}
               multiple
               allowCustomValues
-              leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-input-placeholder')}
+              leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-dim-2')}
             />
           </div>
         </div>
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">Avatar Sizes &amp; Status</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Avatar Sizes &amp; Status</h2>
+        <p className="text-sm text-dim-2">
           Five sizes (<code>xs sm md lg xl</code>) with optional <code>status</code> dot (<code>active</code> = emerald, <code>inactive</code> = amber).
           Image falls back to initials extracted from <code>name</code>.
         </p>
@@ -349,51 +349,51 @@ export default function DebugStylesPage() {
             {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
               <div key={size} className="flex flex-col items-center gap-2">
                 <Avatar name="Alice Chen" size={size} status="active" />
-                <code className="text-[10px] text-input-placeholder">{size} / active</code>
+                <code className="text-[10px] text-dim-2">{size} / active</code>
               </div>
             ))}
             {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
               <div key={`${size}-inactive`} className="flex flex-col items-center gap-2">
                 <Avatar name="Bob Ramirez" size={size} status="inactive" />
-                <code className="text-[10px] text-input-placeholder">{size} / inactive</code>
+                <code className="text-[10px] text-dim-2">{size} / inactive</code>
               </div>
             ))}
             <div className="flex flex-col items-center gap-2">
               <Avatar name="No Status" size="md" />
-              <code className="text-[10px] text-input-placeholder">md / none</code>
+              <code className="text-[10px] text-dim-2">md / none</code>
             </div>
           </div>
         </div>
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">StackedAvatars</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">StackedAvatars</h2>
+        <p className="text-sm text-dim-2">
           Pass a <code>users</code> array and a <code>max</code> cap. Overflow renders a <code>+N</code> badge using the <code>input-surface</code> surface.
         </p>
         <div className="panel rounded-xl p-4 flex flex-wrap items-center gap-8">
           <div className="flex flex-col gap-1">
             <StackedAvatars users={sampleUsers} size="sm" max={3} />
-            <code className="text-[10px] text-input-placeholder">size=sm max=3</code>
+            <code className="text-[10px] text-dim-2">size=sm max=3</code>
           </div>
           <div className="flex flex-col gap-1">
             <StackedAvatars users={sampleUsers} size="md" max={4} />
-            <code className="text-[10px] text-input-placeholder">size=md max=4</code>
+            <code className="text-[10px] text-dim-2">size=md max=4</code>
           </div>
           <div className="flex flex-col gap-1">
             <StackedAvatars users={sampleUsers} size="lg" max={2} />
-            <code className="text-[10px] text-input-placeholder">size=lg max=2</code>
+            <code className="text-[10px] text-dim-2">size=lg max=2</code>
           </div>
           <div className="flex flex-col gap-1">
             <StackedAvatars users={sampleUsers} size="md" max={10} showOverflow={false} />
-            <code className="text-[10px] text-input-placeholder">showOverflow=false</code>
+            <code className="text-[10px] text-dim-2">showOverflow=false</code>
           </div>
         </div>
       </section>
 
       <section className="space-y-4 pt-4">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-input-placeholder">UserCard</h2>
-        <p className="text-sm text-input-placeholder">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">UserCard</h2>
+        <p className="text-sm text-dim-2">
           Combines Avatar + identity lines + optional <code>badge</code> pill + optional <code>trailing</code> action slot.
           Pass <code>onClick</code> to make it a button (adds hover + focus ring).
         </p>

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -159,18 +159,18 @@ export default function OAuthConsentPage() {
       <div className="w-full max-w-md rounded-2xl border border-line-subtle bg-surface-card p-6 shadow-sm">
         <div className="flex flex-col items-center text-center">
           <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
-            <Icon icon={Sparkles} className="h-6 w-6 text-input-text" aria-hidden="true" />
+            <Icon icon={Sparkles} className="h-6 w-6 text-ink" aria-hidden="true" />
           </div>
-          <h1 className="text-lg font-semibold text-input-text">Authorize access</h1>
-          <p className="mt-1 text-sm text-input-placeholder">
-            <span className="font-medium text-input-text">{appName}</span> wants to connect to your Blawby account.
+          <h1 className="text-lg font-semibold text-ink">Authorize access</h1>
+          <p className="mt-1 text-sm text-dim-2">
+            <span className="font-medium text-ink">{appName}</span> wants to connect to your Blawby account.
           </p>
           {clientInfo?.uri ? (
             <a
               href={clientInfo.uri}
               target="_blank"
               rel="noreferrer"
-              className="mt-2 text-xs text-input-placeholder underline-offset-2 hover:underline"
+              className="mt-2 text-xs text-dim-2 underline-offset-2 hover:underline"
             >
               {clientInfo.uri}
             </a>
@@ -184,7 +184,7 @@ export default function OAuthConsentPage() {
         ) : (
           <>
             {clientInfoPending ? (
-              <p className="mt-6 text-sm text-input-placeholder">Loading client details…</p>
+              <p className="mt-6 text-sm text-dim-2">Loading client details…</p>
             ) : null}
 
             {clientInfo?.icon ? (
@@ -200,18 +200,18 @@ export default function OAuthConsentPage() {
 
             <div className="mt-6 space-y-5">
               {requestedScopes.length === 0 ? (
-                <p className="text-sm text-input-placeholder">No specific permissions were requested.</p>
+                <p className="text-sm text-dim-2">No specific permissions were requested.</p>
               ) : (
                 scopeGroups.map((group) => (
                   <div key={group.category} className="space-y-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-input-placeholder">
+                    <h2 className="text-xs font-semibold uppercase tracking-wide text-dim-2">
                       {group.label}
                     </h2>
                     <ul className="space-y-2">
                       {group.scopes.map((scope) => (
                         <li key={scope.id}>
-                          <p className="text-sm font-medium text-input-text">{scope.title}</p>
-                          <p className="text-sm text-input-placeholder">{scope.description}</p>
+                          <p className="text-sm font-medium text-ink">{scope.title}</p>
+                          <p className="text-sm text-dim-2">{scope.description}</p>
                         </li>
                       ))}
                     </ul>
@@ -239,7 +239,7 @@ export default function OAuthConsentPage() {
               </Button>
             </div>
 
-            <p className="mt-4 text-center text-xs text-input-placeholder">
+            <p className="mt-4 text-center text-xs text-dim-2">
               You can revoke access later from your MCP integration settings.
             </p>
           </>

--- a/src/pages/PaymentResultPage.tsx
+++ b/src/pages/PaymentResultPage.tsx
@@ -52,7 +52,7 @@ const OUTCOMES: Record<PaymentOutcome, OutcomeConfig> = {
     headline: 'Verifying your payment…',
     body: 'Please wait a moment while we confirm your payment status.',
     badge: 'Checking status',
-    badgeClass: 'bg-surface-utility/15 text-input-placeholder border-line-subtle',
+    badgeClass: 'bg-surface-utility/15 text-dim-2 border-line-subtle',
   },
 };
 

--- a/src/pages/PracticeHomePage.tsx
+++ b/src/pages/PracticeHomePage.tsx
@@ -328,8 +328,8 @@ const PracticeHomePage = () => {
       <div className="mx-auto flex max-w-6xl flex-col gap-7">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 max-w-full">
-            <h1 className="truncate text-2xl font-semibold text-input-text">Welcome back, {firstName}</h1>
-            <p className="mt-1 text-sm text-input-placeholder">
+            <h1 className="truncate text-2xl font-semibold text-ink">Welcome back, {firstName}</h1>
+            <p className="mt-1 text-sm text-dim-2">
               Here&apos;s what&apos;s happening with your practice today.
             </p>
           </div>
@@ -354,11 +354,11 @@ const PracticeHomePage = () => {
         {!setupDismissed && completeCount < setupSteps.length && (
           <section className="card p-6 md:p-7">
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <h2 className="text-base font-semibold text-input-text">
+              <h2 className="text-base font-semibold text-ink">
                 Finish setting up your practice
               </h2>
               <div className="flex items-center gap-3">
-                <span className="text-sm font-medium text-input-placeholder">
+                <span className="text-sm font-medium text-dim-2">
                   {setupLoading ? 'Checking setup' : `${completeCount} of ${setupSteps.length} complete`}
                 </span>
                 <button
@@ -397,13 +397,13 @@ const PracticeHomePage = () => {
                         <Check className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />
                       </span>
                     ) : (
-                      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full border border-line-subtle text-[10px] font-semibold text-input-text">
+                      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full border border-line-subtle text-[10px] font-semibold text-ink">
                         {idx + 1}
                       </span>
                     )}
-                    <span className="text-sm font-semibold text-input-text">{step.title}</span>
+                    <span className="text-sm font-semibold text-ink">{step.title}</span>
                   </div>
-                  <p className="text-xs leading-snug text-input-placeholder">{step.description}</p>
+                  <p className="text-xs leading-snug text-dim-2">{step.description}</p>
                 </button>
               ))}
             </div>
@@ -415,7 +415,7 @@ const PracticeHomePage = () => {
 
         <section className="flex flex-col gap-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-input-text">Cashflow</h2>
+            <h2 className="text-lg font-semibold text-ink">Cashflow</h2>
             <SegmentedToggle<CashflowRange>
               value={cashflowRange}
               options={CASHFLOW_RANGES}
@@ -435,8 +435,8 @@ const PracticeHomePage = () => {
             </div>
           ) : practiceBillingError ? (
             <div className="card-muted rounded-2xl p-6">
-              <p className="text-sm font-medium text-input-text">Cashflow could not load.</p>
-              <p className="mt-1 text-sm text-input-placeholder">{practiceBillingError}</p>
+              <p className="text-sm font-medium text-ink">Cashflow could not load.</p>
+              <p className="mt-1 text-sm text-dim-2">{practiceBillingError}</p>
             </div>
           ) : hasCashflowData ? (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -445,16 +445,16 @@ const PracticeHomePage = () => {
                   key={m.id}
                   className="flex flex-col gap-2 rounded-2xl border border-card-border bg-card p-5"
                 >
-                  <span className="text-xs font-medium text-input-placeholder">{m.label}</span>
-                  <span className="text-3xl font-bold tabular-nums text-input-text">{formatCurrency(m.value)}</span>
-                  <span className="text-xs leading-snug text-input-placeholder">{m.helper}</span>
+                  <span className="text-xs font-medium text-dim-2">{m.label}</span>
+                  <span className="text-3xl font-bold tabular-nums text-ink">{formatCurrency(m.value)}</span>
+                  <span className="text-xs leading-snug text-dim-2">{m.helper}</span>
                 </div>
               ))}
             </div>
           ) : (
             <div className="card-muted flex flex-col items-start gap-3 rounded-2xl p-6">
-              <p className="text-sm font-medium text-input-text">No invoice activity yet.</p>
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm font-medium text-ink">No invoice activity yet.</p>
+              <p className="text-sm text-dim-2">
                 Create and send an invoice, then collected revenue, overdue balances, and ready-to-invoice work will appear here.
               </p>
               <Button variant="secondary" icon={Plus} onClick={handleNewInvoice}>
@@ -466,7 +466,7 @@ const PracticeHomePage = () => {
 
         <section className="flex flex-col gap-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-input-text">Recent intakes</h2>
+            <h2 className="text-lg font-semibold text-ink">Recent intakes</h2>
             {hasIntakes && (
               <Button variant="link" onClick={handleViewAllIntakes}>
                 View all
@@ -476,10 +476,10 @@ const PracticeHomePage = () => {
           {hasIntakes ? (
             <div className="overflow-hidden rounded-2xl border border-card-border bg-card">
               <div className="hidden grid-cols-[260px_1fr_140px_110px] items-center gap-4 border-b border-line-subtle px-5 py-3 md:grid">
-                <span className="text-[11px] font-semibold uppercase tracking-wider text-input-placeholder">Client</span>
-                <span className="text-[11px] font-semibold uppercase tracking-wider text-input-placeholder">Subject</span>
-                <span className="text-[11px] font-semibold uppercase tracking-wider text-input-placeholder">Date submitted</span>
-                <span className="text-right text-[11px] font-semibold uppercase tracking-wider text-input-placeholder">Status</span>
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-dim-2">Client</span>
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-dim-2">Subject</span>
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-dim-2">Date submitted</span>
+                <span className="text-right text-[11px] font-semibold uppercase tracking-wider text-dim-2">Status</span>
               </div>
               {recentIntakes.map((row, idx) => {
                 const contactName = row.metadata?.name?.trim() || row.metadata?.email?.trim() || 'Unknown contact';
@@ -495,19 +495,19 @@ const PracticeHomePage = () => {
                     ].filter(Boolean).join(' ')}
                   >
                     <div className="flex min-w-0 items-center gap-2.5">
-                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card-hover text-[11px] font-semibold text-input-text">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card-hover text-[11px] font-semibold text-ink">
                         {initialsFor(contactName)}
                       </span>
-                      <span className="truncate text-sm font-medium text-input-text">{contactName}</span>
+                      <span className="truncate text-sm font-medium text-ink">{contactName}</span>
                     </div>
-                    <span className="truncate text-sm text-input-placeholder">{subject}</span>
-                    <span className="truncate text-sm text-input-placeholder">{formatRelativeTime(row.created_at)}</span>
+                    <span className="truncate text-sm text-dim-2">{subject}</span>
+                    <span className="truncate text-sm text-dim-2">{formatRelativeTime(row.created_at)}</span>
                     <div className="flex items-center gap-2 md:justify-end">
                       <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${intakeStatusClass(row.triage_status)}`}>
                         {intakeStatusLabel(row.triage_status)}
                       </span>
                       <ArrowRight
-                        className="hidden h-4 w-4 text-input-placeholder transition-opacity group-hover:opacity-100 md:block md:opacity-0"
+                        className="hidden h-4 w-4 text-dim-2 transition-opacity group-hover:opacity-100 md:block md:opacity-0"
                         aria-hidden="true"
                       />
                     </div>
@@ -528,13 +528,13 @@ const PracticeHomePage = () => {
             </div>
           ) : recentIntakesError ? (
             <div className="card-muted rounded-2xl p-6">
-              <p className="text-sm font-medium text-input-text">Recent intakes could not load.</p>
-              <p className="mt-1 text-sm text-input-placeholder">{recentIntakesError}</p>
+              <p className="text-sm font-medium text-ink">Recent intakes could not load.</p>
+              <p className="mt-1 text-sm text-dim-2">{recentIntakesError}</p>
             </div>
           ) : (
             <div className="card-muted flex flex-col items-start gap-3 rounded-2xl p-6">
-              <p className="text-sm font-medium text-input-text">No intake responses yet.</p>
-              <p className="text-sm text-input-placeholder">
+              <p className="text-sm font-medium text-ink">No intake responses yet.</p>
+              <p className="text-sm text-dim-2">
                 New submissions will appear here after a visitor completes an intake form.
               </p>
               <Button variant="secondary" onClick={() => practiceBasePath && navigate(`${practiceBasePath}/intakes/forms`)}>

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -64,7 +64,7 @@ const PricingPage = () => {
               variant="ghost"
               size="sm"
               onClick={handleClose}
-              className="text-sm text-input-placeholder hover:text-input-text"
+              className="text-sm text-dim-2 hover:text-ink"
               icon={ArrowLeft}
               iconClassName="h-4 w-4"
               iconPosition="left"

--- a/src/shared/components/AnnouncementBanner.tsx
+++ b/src/shared/components/AnnouncementBanner.tsx
@@ -21,29 +21,29 @@ interface AnnouncementBannerProps {
 
 const toneStyles: Record<AnnouncementTone, { container: string; title: string; body: string; rail: string }> = {
   warning: {
-    container: 'border-line-subtle bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
-    title: 'text-input-text',
-    body: 'text-input-placeholder',
+    container: 'border-line-subtle bg-surface-panel/60 text-ink backdrop-blur-xl shadow-glass',
+    title: 'text-ink',
+    body: 'text-dim-2',
     rail: 'bg-amber-500/70'
   },
   info: {
-    container: 'border-line-subtle bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
-    title: 'text-input-text',
-    body: 'text-input-placeholder',
+    container: 'border-line-subtle bg-surface-panel/60 text-ink backdrop-blur-xl shadow-glass',
+    title: 'text-ink',
+    body: 'text-dim-2',
     rail: 'bg-sky-500/70'
   },
   success: {
-    container: 'border-line-subtle bg-surface-panel/60 text-input-text backdrop-blur-xl shadow-glass',
-    title: 'text-input-text',
-    body: 'text-input-placeholder',
+    container: 'border-line-subtle bg-surface-panel/60 text-ink backdrop-blur-xl shadow-glass',
+    title: 'text-ink',
+    body: 'text-dim-2',
     rail: 'bg-emerald-500/70'
   }
 };
 
 const flatToneStyles: Record<AnnouncementTone, string> = {
-  warning: 'border border-line-subtle bg-surface-panel/40 text-input-text backdrop-blur-xl',
-  info: 'border border-line-subtle bg-surface-panel/40 text-input-text backdrop-blur-xl',
-  success: 'border border-line-subtle bg-surface-panel/40 text-input-text backdrop-blur-xl'
+  warning: 'border border-line-subtle bg-surface-panel/40 text-ink backdrop-blur-xl',
+  info: 'border border-line-subtle bg-surface-panel/40 text-ink backdrop-blur-xl',
+  success: 'border border-line-subtle bg-surface-panel/40 text-ink backdrop-blur-xl'
 };
 
 const AnnouncementBanner = ({

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -260,10 +260,10 @@ const AuthForm = ({
     <div className={`w-full ${className}`}>
       {showHeader && (
         <div className="mb-6 text-center">
-          <h2 className="text-2xl font-bold text-input-text">
+          <h2 className="text-2xl font-bold text-ink">
             {resolvedMode === 'signup' ? t('signup.title') : t('signin.title')}
           </h2>
-          <p className="mt-2 text-sm text-input-placeholder">
+          <p className="mt-2 text-sm text-dim-2">
             {resolvedMode === 'signup' ? t('signup.subtitle') : t('signin.subtitle')}
           </p>
         </div>
@@ -300,7 +300,7 @@ const AuthForm = ({
               <div className="w-full border-t border-line-subtle" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-[rgb(var(--surface-overlay))] text-input-placeholder font-medium">{t('common.orContinueWithEmail')}</span>
+              <span className="px-2 bg-[rgb(var(--surface-overlay))] text-dim-2 font-medium">{t('common.orContinueWithEmail')}</span>
             </div>
           </div>
         )}
@@ -323,7 +323,7 @@ const AuthForm = ({
                         setFormData(prev => ({ ...prev, name: String(value) }));
                       }}
                       placeholder={t('signup.fullNamePlaceholder')}
-                      icon={CircleUser} iconClassName="h-5 w-5 text-input-placeholder"
+                      icon={CircleUser} iconClassName="h-5 w-5 text-dim-2"
                       error={fieldError?.message}
                       disabled={disableActions}
                       data-testid="signup-name-input"

--- a/src/shared/components/ConfirmationDialog.tsx
+++ b/src/shared/components/ConfirmationDialog.tsx
@@ -132,10 +132,10 @@ export default function ConfirmationDialog({
               {/* Warning Items List */}
               {warningItems.length > 0 && (
                 <div className="mb-4 space-y-2">
-                  <p className="text-sm font-medium text-input-text">
+                  <p className="text-sm font-medium text-ink">
                     This will permanently delete:
                   </p>
-                  <ul className="space-y-1 text-sm text-input-placeholder">
+                  <ul className="space-y-1 text-sm text-dim-2">
                     {warningItems.map((item, idx) => (
                       <li key={idx}>• {item}</li>
                     ))}
@@ -146,9 +146,9 @@ export default function ConfirmationDialog({
               <div className="space-y-4 pt-2">
                 {/* Confirmation Input */}
                 <div className="space-y-2">
-                  <label htmlFor={confirmationInputId} className="block text-sm font-medium text-input-text">
+                  <label htmlFor={confirmationInputId} className="block text-sm font-medium text-ink">
                     {confirmationLabel}
-                    <span className="font-mono text-xs font-bold bg-surface-utility/40 border border-line-utility/50 dark:border-white/20 px-2 py-0.5 rounded shadow-sm ml-2 text-input-text inline-flex items-center">
+                    <span className="font-mono text-xs font-bold bg-surface-utility/40 border border-line-utility/50 dark:border-white/20 px-2 py-0.5 rounded shadow-sm ml-2 text-ink inline-flex items-center">
                       {confirmationValue}
                     </span>
                   </label>
@@ -193,7 +193,7 @@ export default function ConfirmationDialog({
                 {/* Password Input */}
                 {requirePassword && (
                   <div className="space-y-2">
-                    <label htmlFor={confirmationPasswordId} className="block text-sm font-medium text-input-text">
+                    <label htmlFor={confirmationPasswordId} className="block text-sm font-medium text-ink">
                       {passwordLabel}
                     </label>
                     <input

--- a/src/shared/components/DebugOverlay.tsx
+++ b/src/shared/components/DebugOverlay.tsx
@@ -188,12 +188,12 @@ export const DebugOverlay: FunctionComponent<DebugOverlayProps> = ({ isVisible =
       aria-label="Debug information overlay"
       aria-live="polite"
     >
-      <div className="panel p-4 text-xs font-mono text-input-text">
+      <div className="panel p-4 text-xs font-mono text-ink">
         <div className="mb-2 flex justify-between items-center">
           <strong>Debug Overlay</strong>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="text-input-placeholder hover:text-input-text focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-opacity-50 rounded px-1"
+            className="text-dim-2 hover:text-ink focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-opacity-50 rounded px-1"
             aria-label={isExpanded ? 'Collapse debug overlay' : 'Expand debug overlay'}
             aria-expanded={isExpanded}
           >
@@ -215,7 +215,7 @@ export const DebugOverlay: FunctionComponent<DebugOverlayProps> = ({ isVisible =
         <div className="mb-2">
           <div><strong>Tool Calls ({toolCalls.length}):</strong></div>
           {toolCalls.length === 0 ? (
-            <div className="text-input-placeholder" aria-label="No tool calls have been detected">No tool calls detected</div>
+            <div className="text-dim-2" aria-label="No tool calls have been detected">No tool calls detected</div>
           ) : (
             <div className="max-h-32 overflow-y-auto" role="list" aria-label="List of tool calls">
               {toolCalls.map((call, index) => (
@@ -232,13 +232,13 @@ export const DebugOverlay: FunctionComponent<DebugOverlayProps> = ({ isVisible =
           )}
         </div>
         
-        <div className="text-xs text-input-placeholder" aria-label={lastUpdated ? `Last updated at ${lastUpdated.toLocaleTimeString()}` : 'No successful updates yet'}>
+        <div className="text-xs text-dim-2" aria-label={lastUpdated ? `Last updated at ${lastUpdated.toLocaleTimeString()}` : 'No successful updates yet'}>
           Last updated: {lastUpdated ? lastUpdated.toLocaleTimeString() : 'Never'}
         </div>
         
         {isExpanded && (
           <div className="mt-2 pt-2 border-t border-line-subtle" role="region" aria-label="Additional debug information">
-            <div className="text-xs text-input-placeholder">
+            <div className="text-xs text-dim-2">
               <div>Press <kbd className="bg-surface-utility/40 px-1 rounded">Esc</kbd> to collapse</div>
               <div>Press <kbd className="bg-surface-utility/40 px-1 rounded">Enter</kbd> or <kbd className="bg-surface-utility/40 px-1 rounded">Space</kbd> to toggle</div>
             </div>

--- a/src/shared/components/PlaceholderPage.tsx
+++ b/src/shared/components/PlaceholderPage.tsx
@@ -18,9 +18,9 @@ export const PlaceholderPage = ({ title, subtitle, sections }: PlaceholderPagePr
   <div className="h-full overflow-y-auto p-6">
     <div className="max-w-5xl mx-auto space-y-6">
       <div className="space-y-2">
-        <h1 className="text-2xl font-semibold text-input-text">{title}</h1>
+        <h1 className="text-2xl font-semibold text-ink">{title}</h1>
         {subtitle && (
-          <p className="text-sm text-input-placeholder">{subtitle}</p>
+          <p className="text-sm text-dim-2">{subtitle}</p>
         )}
       </div>
       {sections.map((section) => (
@@ -29,13 +29,13 @@ export const PlaceholderPage = ({ title, subtitle, sections }: PlaceholderPagePr
           className="card p-5 space-y-2"
         >
           <div>
-            <h2 className="text-lg font-semibold text-input-text">{section.title}</h2>
+            <h2 className="text-lg font-semibold text-ink">{section.title}</h2>
             {section.description && (
-              <p className="text-sm text-input-placeholder">{section.description}</p>
+              <p className="text-sm text-dim-2">{section.description}</p>
             )}
           </div>
           {section.content ?? (
-            <p className="text-xs text-input-placeholder">{placeholderNote}</p>
+            <p className="text-xs text-dim-2">{placeholderNote}</p>
           )}
         </div>
       ))}

--- a/src/shared/components/Toast.tsx
+++ b/src/shared/components/Toast.tsx
@@ -71,11 +71,11 @@ const ToastComponent: FunctionComponent<ToastProps> = ({ toast, onRemove }) => {
           {getIcon()}
         </div>
         <div className="ml-3 flex-1">
-          <h3 className="text-sm font-medium text-input-text">
+          <h3 className="text-sm font-medium text-ink">
             {toast.title}
           </h3>
           {toast.message && (
-            <p className="mt-1 text-sm text-input-placeholder">
+            <p className="mt-1 text-sm text-dim-2">
               {toast.message}
             </p>
           )}
@@ -83,7 +83,7 @@ const ToastComponent: FunctionComponent<ToastProps> = ({ toast, onRemove }) => {
         <div className="ml-4 flex-shrink-0">
           <button
             onClick={handleRemove}
-            className="inline-flex text-input-placeholder hover:text-input-text transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-accent-500 rounded-sm focus:outline-none"
+            className="inline-flex text-dim-2 hover:text-ink transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-accent-500 rounded-sm focus:outline-none"
           >
             <Icon icon={X} className="h-4 w-4"  />
           </button>

--- a/src/shared/ui/Divider.tsx
+++ b/src/shared/ui/Divider.tsx
@@ -37,7 +37,7 @@ export function Divider({
         className={cn('flex items-center gap-3', className)}
       >
         <div className={cn('flex-1 border-t', variantClasses[variant])} />
-        <span className="text-xs text-input-placeholder shrink-0">{label}</span>
+        <span className="text-xs text-dim-2 shrink-0">{label}</span>
         <div className={cn('flex-1 border-t', variantClasses[variant])} />
       </div>
     );

--- a/src/shared/ui/DragDropOverlay.tsx
+++ b/src/shared/ui/DragDropOverlay.tsx
@@ -72,8 +72,8 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
           </div>
         </div>
         <div>
-          <h3 className="m-0 text-2xl font-semibold text-input-text">Add anything</h3>
-          <p className="mt-1 text-sm text-input-placeholder">
+          <h3 className="m-0 text-2xl font-semibold text-ink">Add anything</h3>
+          <p className="mt-1 text-sm text-dim-2">
             Drop any file here to add it to the conversation
           </p>
         </div>

--- a/src/shared/ui/Kbd.tsx
+++ b/src/shared/ui/Kbd.tsx
@@ -9,7 +9,7 @@ interface KbdProps {
 export const Kbd = ({ children, className }: KbdProps) => (
   <kbd
     className={cn(
-      'inline-flex min-w-[1.5em] items-center justify-center rounded border border-line-subtle bg-surface-utility/40 px-1.5 py-0.5 font-mono text-xs text-input-text',
+      'inline-flex min-w-[1.5em] items-center justify-center rounded border border-line-subtle bg-surface-utility/40 px-1.5 py-0.5 font-mono text-xs text-ink',
       className
     )}
   >

--- a/src/shared/ui/Logo.tsx
+++ b/src/shared/ui/Logo.tsx
@@ -30,7 +30,7 @@ export const Logo = ({ size = 'md', showText = true, className = '', children }:
         className={`${sizeClasses[size]} object-contain`}
       />
       {showText && (
-        <span className={`font-bold text-input-text ${textSizeClasses[size]}`}>
+        <span className={`font-bold text-ink ${textSizeClasses[size]}`}>
           Blawby AI
         </span>
       )}

--- a/src/shared/ui/activity/ActivityTimeline.tsx
+++ b/src/shared/ui/activity/ActivityTimeline.tsx
@@ -170,21 +170,21 @@ export const ActivityTimeline = ({
                     name={item.person.name}
                     src={item.person.imageUrl}
                     size="md"
-                    className="ring-1 ring-line-utility/30 bg-surface-utility/10 text-input-text"
+                    className="ring-1 ring-line-utility/30 bg-surface-utility/10 text-ink"
                   />
-                  <span className="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-utility/30 shadow-sm sm:h-5 sm:w-5">
+                  <span className="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full bg-surface-overlay text-ink ring-1 ring-line-utility/30 shadow-sm sm:h-5 sm:w-5">
                     <Icon icon={MessagesSquare} className="h-2.5 w-2.5 sm:h-3 sm:w-3" aria-hidden="true"  />
                   </span>
                 </div>
               ) : (
-                <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-overlay text-input-text ring-1 ring-line-subtle shadow-sm">
+                <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-overlay text-ink ring-1 ring-line-subtle shadow-sm">
                   {item.type === 'paid' ? (
                     <Icon icon={CheckCircle2} aria-hidden="true" className="h-5 w-5 text-accent-success"  />
                   ) : TYPE_ICONS[item.type] ? (
                     (() => {
                       const Icon = TYPE_ICONS[item.type];
                       return Icon ? (
-                        <Icon className="h-4 w-4 text-input-placeholder dark:text-input-placeholder/80" />
+                        <Icon className="h-4 w-4 text-dim-2 dark:text-dim-2/80" />
                       ) : null;
                     })()
                   ) : (
@@ -197,8 +197,8 @@ export const ActivityTimeline = ({
             {item.type === 'commented' ? (
               <>
                 <div className="flex-auto min-w-0">
-                  <div className="text-sm leading-5 text-input-placeholder dark:text-input-placeholder/80">
-                    <div className="font-semibold text-input-text">{item.person.name}</div>
+                  <div className="text-sm leading-5 text-dim-2 dark:text-dim-2/80">
+                    <div className="font-semibold text-ink">{item.person.name}</div>
                     <time dateTime={item.dateTime ?? item.date}>Commented {item.date}</time>
                   </div>
                   {editingId === item.id ? (
@@ -239,19 +239,19 @@ export const ActivityTimeline = ({
                   ) : (
                     <>
                       {item.comment && (
-                        <p className="mt-2 text-sm leading-6 text-input-text">
+                        <p className="mt-2 text-sm leading-6 text-ink">
                           {item.comment}
                         </p>
                       )}
                       {(onEditComment || onDeleteComment) && (
-                        <div className="mt-2 flex gap-3 text-xs text-input-placeholder dark:text-input-placeholder/80">
+                        <div className="mt-2 flex gap-3 text-xs text-dim-2 dark:text-dim-2/80">
                           {onEditComment && (
                             <button
                               type="button"
                               onClick={() => startEdit(item.id, item.comment)}
                               disabled={commentActionsDisabled || actionInFlightId === item.id}
                               className={cn(
-                                'hover:text-input-text',
+                                'hover:text-ink',
                                 (commentActionsDisabled || actionInFlightId === item.id) && 'opacity-50 cursor-not-allowed'
                               )}
                             >
@@ -281,15 +281,15 @@ export const ActivityTimeline = ({
               <>
                 <div className="flex-auto min-w-0">
                   <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
-                    <p className="flex-1 py-0.5 text-sm leading-5 text-input-text">
+                    <p className="flex-1 py-0.5 text-sm leading-5 text-ink">
                   <span className="font-semibold">{item.person.name}</span>{' '}
                   {item.actionMeta?.type === 'status_change' ? (
                     <>
-                      <span className="text-input-placeholder dark:text-input-placeholder/80">updated the status</span>{' '}
-                      <span className="text-input-placeholder dark:text-input-placeholder/80">from</span>{' '}
-                      <span className="font-semibold text-input-text">{item.actionMeta.from}</span>{' '}
-                      <span className="text-input-placeholder dark:text-input-placeholder/80">to</span>{' '}
-                      <span className="font-semibold text-input-text">{item.actionMeta.to}</span>
+                      <span className="text-dim-2 dark:text-dim-2/80">updated the status</span>{' '}
+                      <span className="text-dim-2 dark:text-dim-2/80">from</span>{' '}
+                      <span className="font-semibold text-ink">{item.actionMeta.from}</span>{' '}
+                      <span className="text-dim-2 dark:text-dim-2/80">to</span>{' '}
+                      <span className="font-semibold text-ink">{item.actionMeta.to}</span>
                     </>
                   ) : (
                     (() => {
@@ -301,29 +301,29 @@ export const ActivityTimeline = ({
                           return (
                             <button
                               type="button"
-                              className="font-semibold text-input-text hover:text-accent-300"
+                              className="font-semibold text-ink hover:text-accent-300"
                               onClick={() => onTaskClick(actionMeta.taskId)}
                             >
                               {trimmed}
                             </button>
                           );
                         }
-                        return <span className="text-input-text">{trimmed}</span>;
+                        return <span className="text-ink">{trimmed}</span>;
                       }
                       const [, verb, rest] = match;
                       return (
                         <>
-                          <span className="text-input-placeholder dark:text-input-placeholder/80">{verb}</span>{' '}
+                          <span className="text-dim-2 dark:text-dim-2/80">{verb}</span>{' '}
                           {actionMeta?.type === 'task_event' && onTaskClick ? (
                             <button
                               type="button"
-                              className="font-semibold text-input-text hover:text-accent-300"
+                              className="font-semibold text-ink hover:text-accent-300"
                               onClick={() => onTaskClick(actionMeta.taskId)}
                             >
                               {rest}
                             </button>
                           ) : (
-                            <span className="text-input-text">{rest}</span>
+                            <span className="text-ink">{rest}</span>
                           )}
                         </>
                       );
@@ -332,7 +332,7 @@ export const ActivityTimeline = ({
                     </p>
                     <time
                       dateTime={item.dateTime ?? item.date}
-                      className="shrink-0 py-0.5 text-xs leading-5 text-input-placeholder dark:text-input-placeholder/80 sm:text-right"
+                      className="shrink-0 py-0.5 text-xs leading-5 text-dim-2 dark:text-dim-2/80 sm:text-right"
                     >
                       {item.date}
                     </time>
@@ -351,7 +351,7 @@ export const ActivityTimeline = ({
           name={composerPerson?.name ?? 'You'}
           src={composerPerson?.imageUrl ?? null}
           size="sm"
-          className="ring-1 ring-line-subtle bg-surface-utility/10 text-input-text dark:ring-line-subtle sm:mt-1"
+          className="ring-1 ring-line-subtle bg-surface-utility/10 text-ink dark:ring-line-subtle sm:mt-1"
         />
         <form className="flex-auto space-y-2" onSubmit={handleSubmit}>
           <MarkdownUploadTextarea

--- a/src/shared/ui/address/AddressExperienceForm.tsx
+++ b/src/shared/ui/address/AddressExperienceForm.tsx
@@ -320,7 +320,7 @@ export const AddressExperienceForm = ({
   return (
     <div className={containerClasses} data-testid="address-experience-form">
       {message && (
-        <div className="mb-4 text-input-text dark:text-input-text/80">
+        <div className="mb-4 text-ink dark:text-ink/80">
           {message}
         </div>
       )}

--- a/src/shared/ui/address/AddressFields.tsx
+++ b/src/shared/ui/address/AddressFields.tsx
@@ -191,7 +191,7 @@ export const AddressFields = forwardRef<HTMLDivElement, AddressFieldsProps>(
         {/* ── Street address + autocomplete ─────────────────────────── */}
         <div>
           {label && (
-            <label htmlFor={streetInputId} className="mb-1 block text-sm font-medium text-input-text">
+            <label htmlFor={streetInputId} className="mb-1 block text-sm font-medium text-ink">
               {label}
             </label>
           )}
@@ -279,7 +279,7 @@ export const AddressFields = forwardRef<HTMLDivElement, AddressFieldsProps>(
                             'w-full px-3 py-2 text-left text-sm transition-colors duration-150',
                             isActive
                               ? 'bg-accent-500/15 text-accent-400'
-                              : 'text-input-text hover:bg-surface-utility/10'
+                              : 'text-ink hover:bg-surface-utility/10'
                           )}
                         >
                           {s.formatted}
@@ -289,7 +289,7 @@ export const AddressFields = forwardRef<HTMLDivElement, AddressFieldsProps>(
                   })}
                 </ul>
               ) : (
-                <p className="px-3 py-2 text-sm text-input-placeholder">
+                <p className="px-3 py-2 text-sm text-dim-2">
                   No suggestions found.
                 </p>
               )}

--- a/src/shared/ui/address/AddressInput.tsx
+++ b/src/shared/ui/address/AddressInput.tsx
@@ -219,7 +219,7 @@ export const AddressInput = ({
     <div className={cn('relative', className)} ref={dropdownRef}>
       {/* Description */}
       {description && (
-        <p className="text-xs text-input-placeholder dark:text-input-placeholder/80 mt-1 mb-4">
+        <p className="text-xs text-dim-2 dark:text-dim-2/80 mt-1 mb-4">
           {description}
         </p>
       )}

--- a/src/shared/ui/cards/InfoCard.tsx
+++ b/src/shared/ui/cards/InfoCard.tsx
@@ -30,8 +30,8 @@ export const InfoCard = ({
   >
     <header className="flex items-center justify-between gap-2">
       <div className="flex items-center gap-2.5">
-        {Icon ? <Icon className="h-[18px] w-[18px] text-input-placeholder" aria-hidden="true" /> : null}
-        <h3 className="text-base font-semibold text-input-text">{title}</h3>
+        {Icon ? <Icon className="h-[18px] w-[18px] text-dim-2" aria-hidden="true" /> : null}
+        <h3 className="text-base font-semibold text-ink">{title}</h3>
       </div>
       {trailing}
     </header>

--- a/src/shared/ui/cards/NextStepsCard.tsx
+++ b/src/shared/ui/cards/NextStepsCard.tsx
@@ -33,7 +33,7 @@ const getStatusStyles = (status?: NextStepsStatus) => {
   }
   if (status === 'incomplete') {
     return {
-      wrapper: 'border-line-subtle text-input-placeholder',
+      wrapper: 'border-line-subtle text-dim-2',
       icon: 'circle'
     };
   }
@@ -46,9 +46,9 @@ const getStatusStyles = (status?: NextStepsStatus) => {
 export const NextStepsCard = ({ title, subtitle, items, action }: NextStepsCardProps) => (
   <div className="panel p-6 space-y-4">
     <div>
-      <h2 className="text-lg font-semibold text-input-text">{title}</h2>
+      <h2 className="text-lg font-semibold text-ink">{title}</h2>
       {subtitle && (
-        <p className="text-sm text-input-placeholder">
+        <p className="text-sm text-dim-2">
           {subtitle}
         </p>
       )}
@@ -72,9 +72,9 @@ export const NextStepsCard = ({ title, subtitle, items, action }: NextStepsCardP
             )}
           </span>
           <div className="flex-1">
-            <p className="text-sm font-medium text-input-text">{item.title}</p>
+            <p className="text-sm font-medium text-ink">{item.title}</p>
             {item.description && (
-              <p className="text-xs text-input-placeholder">
+              <p className="text-xs text-dim-2">
                 {item.description}
               </p>
             )}

--- a/src/shared/ui/cards/StatCard.tsx
+++ b/src/shared/ui/cards/StatCard.tsx
@@ -16,15 +16,15 @@ export function StatCard({ label, value, trend, icon, className }: StatCardProps
     ? 'text-emerald-500'
     : trend?.direction === 'down'
       ? 'text-red-500'
-      : 'text-input-placeholder';
+      : 'text-dim-2';
 
   return (
     <div className={cn('panel p-4 rounded-2xl', className)}>
       <div className="flex items-start justify-between mb-2">
-        <span className="text-xs text-input-placeholder">{label}</span>
-        {icon && <span className="text-input-placeholder/60">{icon}</span>}
+        <span className="text-xs text-dim-2">{label}</span>
+        {icon && <span className="text-dim-2/60">{icon}</span>}
       </div>
-      <div className="text-2xl font-semibold text-input-text tabular-nums">{value}</div>
+      <div className="text-2xl font-semibold text-ink tabular-nums">{value}</div>
       {trend && (
         <div className={cn('flex items-center gap-1 mt-1.5', trendColor)}>
           <TrendIcon size={13} />

--- a/src/shared/ui/collection/CollectionSectionList.tsx
+++ b/src/shared/ui/collection/CollectionSectionList.tsx
@@ -34,13 +34,13 @@ export function CollectionSectionList<TItem>({
         <section key={section.id} className={cn('grid gap-3', sectionClassName)}>
           <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h2 className="text-base font-semibold text-input-text">{section.label}</h2>
+              <h2 className="text-base font-semibold text-ink">{section.label}</h2>
               {section.description ? (
-                <p className="mt-1 text-sm text-input-placeholder">{section.description}</p>
+                <p className="mt-1 text-sm text-dim-2">{section.description}</p>
               ) : null}
             </div>
             {typeof section.count === 'number' ? (
-              <p className="text-xs font-medium uppercase tracking-[0.08em] text-input-placeholder">
+              <p className="text-xs font-medium uppercase tracking-[0.08em] text-dim-2">
                 {section.count} item{section.count === 1 ? '' : 's'}
               </p>
             ) : null}

--- a/src/shared/ui/collection/CollectionToolbar.tsx
+++ b/src/shared/ui/collection/CollectionToolbar.tsx
@@ -45,8 +45,8 @@ export const CollectionToolbar = ({
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           {(title || description) ? (
             <div className="min-w-0">
-              {title ? <div className="text-sm font-semibold text-input-text sm:text-base">{title}</div> : null}
-              {description ? <div className="mt-1 text-sm text-input-placeholder">{description}</div> : null}
+              {title ? <div className="text-sm font-semibold text-ink sm:text-base">{title}</div> : null}
+              {description ? <div className="mt-1 text-sm text-dim-2">{description}</div> : null}
             </div>
           ) : null}
           {actions ? <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div> : null}
@@ -75,7 +75,7 @@ export const CollectionToolbar = ({
             </div>
           ) : null}
           {resultSummary ? (
-            <div className="text-xs font-medium uppercase tracking-[0.08em] text-input-placeholder">
+            <div className="text-xs font-medium uppercase tracking-[0.08em] text-dim-2">
               {resultSummary}
             </div>
           ) : null}

--- a/src/shared/ui/detail/DetailRow.tsx
+++ b/src/shared/ui/detail/DetailRow.tsx
@@ -19,8 +19,8 @@ export const DetailRow = ({ label, value, emptyText = 'Not set', className }: De
   const empty = isEmpty(value);
   return (
     <div className={cn('flex items-center justify-between gap-3 text-sm', className)}>
-      <span className="text-input-placeholder">{label}</span>
-      <span className={cn('text-right', empty ? 'text-input-placeholder' : 'text-input-text')}>
+      <span className="text-dim-2">{label}</span>
+      <span className={cn('text-right', empty ? 'text-dim-2' : 'text-ink')}>
         {empty ? emptyText : value}
       </span>
     </div>

--- a/src/shared/ui/dialog/DialogDescription.tsx
+++ b/src/shared/ui/dialog/DialogDescription.tsx
@@ -8,7 +8,7 @@ export interface DialogDescriptionProps {
 }
 
 export const DialogDescription: FunctionComponent<DialogDescriptionProps> = ({ children, id, className }) => (
-  <p id={id} className={cn('m-0 text-sm leading-6 text-input-placeholder', className)}>
+  <p id={id} className={cn('m-0 text-sm leading-6 text-dim-2', className)}>
     {children}
   </p>
 );

--- a/src/shared/ui/dialog/DialogHeader.tsx
+++ b/src/shared/ui/dialog/DialogHeader.tsx
@@ -56,7 +56,7 @@ export const DialogHeader: FunctionComponent<DialogHeaderProps> = ({
           size="icon-xs"
           onClick={onClose}
           aria-label="Close"
-          className="mt-0.5 shrink-0 rounded-full text-input-placeholder hover:bg-surface-hover hover:text-input-text"
+          className="mt-0.5 shrink-0 rounded-full text-dim-2 hover:bg-surface-hover hover:text-ink"
           icon={<Icon icon={X} className="h-4 w-4" />}
         />
       )}

--- a/src/shared/ui/dialog/DialogTitle.tsx
+++ b/src/shared/ui/dialog/DialogTitle.tsx
@@ -8,7 +8,7 @@ export interface DialogTitleProps {
 }
 
 export const DialogTitle: FunctionComponent<DialogTitleProps> = ({ children, id, className }) => (
-  <h2 id={id} className={cn('m-0 text-lg font-bold leading-tight text-input-text', className)}>
+  <h2 id={id} className={cn('m-0 text-lg font-bold leading-tight text-ink', className)}>
     {children}
   </h2>
 );

--- a/src/shared/ui/dialog/Fullscreen.tsx
+++ b/src/shared/ui/dialog/Fullscreen.tsx
@@ -105,7 +105,7 @@ export const Fullscreen: FunctionComponent<FullscreenProps> = ({
         aria-modal="true"
         aria-label={ariaLabel}
         tabIndex={-1}
-        className="ui-surface-enter relative z-10 flex min-h-full w-full flex-col text-input-text backdrop-blur-3xl shadow-2xl"
+        className="ui-surface-enter relative z-10 flex min-h-full w-full flex-col text-ink backdrop-blur-3xl shadow-2xl"
         style={{
           background: 'linear-gradient(to bottom right, var(--glass-bg-top), var(--glass-bg-mid), var(--glass-bg-bottom))'
         }}
@@ -116,7 +116,7 @@ export const Fullscreen: FunctionComponent<FullscreenProps> = ({
             size="icon-xs"
             onClick={onClose}
             aria-label="Close"
-            className="absolute right-4 top-4 z-10 rounded-full text-input-placeholder hover:bg-surface-hover hover:text-input-text"
+            className="absolute right-4 top-4 z-10 rounded-full text-dim-2 hover:bg-surface-hover hover:text-ink"
             icon={<Icon icon={X} className="h-4 w-4" />}
           />
         )}

--- a/src/shared/ui/dialog/InfoListDialog.tsx
+++ b/src/shared/ui/dialog/InfoListDialog.tsx
@@ -72,7 +72,7 @@ export const InfoListDialog: FunctionComponent<InfoListDialogProps> = ({
         <div className="flex items-start gap-3">
           {HeaderIcon ? (
             <div className="input-surface mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl">
-              <Icon icon={HeaderIcon} className={headerIconClassName ?? 'h-5 w-5 text-input-text'} aria-hidden="true" />
+              <Icon icon={HeaderIcon} className={headerIconClassName ?? 'h-5 w-5 text-ink'} aria-hidden="true" />
             </div>
           ) : null}
           <div className="min-w-0 space-y-1">
@@ -87,13 +87,13 @@ export const InfoListDialog: FunctionComponent<InfoListDialogProps> = ({
           <div key={item.id}>
             <div className="flex items-start gap-3 py-1">
               <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-surface-utility/10">
-                <Icon icon={item.icon} className={item.iconClassName ?? 'h-5 w-5 text-input-text'} aria-hidden="true" />
+                <Icon icon={item.icon} className={item.iconClassName ?? 'h-5 w-5 text-ink'} aria-hidden="true" />
               </div>
               <div className="min-w-0 space-y-1">
-                <div className="text-sm font-semibold text-input-text">
+                <div className="text-sm font-semibold text-ink">
                   {item.title}
                 </div>
-                <div className="text-sm text-input-placeholder">
+                <div className="text-sm text-dim-2">
                   {item.description}
                 </div>
               </div>

--- a/src/shared/ui/dropdown/DropdownMenuCheckboxItem.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuCheckboxItem.tsx
@@ -41,7 +41,7 @@ export const DropdownMenuCheckboxItem = ({
   return (
     <div 
       className={cn(
-        'flex items-center justify-between px-2 py-1.5 text-sm text-input-text',
+        'flex items-center justify-between px-2 py-1.5 text-sm text-ink',
         'hover:bg-surface-utility/10',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent-500/50',
         'dark:focus-visible:ring-accent-400/40',

--- a/src/shared/ui/dropdown/DropdownMenuContent.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuContent.tsx
@@ -113,7 +113,7 @@ export const DropdownMenuContent = ({
       role="menu"
       ref={(node) => setContentRef(node)}
       className={cn(
-        'fixed z-50 min-w-max overflow-hidden rounded-xl border border-white/10 bg-surface-overlay shadow-glass text-input-text',
+        'fixed z-50 min-w-max overflow-hidden rounded-xl border border-white/10 bg-surface-overlay shadow-glass text-ink',
         centerTransform,
         className,
       )}

--- a/src/shared/ui/dropdown/DropdownMenuItem.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuItem.tsx
@@ -33,7 +33,7 @@ export const DropdownMenuItem = ({
       onClick={(e) => { e.stopPropagation(); handleClick(); }}
       disabled={disabled}
       className={cn(
-        'w-full text-left px-2 py-1.5 text-sm text-input-text',
+        'w-full text-left px-2 py-1.5 text-sm text-ink',
         'hover:bg-surface-utility/10 focus:outline-none focus:bg-surface-utility/20',
         disabled && 'opacity-50 cursor-not-allowed',
         className

--- a/src/shared/ui/dropdown/DropdownMenuTrigger.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuTrigger.tsx
@@ -144,7 +144,7 @@ export const DropdownMenuTrigger = ({
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       className={cn(
-        'flex items-center gap-2 px-3 py-1 text-sm text-input-text rounded-xl',
+        'flex items-center gap-2 px-3 py-1 text-sm text-ink rounded-xl',
         'hover:bg-surface-utility/10 focus:outline-none focus:ring-2 focus:ring-accent-500',
         className
       )}

--- a/src/shared/ui/feedback/EmptyState.tsx
+++ b/src/shared/ui/feedback/EmptyState.tsx
@@ -19,13 +19,13 @@ export function EmptyState({
   return (
     <div className={cn('flex flex-col items-center justify-center text-center py-12 px-6', className)}>
       {icon && (
-        <div className="mb-4 text-input-placeholder/60">
+        <div className="mb-4 text-dim-2/60">
           {icon}
         </div>
       )}
-      <h3 className="text-sm font-medium text-input-text mb-1">{title}</h3>
+      <h3 className="text-sm font-medium text-ink mb-1">{title}</h3>
       {description && (
-        <p className="text-sm text-input-placeholder max-w-xs">{description}</p>
+        <p className="text-sm text-dim-2 max-w-xs">{description}</p>
       )}
       {action && <div className="mt-4">{action}</div>}
     </div>

--- a/src/shared/ui/feedback/ErrorState.tsx
+++ b/src/shared/ui/feedback/ErrorState.tsx
@@ -26,9 +26,9 @@ export function ErrorState({
       <div className="mb-4 text-red-400/70">
         {icon ?? <AlertCircle size={40} strokeWidth={1.5} />}
       </div>
-      <h3 className="text-sm font-medium text-input-text mb-1">{title}</h3>
+      <h3 className="text-sm font-medium text-ink mb-1">{title}</h3>
       {description && (
-        <p className="text-sm text-input-placeholder max-w-xs">{description}</p>
+        <p className="text-sm text-dim-2 max-w-xs">{description}</p>
       )}
       <div className="mt-4">
         {action ?? (onRetry && (

--- a/src/shared/ui/form/FormDescription.tsx
+++ b/src/shared/ui/form/FormDescription.tsx
@@ -12,7 +12,7 @@ export const FormDescription = ({
 }: FormDescriptionProps) => {
   return (
     <p className={cn(
-      'text-xs text-input-placeholder mt-1',
+      'text-xs text-dim-2 mt-1',
       className
     )}>
       {children}

--- a/src/shared/ui/form/FormLabel.tsx
+++ b/src/shared/ui/form/FormLabel.tsx
@@ -18,7 +18,7 @@ export const FormLabel = ({
     <label
       htmlFor={htmlFor}
       className={cn(
-        'block text-sm font-medium text-input-text',
+        'block text-sm font-medium text-ink',
         required && 'after:content-["*"] after:ml-1 after:text-red-500',
         className
       )}

--- a/src/shared/ui/input/Checkbox.tsx
+++ b/src/shared/ui/input/Checkbox.tsx
@@ -129,14 +129,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({
       
       <div className="flex-1 min-w-0">
         {displayLabel && (
-          <label htmlFor={checkboxId} className="text-sm font-medium text-input-text">
+          <label htmlFor={checkboxId} className="text-sm font-medium text-ink">
             {displayLabel}
             {required && <span className="text-red-500 ml-1">*</span>}
           </label>
         )}
         
         {displayDescription && !error && (
-          <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+          <p id={descriptionId} className="text-xs text-dim-2 mt-1">
             {displayDescription}
           </p>
         )}

--- a/src/shared/ui/input/Combobox.tsx
+++ b/src/shared/ui/input/Combobox.tsx
@@ -109,7 +109,7 @@ function Chip({
         compact ? 'min-h-8 px-3 py-1 text-sm' : 'px-2 py-0.5',
         isCustom
           ? 'border-accent-500/25 bg-accent-500/12 text-accent-utility'
-          : 'border-line-subtle bg-surface-utility/10 text-input-text'
+          : 'border-line-subtle bg-surface-utility/10 text-ink'
       )}
     >
       <span className="truncate">{label}</span>
@@ -123,7 +123,7 @@ function Chip({
           e.stopPropagation();
           onRemove();
         }}
-        className="ml-0.5 rounded text-input-placeholder transition-colors hover:text-input-text"
+        className="ml-0.5 rounded text-dim-2 transition-colors hover:text-ink"
         aria-label={`Remove ${label}`}
       >
         <Icon icon={X} className={cn(compact ? 'h-4 w-4' : 'h-3 w-3')}  />
@@ -167,14 +167,14 @@ function DropdownOption({
         'group relative flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-all',
         option.disabled && 'cursor-not-allowed opacity-45',
         isSelected || isFocused
-          ? 'bg-accent-500/15 text-input-text'
-          : 'text-input-text hover:bg-surface-utility/10 dark:hover:bg-surface-utility/20',
+          ? 'bg-accent-500/15 text-ink'
+          : 'text-ink hover:bg-surface-utility/10 dark:hover:bg-surface-utility/20',
         option.disabled && 'hover:bg-transparent dark:hover:bg-transparent'
       )}
     >
       <span className="flex min-w-0 items-start gap-2.5">
         {resolvedOptionLeading && (
-          <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center text-input-placeholder group-hover:text-input-text">
+          <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center text-dim-2 group-hover:text-ink">
             {resolvedOptionLeading}
           </span>
         )}
@@ -183,7 +183,7 @@ function DropdownOption({
             {option.label}
           </span>
           {option.description ? (
-            <span className="mt-0.5 block truncate text-xs text-input-placeholder">
+            <span className="mt-0.5 block truncate text-xs text-dim-2">
               {option.description}
             </span>
           ) : null}
@@ -191,7 +191,7 @@ function DropdownOption({
       </span>
       <span className="flex flex-shrink-0 items-center gap-2">
         {resolvedOptionMeta && (
-          <span className="text-xs text-input-placeholder">{resolvedOptionMeta}</span>
+          <span className="text-xs text-dim-2">{resolvedOptionMeta}</span>
         )}
         {isSelected && (
           <Icon icon={Check} className="h-4 w-4 text-accent-400" aria-hidden="true"  />
@@ -496,7 +496,7 @@ export function Combobox({
       {resolvedLeading && (
         <span
           className={cn(
-            'pointer-events-none flex-shrink-0 text-input-placeholder',
+            'pointer-events-none flex-shrink-0 text-dim-2',
             isMultiple ? 'pt-1' : ''
           )}
         >
@@ -522,7 +522,7 @@ export function Combobox({
           <span
             className={cn(
               'block truncate text-sm',
-              !hasValue && 'text-input-placeholder'
+              !hasValue && 'text-dim-2'
             )}
           >
             {hasValue ? displayText : placeholder}
@@ -536,13 +536,13 @@ export function Combobox({
           type="button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={(e) => { e.stopPropagation(); clear(); }}
-          className="flex-shrink-0 text-input-placeholder hover:text-input-text transition-colors"
+          className="flex-shrink-0 text-dim-2 hover:text-ink transition-colors"
           aria-label="Clear selection"
         >
           <Icon icon={X} className="h-4 w-4"  />
         </button>
       ) : (
-        <span className="flex-shrink-0 text-input-placeholder pointer-events-none">
+        <span className="flex-shrink-0 text-dim-2 pointer-events-none">
           {searchable
             ? <Icon icon={ChevronsUpDown} className="h-4 w-4"  />
             : <Icon icon={ChevronDown} className={cn('h-4 w-4 transition-transform', isOpen && 'rotate-180')}  />
@@ -556,7 +556,7 @@ export function Combobox({
     <div ref={containerRef} className={cn('relative w-full', className, disabled && 'opacity-50 pointer-events-none')}>
       {/* Label */}
       {label && (
-        <label htmlFor={inputId} className="mb-1 block text-sm font-medium text-input-text">
+        <label htmlFor={inputId} className="mb-1 block text-sm font-medium text-ink">
           {label}
         </label>
       )}
@@ -620,8 +620,8 @@ export function Combobox({
                 }}
                 onKeyDown={handleKeyDown}
                 className={cn(
-                  'w-full rounded-xl bg-surface-utility/10 px-3 py-1.5 text-sm text-input-text',
-                  'placeholder:text-input-placeholder/60',
+                  'w-full rounded-xl bg-surface-utility/10 px-3 py-1.5 text-sm text-ink',
+                  'placeholder:text-dim-2/60',
                   'focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500/30'
                 )}
                 aria-autocomplete="list"
@@ -647,8 +647,8 @@ export function Combobox({
                 className={cn(
                   'flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors',
                   clampedFocus === 0
-                    ? 'bg-accent-500/15 text-input-text'
-                    : 'text-input-text hover:bg-surface-utility/10 focus:bg-surface-utility/20'
+                    ? 'bg-accent-500/15 text-ink'
+                    : 'text-ink hover:bg-surface-utility/10 focus:bg-surface-utility/20'
                 )}
               >
                 <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-accent-500/20 text-accent-utility">
@@ -685,7 +685,7 @@ export function Combobox({
             })}
 
             {filteredOptions.length === 0 && !showAddRow && !resolvedFooter && (
-              <p className="px-4 py-3 text-center text-sm text-input-placeholder">
+              <p className="px-4 py-3 text-center text-sm text-dim-2">
                 {allowCustomValues
                   ? (trimmedQuery
                     ? 'No matches. Keep typing to add it.'
@@ -700,7 +700,7 @@ export function Combobox({
               {resolvedFooter}
             </div>
           ) : allowCustomValues && filteredOptions.length === 0 && !showAddRow ? (
-            <div className="flex items-center gap-2 border-t border-line-subtle px-3 py-2 text-xs text-input-placeholder">
+            <div className="flex items-center gap-2 border-t border-line-subtle px-3 py-2 text-xs text-dim-2">
               <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded bg-accent-500/20 text-accent-utility">
                 <Icon icon={Plus} className="h-3 w-3" />
               </span>
@@ -712,10 +712,10 @@ export function Combobox({
 
       {/* Description / hint */}
       {description && (
-        <p className="mt-1 pl-1 text-xs text-input-placeholder">{description}</p>
+        <p className="mt-1 pl-1 text-xs text-dim-2">{description}</p>
       )}
       {allowCustomValues && !hideCustomHint && !isOpen && !description && (
-        <p className="mt-1 pl-1 text-xs text-input-placeholder">
+        <p className="mt-1 pl-1 text-xs text-dim-2">
           Select an option or type to add your own.
         </p>
       )}

--- a/src/shared/ui/input/CurrencyInput.tsx
+++ b/src/shared/ui/input/CurrencyInput.tsx
@@ -82,7 +82,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -95,14 +95,14 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(({
   return (
     <div className="w-full">
       {label ? (
-        <label htmlFor={inputId} className="mb-1 block text-sm font-medium text-input-text">
+        <label htmlFor={inputId} className="mb-1 block text-sm font-medium text-ink">
           {label}
           {required ? <span className="ml-1 text-red-500">*</span> : null}
         </label>
       ) : null}
 
       <div className="relative">
-        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-input-placeholder">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-dim-2">
           <span className="text-sm">$</span>
         </div>
 
@@ -210,7 +210,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(({
       ) : null}
 
       {description ? (
-        <p id={descriptionId} className="mt-1 text-xs text-input-placeholder">
+        <p id={descriptionId} className="mt-1 text-xs text-dim-2">
           {description}
         </p>
       ) : null}

--- a/src/shared/ui/input/DatePicker.tsx
+++ b/src/shared/ui/input/DatePicker.tsx
@@ -113,7 +113,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
   };
 
   const inputClasses = cn(
-    'w-full min-h-[44px] rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full min-h-[44px] rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'appearance-none input-surface border-none',
     sizeClasses[size],
@@ -125,7 +125,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
   return (
     <div className="w-full">
       {displayLabel && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {displayLabel}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -169,7 +169,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
       )}
       
       {displayDescription && !_displayError && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -103,7 +103,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -131,7 +131,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
   return (
     <div className="w-full">
       {displayLabel && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {displayLabel}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -139,7 +139,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
       
       <div className="relative">
         <div className="absolute inset-y-0 left-0 z-10 flex items-center pl-3 pointer-events-none">
-          <Icon icon={Mail} className="w-4 h-4 text-input-placeholder"  />
+          <Icon icon={Mail} className="w-4 h-4 text-dim-2"  />
         </div>
         
         <input
@@ -188,7 +188,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
       )}
       
       {displayDescription && !displayError && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/input/FileInput.tsx
+++ b/src/shared/ui/input/FileInput.tsx
@@ -147,7 +147,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
   return (
     <div className="w-full">
       {displayLabel && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {displayLabel}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -186,7 +186,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
         
         <div className="p-6 text-center">
           <svg
-            className="mx-auto h-12 w-12 text-input-placeholder"
+            className="mx-auto h-12 w-12 text-dim-2"
             stroke="currentColor"
             fill="none"
             viewBox="0 0 48 48"
@@ -200,14 +200,14 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
           </svg>
           
           <div className="mt-4">
-            <p className="text-sm text-input-placeholder">
+            <p className="text-sm text-dim-2">
               <span className="font-medium text-accent-600 dark:text-accent-400">
                 Click to upload
               </span>
               {' '}or drag and drop
             </p>
             {accept && showAcceptText && (
-              <p className="text-xs text-input-placeholder mt-1">
+              <p className="text-xs text-dim-2 mt-1">
                 {accept}
               </p>
             )}
@@ -220,10 +220,10 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
           {files.map((file, index) => (
             <div key={index} className="input-surface flex items-center justify-between p-2 rounded">
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-input-text truncate">
+                <p className="text-sm font-medium text-ink truncate">
                   {file.name}
                 </p>
-                <p className="text-xs text-input-placeholder">
+                <p className="text-xs text-dim-2">
                   {formatFileSize(file.size)}
                 </p>
               </div>
@@ -253,7 +253,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
       )}
       
       {displayDescription && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/input/LogoUploadInput.tsx
+++ b/src/shared/ui/input/LogoUploadInput.tsx
@@ -80,13 +80,13 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
   return (
     <div className={cn('w-full', className)}>
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink">
           {label}
           {required && <span className="ml-1 text-red-500">*</span>}
         </label>
       )}
       {description && (
-        <p className="mt-1 text-xs text-input-placeholder">
+        <p className="mt-1 text-xs text-dim-2">
           {description}
         </p>
       )}
@@ -138,7 +138,7 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-surface-utility/10">
-            <Icon icon={User} className="h-1/2 w-1/2 text-input-placeholder"  />
+            <Icon icon={User} className="h-1/2 w-1/2 text-dim-2"  />
           </div>
         )}
         </div>

--- a/src/shared/ui/input/MarkdownUploadTextarea.tsx
+++ b/src/shared/ui/input/MarkdownUploadTextarea.tsx
@@ -269,7 +269,7 @@ export const MarkdownUploadTextarea = ({
   return (
     <div className={cn('@container space-y-2', className)}>
       {showLabel ? (
-        <label htmlFor={editorId} className="block text-sm font-medium text-input-text">
+        <label htmlFor={editorId} className="block text-sm font-medium text-ink">
           {label}
         </label>
       ) : null}
@@ -283,8 +283,8 @@ export const MarkdownUploadTextarea = ({
                 className={cn(
                   'rounded-xl px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'write'
-                    ? 'bg-surface-workspace/90 text-input-text shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
-                    : 'text-input-placeholder hover:text-input-text'
+                    ? 'bg-surface-workspace/90 text-ink shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
+                    : 'text-dim-2 hover:text-ink'
                 )}
                 onClick={() => setActiveTab('write')}
               >
@@ -295,8 +295,8 @@ export const MarkdownUploadTextarea = ({
                 className={cn(
                   'rounded-xl px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'preview'
-                    ? 'bg-surface-workspace/90 text-input-text shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
-                    : 'text-input-placeholder hover:text-input-text'
+                    ? 'bg-surface-workspace/90 text-ink shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
+                    : 'text-dim-2 hover:text-ink'
                 )}
                 onClick={() => setActiveTab('preview')}
               >
@@ -308,7 +308,7 @@ export const MarkdownUploadTextarea = ({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-line-subtle bg-surface-overlay/40 text-input-placeholder transition-colors hover:text-input-text"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-line-subtle bg-surface-overlay/40 text-dim-2 transition-colors hover:text-ink"
                     aria-label="Formatting options"
                   >
                     <Icon icon={MoreVertical} className="h-4 w-4" aria-hidden="true" />
@@ -381,39 +381,39 @@ export const MarkdownUploadTextarea = ({
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-            <div className="hidden items-center gap-2 text-input-placeholder @xl:flex @xl:flex-wrap">
+            <div className="hidden items-center gap-2 text-dim-2 @xl:flex @xl:flex-wrap">
               <div className="flex items-center gap-1">
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Insert heading" onClick={() => prependToLine('# ', 'Heading')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Insert heading" onClick={() => prependToLine('# ', 'Heading')}>
                   <span className="text-xs font-semibold leading-none">H</span>
                 </button>
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Bold" onClick={() => replaceSelection('**', '**', 'bold text')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Bold" onClick={() => replaceSelection('**', '**', 'bold text')}>
                   <span className="text-xs font-semibold leading-none">B</span>
                 </button>
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Italic" onClick={() => replaceSelection('*', '*', 'italic text')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Italic" onClick={() => replaceSelection('*', '*', 'italic text')}>
                   <span className="text-xs italic leading-none">I</span>
                 </button>
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Quote" onClick={() => prependToLine('> ', 'Quoted text')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Quote" onClick={() => prependToLine('> ', 'Quoted text')}>
                   <Icon icon={PanelLeft} className="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
               <div className="h-4 w-px bg-line-glass/50" />
               <div className="flex items-center gap-1">
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Code block" onClick={() => replaceSelection('```\n', '\n```', 'code')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Code block" onClick={() => replaceSelection('```\n', '\n```', 'code')}>
                   <Icon icon={Code} className="h-4 w-4" aria-hidden="true" />
                 </button>
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Insert link" onClick={() => replaceSelection('[', '](https://)', 'link text')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Insert link" onClick={() => replaceSelection('[', '](https://)', 'link text')}>
                   <Icon icon={Link} className="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
               <div className="h-4 w-px bg-line-glass/50" />
               <div className="flex items-center gap-1">
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Bulleted list" onClick={() => prependToLine('- ', 'List item')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Bulleted list" onClick={() => prependToLine('- ', 'List item')}>
                   <Icon icon={List} className="h-4 w-4" aria-hidden="true" />
                 </button>
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Numbered list" onClick={() => prependToLine('1. ', 'List item')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Numbered list" onClick={() => prependToLine('1. ', 'List item')}>
                   <Icon icon={ListOrdered} className="h-4 w-4" aria-hidden="true" />
                 </button>
-                <button type="button" className="rounded p-1 transition-colors hover:text-input-text" aria-label="Task list" onClick={() => prependToLine('- [ ] ', 'Task')}>
+                <button type="button" className="rounded p-1 transition-colors hover:text-ink" aria-label="Task list" onClick={() => prependToLine('- [ ] ', 'Task')}>
                   <Icon icon={FileText} className="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
@@ -437,7 +437,7 @@ export const MarkdownUploadTextarea = ({
               maxLength={maxLength}
               placeholder={placeholder}
               className={cn(
-                'w-full resize-y bg-transparent px-4 py-3 text-sm text-input-text placeholder:text-input-placeholder focus:outline-none',
+                'w-full resize-y bg-transparent px-4 py-3 text-sm text-ink placeholder:text-dim-2 focus:outline-none',
                 disabled ? 'cursor-not-allowed opacity-60' : ''
               )}
               onInput={(event) => onChange((event.currentTarget as HTMLTextAreaElement).value)}
@@ -468,7 +468,7 @@ export const MarkdownUploadTextarea = ({
               }}
             />
             {isDragActive && (
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-surface-overlay/70 text-sm font-medium text-input-text">
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-surface-overlay/70 text-sm font-medium text-ink">
                 Drop files to upload and insert links
               </div>
             )}
@@ -499,20 +499,20 @@ export const MarkdownUploadTextarea = ({
                 )}
               </div>
             ) : (
-              <p className="text-sm text-input-placeholder">Nothing to preview yet.</p>
+              <p className="text-sm text-dim-2">Nothing to preview yet.</p>
             )}
           </div>
         )}
 
         {showFooter ? (
           <div className="flex flex-col gap-2 border-t border-line-subtle px-4 py-2 text-sm @xl:flex-row @xl:items-center @xl:justify-between">
-            <div className="flex items-center gap-2 text-input-placeholder">
+            <div className="flex items-center gap-2 text-dim-2">
               {uploadsEnabled ? (
                 <>
                   <Icon icon={CloudUpload} className="h-4 w-4" aria-hidden="true"  />
                   <button
                     type="button"
-                    className="hover:text-input-text"
+                    className="hover:text-ink"
                     onClick={() => fileInputRef.current?.click()}
                     disabled={disabled}
                   >
@@ -521,7 +521,7 @@ export const MarkdownUploadTextarea = ({
                 </>
               ) : null}
             </div>
-            <div className="text-input-placeholder @xl:text-right">{value.length}/{maxLength}</div>
+            <div className="text-dim-2 @xl:text-right">{value.length}/{maxLength}</div>
           </div>
         ) : null}
       </div>
@@ -545,7 +545,7 @@ export const MarkdownUploadTextarea = ({
       {uploadItems.length > 0 && (
         <div className="space-y-1 rounded-xl border border-line-subtle bg-surface-overlay/50 px-3 py-2">
           {uploadItems.map((item) => (
-            <div key={item.id} className="flex items-center gap-2 text-xs text-input-placeholder">
+            <div key={item.id} className="flex items-center gap-2 text-xs text-dim-2">
               <Icon icon={FileText} className="h-4 w-4" aria-hidden="true"  />
               <span className="truncate">{item.name}</span>
               {item.status === 'uploading' && <span>{item.progress}%</span>}

--- a/src/shared/ui/input/NumberInput.tsx
+++ b/src/shared/ui/input/NumberInput.tsx
@@ -90,7 +90,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -154,7 +154,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
   return (
     <div className="w-full">
       {displayLabel && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {displayLabel}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -220,7 +220,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
       )}
       
       {displayDescription && !displayError && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -93,7 +93,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -151,7 +151,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
   return (
     <div className="w-full">
       {displayLabel && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {displayLabel}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -183,7 +183,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
           disabled={disabled}
           aria-label={showPassword ? "Hide password" : "Show password"}
           aria-pressed={showPassword}
-          className="absolute inset-y-0 right-0 flex items-center pr-3 text-input-placeholder hover:text-[rgb(var(--accent-foreground))] focus:ring-2 ring-inset focus:ring-accent-500 focus:ring-offset-1 focus-visible:ring-2 ring-inset focus-visible:ring-accent-500 focus-visible:ring-offset-1"
+          className="absolute inset-y-0 right-0 flex items-center pr-3 text-dim-2 hover:text-[rgb(var(--accent-foreground))] focus:ring-2 ring-inset focus:ring-accent-500 focus:ring-offset-1 focus-visible:ring-2 ring-inset focus-visible:ring-accent-500 focus-visible:ring-offset-1"
         >
           {showPassword ? (
             <Icon icon={EyeOff} className="w-4 h-4"  />
@@ -194,7 +194,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
       </div>
       
       {showStrength && value && (
-        <div className="mt-2 flex items-center justify-between text-xs text-input-placeholder">
+        <div className="mt-2 flex items-center justify-between text-xs text-dim-2">
           <span>Password strength:</span>
           <span className={cn('px-2 py-0.5 rounded-full font-medium', strengthVariantClasses[strengthVariant])}>
             {strengthText}
@@ -209,7 +209,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
       )}
       
       {displayDescription && !displayError && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -372,7 +372,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   const isInvalid = Boolean(error) || showInvalidValidation;
 
   const inputClasses = cn(
-    'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -394,7 +394,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   return (
     <div className="w-full">
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {label}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -417,7 +417,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
               aria-haspopup="listbox"
               aria-label={`Select country. Current: ${currentCountry.name} (+${currentCountry.callingCode})`}
               className={cn(
-                'inline-flex items-center rounded-l-xl rounded-r-none text-input-text hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500 transition-colors input-surface border-r border-line-subtle',
+                'inline-flex items-center rounded-l-xl rounded-r-none text-ink hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500 transition-colors input-surface border-r border-line-subtle',
                 sizeClasses[size],
                 disabled && 'opacity-50 cursor-not-allowed',
               )}
@@ -434,7 +434,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
               >
                 <div className="p-2 border-b border-line-subtle">
                   <div className="relative">
-                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-input-placeholder" aria-hidden="true" />
+                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-dim-2" aria-hidden="true" />
                     <input
                       ref={searchInputRef}
                       type="text"
@@ -463,7 +463,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
                   className="max-h-64 overflow-y-auto py-1 text-sm"
                 >
                   {filteredCountries.length === 0 ? (
-                    <div className="px-3 py-2 text-sm text-input-placeholder">No matches</div>
+                    <div className="px-3 py-2 text-sm text-dim-2">No matches</div>
                   ) : (
                     filteredCountries.map((country, index) => (
                       <button
@@ -475,7 +475,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
                         onClick={() => selectCountry(country)}
                         onMouseEnter={() => setFocusedIndex(index)}
                         className={cn(
-                          'inline-flex w-full px-3 py-2 text-sm text-input-text hover:bg-surface-utility/40 focus:outline-none',
+                          'inline-flex w-full px-3 py-2 text-sm text-ink hover:bg-surface-utility/40 focus:outline-none',
                           index === focusedIndex && 'bg-surface-utility/60',
                           country.iso === selectedIso && 'font-medium',
                         )}
@@ -484,7 +484,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
                         <span className="inline-flex items-center gap-2 w-full">
                           <span className="text-base" aria-hidden="true">{country.emoji}</span>
                           <span className="flex-1 text-left truncate">{country.name}</span>
-                          <span className="text-input-placeholder">+{country.callingCode}</span>
+                          <span className="text-dim-2">+{country.callingCode}</span>
                         </span>
                       </button>
                     ))
@@ -498,7 +498,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
         <div className="relative flex-1">
           {!showCountryCode ? (
             <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-              <Phone className="w-4 h-4 text-input-placeholder shrink-0" aria-hidden="true" />
+              <Phone className="w-4 h-4 text-dim-2 shrink-0" aria-hidden="true" />
             </div>
           ) : null}
 
@@ -557,7 +557,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
       )}
 
       {description && !error && !showInvalidValidation && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {description}
         </p>
       )}

--- a/src/shared/ui/input/RadioGroup.tsx
+++ b/src/shared/ui/input/RadioGroup.tsx
@@ -84,7 +84,7 @@ export const RadioGroup = ({
   return (
     <div className={cn('space-y-2', className)}>
       {displayLabel && (
-        <label className="block text-sm font-medium text-input-text">
+        <label className="block text-sm font-medium text-ink">
           {displayLabel}
           {required && <span className="text-red-500 ml-1">*</span>}
         </label>
@@ -122,7 +122,7 @@ export const RadioGroup = ({
               <label
                 htmlFor={`${instanceId}-${option.value}`}
                 className={cn(
-                  'text-sm font-medium text-input-text',
+                  'text-sm font-medium text-ink',
                   (disabled || option.disabled) && 'opacity-50 cursor-not-allowed'
                 )}
               >
@@ -130,7 +130,7 @@ export const RadioGroup = ({
               </label>
               
               {option.description && (
-                <p className="text-xs text-input-placeholder mt-1">
+                <p className="text-xs text-dim-2 mt-1">
                   {option.description}
                 </p>
               )}
@@ -140,7 +140,7 @@ export const RadioGroup = ({
       </div>
       
       {displayDescription && !displayError && (
-        <p className="text-xs text-input-placeholder mt-1">
+        <p className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/input/RadioGroupWithDescriptions.tsx
+++ b/src/shared/ui/input/RadioGroupWithDescriptions.tsx
@@ -20,7 +20,7 @@ export const RadioGroupWithDescriptions = ({
   className
 }: RadioGroupWithDescriptionsProps) => (
   <fieldset className={className}>
-    <legend className="mb-1 block text-sm font-medium text-input-text">{label}</legend>
+    <legend className="mb-1 block text-sm font-medium text-ink">{label}</legend>
     <div className="card overflow-hidden rounded-2xl">
       {options.map((option, index) => {
         const isSelected = value === option.value;
@@ -36,8 +36,8 @@ export const RadioGroupWithDescriptions = ({
               !isFirst && 'border-t border-line-subtle',
               'focus-within:outline-none focus-within:ring-2 ring-inset focus-within:ring-accent-500/50 focus-within:ring-inset',
               isSelected
-                ? 'bg-surface-panel/40 ring-1 ring-inset ring-accent-500/45 text-input-text'
-                : 'text-input-text hover:bg-surface-panel/10'
+                ? 'bg-surface-panel/40 ring-1 ring-inset ring-accent-500/45 text-ink'
+                : 'text-ink hover:bg-surface-panel/10'
             )}
           >
             <input
@@ -61,11 +61,11 @@ export const RadioGroupWithDescriptions = ({
               {isSelected && <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />}
             </span>
             <span className="flex flex-col">
-              <span className="block text-sm font-medium text-input-text">
+              <span className="block text-sm font-medium text-ink">
                 {option.label}
               </span>
               {option.description && (
-                <span className="block text-xs text-input-placeholder">
+                <span className="block text-xs text-dim-2">
                   {option.description}
                 </span>
               )}

--- a/src/shared/ui/input/Slider.tsx
+++ b/src/shared/ui/input/Slider.tsx
@@ -78,9 +78,9 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(function Slider(
     <div className={cn('flex flex-col gap-1.5', className)}>
       {(label || showValue) && (
         <div className="flex items-center justify-between">
-          {label && <span className="text-xs text-input-placeholder">{label}</span>}
+          {label && <span className="text-xs text-dim-2">{label}</span>}
           {showValue && (
-            <span className="text-xs font-medium text-input-text tabular-nums">
+            <span className="text-xs font-medium text-ink tabular-nums">
               {currentValue}
             </span>
           )}

--- a/src/shared/ui/input/URLInput.tsx
+++ b/src/shared/ui/input/URLInput.tsx
@@ -121,7 +121,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-input-text placeholder:text-input-placeholder',
+    'w-full rounded-xl text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -250,7 +250,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
   return (
     <div className="w-full">
       {displayLabel && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-input-text mb-1">
+        <label htmlFor={inputId} className="block text-sm font-medium text-ink mb-1">
           {displayLabel}
           {required && <span className="text-accent-error ml-1">*</span>}
         </label>
@@ -258,7 +258,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
       
       <div className="relative">
         <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-          <Icon icon={Link} className="w-4 h-4 text-input-placeholder"  />
+          <Icon icon={Link} className="w-4 h-4 text-dim-2"  />
         </div>
         
         <input
@@ -299,7 +299,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
         
         return (
           <div className="mt-2 p-2 bg-[rgb(var(--surface-panel))] dark:bg-[rgb(var(--surface-panel))]/80 rounded border">
-            <p className="text-xs text-input-placeholder mb-1">Preview:</p>
+            <p className="text-xs text-dim-2 mb-1">Preview:</p>
             {isSafeProtocol ? (
               <a
                 href={value}
@@ -310,7 +310,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
                 {value}
               </a>
             ) : (
-              <span className="text-sm text-input-placeholder">
+              <span className="text-sm text-dim-2">
                 {value}
               </span>
             )}
@@ -331,7 +331,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
       )}
       
       {displayDescription && !displayError && (
-        <p id={descriptionId} className="text-xs text-input-placeholder mt-1">
+        <p id={descriptionId} className="text-xs text-dim-2 mt-1">
           {displayDescription}
         </p>
       )}

--- a/src/shared/ui/inspector/InspectorPrimitives.tsx
+++ b/src/shared/ui/inspector/InspectorPrimitives.tsx
@@ -58,7 +58,7 @@ export const InspectorGroup = ({
     <div className="mb-1.5">
       {label ? (
         <div className="flex items-center justify-between px-5 pb-0.5 pt-2">
-          <p className="text-[11px] font-bold uppercase tracking-wider text-input-placeholder/90">
+          <p className="text-[11px] font-bold uppercase tracking-wider text-dim-2/90">
             {label}
           </p>
           {onToggle ? (
@@ -68,7 +68,7 @@ export const InspectorGroup = ({
               disabled={disabled}
               aria-expanded={isOpen}
               aria-label="Toggle group options"
-              className={`flex h-7 w-7 items-center justify-center rounded-md text-input-placeholder transition hover:bg-surface-app-frame/60 dark:hover:bg-surface-panel/40 hover:text-input-text disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-surface-app-frame/60 dark:bg-surface-panel/40 text-input-text' : ''}`}
+              className={`flex h-7 w-7 items-center justify-center rounded-md text-dim-2 transition hover:bg-surface-app-frame/60 dark:hover:bg-surface-panel/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-surface-app-frame/60 dark:bg-surface-panel/40 text-ink' : ''}`}
             >
               <Settings className="h-4 w-4" />
             </button>
@@ -111,15 +111,15 @@ export const InspectorEditableRow = ({
       <div className="flex items-start justify-between gap-1.5 group">
         <div className="min-w-0 flex-1">
           {label ? (
-            <p className="text-[11px] font-bold uppercase tracking-wider text-input-placeholder/90 group-hover:text-input-text transition-colors cursor-default">{label}</p>
+            <p className="text-[11px] font-bold uppercase tracking-wider text-dim-2/90 group-hover:text-ink transition-colors cursor-default">{label}</p>
           ) : null}
           {!isOpen && (
             summaryIsString ? (
-              <p className={`mt-0.5 truncate text-[14px] ${summaryMuted ? 'text-input-placeholder/60' : 'text-input-text'} cursor-default`}>
+              <p className={`mt-0.5 truncate text-[14px] ${summaryMuted ? 'text-dim-2/60' : 'text-ink'} cursor-default`}>
                 {resolvedSummary}
               </p>
             ) : (
-              <div className={`mt-0.5 min-w-0 cursor-default text-[14px] ${summaryMuted ? 'text-input-placeholder/60' : 'text-input-text'}`}>
+              <div className={`mt-0.5 min-w-0 cursor-default text-[14px] ${summaryMuted ? 'text-dim-2/60' : 'text-ink'}`}>
                 {resolvedSummary}
               </div>
             )
@@ -131,7 +131,7 @@ export const InspectorEditableRow = ({
             onClick={onToggle}
             disabled={disabled}
             aria-expanded={isOpen}
-            className={`flex-shrink-0 ${label ? '-mt-1' : 'mt-0.5'} inline-flex h-7 w-7 items-center justify-center rounded-md text-input-placeholder transition hover:bg-surface-app-frame/60 dark:hover:bg-surface-panel/40 hover:text-input-text disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-surface-app-frame/60 dark:bg-surface-panel/40 text-input-text' : ''}`}
+            className={`flex-shrink-0 ${label ? '-mt-1' : 'mt-0.5'} inline-flex h-7 w-7 items-center justify-center rounded-md text-dim-2 transition hover:bg-surface-app-frame/60 dark:hover:bg-surface-panel/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-surface-app-frame/60 dark:bg-surface-panel/40 text-ink' : ''}`}
             aria-label={`${isOpen ? 'Close' : 'Open'} ${label} controls`}
           >
             <Settings className="h-4 w-4" />
@@ -167,9 +167,9 @@ export const InspectorHeaderPerson = ({
         className="h-14 w-14"
         bgClassName="bg-surface-app-frame/60 dark:bg-white/[0.08]"
       />
-      <p className="mt-3 text-[15px] font-semibold text-input-text">{name}</p>
+      <p className="mt-3 text-[15px] font-semibold text-ink">{name}</p>
       {secondaryLine ? (
-        <p className="mt-0.5 text-[12px] text-input-placeholder">{secondaryLine}</p>
+        <p className="mt-0.5 text-[12px] text-dim-2">{secondaryLine}</p>
       ) : null}
     </div>
   );
@@ -300,12 +300,12 @@ export const InspectorHeaderEntity = ({
 }: InspectorHeaderEntityProps) => {
   return (
     <div className="flex flex-col gap-1.5 px-5 pb-4 pt-5">
-      <p className="text-[10px] font-medium uppercase tracking-widest text-input-placeholder/90">{chip}</p>
+      <p className="text-[10px] font-medium uppercase tracking-widest text-dim-2/90">{chip}</p>
       <div className="flex items-start justify-between gap-2">
-        <p className="min-w-0 flex-1 text-[15px] font-semibold leading-snug text-input-text">{title}</p>
+        <p className="min-w-0 flex-1 text-[15px] font-semibold leading-snug text-ink">{title}</p>
         <div className="mt-0.5 shrink-0">{statusBadge}</div>
       </div>
-      {subtitle ? <p className="text-[12px] text-input-placeholder">{subtitle}</p> : null}
+      {subtitle ? <p className="text-[12px] text-dim-2">{subtitle}</p> : null}
     </div>
   );
 };

--- a/src/shared/ui/inspector/SetupInspectorContent.tsx
+++ b/src/shared/ui/inspector/SetupInspectorContent.tsx
@@ -187,7 +187,7 @@ export function SetupInspectorContent({
               <div className="flex justify-end">
                 <button
                   type="button"
-                  className="rounded-md bg-surface-panel/40 px-3 py-1.5 text-xs font-semibold text-input-text transition hover:bg-surface-panel/60 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-surface-panel/40 px-3 py-1.5 text-xs font-semibold text-ink transition hover:bg-surface-panel/60 disabled:cursor-not-allowed disabled:opacity-50"
                   disabled={isReadOnly}
                   onClick={() => { void commitDraft('address', '', true); }}
                 >

--- a/src/shared/ui/layout/ContentHeader.tsx
+++ b/src/shared/ui/layout/ContentHeader.tsx
@@ -23,7 +23,7 @@ export const ContentHeader = ({
     <div className={cn('px-6 py-4', className)}>
       <div className="flex items-center gap-3">
         {leading ? <div className="flex items-center">{leading}</div> : null}
-        <HeadingTag className="flex-1 text-lg font-semibold text-input-text">
+        <HeadingTag className="flex-1 text-lg font-semibold text-ink">
           {title}
         </HeadingTag>
         {trailing ? <div className="flex items-center">{trailing}</div> : null}

--- a/src/shared/ui/layout/DetailHeader.tsx
+++ b/src/shared/ui/layout/DetailHeader.tsx
@@ -94,7 +94,7 @@ export const DetailHeader = ({
   return (
     <div className={cn('flex flex-col border-b border-line-subtle bg-transparent', className)}>
       {headerRow}
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 px-4 pb-2 text-xs text-input-placeholder">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 px-4 pb-2 text-xs text-dim-2">
         {secondaryRow}
       </div>
     </div>

--- a/src/shared/ui/layout/IconContainer.tsx
+++ b/src/shared/ui/layout/IconContainer.tsx
@@ -20,7 +20,7 @@ export const IconContainer = ({
 
   return (
     <div className={cn(
-      'text-input-placeholder flex-shrink-0 flex items-start justify-center pt-2',
+      'text-dim-2 flex-shrink-0 flex items-start justify-center pt-2',
       sizeClasses[size],
       className
     )}>

--- a/src/shared/ui/layout/LazyRouteBoundary.tsx
+++ b/src/shared/ui/layout/LazyRouteBoundary.tsx
@@ -5,9 +5,9 @@ import { Button } from '@/shared/ui/Button';
 import { RouteFallback } from './RouteFallback';
 
 export const ChunkLoadFallback = () => (
-  <div className="m-6 rounded-xl border border-accent-error/30 bg-accent-error/5 p-6 text-sm text-input-text">
+  <div className="m-6 rounded-xl border border-accent-error/30 bg-accent-error/5 p-6 text-sm text-ink">
     <p className="font-semibold">This page failed to load.</p>
-    <p className="mt-1 text-input-placeholder">
+    <p className="mt-1 text-dim-2">
       A code chunk could not be downloaded. Reload to try again.
     </p>
     <Button

--- a/src/shared/ui/layout/LoadingBlock.tsx
+++ b/src/shared/ui/layout/LoadingBlock.tsx
@@ -48,7 +48,7 @@ export const LoadingBlock = ({
       <div className="flex flex-col items-center gap-2">
         {showSpinner ? <LoadingSpinner size={size} ariaLabel={resolvedLabel} announce={false} /> : null}
         {!showLabel ? <span className="sr-only">{resolvedLabel}</span> : null}
-        {showLabel ? <span className="text-sm text-input-placeholder">{resolvedLabel}</span> : null}
+        {showLabel ? <span className="text-sm text-dim-2">{resolvedLabel}</span> : null}
       </div>
     </div>
   );

--- a/src/shared/ui/layout/LoadingScreen.tsx
+++ b/src/shared/ui/layout/LoadingScreen.tsx
@@ -50,7 +50,7 @@ export const LoadingScreen = ({
       <div className="flex flex-col items-center gap-2">
         {showSpinner ? <LoadingSpinner size={size} ariaLabel={resolvedLabel} announce={false} /> : null}
         {!showLabel ? <span className="sr-only">{resolvedLabel}</span> : null}
-        {showLabel ? <span className="text-sm text-input-placeholder">{resolvedLabel}</span> : null}
+        {showLabel ? <span className="text-sm text-dim-2">{resolvedLabel}</span> : null}
       </div>
     </div>
   );

--- a/src/shared/ui/layout/PanelEmptyState.tsx
+++ b/src/shared/ui/layout/PanelEmptyState.tsx
@@ -16,7 +16,7 @@ export const PanelEmptyState = ({
   className
 }: PanelEmptyStateProps) => (
   <div className={cn('px-6 py-8 text-center sm:text-left', className)}>
-    <p className="text-sm text-input-placeholder">
+    <p className="text-sm text-dim-2">
       {message}
     </p>
     {children && <div className="mt-3">{children}</div>}

--- a/src/shared/ui/layout/PanelSectionHeader.tsx
+++ b/src/shared/ui/layout/PanelSectionHeader.tsx
@@ -21,9 +21,9 @@ export const PanelSectionHeader = ({
 }: PanelSectionHeaderProps) => (
   <header className={cn('flex flex-wrap items-center justify-between gap-3 border-b border-line-subtle px-6 py-4', className)}>
     <div>
-      <h3 className="text-sm font-semibold text-input-text">{title}</h3>
+      <h3 className="text-sm font-semibold text-ink">{title}</h3>
       {(subtitle !== undefined) && (
-        <p className="text-xs text-input-placeholder">
+        <p className="text-xs text-dim-2">
           {subtitle} {subtitleSuffix}
         </p>
       )}

--- a/src/shared/ui/layout/WorkspaceListHeader.tsx
+++ b/src/shared/ui/layout/WorkspaceListHeader.tsx
@@ -53,7 +53,7 @@ export const WorkspaceListHeader = ({
       </Button>
       ) : null}
       {title ? (
-        <div className={cn('workspace-header__identity', centerTitle && 'absolute left-1/2 -translate-x-1/2 text-center', 'text-input-text')}>
+        <div className={cn('workspace-header__identity', centerTitle && 'absolute left-1/2 -translate-x-1/2 text-center', 'text-ink')}>
           {title}
         </div>
       ) : null}

--- a/src/shared/ui/layout/WorkspacePlaceholderState.tsx
+++ b/src/shared/ui/layout/WorkspacePlaceholderState.tsx
@@ -49,12 +49,12 @@ export const WorkspacePlaceholderState = ({
     <div className="panel w-full max-w-lg rounded-[28px] border border-line-subtle px-8 py-8 text-center shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl">
       {icon ? (
         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
-          <Icon icon={icon} className="h-6 w-6 text-input-placeholder" aria-hidden="true" />
+          <Icon icon={icon} className="h-6 w-6 text-dim-2" aria-hidden="true" />
         </div>
       ) : null}
-      <h3 className="mt-4 text-sm font-semibold text-input-text">{title}</h3>
-      <p className="mt-2 text-sm text-input-placeholder">{description}</p>
-      {caption ? <p className="mt-2 text-xs text-input-placeholder">{caption}</p> : null}
+      <h3 className="mt-4 text-sm font-semibold text-ink">{title}</h3>
+      <p className="mt-2 text-sm text-dim-2">{description}</p>
+      {caption ? <p className="mt-2 text-xs text-dim-2">{caption}</p> : null}
       {primaryAction || secondaryAction ? (
         <div className="mt-4 flex flex-wrap justify-center gap-2">
           {primaryAction ? renderActionButton(primaryAction) : null}

--- a/src/shared/ui/list/EntityList.tsx
+++ b/src/shared/ui/list/EntityList.tsx
@@ -78,7 +78,7 @@ export function EntityList<T extends { id: string }>({
   if (items.length === 0) {
     return (
       <div className={cn('p-4', className)}>
-        {emptyState ?? <div className="text-sm text-input-placeholder">No items found.</div>}
+        {emptyState ?? <div className="text-sm text-dim-2">No items found.</div>}
       </div>
     );
   }
@@ -110,7 +110,7 @@ export function EntityList<T extends { id: string }>({
       </VList>
       {isLoadingMore ? (
         <div className="flex flex-shrink-0 justify-center px-4 py-3">
-          <LoadingSpinner size="sm" ariaLabel="Loading more items" className="text-input-placeholder" />
+          <LoadingSpinner size="sm" ariaLabel="Loading more items" className="text-dim-2" />
         </div>
       ) : null}
       {loadMoreRef ? <div ref={loadMoreRef} className="h-6 flex-shrink-0" /> : null}

--- a/src/shared/ui/list/List.tsx
+++ b/src/shared/ui/list/List.tsx
@@ -35,11 +35,11 @@ export function ListItem({
         className,
       )}
     >
-      {icon && <span className="shrink-0 text-input-placeholder">{icon}</span>}
+      {icon && <span className="shrink-0 text-dim-2">{icon}</span>}
       <div className="flex-1 min-w-0">
-        <p className="text-sm text-input-text truncate">{title}</p>
+        <p className="text-sm text-ink truncate">{title}</p>
         {description && (
-          <p className="text-xs text-input-placeholder truncate">{description}</p>
+          <p className="text-xs text-dim-2 truncate">{description}</p>
         )}
       </div>
       {trailing && <span className="shrink-0">{trailing}</span>}

--- a/src/shared/ui/markdown/markdownComponents.tsx
+++ b/src/shared/ui/markdown/markdownComponents.tsx
@@ -59,7 +59,7 @@ const CopyButton = ({ text }: { text: string }) => {
     <button
       type="button"
       onClick={handleCopy}
-      className="absolute top-2 right-2 inline-flex items-center gap-1 rounded-md border border-[rgb(var(--surface-utility))]/10 bg-[rgb(var(--surface-app-frame))]/60 px-2 py-1 text-[11px] font-medium text-input-text opacity-0 transition focus-visible:opacity-100 group-hover:opacity-100"
+      className="absolute top-2 right-2 inline-flex items-center gap-1 rounded-md border border-[rgb(var(--surface-utility))]/10 bg-[rgb(var(--surface-app-frame))]/60 px-2 py-1 text-[11px] font-medium text-ink opacity-0 transition focus-visible:opacity-100 group-hover:opacity-100"
       aria-label="Copy code snippet"
     >
       {copied ? (

--- a/src/shared/ui/media/Image.tsx
+++ b/src/shared/ui/media/Image.tsx
@@ -59,7 +59,7 @@ export function Image({
         <div className="absolute inset-0 animate-pulse bg-surface-utility/10" />
       )}
       {status === 'error' ? (
-        <div className="absolute inset-0 flex items-center justify-center text-input-placeholder/50">
+        <div className="absolute inset-0 flex items-center justify-center text-dim-2/50">
           {fallback ?? <ImageOff size={24} />}
         </div>
       ) : (

--- a/src/shared/ui/navigation/Breadcrumbs.tsx
+++ b/src/shared/ui/navigation/Breadcrumbs.tsx
@@ -21,7 +21,7 @@ export const Breadcrumbs = ({
 }: BreadcrumbsProps) => {
   const lastIndex = items.length - 1;
   return (
-    <nav aria-label="Breadcrumb" className={cn('flex items-center text-sm text-input-placeholder', className)}>
+    <nav aria-label="Breadcrumb" className={cn('flex items-center text-sm text-dim-2', className)}>
       <ol className="flex items-center gap-2">
         {items.map((item, index) => {
           const isLast = index === lastIndex;
@@ -29,12 +29,12 @@ export const Breadcrumbs = ({
             <button
               type="button"
               onClick={() => onNavigate?.(item.href as string)}
-              className="text-input-placeholder hover:text-input-text transition-colors"
+              className="text-dim-2 hover:text-ink transition-colors"
             >
               {item.label}
             </button>
           ) : (
-            <span className={cn(isLast ? 'text-input-text' : '')}>{item.label}</span>
+            <span className={cn(isLast ? 'text-ink' : '')}>{item.label}</span>
           );
           return (
             <li key={`${item.label}-${index}`} className="flex items-center gap-2">

--- a/src/shared/ui/navigation/Pagination.tsx
+++ b/src/shared/ui/navigation/Pagination.tsx
@@ -53,7 +53,7 @@ export function Pagination({
       </button>
       {pages.map((page, i) =>
         page === 'dots' ? (
-          <span key={`dots-${i}`} className="px-1 text-input-placeholder text-sm">...</span>
+          <span key={`dots-${i}`} className="px-1 text-dim-2 text-sm">...</span>
         ) : (
           <button
             key={page}
@@ -65,7 +65,7 @@ export function Pagination({
               btnSize,
               page === currentPage
                 ? 'bg-accent-500/12 text-accent-600 dark:text-accent-400'
-                : 'btn-ghost text-input-text',
+                : 'btn-ghost text-ink',
             )}
           >
             {page}

--- a/src/shared/ui/navigation/Stepper.tsx
+++ b/src/shared/ui/navigation/Stepper.tsx
@@ -63,7 +63,7 @@ export function Stepper({
                   'w-8 h-8 text-xs font-medium',
                   status === 'completed' && 'bg-accent-500 text-[rgb(var(--accent-foreground))]',
                   status === 'active' && 'bg-accent-500/15 text-accent-600 dark:text-accent-400 ring-2 ring-accent-500/30',
-                  status === 'upcoming' && 'bg-surface-utility/10 text-input-placeholder',
+                  status === 'upcoming' && 'bg-surface-utility/10 text-dim-2',
                 )}
               >
                 {status === 'completed' ? (
@@ -90,12 +90,12 @@ export function Stepper({
             )}>
               <p className={cn(
                 'text-xs font-medium',
-                status === 'active' ? 'text-input-text' : 'text-input-placeholder',
+                status === 'active' ? 'text-ink' : 'text-dim-2',
               )}>
                 {step.label}
               </p>
               {step.description && (
-                <p className="text-[11px] text-input-placeholder/70 mt-0.5">{step.description}</p>
+                <p className="text-[11px] text-dim-2/70 mt-0.5">{step.description}</p>
               )}
             </div>
           </div>

--- a/src/shared/ui/overlays/ContextMenu.tsx
+++ b/src/shared/ui/overlays/ContextMenu.tsx
@@ -69,7 +69,7 @@ export function ContextMenu({ children, items, className }: ContextMenuProps) {
                   'hover:bg-surface-utility/10',
                   'disabled:opacity-45 disabled:cursor-not-allowed',
                   item.destructive && 'text-red-500',
-                  !item.destructive && 'text-input-text',
+                  !item.destructive && 'text-ink',
                 )}
               >
                 {item.icon && <span className="shrink-0 w-4">{item.icon}</span>}

--- a/src/shared/ui/profile/molecules/StackedAvatars.tsx
+++ b/src/shared/ui/profile/molecules/StackedAvatars.tsx
@@ -67,7 +67,7 @@ export const StackedAvatars = ({
       {showOverflow && overflowCount > 0 && (
         <div
           className={cn(
-            'input-surface rounded-full text-input-text font-semibold flex items-center justify-center',
+            'input-surface rounded-full text-ink font-semibold flex items-center justify-center',
             ringClasses,
             config.badge
           )}

--- a/src/shared/ui/shell/ErrorPage.tsx
+++ b/src/shared/ui/shell/ErrorPage.tsx
@@ -22,8 +22,8 @@ export function ErrorPage({
       <div className="mb-6 text-red-400/60">
         <AlertOctagon size={56} strokeWidth={1.2} />
       </div>
-      <h1 className="text-xl font-semibold text-input-text mb-2">{title}</h1>
-      <p className="text-sm text-input-placeholder max-w-sm mb-6">{description}</p>
+      <h1 className="text-xl font-semibold text-ink mb-2">{title}</h1>
+      <p className="text-sm text-dim-2 max-w-sm mb-6">{description}</p>
       {action ?? (
         <div className="flex items-center gap-3">
           {onRetry && (

--- a/src/shared/ui/shell/NotFoundPage.tsx
+++ b/src/shared/ui/shell/NotFoundPage.tsx
@@ -17,11 +17,11 @@ export function NotFoundPage({
 }: NotFoundPageProps) {
   return (
     <div className={cn('flex flex-col items-center justify-center min-h-[60vh] px-6 text-center', className)}>
-      <div className="mb-6 text-input-placeholder/40">
+      <div className="mb-6 text-dim-2/40">
         <FileQuestion size={56} strokeWidth={1.2} />
       </div>
-      <h1 className="text-xl font-semibold text-input-text mb-2">{title}</h1>
-      <p className="text-sm text-input-placeholder max-w-sm mb-6">{description}</p>
+      <h1 className="text-xl font-semibold text-ink mb-2">{title}</h1>
+      <p className="text-sm text-dim-2 max-w-sm mb-6">{description}</p>
       {action ?? (
         <a href="/" className="btn btn-primary btn-md link-plain">
           Go home

--- a/src/shared/ui/table/ColumnEditor.tsx
+++ b/src/shared/ui/table/ColumnEditor.tsx
@@ -86,7 +86,7 @@ export const ColumnEditor = ({
                 />
               ))
             ) : (
-              <p className="px-2 py-1.5 text-xs text-input-placeholder">
+              <p className="px-2 py-1.5 text-xs text-dim-2">
                 No additional columns active
               </p>
             )}
@@ -117,7 +117,7 @@ const ColumnSection = ({
   children: ComponentChildren;
 }) => (
   <div className="pb-2 last:pb-1">
-    <h3 className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-input-placeholder">
+    <h3 className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-dim-2">
       {title}
     </h3>
     <div className="flex flex-col">{children}</div>
@@ -125,7 +125,7 @@ const ColumnSection = ({
 );
 
 const FixedColumnRow = ({ label }: { label: string }) => (
-  <div className="px-2 py-1.5 text-sm text-input-text">{label}</div>
+  <div className="px-2 py-1.5 text-sm text-ink">{label}</div>
 );
 
 const ToggleColumnRow = ({
@@ -146,7 +146,7 @@ const ToggleColumnRow = ({
       'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
       'hover:bg-surface-utility/10',
       'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
-      checked ? 'text-input-text' : 'text-input-placeholder',
+      checked ? 'text-ink' : 'text-dim-2',
     )}
   >
     <span

--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -207,7 +207,7 @@ export const DataTable = ({
             <dt className="sr-only">{mobileColumn.label}</dt>
             <dd
               className={cn(
-                'mt-1 truncate text-input-text',
+                'mt-1 truncate text-ink',
                 mobileColumn.mobileClassName
               )}
             >
@@ -234,12 +234,12 @@ export const DataTable = ({
               const isLast = index === columns.length - 1;
               const baseHeaderClass = isPrimary
                 ? cn(
-                  'text-left text-sm font-semibold text-input-text',
+                  'text-left text-sm font-semibold text-ink',
                   density === 'compact' ? 'py-2.5 pl-4' : 'py-3.5 pl-4',
                   isLast ? 'pr-4' : 'pr-3'
                 )
                 : cn(
-                  'text-left text-sm font-semibold text-input-text whitespace-nowrap',
+                  'text-left text-sm font-semibold text-ink whitespace-nowrap',
                   density === 'compact' ? 'py-2.5' : 'py-3.5',
                   isLast ? 'pl-3 pr-4' : 'px-3'
                 );
@@ -269,7 +269,7 @@ export const DataTable = ({
             if (sourceRows.length === 0) {
               return (
                 <tr>
-                  <td colSpan={columns.length} className="px-4 py-6 text-sm text-input-placeholder">
+                  <td colSpan={columns.length} className="px-4 py-6 text-sm text-dim-2">
                     {emptyState ?? 'No results'}
                   </td>
                 </tr>
@@ -293,12 +293,12 @@ export const DataTable = ({
                     const isLast = index === columns.length - 1;
                     const baseCellClass = isPrimary
                       ? cn(
-                        'w-full max-w-0 text-sm font-medium text-input-text sm:w-auto sm:max-w-none',
+                        'w-full max-w-0 text-sm font-medium text-ink sm:w-auto sm:max-w-none',
                         density === 'compact' ? 'py-2.5 pl-4' : 'py-3 pl-4',
                         isLast ? 'pr-4' : 'pr-3'
                       )
                       : cn(
-                        'text-sm text-input-placeholder',
+                        'text-sm text-dim-2',
                         density === 'compact' ? 'py-2.5' : 'py-3',
                         isLast ? 'pl-3 pr-4' : 'px-3'
                       );

--- a/src/shared/ui/upload/molecules/FileCard.tsx
+++ b/src/shared/ui/upload/molecules/FileCard.tsx
@@ -103,7 +103,7 @@ export const FileCard = ({
             />
           ) : (
             <div className={cn('flex h-14 w-14 items-center justify-center rounded-2xl', fileType.color)}>
-              <Icon icon={fileType.icon} className="h-7 w-7 text-input-text" />
+              <Icon icon={fileType.icon} className="h-7 w-7 text-ink" />
             </div>
           )}
           {shouldShowTileStatus ? (
@@ -126,12 +126,12 @@ export const FileCard = ({
           ) : null}
         </div>
         <div className="flex flex-col gap-0.5 p-3">
-          <p className="truncate text-sm font-medium text-input-text" title={fileName}>{fileName}</p>
+          <p className="truncate text-sm font-medium text-ink" title={fileName}>{fileName}</p>
           {associationLabel ? (
-            <p className="truncate text-xs text-input-placeholder" title={associationLabel}>{associationLabel}</p>
+            <p className="truncate text-xs text-dim-2" title={associationLabel}>{associationLabel}</p>
           ) : null}
           {timestampLabel ? (
-            <p className="text-[11px] uppercase tracking-wide text-input-placeholder">{timestampLabel}</p>
+            <p className="text-[11px] uppercase tracking-wide text-dim-2">{timestampLabel}</p>
           ) : null}
         </div>
       </>

--- a/src/shared/ui/upload/molecules/UploadQueueRow.tsx
+++ b/src/shared/ui/upload/molecules/UploadQueueRow.tsx
@@ -36,8 +36,8 @@ export const UploadQueueRow = ({
       <div className="flex items-start gap-3">
         <FileIcon fileName={fileName} mimeType={mimeType} size="sm" />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-input-text">{fileName}</p>
-          <div className="mt-0.5 flex items-center gap-2 text-xs text-input-placeholder">
+          <p className="truncate text-sm font-medium text-ink">{fileName}</p>
+          <div className="mt-0.5 flex items-center gap-2 text-xs text-dim-2">
             <span>{formatFileSize(fileSize)}</span>
             {status === 'uploading' ? (
               <>

--- a/src/shared/ui/upload/organisms/UploadDropzone.tsx
+++ b/src/shared/ui/upload/organisms/UploadDropzone.tsx
@@ -99,12 +99,12 @@ export const UploadDropzone = ({
         }}
       />
       <div className="flex w-full max-w-[520px] flex-col items-center justify-center text-center">
-        <Icon icon={Upload} className="mb-3 h-6 w-6 text-input-placeholder" />
-        <p className="text-sm font-medium text-input-text">{instructionText}</p>
-        <p className="mt-1 text-xs text-input-placeholder">{validationText}</p>
+        <Icon icon={Upload} className="mb-3 h-6 w-6 text-dim-2" />
+        <p className="text-sm font-medium text-ink">{instructionText}</p>
+        <p className="mt-1 text-xs text-dim-2">{validationText}</p>
       </div>
       {helperText ? (
-        <p className="mt-2 text-center text-xs text-input-placeholder">{helperText}</p>
+        <p className="mt-2 text-center text-xs text-dim-2">{helperText}</p>
       ) : null}
     </div>
   );

--- a/src/shared/ui/upload/organisms/UploadSurface.tsx
+++ b/src/shared/ui/upload/organisms/UploadSurface.tsx
@@ -64,7 +64,7 @@ export const UploadSurface = ({
           ))}
         </div>
       ) : emptyStateLabel ? (
-        <div className="mt-3 rounded-xl border border-line-subtle px-3 py-4 text-center text-sm text-input-placeholder">
+        <div className="mt-3 rounded-xl border border-line-subtle px-3 py-4 text-center text-sm text-dim-2">
           {emptyStateLabel}
         </div>
       ) : null}

--- a/src/shared/utils/intakeStrength.ts
+++ b/src/shared/utils/intakeStrength.ts
@@ -57,7 +57,7 @@ export const resolveStrengthStyle = (tier: StrengthTier): { percent: number; rin
       return { percent: 100, ringClass: 'text-emerald-400', bgClass: 'bg-emerald-400' };
     case 'none':
     default:
-      return { percent: 0, ringClass: 'text-input-placeholder/20', bgClass: 'bg-input-placeholder/20' };
+      return { percent: 0, ringClass: 'text-dim-2/20', bgClass: 'bg-input-placeholder/20' };
   }
 };
 


### PR DESCRIPTION
## Summary

Largest mechanical slice of Commit 8. Bulk-replaces the `text-input-*` Tailwind class family across the codebase via `sed -i`. Net diff: **exactly +1446 / -1446** — one substitution per occurrence, no other changes.

| Old class | New class | Maps to | Occurrences |
|---|---|---|---:|
| `text-input-text` | `text-ink` | `--ink` (primary text) | 681 |
| `text-input-placeholder` | `text-dim-2` | `--dim-2` (placeholder) | 842 |

## ⚠️ This is a real visual change, not a no-op rename

While planning this sweep I discovered that `text-input-*` was **dead** — it was never defined in `tailwind.config.js` and there were no matching `.text-input-*` rules in `src/index.css`. Tailwind was emitting these classes as literal HTML class names that styled nothing.

That means previously:
- `<p className="text-input-placeholder">helper text</p>` inherited its color from a parent (or used a browser default if no parent rule applied)
- The intent of the developer was *placeholder dim* — but the visual was whatever happened to inherit

Now:
- `text-dim-2` is a real Tailwind utility backed by `rgb(var(--dim-2-rgb))` → `#9aa1b3` on light theme
- Placeholders, helper text, captions, meta lines across the entire app will now match the design system

**CSS bundle grew 142.46 → 149.34 kB (~5 kB)** — direct evidence the previously-dead utilities now generate real output.

## Why this is fine

The intent in every call site was always to apply DS-token text colors. The classes were just pointing at the wrong (nonexistent) target. Most diffs will be visually subtle:
- Placeholder text becoming slightly more grey (matching design)
- Captions/helper text moving from inherited dark navy to the designed `--dim-2` grey
- A few places where text was rendering darker than designed will now appear lighter (per spec)

Where the diff is **un**desirable, it indicates a place where the prior accidental inheritance happened to look right — those become follow-ups, not blockers. Per audit, this slice is the "biggest mechanical pass" precisely because the breadth is too large to QA per-site; the win is fixing 1446 mis-styled elements in one shot.

## Commits

1. **`054c0cf9`** — `chore(ds): sweep text-input-* family → text-ink / text-dim-2 (8.1a)` — the mechanical sweep itself via `grep -rl ... | xargs sed -i ...`. 244 files touched.
2. **`8a1e87d9`** — `docs(ds): mark 8.1a complete in audit ladder` — strikethrough PR-13 in the audit ladder.

## Test plan

- [x] `grep -r "text-input-" src/` returns zero matches in `.ts`/`.tsx` files
- [x] Net diff: exactly `+1446 / -1446` across `244 files changed`
- [x] `npm run build` green
- [x] `npm run type-check` 0 errors
- [x] `npm run lint:src` baseline preserved (the pre-existing `OAuthConsentPage.tsx:187` error now reports at column 54 instead of 66 because sed touched that file; same error otherwise)
- [ ] Visual smoke at `https://local.blawby.com` — placeholders/helpers should match design more closely. Diffs expected; regressions should be filed as follow-ups, not block this PR.

## What's next

After this lands, **PR-14** tackles the remaining token-utility violations in one combined pass:
- `bg-surface-*` (308 / 126 files)
- `bg-accent-N` (55 / 38 files)
- `rounded-xl` (225 / 107 files)
- `font-display` (8 / 2 files)

Then PR-15 (DataTable), PR-16 (SegmentedToggle), PR-17/18 (status + input-surface alias sweeps), PR-19 (a11y + final gates).