### PR TITLE
ds: PR-14 — sweep rounded-xl + font-display + bg-accent-N + bg-surface-* (8.1b/c/d)

### DIFF
--- a/docs/design-system-commit-8-audit.md
+++ b/docs/design-system-commit-8-audit.md
@@ -200,7 +200,7 @@ In dependency order (each can be its own PR):
 
 1. ~~**PR-12** (this one is fast): `chore(ds): delete .card-surface alias (8.4a)` — single-file edit, zero risk.~~ ✅ **landed in PR #655 (commit `99171487`)**.
 2. ~~**PR-13**: `chore(ds): replace text-input-* family (8.1a)` — big mechanical PR.~~ ✅ **landed in PR #656 (commit `054c0cf9`).** Net +1446/-1446 across 244 files. Note: `text-input-*` was actually dead (missing from tailwind config); replacement with `text-ink` / `text-dim-2` is a real visual change. CSS bundle grew ~5 kB.
-3. **PR-14**: `chore(ds): replace bg-surface-* + bg-accent-N + font-display + rounded-xl (8.1b/c/d combined)` — second mechanical sweep.
+3. ~~**PR-14**: `chore(ds): replace bg-surface-* + bg-accent-N + font-display + rounded-xl (8.1b/c/d combined)` — second mechanical sweep.~~ ✅ **landed in PR #657 (commit `9acfe6ca`).** Net +542/-542 across 185 files. CSS bundle 149→156 kB. Discovered additional dead families (text-accent-N, ring-accent-N, border-accent-N, *-error/*-success/*-foreground variants) out of scope here — those go in a dedicated PR with semantic mapping.
 4. **PR-15**: `refactor(ds): DataTable → CSS grid for 6 non-invoice tables (8.2)`.
 5. **PR-16**: `refactor(ds): migrate SegmentedToggle callers to Seg; delete SegmentedToggle (8.3)`.
 6. **PR-17**: `refactor(ds): migrate .status-* callers to <Pill>; delete alias (8.4b/d-partial)`.

--- a/src/app/ErrorBoundary.tsx
+++ b/src/app/ErrorBoundary.tsx
@@ -35,7 +35,7 @@ export class ErrorBoundary extends Component<Props, State> {
                     <h2 className="text-xl font-bold text-accent-error-light mb-4">Something went wrong</h2>
                     <details className="my-4">
                         <summary className="cursor-pointer text-accent-500 font-medium hover:text-accent-400 transition-colors">Error details</summary>
-                        <pre className="mt-2 p-4 bg-surface-workspace/40 dark:bg-surface-utility/10 border border-line-subtle rounded-xl overflow-x-auto text-sm text-accent-error/80">{this.state.error?.message}</pre>
+                        <pre className="mt-2 p-4 bg-paper/40 dark:bg-paper-2/10 border border-line-subtle rounded-r-md overflow-x-auto text-sm text-accent-error/80">{this.state.error?.message}</pre>
                     </details>
                     <Button 
                         variant="primary"

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -669,7 +669,7 @@ export function MainApp({
           </a>
         ) : null}
         {conversationHeaderMatterLabel ? (
-          <span className="inline-flex min-w-0 items-center gap-1.5 truncate rounded-full bg-accent-500/10 px-2 py-0.5 text-accent-utility">
+          <span className="inline-flex min-w-0 items-center gap-1.5 truncate rounded-full bg-accent/10 px-2 py-0.5 text-accent-utility">
             <Icon icon={Briefcase} className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{conversationHeaderMatterLabel}</span>
           </span>
@@ -688,8 +688,8 @@ export function MainApp({
     if (!isPracticeWorkspace) return undefined;
     if (isSocketReady) return undefined;
     return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-accent-500/15 px-2 py-0.5 text-[11px] font-semibold text-accent-utility">
-        <span className="h-1.5 w-1.5 rounded-full bg-accent-500" aria-hidden="true" />
+      <span className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 text-[11px] font-semibold text-accent-utility">
+        <span className="h-1.5 w-1.5 rounded-full bg-accent" aria-hidden="true" />
         Unread
       </span>
     );

--- a/src/features/chat/components/ChatDockedAction.tsx
+++ b/src/features/chat/components/ChatDockedAction.tsx
@@ -55,7 +55,7 @@ export const ChatDockedAction: FunctionComponent<ChatDockedActionProps> = ({
               size="icon-sm"
               onClick={onClose}
               aria-label="Dismiss"
-              className="shrink-0 text-dim-2 hover:bg-surface-hover hover:text-ink"
+              className="shrink-0 text-dim-2 hover:bg-paper-2 hover:text-ink"
             >
               <Icon icon={X} className="h-5 w-5" />
             </Button>

--- a/src/features/chat/components/DraftConversationView.tsx
+++ b/src/features/chat/components/DraftConversationView.tsx
@@ -147,7 +147,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
   const comboboxValue = isPracticeAssistant ? '__blawby_ai__' : (draftContact?.kind === 'user' ? draftContact.userId : '');
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-surface-workspace">
+    <div className="flex h-full min-h-0 flex-col bg-paper">
       <header className="flex items-center justify-between gap-3 border-b border-line-subtle px-4 py-3 sm:px-6">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <Avatar
@@ -219,7 +219,7 @@ export const DraftConversationView: FunctionComponent<DraftConversationViewProps
               }}
               className={cn(
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm',
-                'text-ink hover:bg-surface-utility/10 focus-visible:bg-surface-utility/10',
+                'text-ink hover:bg-paper-2/10 focus-visible:bg-paper-2/10',
               )}
             >
               <span className="text-accent-utility">+ Invite a new contact</span>

--- a/src/features/chat/components/MessageActions.tsx
+++ b/src/features/chat/components/MessageActions.tsx
@@ -253,7 +253,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 											href={url}
 											target="_blank"
 											rel="noopener noreferrer"
-											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-xl font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
+											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
 										>
 											{action.label}
 										</a>
@@ -284,7 +284,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 										<button
 											key={getChatActionKey(action, idx)}
 											type="button"
-											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-xl font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
+											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
 											onClick={() => navigate(`${parsed.pathname}${parsed.search}${parsed.hash}`)}
 										>
 											{action.label}
@@ -297,7 +297,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 										href={action.url}
 										target="_blank"
 										rel="noopener noreferrer"
-										className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-xl font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
+										className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
 									>
 										{action.label}
 									</a>
@@ -413,8 +413,8 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 			{/* Display generated PDF */}
 			{generatedPDF && (
 				<div className="my-2">
-					<div className="flex items-center gap-2 p-3 rounded-xl panel">
-						<div className="w-8 h-8 rounded bg-surface-utility/60 dark:bg-surface-utility/10 flex items-center justify-center flex-shrink-0">
+					<div className="flex items-center gap-2 p-3 rounded-r-md panel">
+						<div className="w-8 h-8 rounded bg-paper-2/60 dark:bg-paper-2/10 flex items-center justify-center flex-shrink-0">
 							<Icon icon={FileIcon} className="w-4 h-4 text-ink"  />
 						</div>
 						<div className="flex-1 min-w-0">

--- a/src/features/chat/components/MessageAttachments.tsx
+++ b/src/features/chat/components/MessageAttachments.tsx
@@ -42,7 +42,7 @@ const ImageAttachment: FunctionComponent<ImageAttachmentProps> = ({ file, onClic
         src={src}
         type={file.type}
         alt={file.name}
-        className="max-w-[300px] max-h-[300px] w-auto h-auto block cursor-pointer rounded-xl"
+        className="max-w-[300px] max-h-[300px] w-auto h-auto block cursor-pointer rounded-r-md"
         onClick={() => onClick(file, src)}
       />
     </div>
@@ -52,7 +52,7 @@ const ImageAttachment: FunctionComponent<ImageAttachmentProps> = ({ file, onClic
 const AudioAttachment: FunctionComponent<{ file: FileAttachment }> = ({ file }) => {
   const src = useResolvedAttachmentUrl(file);
   return (
-    <div className="my-2 rounded-xl overflow-hidden max-w-75 w-full">
+    <div className="my-2 rounded-r-md overflow-hidden max-w-75 w-full">
       <LazyMedia src={src} type={file.type} alt={file.name} className="w-full h-auto block cursor-pointer" />
     </div>
   );
@@ -61,7 +61,7 @@ const AudioAttachment: FunctionComponent<{ file: FileAttachment }> = ({ file }) 
 const VideoAttachment: FunctionComponent<{ file: FileAttachment }> = ({ file }) => {
   const src = useResolvedAttachmentUrl(file);
   return (
-    <div className="my-2 rounded-xl overflow-hidden max-w-75 w-full">
+    <div className="my-2 rounded-r-md overflow-hidden max-w-75 w-full">
       <LazyMedia src={src} type={file.type} alt={file.name} className="w-full h-auto block cursor-pointer" />
     </div>
   );
@@ -103,7 +103,7 @@ const DocumentAttachment: FunctionComponent<DocumentAttachmentProps> = ({ file, 
 
   return (
     <div
-      className="flex items-center gap-2 p-2 rounded-xl panel cursor-pointer my-2 max-w-[300px]"
+      className="flex items-center gap-2 p-2 rounded-r-md panel cursor-pointer my-2 max-w-[300px]"
       onClick={() => { void handleClick(); }}
       onKeyDown={handleKeyDown}
       role="button"
@@ -111,7 +111,7 @@ const DocumentAttachment: FunctionComponent<DocumentAttachmentProps> = ({ file, 
       aria-busy={busy}
       aria-label={`Open ${file.name}`}
     >
-      <div className="w-8 h-8 rounded bg-surface-base flex items-center justify-center flex-shrink-0">
+      <div className="w-8 h-8 rounded bg-paper flex items-center justify-center flex-shrink-0">
         {getDocumentIcon(file)}
       </div>
       <div className="flex-1 min-w-0">

--- a/src/features/chat/components/MessageComposer.tsx
+++ b/src/features/chat/components/MessageComposer.tsx
@@ -343,7 +343,7 @@ const MessageComposer = ({
         )}
         <div className="message-composer-container">
           {replyTo && (
-            <div className="flex items-center justify-between gap-3 rounded-t-2xl bg-surface-utility/40 dark:bg-surface-utility/20 px-4 py-1.5 text-sm text-ink -mx-2 -mt-1">
+            <div className="flex items-center justify-between gap-3 rounded-t-2xl bg-paper-2/40 dark:bg-paper-2/20 px-4 py-1.5 text-sm text-ink -mx-2 -mt-1">
               <div className="flex min-w-0 items-center gap-2">
                 <span className="text-ink/70">
                   <Trans
@@ -481,7 +481,7 @@ const MessageComposer = ({
                 <div 
                   id="mention-listbox"
                   role="listbox"
-                  className="absolute bottom-full left-2 right-2 z-40 mb-2 overflow-hidden rounded-xl border border-line-subtle bg-surface-workspace dark:bg-surface-overlay/95 shadow-glass backdrop-blur-2xl"
+                  className="absolute bottom-full left-2 right-2 z-40 mb-2 overflow-hidden rounded-r-md border border-line-subtle bg-paper dark:bg-card/95 shadow-glass backdrop-blur-2xl"
                 >
                   <div className="max-h-56 overflow-y-auto py-1">
                     {filteredMentionCandidates.map((candidate, index) => (
@@ -495,8 +495,8 @@ const MessageComposer = ({
                         onClick={() => handleMentionSelect(index)}
                         className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
                           index === mentionFocusIndex
-                            ? 'bg-accent-500/15 text-[rgb(var(--accent-foreground))]'
-                            : 'text-ink hover:bg-surface-utility/40'
+                            ? 'bg-accent/15 text-[rgb(var(--accent-foreground))]'
+                            : 'text-ink hover:bg-paper-2/40'
                         }`}
                       >
                         <span className="truncate">{candidate.name}</span>

--- a/src/features/chat/components/MessageContent.tsx
+++ b/src/features/chat/components/MessageContent.tsx
@@ -68,7 +68,7 @@ export const MessageContent: FunctionComponent<MessageContentProps> = ({
 
   if (isAnalysisMessage) {
     return (
-      <div className={`status-info flex items-center gap-2 px-3 py-2 rounded-xl ${className}`}>
+      <div className={`status-info flex items-center gap-2 px-3 py-2 rounded-r-md ${className}`}>
         <LoadingSpinner size="md" ariaLabel={analysisAriaLabel} />
         <ChatMarkdown text={displayContent} isStreaming={isStreaming} variant={variant} size={size} />
       </div>
@@ -79,7 +79,7 @@ export const MessageContent: FunctionComponent<MessageContentProps> = ({
   // sharper bottom-right corner; received uses a raised surface with a sharper
   // bottom-left corner. Padding & radius mirror the design components.
   const bubbleClassName = isUser
-    ? 'inline-block max-w-full rounded-2xl rounded-br-[4px] bg-accent-500 px-[14px] py-[10px] text-[rgb(var(--accent-foreground))] shadow-sm'
+    ? 'inline-block max-w-full rounded-2xl rounded-br-[4px] bg-accent px-[14px] py-[10px] text-[rgb(var(--accent-foreground))] shadow-sm'
     : 'inline-block max-w-full rounded-2xl rounded-bl-[4px] bg-[rgb(var(--surface-card-hover))] px-[14px] py-[10px] text-ink';
 
   // The outer wrapper is a flex row so the inline-block bubble follows the

--- a/src/features/chat/components/MessagesListPanel.tsx
+++ b/src/features/chat/components/MessagesListPanel.tsx
@@ -95,7 +95,7 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
             {t('workspace.conversationList.title', { defaultValue: 'Messages' })}
           </h2>
           <span
-            className="inline-flex h-5 min-w-[28px] items-center justify-center rounded-full bg-accent-500/15 px-1.5 text-[11px] font-semibold text-accent-utility"
+            className="inline-flex h-5 min-w-[28px] items-center justify-center rounded-full bg-accent/15 px-1.5 text-[11px] font-semibold text-accent-utility"
             aria-label={t('workspace.conversationList.countLabel', {
               defaultValue: '{{count}} conversations',
               count: badgeCount,
@@ -145,7 +145,7 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
             type="button"
             onClick={() => onSelectDraftEntry?.()}
             className={cn(
-              'mx-2 mt-2 mb-1 flex w-[calc(100%-1rem)] items-start gap-3 rounded-xl px-3 py-2.5 text-left transition-colors',
+              'mx-2 mt-2 mb-1 flex w-[calc(100%-1rem)] items-start gap-3 rounded-r-md px-3 py-2.5 text-left transition-colors',
               activeConversationId === null && 'nav-item-active'
             )}
             aria-current={activeConversationId === null ? 'page' : undefined}
@@ -161,7 +161,7 @@ const MessagesListPanel: FunctionComponent<MessagesListPanelProps> = ({
                 <span className="block truncate text-sm font-semibold text-ink">
                   {draftEntry.contactName ?? t('workspace.conversationList.draftPlaceholder', { defaultValue: 'New conversation' })}
                 </span>
-                <span className="rounded-full bg-accent-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent-utility">
+                <span className="rounded-full bg-accent/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent-utility">
                   {t('workspace.conversationList.draftBadge', { defaultValue: 'Draft' })}
                 </span>
               </div>

--- a/src/features/chat/components/VirtualMessageList.tsx
+++ b/src/features/chat/components/VirtualMessageList.tsx
@@ -864,7 +864,7 @@ const VirtualMessageList: FunctionComponent<VirtualMessageListProps> = ({
         {showScrollToBottom && (
             <button
                 type="button"
-                className="absolute bottom-4 left-1/2 z-20 inline-flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full bg-accent-500 text-accent-foreground shadow-lg transition hover:bg-accent-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-utility border border-line-utility"
+                className="absolute bottom-4 left-1/2 z-20 inline-flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full bg-accent text-accent-foreground shadow-lg transition hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-utility border border-line-utility"
                 onClick={scrollToBottom}
                 aria-label="Scroll to latest message"
             >

--- a/src/features/chat/views/ConversationListView.tsx
+++ b/src/features/chat/views/ConversationListView.tsx
@@ -32,7 +32,7 @@ const ConversationListSkeleton = ({ rows = 6 }: { rows?: number }) => (
       return (
         <div
           key={i}
-          className="mb-1 flex w-full items-start gap-3 rounded-xl px-3 py-2.5"
+          className="mb-1 flex w-full items-start gap-3 rounded-r-md px-3 py-2.5"
           aria-hidden="true"
         >
           <SkeletonLoader variant="avatar" />
@@ -61,7 +61,7 @@ const ConversationListEmptyState = ({
 }: { title: string; hint: string }) => (
   <div className="flex h-full flex-1 items-center justify-center px-6 py-10">
     <div className="flex max-w-xs flex-col items-center gap-3 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-subtle">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-card/60 ring-1 ring-line-subtle">
         <Icon
           icon={MessageSquare}
           className="h-6 w-6 text-dim-2"
@@ -107,7 +107,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
       type="button"
       aria-current={isActive ? 'page' : undefined}
       className={cn(
-        'flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
+        'flex w-full items-start gap-3 rounded-r-md px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
         isActive ? 'nav-item-active' : 'nav-item-inactive'
       )}
     >
@@ -166,7 +166,7 @@ const ConversationItem = memo(({ conversation, preview, fallbackName, isActive, 
         aria-hidden="true"
         className={cn(
           'mt-2 h-2 w-2 flex-shrink-0 rounded-full transition-opacity',
-          isUnread ? 'bg-accent-500 opacity-100' : 'opacity-0'
+          isUnread ? 'bg-accent opacity-100' : 'opacity-0'
         )}
       />
       {isUnread && (

--- a/src/features/chat/views/WidgetConversationListView.tsx
+++ b/src/features/chat/views/WidgetConversationListView.tsx
@@ -48,7 +48,7 @@ const WidgetConversationListEmptyState = ({
 }: { title: string; hint: string }) => (
   <div className="flex flex-1 items-center justify-center px-6 py-10">
     <div className="flex max-w-xs flex-col items-center gap-3 text-center">
-      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-overlay/60 ring-1 ring-line-subtle">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-card/60 ring-1 ring-line-subtle">
         <Icon
           icon={MessageSquare}
           className="h-6 w-6 text-dim-2"
@@ -155,7 +155,7 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
                   type="button"
                   className={cn(
                     'flex w-full items-start gap-3 px-3 py-3 text-left transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
-                    isActive ? 'bg-surface-utility/10' : 'hover:bg-surface-utility/5'
+                    isActive ? 'bg-paper-2/10' : 'hover:bg-paper-2/5'
                   )}
                   onClick={() => onSelectConversation(conversation.id)}
                 >
@@ -188,7 +188,7 @@ const WidgetConversationListView: FunctionComponent<WidgetConversationListViewPr
                           <span className={chatTypography.headerTime}>{timeLabel}</span>
                         )}
                         {isUnread && (
-                          <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-accent-500 px-1.5 py-0.5 text-[11px] font-semibold text-[rgb(var(--accent-foreground))]">
+                          <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-accent px-1.5 py-0.5 text-[11px] font-semibold text-[rgb(var(--accent-foreground))]">
                             {unreadCount}
                           </span>
                         )}

--- a/src/features/chat/views/WorkspaceHomeView.tsx
+++ b/src/features/chat/views/WorkspaceHomeView.tsx
@@ -83,7 +83,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
             type="button"
             onClick={onOpenRecentMessage}
             disabled={!canOpenRecentMessage}
-            className="card px-5 py-5 text-left transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+            className="card px-5 py-5 text-left transition-all duration-300 hover:scale-[1.01] hover:bg-paper-2/40 dark:hover:bg-paper-2/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
             aria-label={t('workspace.home.recentMessage')}
           >
             <div className="text-xs font-semibold uppercase tracking-wide text-dim-2">
@@ -117,12 +117,12 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
           type="button"
           onClick={onSendMessage}
           disabled={!canSendMessage}
-          className="card flex w-full items-center justify-between px-6 py-5 text-left text-ink transition-all duration-300 hover:scale-[1.01] hover:bg-surface-utility/40 dark:hover:bg-surface-utility/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+          className="card flex w-full items-center justify-between px-6 py-5 text-left text-ink transition-all duration-300 hover:scale-[1.01] hover:bg-paper-2/40 dark:hover:bg-paper-2/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
           aria-label={t('workspace.home.sendMessage')}
         >
           <span className="text-lg font-bold tracking-tight">{t('workspace.home.sendMessage')}</span>
           <span
-            className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-accent-500 text-[rgb(var(--accent-foreground))] pointer-events-none transition-all duration-300"
+            className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-accent text-[rgb(var(--accent-foreground))] pointer-events-none transition-all duration-300"
             aria-hidden="true"
           >
             <Icon icon={Send} className="h-5 w-5" aria-hidden="true"  />

--- a/src/features/client-dashboard/components/ClientActionRequiredWidget.tsx
+++ b/src/features/client-dashboard/components/ClientActionRequiredWidget.tsx
@@ -44,7 +44,7 @@ export const ClientActionRequiredWidget = ({
           <LoadingSpinner size="md" />
         </div>
       ) : error ? (
-        <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
+        <div className="rounded-r-md border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : items.length === 0 ? (
@@ -55,7 +55,7 @@ export const ClientActionRequiredWidget = ({
             const ItemIcon = ICONS[item.reason];
             return (
               <Fragment key={item.id}>
-                <div className="rounded-xl border border-line-subtle bg-surface px-4 py-3">
+                <div className="rounded-r-md border border-line-subtle bg-surface px-4 py-3">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex min-w-0 gap-3">
                       <Icon

--- a/src/features/client-dashboard/components/ClientMattersGrid.tsx
+++ b/src/features/client-dashboard/components/ClientMattersGrid.tsx
@@ -32,7 +32,7 @@ export const ClientMattersGrid = ({
       {loading ? (
         <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="space-y-3 rounded-xl bg-surface-overlay/80 p-6 outline outline-1 outline-line-glass/40">
+            <div key={i} className="space-y-3 rounded-r-md bg-card/80 p-6 outline outline-1 outline-line-glass/40">
               <SkeletonLoader variant="text" width="w-32" />
               <SkeletonLoader variant="text" width="w-24" />
               <SkeletonLoader variant="text" width="w-20" />
@@ -40,7 +40,7 @@ export const ClientMattersGrid = ({
           ))}
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
+        <div className="mt-6 rounded-r-md border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : matters.length === 0 ? (
@@ -50,15 +50,15 @@ export const ClientMattersGrid = ({
           {matters.map((matter) => (
             <li
               key={matter.id}
-              className="overflow-hidden rounded-xl bg-surface-overlay/80 outline outline-1 outline-line-glass/40 backdrop-blur-xl"
+              className="overflow-hidden rounded-r-md bg-card/80 outline outline-1 outline-line-glass/40 backdrop-blur-xl"
             >
               <button
                 type="button"
                 onClick={() => onViewMatter?.(matter.id)}
-                className="block w-full text-left transition-colors hover:bg-surface-utility/20"
+                className="block w-full text-left transition-colors hover:bg-paper-2/20"
               >
-                <div className="flex items-start gap-3 border-b border-line-subtle bg-surface-overlay/70 p-5">
-                  <div className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-surface-utility/30">
+                <div className="flex items-start gap-3 border-b border-line-subtle bg-card/70 p-5">
+                  <div className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-paper-2/30">
                     <Icon icon={Briefcase} className="h-5 w-5 text-dim-2" aria-hidden />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -68,7 +68,7 @@ export const ClientMattersGrid = ({
                     ) : null}
                   </div>
                 </div>
-                <dl className="divide-y divide-line-subtle bg-surface-overlay/60 px-5 py-3 text-sm">
+                <dl className="divide-y divide-line-subtle bg-card/60 px-5 py-3 text-sm">
                   <div className="flex justify-between gap-x-4 py-2">
                     <dt className="text-dim-2">Status</dt>
                     <dd className="text-ink">{matter.statusLabel ?? '—'}</dd>

--- a/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
+++ b/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
@@ -30,7 +30,7 @@ const statusClass = (status: ClientInvoiceActivityEntry['status']) => {
   const normalized = String(status).toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
+  return 'bg-card/80 text-dim-2 ring-line-subtle';
 };
 
 export const ClientRecentInvoicesTable = ({
@@ -90,8 +90,8 @@ export const ClientRecentInvoicesTable = ({
                       <tr className="text-sm text-ink">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
-                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
-                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-card/70" />
+                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-subtle bg-card/70" />
                         </th>
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (

--- a/src/features/clients/pages/PracticeContactEditorPage.tsx
+++ b/src/features/clients/pages/PracticeContactEditorPage.tsx
@@ -309,12 +309,12 @@ export function PracticeContactEditorPage({
     >
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
         {loading ? (
-          <div className="rounded-xl border border-line-subtle bg-surface-card p-6">
+          <div className="rounded-r-md border border-line-subtle bg-card p-6">
             <LoadingBlock label="Loading contact..." />
           </div>
         ) : null}
         {error ? (
-          <div className="rounded-xl border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
+          <div className="rounded-r-md border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
             {error}
           </div>
         ) : null}

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -863,7 +863,7 @@ export const PracticeContactsPage = ({
         <ul>
           {letters.map((letter) => (
             <li key={letter} data-letter={letter}>
-              <div className="sticky top-0 z-10 bg-surface-collection/80 backdrop-blur-sm px-4 py-1.5 text-xs font-semibold text-dim-2 border-y border-line-subtle">
+              <div className="sticky top-0 z-10 bg-paper-2/80 backdrop-blur-sm px-4 py-1.5 text-xs font-semibold text-dim-2 border-y border-line-subtle">
                 {letter}
               </div>
               {groupedClients[letter].map((client) => {
@@ -913,7 +913,7 @@ export const PracticeContactsPage = ({
         </ul>
       </div>
           {letters.length > 0 ? (
-        <div className="pointer-events-auto absolute right-1 top-1/2 z-20 -translate-y-1/2 hidden md:flex flex-col items-center gap-1 text-[11px] font-medium text-dim-2 bg-surface-workspace/80">
+        <div className="pointer-events-auto absolute right-1 top-1/2 z-20 -translate-y-1/2 hidden md:flex flex-col items-center gap-1 text-[11px] font-medium text-dim-2 bg-paper/80">
           {letters.map((letter) => (
             <Button
               key={letter}
@@ -931,8 +931,8 @@ export const PracticeContactsPage = ({
                 'relative h-4 w-4 min-h-0 min-w-0 p-0 text-[11px] flex items-center justify-center rounded-full transition-colors',
                 "before:absolute before:-inset-3.5 before:content-['']",
                 activeLetter === letter
-                  ? 'text-accent-foreground font-bold bg-accent-500'
-                  : 'text-dim-2 hover:text-ink hover:bg-surface-utility/40'
+                  ? 'text-accent-foreground font-bold bg-accent'
+                  : 'text-dim-2 hover:text-ink hover:bg-paper-2/40'
               )}
             >
               {letter}

--- a/src/features/engagements/pages/ClientEngagementReviewPage.tsx
+++ b/src/features/engagements/pages/ClientEngagementReviewPage.tsx
@@ -181,7 +181,7 @@ const SignaturePad: FunctionComponent<{
         <canvas
           ref={canvasRef}
           className={cn(
-            'block h-32 w-full cursor-crosshair rounded-lg border border-dashed border-card-border bg-surface-card',
+            'block h-32 w-full cursor-crosshair rounded-lg border border-dashed border-card-border bg-card',
             disabled && 'cursor-not-allowed opacity-60',
           )}
           onMouseDown={(e) => startDraw(e as unknown as MouseEvent)}
@@ -292,7 +292,7 @@ const EngagementLetter: FunctionComponent<{
   const noGuarantee = proposal?.no_guarantee_language;
 
   return (
-    <article className="rounded-2xl border border-card-border bg-surface-card p-6 sm:p-10 space-y-6 leading-relaxed text-ink">
+    <article className="rounded-2xl border border-card-border bg-card p-6 sm:p-10 space-y-6 leading-relaxed text-ink">
       <header className="text-center space-y-2 border-b border-line-subtle pb-6">
         <h1 className="text-xl font-bold uppercase tracking-widest">Engagement Letter</h1>
         <p className="text-sm font-medium">{practiceName}</p>
@@ -464,14 +464,14 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
 
   return (
     <div className="min-h-dvh bg-app-background">
-      <header className="sticky top-0 z-10 border-b border-card-border bg-surface-overlay/80 backdrop-blur-xl">
+      <header className="sticky top-0 z-10 border-b border-card-border bg-card/80 backdrop-blur-xl">
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
           <div className="flex min-w-0 items-center gap-2">
             {onBack && (
               <button
                 type="button"
                 onClick={onBack}
-                className="rounded-md p-1.5 text-dim-2 hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                className="rounded-md p-1.5 text-dim-2 hover:bg-paper-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                 aria-label="Back"
               >
                 <ChevronLeft className="h-5 w-5" />

--- a/src/features/engagements/pages/CreateEngagementPage.tsx
+++ b/src/features/engagements/pages/CreateEngagementPage.tsx
@@ -200,9 +200,9 @@ const EngagementLetterPreview: FunctionComponent<{
   const today = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
   return (
-    <div className="rounded-xl border border-card-border bg-surface-card text-sm leading-relaxed text-ink shadow-sm overflow-hidden">
+    <div className="rounded-r-md border border-card-border bg-card text-sm leading-relaxed text-ink shadow-sm overflow-hidden">
       {/* Letterhead */}
-      <div className="border-b border-line-subtle bg-surface-overlay/20 px-6 py-4 space-y-0.5">
+      <div className="border-b border-line-subtle bg-card/20 px-6 py-4 space-y-0.5">
         <p className="text-xs font-semibold uppercase tracking-widest text-dim-2">
           {practiceName || 'Your Practice'}
         </p>
@@ -232,7 +232,7 @@ const EngagementLetterPreview: FunctionComponent<{
 
         {/* Fee summary */}
         {form.billingType ? (
-          <div className="rounded-lg border border-line-subtle bg-surface-overlay/30 px-4 py-3 space-y-1">
+          <div className="rounded-lg border border-line-subtle bg-card/30 px-4 py-3 space-y-1">
             <p className="text-xs font-semibold uppercase tracking-widest text-dim-2">Fee Summary</p>
             <p className="text-xs">{billingSummaryLine(form)}</p>
             {form.feeNotes.trim() && (
@@ -272,7 +272,7 @@ const SelectedIntakeCard: FunctionComponent<{
   const email = intake.metadata?.email?.trim() || '';
   const subject = resolveIntakeTitle(intake.metadata, '');
   return (
-    <div className="flex items-start justify-between gap-3 rounded-lg border border-card-border bg-surface-card px-3 py-2.5">
+    <div className="flex items-start justify-between gap-3 rounded-lg border border-card-border bg-card px-3 py-2.5">
       <div className="min-w-0 flex-1">
         <p className="truncate font-medium text-ink">{name}</p>
         {email && <p className="truncate text-sm text-dim-2">{email}</p>}

--- a/src/features/engagements/pages/EngagementDetailPage.tsx
+++ b/src/features/engagements/pages/EngagementDetailPage.tsx
@@ -48,7 +48,7 @@ import { useEngagementDetail } from '../hooks/useEngagementDetail';
 
 const STATUS_VARIANTS: Record<EngagementStatus, { label: string; className: string }> = {
   draft:    { label: 'Draft',    className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' },
-  sent:     { label: 'Sent',     className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' },
+  sent:     { label: 'Sent',     className: 'bg-card/60 text-dim-2 ring-line-subtle' },
   accepted: { label: 'Accepted', className: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300' },
   declined: { label: 'Declined', className: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300' },
 };
@@ -66,8 +66,8 @@ const CONFLICT_VARIANTS: Record<ConflictStatus, { label: string; className: stri
   clear:             { label: 'Clear',             className: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300' },
   review_required:   { label: 'Review Required',   className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' },
   conflicted:        { label: 'Conflicted',        className: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300' },
-  unknown:           { label: 'Unknown',           className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' },
-  insufficient_data: { label: 'Insufficient Data', className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' },
+  unknown:           { label: 'Unknown',           className: 'bg-card/60 text-dim-2 ring-line-subtle' },
+  insufficient_data: { label: 'Insufficient Data', className: 'bg-card/60 text-dim-2 ring-line-subtle' },
 };
 
 // ── Display helpers ──────────────────────────────────────────────────────────
@@ -235,7 +235,7 @@ const FeeStructureCard: FunctionComponent<{ proposal: ProposalData | null }> = (
 const ContractBodyCard: FunctionComponent<{ engagement: EngagementDetail }> = ({ engagement }) => (
   <SectionCard title="Contract body">
     {engagement.contract_body?.trim() ? (
-      <div className="max-h-[360px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-line-subtle bg-surface-overlay/30 p-3 text-sm leading-relaxed text-ink">
+      <div className="max-h-[360px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-line-subtle bg-card/30 p-3 text-sm leading-relaxed text-ink">
         {engagement.contract_body}
       </div>
     ) : (
@@ -499,7 +499,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center justify-between gap-3 p-5 text-left transition-colors hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:p-6"
+        className="flex w-full items-center justify-between gap-3 p-5 text-left transition-colors hover:bg-paper-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:p-6"
       >
         <div className="flex min-w-0 items-center gap-3">
           <MessagesSquare className="h-4 w-4 shrink-0 text-dim-2" />
@@ -514,7 +514,7 @@ const ConversationPreviewCard: FunctionComponent<ConversationPreviewCardProps> =
       </button>
       {isExpanded && !isMobile && (
         <div className="border-t border-line-subtle">
-          <div className="h-[320px] bg-surface-overlay/20">
+          <div className="h-[320px] bg-card/20">
             <ConversationContent
               isLoading={isLoading}
               error={error}
@@ -1126,7 +1126,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
   const statusBanner = (() => {
     if (isSent) {
       return (
-        <div className="rounded-xl border border-line-subtle bg-surface-overlay/40 p-4 text-sm text-ink">
+        <div className="rounded-r-md border border-line-subtle bg-card/40 p-4 text-sm text-ink">
           <p className="font-medium">Awaiting client response</p>
           <p className="mt-1 text-dim-2">The client received this engagement and will accept or decline online.</p>
         </div>
@@ -1134,7 +1134,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
     }
     if (isAccepted) {
       return (
-        <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-300">
+        <div className="rounded-r-md border border-emerald-500/20 bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-300">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="font-medium">Engagement active</p>
@@ -1155,7 +1155,7 @@ export const EngagementDetailPage: FunctionComponent<EngagementDetailPageProps> 
     }
     if (isDeclined) {
       return (
-        <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 p-4 text-sm text-rose-700 dark:text-rose-300">
+        <div className="rounded-r-md border border-rose-500/20 bg-rose-500/10 p-4 text-sm text-rose-700 dark:text-rose-300">
           <p className="font-medium">Declined</p>
           <p className="mt-1 text-rose-700/80 dark:text-rose-200/80">This engagement was marked declined.</p>
         </div>

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -54,9 +54,9 @@ const engagementStatusBadge = (status: EngagementStatus | string | undefined): S
     case 'draft':
       return { label: 'Draft', className: 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300' };
     case 'sent':
-      return { label: 'Sent', className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' };
+      return { label: 'Sent', className: 'bg-card/60 text-dim-2 ring-line-subtle' };
     default:
-      return { label: '—', className: 'bg-surface-overlay/60 text-dim-2 ring-line-subtle' };
+      return { label: '—', className: 'bg-card/60 text-dim-2 ring-line-subtle' };
   }
 };
 
@@ -117,7 +117,7 @@ const EngagementMobileCard: FunctionComponent<{
     <button
       type="button"
       onClick={onClick}
-      className="w-full rounded-xl border border-card-border bg-surface-card px-4 py-3 text-left transition-colors hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      className="w-full rounded-r-md border border-card-border bg-card px-4 py-3 text-left transition-colors hover:bg-paper-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
     >
       <div className="flex items-start justify-between gap-3 pb-3">
         <span className="font-semibold text-ink break-words">{name}</span>
@@ -290,7 +290,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     : `No ${activeTab} engagements yet.`;
 
   return (
-    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+    <div className="flex h-full flex-col min-h-0 bg-paper">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-line-subtle px-4 py-3 md:px-6">
         <SegmentedToggle<StatusFilter>
           value={activeTab}
@@ -333,7 +333,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
                 stickyHeader
                 className="panel overflow-hidden"
                 bodyClassName="bg-transparent"
-                rowClassName="transition-colors duration-150 hover:!bg-surface-card-hover"
+                rowClassName="transition-colors duration-150 hover:!bg-paper-2"
                 hasMore={hasMore}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={loadMore}
@@ -345,7 +345,7 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
               {isLoading && engagements.length === 0 ? (
                 <div className="flex flex-col gap-3 px-4 py-3">
                   {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={`skeleton-${i}`} className="h-32 rounded-xl bg-surface-card animate-pulse" />
+                    <div key={`skeleton-${i}`} className="h-32 rounded-r-md bg-card animate-pulse" />
                   ))}
                 </div>
               ) : (

--- a/src/features/files/components/FileDetailDrawer.tsx
+++ b/src/features/files/components/FileDetailDrawer.tsx
@@ -47,11 +47,11 @@ const FileDetailContent = ({ file }: { file: OrgFile }) => {
 
   return (
     <div className="space-y-5">
-      <div className="flex aspect-[4/3] w-full items-center justify-center overflow-hidden rounded-2xl bg-surface-panel">
+      <div className="flex aspect-[4/3] w-full items-center justify-center overflow-hidden rounded-2xl bg-paper-2">
         {isImage && previewUrl ? (
           <img src={previewUrl} alt={file.fileName} className="h-full w-full object-contain" />
         ) : isImage && previewLoading ? (
-          <div className="h-full w-full animate-pulse bg-surface-panel" />
+          <div className="h-full w-full animate-pulse bg-paper-2" />
         ) : (
           <div className={`flex h-20 w-20 items-center justify-center rounded-2xl ${fileType.color}`}>
             <Icon icon={fileType.icon} className="h-10 w-10 text-ink" />
@@ -138,7 +138,7 @@ export const FileDetailDrawer = ({ file, isOpen, onClose }: FileDetailDrawerProp
   if (isMobile) {
     return (
       <Fullscreen isOpen={isOpen} onClose={onClose} ariaLabel={`File ${file.fileName}`}>
-        <div className="flex h-full flex-col bg-surface-workspace">
+        <div className="flex h-full flex-col bg-paper">
           <div className="flex-1 overflow-y-auto px-4 py-6">
             <FileDetailContent file={file} />
           </div>

--- a/src/features/files/components/FilesInspectorPanel.tsx
+++ b/src/features/files/components/FilesInspectorPanel.tsx
@@ -87,7 +87,7 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
   return (
     <aside
       aria-label="File details"
-      className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-surface-card"
+      className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-card"
     >
       <header className="flex items-center justify-between border-b border-line-subtle px-4 py-3">
         <h2 className="text-sm font-semibold text-ink">Details</h2>
@@ -95,18 +95,18 @@ export const FilesInspectorPanel = ({ file, practiceSlug, scope, onClose }: File
           type="button"
           onClick={onClose}
           aria-label="Close inspector"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-dim-2 hover:bg-surface-panel hover:text-ink"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-dim-2 hover:bg-paper-2 hover:text-ink"
         >
           <Icon icon={X} className="h-4 w-4" />
         </button>
       </header>
 
       <div className="flex-1 space-y-5 overflow-y-auto px-4 py-5">
-        <div className="flex aspect-[4/3] w-full items-center justify-center overflow-hidden rounded-xl bg-surface-panel">
+        <div className="flex aspect-[4/3] w-full items-center justify-center overflow-hidden rounded-r-md bg-paper-2">
           {isImage && previewUrl ? (
             <img src={previewUrl} alt={file.fileName} className="h-full w-full object-contain" />
           ) : isImage && previewLoading ? (
-            <div className="h-full w-full animate-pulse bg-surface-panel" />
+            <div className="h-full w-full animate-pulse bg-paper-2" />
           ) : (
             <div className={`flex h-20 w-20 items-center justify-center rounded-2xl ${fileType.color}`}>
               <Icon icon={fileType.icon} className="h-10 w-10 text-ink" />

--- a/src/features/files/components/FilesList.tsx
+++ b/src/features/files/components/FilesList.tsx
@@ -38,7 +38,7 @@ export const FilesList = ({
       cells: {
         name: (
           <div className="flex min-w-0 items-center gap-3">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-panel text-dim-2">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-paper-2 text-dim-2">
               <Icon icon={fileType.icon} className="h-4 w-4" />
             </span>
             <span className="min-w-0 truncate" title={file.fileName}>{file.fileName}</span>

--- a/src/features/files/components/FilesViewToggle.tsx
+++ b/src/features/files/components/FilesViewToggle.tsx
@@ -13,13 +13,13 @@ interface FilesViewToggleProps {
 const buttonClass = (active: boolean) => cn(
   'flex h-7 w-7 items-center justify-center rounded-md transition-colors',
   active
-    ? 'bg-surface-card text-ink shadow-sm'
+    ? 'bg-card text-ink shadow-sm'
     : 'text-dim-2 hover:text-ink'
 );
 
 export const FilesViewToggle = ({ value, onChange }: FilesViewToggleProps) => (
   <div
-    className="inline-flex items-center gap-1 rounded-lg border border-line-subtle bg-surface-panel/60 p-1"
+    className="inline-flex items-center gap-1 rounded-lg border border-line-subtle bg-paper-2/60 p-1"
     role="group"
     aria-label="File view mode"
   >

--- a/src/features/files/components/UploadDestinationDialog.tsx
+++ b/src/features/files/components/UploadDestinationDialog.tsx
@@ -184,7 +184,7 @@ export const UploadDestinationDialog = ({
           disabled={isLoading}
         />
         {error ? (
-          <div className="status-error flex items-center justify-between gap-3 rounded-xl px-3 py-2 text-sm">
+          <div className="status-error flex items-center justify-between gap-3 rounded-r-md px-3 py-2 text-sm">
             <span className="min-w-0 flex-1 truncate">{error}</span>
             <Button variant="ghost" size="sm" onClick={() => { void refetch(); }}>
               Retry
@@ -192,7 +192,7 @@ export const UploadDestinationDialog = ({
           </div>
         ) : null}
         {!isLoading && options.length === 0 && !error ? (
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-3 text-sm text-dim-2">
+          <div className="flex items-center justify-between gap-3 rounded-r-md border border-line-subtle bg-paper-2/50 px-3 py-3 text-sm text-dim-2">
             <span className="min-w-0 flex-1">
               {clientUserId
                 ? "You don't have any matters or intakes yet. Open a conversation with the practice to get started."
@@ -213,7 +213,7 @@ export const UploadDestinationDialog = ({
             emptyStateLabel={null}
           />
         ) : options.length > 0 ? (
-          <p className="rounded-xl border border-line-subtle bg-surface-panel/50 px-3 py-4 text-sm text-dim-2">
+          <p className="rounded-r-md border border-line-subtle bg-paper-2/50 px-3 py-4 text-sm text-dim-2">
             Pick a destination above to enable the upload area.
           </p>
         ) : null}

--- a/src/features/intake/components/DocumentChecklist.tsx
+++ b/src/features/intake/components/DocumentChecklist.tsx
@@ -115,10 +115,10 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
         {documents.map((doc) => (
           <div
             key={doc.id}
-            className={`border rounded-xl p-4 transition-all duration-300 ${
+            className={`border rounded-r-md p-4 transition-all duration-300 ${
               dragOverId === doc.id 
-                ? 'border-accent-500 bg-accent-500/10 scale-[1.02]' 
-                : 'border-line-subtle bg-surface-utility/5'
+                ? 'border-accent-500 bg-accent/10 scale-[1.02]' 
+                : 'border-line-subtle bg-paper-2/5'
             }`}
             onDrop={(e) => handleDrop(doc.id, e)}
             onDragOver={(e) => handleDragOver(doc.id, e)}
@@ -144,7 +144,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
                       ? 'bg-emerald-500/10 text-emerald-400'
                       : doc.status === 'pending'
                       ? 'bg-amber-500/10 text-amber-400'
-                      : 'bg-surface-utility/5 text-dim-2'
+                      : 'bg-paper-2/5 text-dim-2'
                   }`}>
                     {getStatusText(doc.status, doc.required)}
                   </span>

--- a/src/features/intake/components/EmbedCodeBlock.tsx
+++ b/src/features/intake/components/EmbedCodeBlock.tsx
@@ -125,7 +125,7 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
         <p className="text-sm text-dim-2">
           Share the direct link or install the widget script on your site.
         </p>
-        <div className="panel rounded-xl px-4 py-3">
+        <div className="panel rounded-r-md px-4 py-3">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
               <p className="text-xs font-medium uppercase tracking-widest text-dim-2">Public link</p>
@@ -150,7 +150,7 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
           Paste this script into your site&apos;s <code>&lt;head&gt;</code> or before <code>&lt;/body&gt;</code> to load this intake flow.
         </p>
         <div className="relative group">
-          <pre className="bg-elevation-2 overflow-x-auto rounded-xl border border-line-subtle p-4 pr-20 text-sm font-mono text-ink">
+          <pre className="bg-elevation-2 overflow-x-auto rounded-r-md border border-line-subtle p-4 pr-20 text-sm font-mono text-ink">
             {snippet}
           </pre>
           <Button
@@ -176,7 +176,7 @@ export function EmbedCodeBlock({ practiceSlug, templateSlug }: EmbedCodeBlockPro
             ref={textareaRef}
             readOnly
             value={snippet}
-            className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-ink"
+            className="w-full resize-none rounded-md border border-line-subtle bg-paper p-3 font-mono text-sm text-ink"
             rows={6}
             aria-label="Embed snippet"
           />
@@ -236,7 +236,7 @@ export function EmbedCodeDialog({ isOpen, onClose, practiceSlug, templateSlug }:
           ref={textareaRef}
           readOnly
           value={snippet}
-          className="w-full resize-none rounded-md border border-line-subtle bg-surface-ground p-3 font-mono text-sm text-ink"
+          className="w-full resize-none rounded-md border border-line-subtle bg-paper p-3 font-mono text-sm text-ink"
           rows={6}
           aria-label="Embed snippet"
         />

--- a/src/features/intake/components/IntakeFilesPanel.tsx
+++ b/src/features/intake/components/IntakeFilesPanel.tsx
@@ -107,7 +107,7 @@ export const IntakeFilesPanel: FunctionComponent<IntakeFilesPanelProps> = ({
 
   return (
     <section
-      className={`rounded-xl border border-card-border bg-surface-card p-4 sm:p-6 ${className ?? ''}`}
+      className={`rounded-r-md border border-card-border bg-card p-4 sm:p-6 ${className ?? ''}`}
     >
       <FilesCollectionPanel
         files={orgFiles}

--- a/src/features/intake/components/IntakePaymentCard.tsx
+++ b/src/features/intake/components/IntakePaymentCard.tsx
@@ -33,7 +33,7 @@ export const IntakePaymentCard: FunctionComponent<IntakePaymentCardProps> = ({ p
           href={paymentRequest.paymentLinkUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="btn btn-primary w-full text-center no-underline inline-flex items-center justify-center h-10 px-4 rounded-xl font-semibold transition-all hover:opacity-90 active:scale-[0.98]"
+          className="btn btn-primary w-full text-center no-underline inline-flex items-center justify-center h-10 px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98]"
         >
           {buttonLabel}
         </a>
@@ -42,7 +42,7 @@ export const IntakePaymentCard: FunctionComponent<IntakePaymentCardProps> = ({ p
           type="button"
           disabled
           aria-disabled="true"
-          className="inline-flex h-10 w-full cursor-not-allowed items-center justify-center rounded-xl bg-accent-500 px-4 text-center font-semibold text-[rgb(var(--accent-foreground))] opacity-70"
+          className="inline-flex h-10 w-full cursor-not-allowed items-center justify-center rounded-r-md bg-accent px-4 text-center font-semibold text-[rgb(var(--accent-foreground))] opacity-70"
           title="Preview only"
         >
           {buttonLabel}

--- a/src/features/intake/components/IntakePaymentForm.tsx
+++ b/src/features/intake/components/IntakePaymentForm.tsx
@@ -317,22 +317,22 @@ export const IntakePaymentForm: FunctionComponent<IntakePaymentFormProps> = ({
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
       {(!stripe || !elements) && (
-        <div className="flex justify-center rounded-xl border border-line-subtle bg-surface-panel/60 px-4 py-3 backdrop-blur-md">
+        <div className="flex justify-center rounded-r-md border border-line-subtle bg-paper-2/60 px-4 py-3 backdrop-blur-md">
           <LoadingSpinner size="sm" ariaLabel="Loading secure payment form" />
         </div>
       )}
-      <div className={variant === 'card' ? "panel p-5" : "rounded-xl border border-line-subtle bg-surface-panel/60 p-4"}>
+      <div className={variant === 'card' ? "panel p-5" : "rounded-r-md border border-line-subtle bg-paper-2/60 p-4"}>
         <PaymentElement options={{ layout: 'tabs' }} />
       </div>
 
       {errorMessage && (
-        <div className="rounded-xl border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground backdrop-blur-xl dark:text-accent-error-light">
+        <div className="rounded-r-md border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground backdrop-blur-xl dark:text-accent-error-light">
           {errorMessage}
         </div>
       )}
 
       {callbackWarning && (
-        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 backdrop-blur-xl dark:text-amber-200">
+        <div className="rounded-r-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 backdrop-blur-xl dark:text-amber-200">
           {callbackWarning}
         </div>
       )}

--- a/src/features/intake/pages/ClientIntakeStatusPage.tsx
+++ b/src/features/intake/pages/ClientIntakeStatusPage.tsx
@@ -50,7 +50,7 @@ const statusPillClass = (kind: ClientIntakeStatusKind): string => {
       return 'bg-accent-warning/15 text-accent-warning ring-accent-warning/30';
     case 'submitted':
     default:
-      return 'bg-surface-utility/40 text-ink ring-line-subtle/30';
+      return 'bg-paper-2/40 text-ink ring-line-subtle/30';
   }
 };
 
@@ -62,7 +62,7 @@ const Card: FunctionComponent<{ children: ComponentChildren; className?: string 
 }) => (
   <section
     className={cn(
-      'rounded-xl border border-card-border bg-surface-card p-4 sm:p-5',
+      'rounded-r-md border border-card-border bg-card p-4 sm:p-5',
       className,
     )}
   >
@@ -108,7 +108,7 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
 }) => {
   if (!intake) {
     return (
-      <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+      <div className="flex h-full flex-col min-h-0 bg-paper">
         <DetailHeader title="Intake Forms" showBack={Boolean(onBack)} onBack={onBack} />
         <div className="p-6 text-sm text-dim-2">
           You have not submitted any intakes yet.
@@ -118,7 +118,7 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
   }
 
   return (
-    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+    <div className="flex h-full flex-col min-h-0 bg-paper">
       <DetailHeader title="Intake Forms" showBack={Boolean(onBack)} onBack={onBack} />
 
       <div className="flex-1 min-h-0 overflow-y-auto">
@@ -141,7 +141,7 @@ export const ClientIntakeStatusPage: FunctionComponent<ClientIntakeStatusPagePro
 
           {/* Next step */}
           {intake.nextStep ? (
-            <Card className="bg-surface-utility/30">
+            <Card className="bg-paper-2/30">
               <SectionHeading>Next Step</SectionHeading>
               <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-ink/90">
                 {intake.nextStep}

--- a/src/features/intake/pages/ClientIntakesView.tsx
+++ b/src/features/intake/pages/ClientIntakesView.tsx
@@ -189,7 +189,7 @@ export const ClientIntakesView: FunctionComponent<ClientIntakesViewProps> = ({
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center bg-surface-workspace">
+      <div className="flex h-full items-center justify-center bg-paper">
         <LoadingSpinner ariaLabel="Loading intake" />
       </div>
     );
@@ -197,7 +197,7 @@ export const ClientIntakesView: FunctionComponent<ClientIntakesViewProps> = ({
 
   if (error) {
     return (
-      <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+      <div className="flex h-full flex-col min-h-0 bg-paper">
         <DetailHeader title="Intake Forms" showBack={Boolean(intakeUuid)} onBack={intakeUuid ? onBack : undefined} />
         <div className="p-6 text-sm text-error">{error}</div>
       </div>

--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -236,7 +236,7 @@ function triageBadgeClass(status?: string | null): string {
     case 'rejected':
       return 'bg-error/10 text-error ring-error/20';
     case 'spam':
-      return 'bg-surface-utility/40 text-dim-2 ring-line-subtle/30';
+      return 'bg-paper-2/40 text-dim-2 ring-line-subtle/30';
     case 'pending_review':
     default:
       return 'bg-warning/10 text-warning ring-warning/20';
@@ -254,7 +254,7 @@ const SectionLabel: FunctionComponent<{ children: ComponentChildren; className?:
 const Card: FunctionComponent<{ children: ComponentChildren; className?: string }> = ({ children, className }) => (
   <section
     className={cn(
-      'rounded-xl border border-card-border bg-surface-card p-4 sm:p-6',
+      'rounded-r-md border border-card-border bg-card p-4 sm:p-6',
       className,
     )}
   >
@@ -299,7 +299,7 @@ const DetailSkeleton: FunctionComponent<{ onBack: () => void }> = ({ onBack }) =
     <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="grid h-full grid-cols-1 xl:grid-cols-[minmax(0,1fr)_280px]">
         <div className="space-y-4 p-6">
-          <div className="rounded-xl border border-card-border bg-surface-card p-6 space-y-3">
+          <div className="rounded-r-md border border-card-border bg-card p-6 space-y-3">
             <SkeletonLoader variant="text" width="w-32" height="h-3" />
             <SkeletonLoader variant="title" width="w-3/4" height="h-7" />
             <SkeletonLoader variant="text" width="w-48" height="h-3" />
@@ -309,7 +309,7 @@ const DetailSkeleton: FunctionComponent<{ onBack: () => void }> = ({ onBack }) =
               <SkeletonLoader variant="text" width="w-5/6" height="h-3" />
             </div>
           </div>
-          <div className="rounded-xl border border-card-border bg-surface-card p-6 space-y-4">
+          <div className="rounded-r-md border border-card-border bg-card p-6 space-y-4">
             <SkeletonLoader variant="text" width="w-32" height="h-3" />
             <div className="grid grid-cols-2 gap-4">
               {[0, 1, 2, 3].map((i) => (
@@ -320,16 +320,16 @@ const DetailSkeleton: FunctionComponent<{ onBack: () => void }> = ({ onBack }) =
               ))}
             </div>
           </div>
-          <div className="rounded-xl border border-card-border bg-surface-card p-6 space-y-3">
+          <div className="rounded-r-md border border-card-border bg-card p-6 space-y-3">
             <SkeletonLoader variant="text" width="w-32" height="h-3" />
             <MessageRowSkeleton lineWidths={['w-40', 'w-56']} />
             <MessageRowSkeleton lineWidths={['w-64', 'w-44']} />
           </div>
         </div>
-        <aside className="hidden xl:block space-y-4 border-l border-line-subtle bg-surface-panel p-6">
+        <aside className="hidden xl:block space-y-4 border-l border-line-subtle bg-paper-2 p-6">
           <SkeletonLoader variant="button" width="w-full" />
           <SkeletonLoader variant="button" width="w-full" />
-          <div className="rounded-xl border border-card-border bg-surface-card p-4 space-y-3">
+          <div className="rounded-r-md border border-card-border bg-card p-4 space-y-3">
             <div className="flex items-center gap-3">
               <SkeletonLoader variant="avatar" />
               <div className="flex-1 space-y-1.5">
@@ -1116,7 +1116,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <SectionLabel>Conversation</SectionLabel>
         <p className="mt-1 text-xs text-dim-2">Continue the client thread from this intake.</p>
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden bg-surface-overlay/20 touch-pan-y">
+      <div className="min-h-0 flex-1 overflow-hidden bg-card/20 touch-pan-y">
         {previewLoading && previewMessages.length === 0 ? (
           <div className="space-y-3 px-4 py-4">
             <MessageRowSkeleton lineWidths={['w-40', 'w-56']} />
@@ -1219,7 +1219,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
     <>
       <Button
         variant="primary"
-        className="btn-primary btn-md w-full !bg-accent-500 text-[rgb(var(--accent-foreground))]"
+        className="btn-primary btn-md w-full !bg-accent text-[rgb(var(--accent-foreground))]"
         disabled={isSubmitting}
         onClick={() => openTriageDialog('accepted')}
       >
@@ -1247,7 +1247,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         <Avatar
           name={name ?? ''}
           size="md"
-          className="bg-surface-utility/40 text-ink ring-1 ring-line-subtle"
+          className="bg-paper-2/40 text-ink ring-1 ring-line-subtle"
         />
         <div className="min-w-0">
           <p className="truncate text-sm font-semibold text-ink">{name ?? 'Unnamed lead'}</p>
@@ -1310,7 +1310,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
   ) : null;
 
   return (
-    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
+    <div className="flex h-full flex-col min-h-0 bg-paper">
       <DetailHeader
         title={name ?? intakeTitle}
         showBack
@@ -1345,7 +1345,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
           </div>
 
           {/* Desktop right panel */}
-          <aside className="hidden xl:flex flex-col gap-4 border-l border-line-subtle bg-surface-panel p-6">
+          <aside className="hidden xl:flex flex-col gap-4 border-l border-line-subtle bg-paper-2 p-6">
             {isPending ? <div className="flex flex-col gap-3">{triageActions}</div> : null}
             {engagementActionCard}
             {aboutCard}
@@ -1409,7 +1409,7 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
                       'flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors',
                       generateTemplateId === t.id
                         ? 'border-accent bg-accent/10 text-[rgb(var(--accent-foreground))]'
-                        : 'border-card-border bg-surface-card text-ink hover:bg-surface-overlay/40',
+                        : 'border-card-border bg-card text-ink hover:bg-card/40',
                     )}
                     onClick={() => setGenerateTemplateId(t.id)}
                   >

--- a/src/features/intake/pages/IntakeTemplatesPage.tsx
+++ b/src/features/intake/pages/IntakeTemplatesPage.tsx
@@ -357,7 +357,7 @@ type StatPillProps = {
 
 function _StatPill({ label, value }: StatPillProps) {
   return (
-    <div className="rounded-xl border border-line-subtle bg-surface-card px-3 py-2">
+    <div className="rounded-r-md border border-line-subtle bg-card px-3 py-2">
       <p className="text-lg font-semibold text-ink">{value}</p>
       <p className="text-xs text-dim-2">{label}</p>
     </div>
@@ -421,7 +421,7 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
   return (
     <div
       className={cn(
-        'rounded-xl border bg-surface-card transition-colors',
+        'rounded-r-md border bg-card transition-colors',
         isActive ? 'border-line-subtle border-l-[3px] border-l-accent-500' : 'border-line-subtle',
       )}
     >
@@ -443,8 +443,8 @@ function SectionCard({ number, icon, title, badge, isActive, isOpen, onToggle, o
             className={cn(
               'rounded-full px-2 py-0.5 text-[11px] font-medium',
               badge.tone === 'required'
-                ? 'bg-accent-500 text-[rgb(var(--accent-foreground))]'
-                : 'bg-surface-input text-dim-2',
+                ? 'bg-accent text-[rgb(var(--accent-foreground))]'
+                : 'bg-card text-dim-2',
             )}
           >
             {badge.label}
@@ -507,7 +507,7 @@ function QuestionRow({ label, preview, isSelected, isLocked, badgeLabel, onSelec
       aria-grabbed={draggable ? false : undefined}
       className={cn(
         'flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm transition-colors',
-        isSelected ? 'bg-accent-500/10' : 'hover:bg-surface-input/60',
+        isSelected ? 'bg-accent/10' : 'hover:bg-card/60',
       )}
       draggable={draggable}
       onDragStart={dragHandlers?.onDragStart}
@@ -543,7 +543,7 @@ function QuestionRow({ label, preview, isSelected, isLocked, badgeLabel, onSelec
 
 function LockedFieldChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-line-subtle bg-surface-input px-2 py-0.5 text-[11px] font-medium text-dim-2">
+    <span className="inline-flex items-center gap-1 rounded-full border border-line-subtle bg-card px-2 py-0.5 text-[11px] font-medium text-dim-2">
       <Lock className="h-3 w-3" />
       {label}
     </span>
@@ -997,7 +997,7 @@ function TemplateEditor({
         onInput={(event) => handleNameChange((event.currentTarget as HTMLInputElement).value)}
         placeholder="New intake form"
         disabled={isSaving}
-        className="w-full min-w-0 rounded-lg border border-transparent bg-transparent px-2 py-1 text-base font-semibold text-ink outline-none transition-colors placeholder:text-dim-2 hover:border-line-subtle focus:border-line-subtle focus:bg-surface-utility/10"
+        className="w-full min-w-0 rounded-lg border border-transparent bg-transparent px-2 py-1 text-base font-semibold text-ink outline-none transition-colors placeholder:text-dim-2 hover:border-line-subtle focus:border-line-subtle focus:bg-paper-2/10"
         aria-label="Form title"
       />
       {slugError ? <p className="mt-1 text-xs text-rose-500">{slugError}</p> : null}
@@ -1074,7 +1074,7 @@ function TemplateEditor({
           hasChanges
             ? 'border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300'
             : hasSavedDraft
-              ? 'border-line-subtle bg-surface-input text-dim-2'
+              ? 'border-line-subtle bg-card text-dim-2'
               : 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
         )}
       >
@@ -1117,7 +1117,7 @@ function TemplateEditor({
     <div className="flex flex-col gap-3 overflow-visible">
       <SectionHeaderLabel>FORM STRUCTURE</SectionHeaderLabel>
       {discardPending ? (
-        <div className="rounded-xl border border-rose-500/20 bg-rose-500/10 p-3">
+        <div className="rounded-r-md border border-rose-500/20 bg-rose-500/10 p-3">
           <p className="text-sm font-semibold text-ink">Discard draft changes?</p>
           <div className="mt-3 flex gap-2">
             <Button
@@ -1335,8 +1335,8 @@ function TemplateEditor({
 
   const livePreview = (
     <div className="flex h-full flex-col items-center py-4">
-      <div className="w-full max-w-[380px] overflow-hidden rounded-xl border border-line-subtle bg-surface-card shadow-glass">
-        <div className="flex h-11 items-center justify-between border-b border-line-subtle bg-surface-utility/50 px-3">
+      <div className="w-full max-w-[380px] overflow-hidden rounded-r-md border border-line-subtle bg-card shadow-glass">
+        <div className="flex h-11 items-center justify-between border-b border-line-subtle bg-paper-2/50 px-3">
           <div className="min-w-0">
             <p className="text-sm font-semibold text-ink">Widget preview</p>
             <p className="truncate text-xs text-dim-2">{practiceSlug || 'public form'} / {draftTemplate.slug || 'new'}</p>
@@ -1346,7 +1346,7 @@ function TemplateEditor({
             target="_blank"
             rel="noreferrer"
             aria-label="Open public form preview"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-dim-2 transition-colors hover:bg-surface-input hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-dim-2 transition-colors hover:bg-card hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40"
           >
             <ExternalLink className="h-4 w-4" aria-hidden="true" />
           </a>
@@ -1438,7 +1438,7 @@ function TemplateEditor({
             <button
               type="button"
               disabled
-              className="flex items-center justify-between rounded-lg border border-line-subtle bg-surface-input px-3 py-2 text-left text-sm text-ink"
+              className="flex items-center justify-between rounded-lg border border-line-subtle bg-card px-3 py-2 text-left text-sm text-ink"
             >
               <span>Free text</span>
               <ChevronDown className="h-4 w-4 text-dim-2" />
@@ -1758,8 +1758,8 @@ function TemplateEditor({
       contentMaxWidth={null}
       sidebar={formStructure}
       inspector={inspectorPanel}
-      sidebarClassName="bg-surface-navigation px-3 py-4 border-0"
-      inspectorClassName="bg-surface-utility p-0 border-0"
+      sidebarClassName="bg-paper-2 px-3 py-4 border-0"
+      inspectorClassName="bg-paper-2 p-0 border-0"
       actions={headerActions}
     >
       {livePreview}
@@ -1894,7 +1894,7 @@ function TemplateListView({
                 onClick={(e) => e.stopPropagation()}
                 disabled={isSaving}
                 aria-label={`Actions for ${template.name}`}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-dim-2 transition-colors hover:bg-surface-utility/10 hover:text-ink disabled:opacity-60"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-dim-2 transition-colors hover:bg-paper-2/10 hover:text-ink disabled:opacity-60"
               >
                 <MoreVertical className="h-4 w-4" />
               </button>
@@ -1944,7 +1944,7 @@ function TemplateListView({
         stickyHeader
         className="panel overflow-hidden"
         bodyClassName="bg-transparent"
-        rowClassName="transition-colors duration-150 hover:!bg-surface-card-hover"
+        rowClassName="transition-colors duration-150 hover:!bg-paper-2"
         emptyState="No intake forms yet."
       />
       {embedTarget ? (
@@ -1966,7 +1966,7 @@ function TemplateListView({
           </p>
           <p className="mt-2 text-sm text-dim-2">
             Links using{' '}
-            <code className="rounded bg-surface-utility px-1.5 py-0.5 font-mono text-xs">
+            <code className="rounded bg-paper-2 px-1.5 py-0.5 font-mono text-xs">
               ?template={deleteTarget?.slug}
             </code>{' '}
             will use the default flow.

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -275,8 +275,8 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
         : 'No leads have come in yet. New consultation inquiries will appear here.';
 
   return (
-    <div className="flex h-full flex-col min-h-0 bg-surface-workspace">
-      <div className="border-b border-line-subtle bg-surface-workspace px-4 py-3 md:px-6">
+    <div className="flex h-full flex-col min-h-0 bg-paper">
+      <div className="border-b border-line-subtle bg-paper px-4 py-3 md:px-6">
         <SegmentedToggle<TriageFilter>
           value={triageFilter}
           options={TRIAGE_FILTERS.map((filter) => ({ value: filter.id, label: filter.label }))}
@@ -309,7 +309,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
                 stickyHeader
                 className="panel overflow-hidden"
                 bodyClassName="bg-transparent"
-                rowClassName="transition-colors duration-150 hover:!bg-surface-card-hover"
+                rowClassName="transition-colors duration-150 hover:!bg-paper-2"
                 hasMore={hasMore}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={loadMore}
@@ -321,7 +321,7 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
               {isLoading && rows.length === 0 ? (
                 <div className="flex flex-col gap-3 px-4 py-3">
                   {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={`skeleton-${i}`} className="h-32 rounded-xl bg-surface-card animate-pulse" />
+                    <div key={`skeleton-${i}`} className="h-32 rounded-r-md bg-card animate-pulse" />
                   ))}
                 </div>
               ) : (
@@ -368,7 +368,7 @@ const IntakeMobileCard: FunctionComponent<IntakeMobileCardProps> = ({ item, onCl
     <button
       type="button"
       onClick={onClick}
-      className="w-full rounded-xl border border-card-border bg-surface-card px-4 py-3 text-left transition-colors hover:bg-surface-card-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      className="w-full rounded-r-md border border-card-border bg-card px-4 py-3 text-left transition-colors hover:bg-paper-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
     >
       <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm">
         {rows.map(({ label, value }) => (

--- a/src/features/invoices/components/InvoiceBuilderSurface.tsx
+++ b/src/features/invoices/components/InvoiceBuilderSurface.tsx
@@ -201,7 +201,7 @@ export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilde
   if (mode === 'edit' && displayErrorMessage && !resolvedInvoice) {
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-6">
-        <div className="rounded-xl border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
+        <div className="rounded-r-md border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
           {displayErrorMessage}
         </div>
       </div>
@@ -211,7 +211,7 @@ export const InvoiceBuilderSurface = forwardRef<InvoiceFormHandle, InvoiceBuilde
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-6">
       {displayErrorMessage ? (
-        <div className="rounded-xl border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
+        <div className="rounded-r-md border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
           {displayErrorMessage}
         </div>
       ) : null}

--- a/src/features/invoices/components/InvoiceForm.tsx
+++ b/src/features/invoices/components/InvoiceForm.tsx
@@ -397,7 +397,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
       >
         <>
             {!resolvedReadOnly && !isValidConnectedAccount ? (
-              <div className="status-warning rounded-xl px-4 py-3 text-sm">
+              <div className="status-warning rounded-r-md px-4 py-3 text-sm">
                 Complete Stripe onboarding to enable invoicing.
               </div>
             ) : null}
@@ -511,7 +511,7 @@ export const InvoiceForm = forwardRef<InvoiceFormHandle, InvoiceFormProps>(({
             <Textarea label="Notes to client" value={notes} onChange={handleNotesChange} rows={3} disabled={resolvedReadOnly} />
             <Textarea label="Internal memo" value={memo} onChange={handleMemoChange} rows={2} disabled={resolvedReadOnly} />
             {sendError ? (
-              <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+              <div className="rounded-r-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">
                 <p>{sendError}</p>
                 {createdInvoiceId ? (
                   <div className="mt-2">

--- a/src/features/invoices/components/InvoiceLineItemsForm.tsx
+++ b/src/features/invoices/components/InvoiceLineItemsForm.tsx
@@ -62,7 +62,7 @@ export const InvoiceLineItemsForm = ({ lineItems, onChange, billingIncrementMinu
       </div>
 
       {lineItems.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-line-subtle p-8 text-center bg-surface-utility/20">
+        <div className="rounded-r-md border border-dashed border-line-subtle p-8 text-center bg-paper-2/20">
            <p className="text-sm text-dim-2">No line items added yet.</p>
            {!readOnly ? (
              <Button

--- a/src/features/invoices/components/InvoiceRowParts.tsx
+++ b/src/features/invoices/components/InvoiceRowParts.tsx
@@ -66,7 +66,7 @@ export const InvoiceStatusActions = ({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="rounded-md p-1 text-dim-2 transition-colors hover:bg-surface-utility/40 hover:text-ink"
+          className="rounded-md p-1 text-dim-2 transition-colors hover:bg-paper-2/40 hover:text-ink"
           aria-label="Invoice actions"
           disabled={hasPendingAction}
           onClick={(event) => event.stopPropagation()}

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -288,7 +288,7 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         toolbar={toolbar}
         emptyState={emptyMessage ?? 'No invoices found'}
         errorState={error ? (
-          <div className="panel rounded-xl p-4 text-sm text-red-300">
+          <div className="panel rounded-r-md p-4 text-sm text-red-300">
             Failed to load invoices: {error}
           </div>
         ) : undefined}

--- a/src/features/invoices/components/SendInvoiceDialog.tsx
+++ b/src/features/invoices/components/SendInvoiceDialog.tsx
@@ -75,13 +75,13 @@ export const SendInvoiceDialog = ({
     >
       {/* Loading overlay */}
       {loading && (
-        <div className="absolute inset-0 z-20 flex items-center justify-center rounded-3xl bg-surface-app-frame/60 backdrop-blur-sm">
+        <div className="absolute inset-0 z-20 flex items-center justify-center rounded-3xl bg-paper/60 backdrop-blur-sm">
           <LoadingSpinner size="lg" />
         </div>
       )}
 
       <DialogBody className="space-y-4">
-        <div className="rounded-xl border border-line-subtle bg-surface-utility/40 dark:bg-surface-utility/10 p-4">
+        <div className="rounded-r-md border border-line-subtle bg-paper-2/40 dark:bg-paper-2/10 p-4">
           <p className="text-sm text-dim-2">Send this invoice now?</p>
           <p className="mt-1 text-base font-semibold text-ink">
             Total due: {formatCurrency(totalAmount)}
@@ -99,7 +99,7 @@ export const SendInvoiceDialog = ({
 
         {/* Embedded invoice preview — visual confirmation before send */}
         {hasPreview && (
-          <div className="rounded-xl border border-line-subtle bg-surface-workspace p-3 overflow-y-auto max-h-[28rem]">
+          <div className="rounded-r-md border border-line-subtle bg-paper p-3 overflow-y-auto max-h-[28rem]">
             <InvoicePreview
               title={previewTitle ?? 'Invoice'}
               referenceLabel={previewReferenceLabel}

--- a/src/features/invoices/components/detail/InvoiceLineItemsTable.tsx
+++ b/src/features/invoices/components/detail/InvoiceLineItemsTable.tsx
@@ -24,7 +24,7 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
         <div className="mt-3 overflow-x-auto">
           <table className="min-w-full divide-y divide-line-subtle text-sm">
             <thead>
-              <tr className="text-left text-xs uppercase tracking-wider text-dim-2 bg-surface-utility/30">
+              <tr className="text-left text-xs uppercase tracking-wider text-dim-2 bg-paper-2/30">
                 <th className="px-5 py-3 font-medium">Description</th>
                 <th className="px-5 py-3 w-20 text-right font-medium">Qty</th>
                 <th className="px-5 py-3 w-32 text-right font-medium">Unit price</th>
@@ -47,7 +47,7 @@ export const InvoiceLineItemsTable = ({ detail }: InvoiceLineItemsTableProps) =>
                 </tr>
               ))}
             </tbody>
-            <tfoot className="bg-surface-utility/10 text-sm">
+            <tfoot className="bg-paper-2/10 text-sm">
               <tr>
                 <td colSpan={3} className="px-5 py-2 text-right text-dim-2">Subtotal</td>
                 <td className="px-5 py-2 text-right text-ink tabular-nums">{formatCurrency(subtotal ?? 0)}</td>

--- a/src/features/invoices/components/detail/InvoicePaymentsSection.tsx
+++ b/src/features/invoices/components/detail/InvoicePaymentsSection.tsx
@@ -29,7 +29,7 @@ export const InvoicePaymentsSection = ({ payments }: InvoicePaymentsSectionProps
         {payments.map((payment) => (
           <li
             key={payment.id}
-            className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
+            className="flex items-start justify-between gap-3 rounded-r-md border border-line-subtle bg-paper-2/20 px-4 py-3"
           >
             <div className="min-w-0">
               <p className="text-sm font-medium text-ink">{formatCurrency(payment.amount)}</p>

--- a/src/features/invoices/components/detail/InvoiceRefundsSection.tsx
+++ b/src/features/invoices/components/detail/InvoiceRefundsSection.tsx
@@ -43,7 +43,7 @@ export const InvoiceRefundsSection = ({
           return (
             <div
               key={`request-${request.id}`}
-              className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
+              className="flex items-start justify-between gap-3 rounded-r-md border border-line-subtle bg-paper-2/20 px-4 py-3"
             >
               <div className="min-w-0">
                 <p className="text-sm font-medium text-ink">
@@ -71,7 +71,7 @@ export const InvoiceRefundsSection = ({
         {refunds.map((refund) => (
           <div
             key={`refund-${refund.id}`}
-            className="flex items-start justify-between gap-3 rounded-xl border border-line-subtle bg-surface-utility/20 px-4 py-3"
+            className="flex items-start justify-between gap-3 rounded-r-md border border-line-subtle bg-paper-2/20 px-4 py-3"
           >
             <div className="min-w-0">
               <p className="text-sm font-medium text-ink">{formatCurrency(refund.amount)}</p>

--- a/src/features/invoices/components/list/InvoiceFilterChips.tsx
+++ b/src/features/invoices/components/list/InvoiceFilterChips.tsx
@@ -48,7 +48,7 @@ const Chip = ({
     className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${
       active
         ? 'border-accent-foreground/50 bg-accent-foreground/10 text-[rgb(var(--accent-foreground))]'
-        : 'border-line-subtle bg-surface-utility/30 text-dim-2 hover:text-ink'
+        : 'border-line-subtle bg-paper-2/30 text-dim-2 hover:text-ink'
     }`}
   >
     {children}

--- a/src/features/invoices/components/list/InvoiceListKpiRow.tsx
+++ b/src/features/invoices/components/list/InvoiceListKpiRow.tsx
@@ -9,8 +9,8 @@ interface InvoiceListKpiRowProps {
 const SkeletonStat = ({ label }: { label: string }) => (
   <div className="panel rounded-2xl p-4">
     <p className="text-xs text-dim-2">{label}</p>
-    <div className="mt-2 h-7 w-24 animate-pulse rounded bg-surface-utility/40" />
-    <div className="mt-2 h-3 w-16 animate-pulse rounded bg-surface-utility/30" />
+    <div className="mt-2 h-7 w-24 animate-pulse rounded bg-paper-2/40" />
+    <div className="mt-2 h-3 w-16 animate-pulse rounded bg-paper-2/30" />
   </div>
 );
 

--- a/src/features/invoices/components/refunds/RefundRequestReviewDialog.tsx
+++ b/src/features/invoices/components/refunds/RefundRequestReviewDialog.tsx
@@ -102,7 +102,7 @@ export const RefundRequestReviewDialog = ({
       disableBackdropClick={loading}
     >
       <DialogBody className="space-y-4">
-        <div className="rounded-xl border border-line-subtle bg-surface-utility/30 px-4 py-3 text-sm">
+        <div className="rounded-r-md border border-line-subtle bg-paper-2/30 px-4 py-3 text-sm">
           <div className="flex items-center justify-between">
             <span className="text-dim-2">Amount</span>
             <span className="font-semibold text-ink">

--- a/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
+++ b/src/features/invoices/pages/ClientInvoiceDetailPage.tsx
@@ -206,7 +206,7 @@ export function ClientInvoiceDetailPage({
             ) : (
               <ul className="mt-2 space-y-2 text-sm">
                 {detail.payments.map((payment) => (
-                  <li key={payment.id} className="rounded-xl border border-line-subtle px-3 py-2">
+                  <li key={payment.id} className="rounded-r-md border border-line-subtle px-3 py-2">
                     <p className="font-medium text-ink">{formatCurrency(payment.amount)} • {payment.status}</p>
                     <p className="text-xs text-dim-2">{renderEventDate(payment.paidAt)}</p>
                   </li>
@@ -222,7 +222,7 @@ export function ClientInvoiceDetailPage({
             ) : (
               <ul className="mt-2 space-y-2 text-sm">
                 {detail.refunds.map((refund) => (
-                  <li key={refund.id} className="rounded-xl border border-line-subtle px-3 py-2">
+                  <li key={refund.id} className="rounded-r-md border border-line-subtle px-3 py-2">
                     <p className="font-medium text-ink">{formatCurrency(refund.amount)} • {refund.status}</p>
                     <p className="text-xs text-dim-2">{renderEventDate(refund.createdAt)}</p>
                   </li>
@@ -267,7 +267,7 @@ export function ClientInvoiceDetailPage({
             ) : (
               <ol className="mt-2 space-y-2 text-sm">
                 {detail.refundRequests.map((request) => (
-                  <li key={request.id} className="rounded-xl border border-line-subtle px-3 py-2">
+                  <li key={request.id} className="rounded-r-md border border-line-subtle px-3 py-2">
                     <p className="font-medium text-ink">{request.status}</p>
                     <p className="text-xs text-dim-2">{renderEventDate(request.createdAt)}</p>
                     {request.reason ? <p className="mt-1 text-xs text-dim-2">{request.reason}</p> : null}

--- a/src/features/invoices/pages/ClientInvoicesPage.tsx
+++ b/src/features/invoices/pages/ClientInvoicesPage.tsx
@@ -168,7 +168,7 @@ export function ClientInvoicesPage({
           onLoadMore={hasMore ? loadMore : undefined}
           renderItem={(invoice) => (
             <div
-              className={cn('w-full px-4 py-3 text-left hover:bg-surface-utility/10')}
+              className={cn('w-full px-4 py-3 text-left hover:bg-paper-2/10')}
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">

--- a/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
+++ b/src/features/invoices/pages/PracticeInvoiceCreatePage.tsx
@@ -114,7 +114,7 @@ export function PracticeInvoiceCreatePage({
     >
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
         {draftId && !draftContext ? (
-          <div className="rounded-xl border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
+          <div className="rounded-r-md border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error-foreground">
             Invoice draft context was not found. Start invoice creation from the matter or invoices page again.
           </div>
         ) : null}

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -286,7 +286,7 @@ export function PracticeInvoicesPage({
           emptyState={<InvoicesEmptyState hasFilters={hasFilters} onCreateInvoice={onCreateInvoice} />}
           onLoadMore={hasMore ? loadMore : undefined}
           renderItem={(invoice) => (
-            <div className={cn('w-full px-4 py-3 text-left hover:bg-surface-utility/10')}>
+            <div className={cn('w-full px-4 py-3 text-left hover:bg-paper-2/10')}>
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <p className="truncate text-sm font-semibold text-ink">{invoice.invoiceNumber || '—'}</p>

--- a/src/features/matters/components/ActivityTimeline.tsx
+++ b/src/features/matters/components/ActivityTimeline.tsx
@@ -82,7 +82,7 @@ const ActivityTimeline: FunctionComponent<ActivityTimelineProps> = ({
             <div className="flex flex-col gap-3 pt-2">
               {/* Error state */}
               {error && (
-                <div className="flex items-center justify-between p-3 bg-red-50 dark:bg-red-900/20 rounded-xl">
+                <div className="flex items-center justify-between p-3 bg-red-50 dark:bg-red-900/20 rounded-r-md">
                   <div className="flex items-center">
                     <div className="text-red-600 dark:text-red-400 text-sm">{error}</div>
                   </div>

--- a/src/features/matters/components/MatterDetailHeader.tsx
+++ b/src/features/matters/components/MatterDetailHeader.tsx
@@ -81,7 +81,7 @@ export const MatterDetailHeader = ({
           ) : (
             <div
               aria-hidden="true"
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-surface-card-raised text-lg font-semibold text-ink"
+              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-card text-lg font-semibold text-ink"
             >
               {heroInitial(clientEmail, clientLabel, title)}
             </div>
@@ -141,7 +141,7 @@ export const MatterDetailHeader = ({
                     <button
                       type="button"
                       onClick={item.onClick}
-                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-card-hover"
+                      className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-ink transition-colors hover:bg-paper-2"
                     >
                       {Icon ? <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" /> : null}
                       {item.label}
@@ -169,7 +169,7 @@ export const MatterDetailHeader = ({
                       <button
                         type="button"
                         onClick={item.onClick}
-                        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-ink transition-colors hover:bg-surface-card-hover"
+                        className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm text-ink transition-colors hover:bg-paper-2"
                       >
                         {Icon ? <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" /> : null}
                         {item.label}

--- a/src/features/matters/components/MatterDetailSkeleton.tsx
+++ b/src/features/matters/components/MatterDetailSkeleton.tsx
@@ -45,9 +45,9 @@ export const MatterDetailSkeleton = () => (
       </div>
 
       {/* Segmented tab group placeholder */}
-      <div className="mt-5 inline-flex gap-1 rounded-2xl border border-line-subtle bg-surface-card-raised p-1">
+      <div className="mt-5 inline-flex gap-1 rounded-2xl border border-line-subtle bg-card p-1">
         {[0, 1, 2, 3, 4].map((i) => (
-          <div key={i} className="skeleton-bar h-9 w-9 rounded-xl" />
+          <div key={i} className="skeleton-bar h-9 w-9 rounded-r-md" />
         ))}
       </div>
 

--- a/src/features/matters/components/MatterDetailsPanel.tsx
+++ b/src/features/matters/components/MatterDetailsPanel.tsx
@@ -167,7 +167,7 @@ const SectionHeader = ({
   onCancel: () => void;
 }) => (
   <div className="mb-4 flex items-center justify-between">
-    <h4 className="font-display text-sm font-semibold tracking-tight text-ink">
+    <h4 className="font-serif text-sm font-semibold tracking-tight text-ink">
       {title}
     </h4>
     {isEditing ? (
@@ -199,7 +199,7 @@ const SectionHeader = ({
         icon={Pencil} iconClassName="h-4 w-4"
         className={cn(
           'text-dim-2 transition-all',
-          'hover:bg-surface-card-hover hover:text-ink focus-visible:text-ink'
+          'hover:bg-paper-2 hover:text-ink focus-visible:text-ink'
         )}
         aria-label={`Edit ${title.toLowerCase()}`}
       />
@@ -382,7 +382,7 @@ export const MatterDetailsPanel = ({
   return (
     <div className="panel divide-y divide-white/[0.06]">
       <div className="flex items-center justify-between px-5 py-4">
-        <h3 className="font-display text-sm font-semibold tracking-tight text-ink">Matter details</h3>
+        <h3 className="font-serif text-sm font-semibold tracking-tight text-ink">Matter details</h3>
         <span aria-hidden="true" className="h-px w-8 bg-gradient-to-r from-accent-500/0 via-accent-500/60 to-accent-500/0" />
       </div>
 
@@ -391,7 +391,7 @@ export const MatterDetailsPanel = ({
         <div className="group px-5 py-4">
           <SectionHeader title="Case" {...sectionProps('identifiers')} />
           {saveError && editing === 'identifiers' && (
-            <div className="mt-3 mb-3 p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+            <div className="mt-3 mb-3 p-2.5 rounded-r-md bg-red-500/10 border border-red-500/20 text-xs text-red-400">
               {saveError}
             </div>
           )}
@@ -442,7 +442,7 @@ export const MatterDetailsPanel = ({
         <div className="group px-5 py-4">
           <SectionHeader title="Parties" {...sectionProps('parties')} />
           {saveError && editing === 'parties' && (
-            <div className="mt-3 mb-3 p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+            <div className="mt-3 mb-3 p-2.5 rounded-r-md bg-red-500/10 border border-red-500/20 text-xs text-red-400">
               {saveError}
             </div>
           )}
@@ -489,7 +489,7 @@ export const MatterDetailsPanel = ({
         <div className="group px-5 py-4">
           <SectionHeader title="Jurisdiction" {...sectionProps('jurisdiction')} />
           {saveError && editing === 'jurisdiction' && (
-            <div className="mt-3 mb-3 p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+            <div className="mt-3 mb-3 p-2.5 rounded-r-md bg-red-500/10 border border-red-500/20 text-xs text-red-400">
               {saveError}
             </div>
           )}
@@ -529,7 +529,7 @@ export const MatterDetailsPanel = ({
         <div className="group px-5 py-4">
           <SectionHeader title="Attorneys" {...sectionProps('attorneys')} />
           {saveError && editing === 'attorneys' && (
-            <div className="mt-3 mb-3 p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+            <div className="mt-3 mb-3 p-2.5 rounded-r-md bg-red-500/10 border border-red-500/20 text-xs text-red-400">
               {saveError}
             </div>
           )}
@@ -583,7 +583,7 @@ export const MatterDetailsPanel = ({
         <div className="group px-5 py-4">
           <SectionHeader title="Financial" {...sectionProps('financial')} />
           {saveError && editing === 'financial' && (
-            <div className="mt-3 mb-3 p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+            <div className="mt-3 mb-3 p-2.5 rounded-r-md bg-red-500/10 border border-red-500/20 text-xs text-red-400">
               {saveError}
             </div>
           )}

--- a/src/features/matters/components/MatterForm.tsx
+++ b/src/features/matters/components/MatterForm.tsx
@@ -441,7 +441,7 @@ const MatterFormInner = ({
               (close) => (
                 <button
                   type="button"
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-accent-utility hover:bg-surface-card-hover"
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-accent-utility hover:bg-paper-2"
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     close();

--- a/src/features/matters/components/MatterListItem.tsx
+++ b/src/features/matters/components/MatterListItem.tsx
@@ -20,7 +20,7 @@ export const MatterListItem = ({ matter, onSelect, isSelected = false }: MatterL
   const rowClassName = cn(
     'relative w-full text-left flex items-center gap-3 px-4 py-3 transition-all duration-150',
     isSelected ? SELECTED_ACCENT_SURFACE_CLASS : '',
-    isInteractive ? 'hover:bg-surface-card-hover cursor-pointer' : 'cursor-default'
+    isInteractive ? 'hover:bg-paper-2 cursor-pointer' : 'cursor-default'
   );
 
   const content = (
@@ -28,14 +28,14 @@ export const MatterListItem = ({ matter, onSelect, isSelected = false }: MatterL
       {isSelected ? (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute inset-y-2 left-0 w-[3px] rounded-full bg-accent-500"
+          className="pointer-events-none absolute inset-y-2 left-0 w-[3px] rounded-full bg-accent"
         />
       ) : null}
       <div className="relative shrink-0">
         <Avatar
           name={matter.clientName}
           size="sm"
-          className="bg-surface-card-raised text-ink ring-1 ring-line-subtle"
+          className="bg-card text-ink ring-1 ring-line-subtle"
         />
         <MatterStatusDot
           status={matter.status}

--- a/src/features/matters/components/MatterOverviewTab.tsx
+++ b/src/features/matters/components/MatterOverviewTab.tsx
@@ -267,7 +267,7 @@ const OpenTasksCard = ({
               <button
                 type="button"
                 onClick={onTaskClick}
-                className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-surface-card-hover"
+                className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-paper-2"
               >
                 <span className="flex min-w-0 items-center gap-2.5">
                   {task.status === 'in_progress' ? (

--- a/src/features/matters/components/MatterSettingsTab.tsx
+++ b/src/features/matters/components/MatterSettingsTab.tsx
@@ -148,7 +148,7 @@ export const MatterSettingsTab = ({
     </div>
 
     {(onCloseMatter || onArchiveMatter || onDeleteMatter) ? (
-      <section className="card space-y-4 rounded-xl border-rose-500/50 p-5">
+      <section className="card space-y-4 rounded-r-md border-rose-500/50 p-5">
         <div className="flex items-center gap-2.5">
           <AlertTriangle className="h-[18px] w-[18px] text-rose-500" />
           <h3 className="text-base font-semibold text-rose-500">Danger zone</h3>

--- a/src/features/matters/components/MatterStatusPopover.tsx
+++ b/src/features/matters/components/MatterStatusPopover.tsx
@@ -145,8 +145,8 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
           onKeyDown={handleListboxKeyDown}
           className={cn(
             'absolute left-0 top-full z-50 mt-2 w-56',
-            'rounded-xl border border-line-subtle',
-            'bg-surface-overlay/95 backdrop-blur-2xl shadow-glass',
+            'rounded-r-md border border-line-subtle',
+            'bg-card/95 backdrop-blur-2xl shadow-glass',
             'py-1 overflow-y-auto max-h-72'
           )}
         >
@@ -171,7 +171,7 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
                   'w-full flex items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors duration-100',
                   isSelected
                     ? cn(MATTER_STATUS_BADGE_CLASS[status], 'ring-1 ring-inset')
-                    : 'text-ink hover:bg-surface-card-hover'
+                    : 'text-ink hover:bg-paper-2'
                 )}
               >
                 <Icon

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -39,9 +39,9 @@ const summaryItemBase = 'min-w-0 flex flex-col gap-1';
 const gridBase = 'grid grid-cols-1 gap-x-4 gap-y-5 @lg:grid-cols-2 @3xl:grid-cols-4 @3xl:gap-x-6';
 const wrapperBase = 'card relative overflow-hidden rounded-[20px] @container p-5 sm:p-7';
 const labelClass = 'text-[10px] font-semibold uppercase tracking-[0.14em] text-dim-2';
-const kpiValueClass = 'font-display text-[28px] font-bold leading-none tracking-tight tabular-nums text-ink';
-const denseValueClass = 'font-display text-[24px] font-bold leading-none tracking-tight tabular-nums text-ink';
-const iconSquareClass = 'inline-flex h-7 w-7 items-center justify-center rounded-lg border border-card-border bg-surface-card-raised text-accent-utility';
+const kpiValueClass = 'font-serif text-[28px] font-bold leading-none tracking-tight tabular-nums text-ink';
+const denseValueClass = 'font-serif text-[24px] font-bold leading-none tracking-tight tabular-nums text-ink';
+const iconSquareClass = 'inline-flex h-7 w-7 items-center justify-center rounded-lg border border-card-border bg-card text-accent-utility';
 const revealClass = 'motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-300';
 
 const Halo = () => (
@@ -182,7 +182,7 @@ export const MatterSummaryCards = ({
                 size="xs"
                 onClick={() => onCreateInvoice?.()}
                 disabled={!onCreateInvoice}
-                className="w-full justify-center font-display font-semibold tracking-wide"
+                className="w-full justify-center font-serif font-semibold tracking-wide"
               >
                 Invoice
               </Button>
@@ -248,13 +248,13 @@ export const MatterSummaryCards = ({
               <p className={cn(labelClass, 'leading-tight')}>{billingTypeLabel}</p>
             </div>
             {Array.isArray(billingRateLines) ? (
-              <div className="mt-3 space-y-1 font-display text-base font-semibold leading-snug tabular-nums text-ink">
+              <div className="mt-3 space-y-1 font-serif text-base font-semibold leading-snug tabular-nums text-ink">
                 {billingRateLines.map((line) => (
                   <p key={line}>{line}</p>
                 ))}
               </div>
             ) : (
-              <p className="mt-3 font-display text-lg font-semibold leading-snug tabular-nums text-ink">{billingRateLines}</p>
+              <p className="mt-3 font-serif text-lg font-semibold leading-snug tabular-nums text-ink">{billingRateLines}</p>
             )}
           </div>
           <div
@@ -275,7 +275,7 @@ export const MatterSummaryCards = ({
               size="md"
               onClick={() => onCreateInvoice?.()}
               disabled={!onCreateInvoice}
-              className="justify-center rounded-full px-8 font-display font-semibold tracking-wide shadow-sm"
+              className="justify-center rounded-full px-8 font-serif font-semibold tracking-wide shadow-sm"
             >
               Invoice
             </Button>

--- a/src/features/matters/components/billing/UnbilledSummaryCard.tsx
+++ b/src/features/matters/components/billing/UnbilledSummaryCard.tsx
@@ -73,7 +73,7 @@ export const UnbilledSummaryCard = ({
           {(matter.milestones ?? []).map((milestone) => {
             if (!milestone.id) return null;
             return (
-              <div key={milestone.id} className="flex items-center justify-between rounded-xl border border-line-subtle px-3 py-2">
+              <div key={milestone.id} className="flex items-center justify-between rounded-r-md border border-line-subtle px-3 py-2">
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-ink">{milestone.description}</p>
                   <p className="text-xs text-dim-2">{formatCurrency(milestone.amount)}</p>

--- a/src/features/matters/components/files/MatterFilesPanel.tsx
+++ b/src/features/matters/components/files/MatterFilesPanel.tsx
@@ -126,7 +126,7 @@ export function MatterFilesPanel({ matterId, matterTitle = null, isPrivilegedUpl
       />
 
       {error ? (
-        <div className="status-error rounded-xl px-3 py-2 text-sm">{error}</div>
+        <div className="status-error rounded-r-md px-3 py-2 text-sm">{error}</div>
       ) : null}
     </div>
   );

--- a/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
+++ b/src/features/matters/components/time-entries/TimeEntriesPanel.tsx
@@ -192,7 +192,7 @@ export const TimeEntriesPanel = ({
                 key={day.dateKey}
                 type="button"
                 onClick={() => openNewEntry(day.dateKey)}
-                className="w-full text-left px-4 py-3 sm:px-6 hover:bg-surface-card-hover transition-colors"
+                className="w-full text-left px-4 py-3 sm:px-6 hover:bg-paper-2 transition-colors"
               >
                 <div className="grid gap-2 sm:grid-cols-12 sm:items-center">
                   <div className="text-sm font-medium text-dim-2 sm:col-span-3">
@@ -202,7 +202,7 @@ export const TimeEntriesPanel = ({
                     <div className="flex items-center gap-3">
                       <div className="flex-1 h-2 rounded-full bg-line-subtle">
                         <div
-                          className="h-2 rounded-full bg-accent-500"
+                          className="h-2 rounded-full bg-accent"
                           style={{ width: `${day.progressPercentage}%` }}
                         />
                       </div>

--- a/src/features/matters/components/time-entries/TimeEntryForm.tsx
+++ b/src/features/matters/components/time-entries/TimeEntryForm.tsx
@@ -128,12 +128,12 @@ export const TimeEntryForm = ({ initialEntry, initialDate, lockDate = false, onS
             options={dateOptions}
             onChange={(value) => { date.value = value; }}
             disabled={lockDate}
-            className="w-full justify-between px-3 py-2 text-sm rounded-xl border border-input-border bg-input-bg focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
+            className="w-full justify-between px-3 py-2 text-sm rounded-r-md border border-input-border bg-input-bg focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
           />
         </div>
         <div>
           <span className="block text-sm font-medium text-ink mb-1">Timezone</span>
-          <div className="input-surface rounded-xl px-3 py-2.5 text-sm text-dim-2 flex items-center">
+          <div className="input-surface rounded-r-md px-3 py-2.5 text-sm text-dim-2 flex items-center">
             UTC
           </div>
         </div>

--- a/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
+++ b/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
@@ -101,7 +101,7 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
               className={[
                 'h-9 w-9 rounded-full text-sm font-medium transition-colors',
                 isCurrentMonth ? 'text-ink' : 'text-dim-2',
-                isSelectedWeek ? 'bg-surface-card-raised text-ink' : 'hover:bg-surface-card-hover',
+                isSelectedWeek ? 'bg-card text-ink' : 'hover:bg-paper-2',
                 isToday ? 'ring-2 ring-accent-500' : 'ring-1 ring-transparent'
               ].join(' ')}
             >

--- a/src/features/matters/pages/ClientMattersPage.tsx
+++ b/src/features/matters/pages/ClientMattersPage.tsx
@@ -438,7 +438,7 @@ export const ClientMattersPage = ({
                     'transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 rounded-t-sm',
                     'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-all after:duration-150',
                     isActive
-                      ? 'text-ink after:bg-accent-500'
+                      ? 'text-ink after:bg-accent'
                       : 'text-dim-2 hover:text-ink after:bg-transparent hover:after:bg-line-subtle'
                   ].join(' ')}
                 >

--- a/src/features/matters/pages/PracticeMatterCreatePage.tsx
+++ b/src/features/matters/pages/PracticeMatterCreatePage.tsx
@@ -271,12 +271,12 @@ export function PracticeMatterCreatePage({
     >
       <DialogBody>
         {convertError ? (
-          <div className="mb-4 rounded-xl border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error">
+          <div className="mb-4 rounded-r-md border border-accent-error/30 bg-accent-error/10 px-4 py-3 text-sm text-accent-error">
             {convertError}
           </div>
         ) : null}
         {convertIntakeUuid && convertLoading && !convertInitialValues ? (
-          <div className="card rounded-xl p-6">
+          <div className="card rounded-r-md p-6">
             <LoadingBlock label="Loading intake details..." />
           </div>
         ) : null}

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -133,7 +133,7 @@ const matterStatusBadgeClass = (status: MatterStatus): string => {
   const base = 'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap';
   if (ACTIVE_STATUSES.has(status)) return `${base} status-success`;
   if (status === 'closed' || DECLINED_STATUSES.has(status)) {
-    return `${base} border border-line-subtle bg-surface-card-hover text-dim-2`;
+    return `${base} border border-line-subtle bg-paper-2 text-dim-2`;
   }
   return `${base} status-warning`;
 };
@@ -233,7 +233,7 @@ const _DetailField = ({ label, value }: { label: string; value: string }) => (
 // Error / warning banners — token-compliant
 // ---------------------------------------------------------------------------
 const WarningBanner = ({ children }: { children: preact.ComponentChildren }) => (
-  <div className="status-warning rounded-xl px-4 py-3 text-sm">{children}</div>
+  <div className="status-warning rounded-r-md px-4 py-3 text-sm">{children}</div>
 );
 
 const ErrorBanner = ({ children }: { children: preact.ComponentChildren }) => (
@@ -2176,7 +2176,7 @@ export const PracticeMattersPage = ({
             type="button"
             onClick={() => setIsShortcutsHelpOpen(true)}
             aria-label="Show keyboard shortcuts"
-            className="hidden h-8 w-8 items-center justify-center rounded-full text-dim-2 transition-colors hover:bg-surface-card-hover hover:text-ink md:inline-flex"
+            className="hidden h-8 w-8 items-center justify-center rounded-full text-dim-2 transition-colors hover:bg-paper-2 hover:text-ink md:inline-flex"
           >
             <span className="text-sm font-semibold">?</span>
           </button>
@@ -2188,7 +2188,7 @@ export const PracticeMattersPage = ({
             disabled={!activePracticeId}
           >
             New Matter
-            <kbd className="ml-2 hidden rounded border border-line-utility bg-surface-card-hover px-1.5 py-0.5 text-[10px] font-medium text-dim-2 md:inline">
+            <kbd className="ml-2 hidden rounded border border-line-utility bg-paper-2 px-1.5 py-0.5 text-[10px] font-medium text-dim-2 md:inline">
               N
             </kbd>
           </Button>
@@ -2211,7 +2211,7 @@ export const PracticeMattersPage = ({
             stickyHeader
             className="panel overflow-hidden"
             bodyClassName="bg-transparent"
-            rowClassName="transition-colors duration-150 hover:!bg-surface-card-hover"
+            rowClassName="transition-colors duration-150 hover:!bg-paper-2"
           />
         )}
       </div>
@@ -2233,7 +2233,7 @@ export const PracticeMattersPage = ({
               ].map((s) => (
                 <li key={s.key} className="flex items-center justify-between gap-4">
                   <span className="text-sm text-ink">{s.desc}</span>
-                  <kbd className="rounded border border-line-utility bg-surface-card-hover px-2 py-0.5 text-xs font-medium text-dim-2">
+                  <kbd className="rounded border border-line-utility bg-paper-2 px-2 py-0.5 text-xs font-medium text-dim-2">
                     {s.key}
                   </kbd>
                 </li>

--- a/src/features/media/components/AudioRecordingUI.tsx
+++ b/src/features/media/components/AudioRecordingUI.tsx
@@ -331,12 +331,12 @@ const AudioRecordingUI: FunctionComponent<AudioRecordingUIProps> = ({
                 onClick={onCancel}
                 aria-label="Cancel recording"
                 title="Cancel recording"
-                className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-all duration-200 text-dim-2 hover:text-red-400 bg-surface-utility/5 hover:bg-red-500/10 animate-zoom-in"
+                className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-all duration-200 text-dim-2 hover:text-red-400 bg-paper-2/5 hover:bg-red-500/10 animate-zoom-in"
             >
                 <Icon icon={X} className="w-5 h-5" aria-hidden="true"  />
             </Button>
             <div className="flex-1 flex items-center gap-4 h-8 animate-zoom-in bg-transparent" aria-live="polite">
-                <canvas ref={canvasRef} width="300" height="40" aria-hidden="true" className="flex-1 h-8 rounded-xl block image-rendering-crisp-edges image-rendering-webkit-optimize-contrast bg-surface-utility/5" />
+                <canvas ref={canvasRef} width="300" height="40" aria-hidden="true" className="flex-1 h-8 rounded-r-md block image-rendering-crisp-edges image-rendering-webkit-optimize-contrast bg-paper-2/5" />
                 <div className="text-sm text-accent-500 font-tabular-nums min-w-10 text-right" role="timer" aria-label={`Recording time: ${formatTime(recordingTime)}`}>
                     {formatTime(recordingTime)}
                 </div>

--- a/src/features/media/components/FileMenu.tsx
+++ b/src/features/media/components/FileMenu.tsx
@@ -146,8 +146,8 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
         aria-expanded={isOpen}
         className={`shadow-lg border disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-subtle focus-visible:ring-offset-0 active:scale-100 ${
           isOpen
-            ? 'bg-surface-utility/20 border-line-subtle'
-            : 'bg-surface-utility/10 border-line-subtle hover:bg-surface-utility/20 hover:border-line-subtle hover:scale-105'
+            ? 'bg-paper-2/20 border-line-subtle'
+            : 'bg-paper-2/10 border-line-subtle hover:bg-paper-2/20 hover:border-line-subtle hover:scale-105'
         }`}
         icon={Plus} iconClassName="w-5 h-5"
       />
@@ -159,7 +159,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
           aria-labelledby="attachment-menu-button"
           className={`
             absolute bottom-full left-0 mb-2 min-w-[220px]
-            p-1 rounded-xl border border-line-subtle bg-surface-overlay/95 backdrop-blur-2xl shadow-glass transition-all duration-200
+            p-1 rounded-r-md border border-line-subtle bg-card/95 backdrop-blur-2xl shadow-glass transition-all duration-200
             ${isClosing ? 'opacity-0 scale-95 pointer-events-none' : 'opacity-100 scale-100'}
           `}
           style={{ zIndex: THEME.zIndex.fileMenu }}

--- a/src/features/media/components/MediaContent.tsx
+++ b/src/features/media/components/MediaContent.tsx
@@ -28,19 +28,19 @@ const MediaContent: FunctionComponent<MediaContentProps> = ({ media }) => {
     const renderMediaContent = () => {
         if (isLoading && !renderUrl) {
             return (
-                <div className="flex h-64 w-64 animate-pulse items-center justify-center rounded-xl bg-surface-panel" />
+                <div className="flex h-64 w-64 animate-pulse items-center justify-center rounded-r-md bg-paper-2" />
             );
         }
         if (!renderUrl) {
             return (
-                <div className="flex h-64 w-64 items-center justify-center rounded-xl bg-surface-panel text-sm text-dim-2">
+                <div className="flex h-64 w-64 items-center justify-center rounded-r-md bg-paper-2 text-sm text-dim-2">
                     Preview unavailable
                 </div>
             );
         }
         if (media.category === 'video') {
             return (
-                <div className="max-w-full max-h-[80vh] rounded-xl overflow-hidden shadow-2xl">
+                <div className="max-w-full max-h-[80vh] rounded-r-md overflow-hidden shadow-2xl">
                     {!isVideoPlayIconing ? (
                         <div
                             className="relative cursor-pointer max-w-full max-h-[80vh]"
@@ -61,7 +61,7 @@ const MediaContent: FunctionComponent<MediaContentProps> = ({ media }) => {
                                 muted
                                 playsInline
                             />
-                            <div className="absolute inset-0 bg-surface-app-frame/80 flex flex-col items-center justify-center gap-2">
+                            <div className="absolute inset-0 bg-paper/80 flex flex-col items-center justify-center gap-2">
                                 <Icon icon={Play} className="text-[rgb(var(--accent-foreground))] w-12 h-12"  />
                                 <p className="text-[rgb(var(--accent-foreground))] text-sm font-medium">Click to play</p>
                             </div>
@@ -84,7 +84,7 @@ const MediaContent: FunctionComponent<MediaContentProps> = ({ media }) => {
             <img
                 src={renderUrl}
                 alt={media.name}
-                className="max-w-full max-h-[80vh] object-contain rounded-xl shadow-2xl cursor-default"
+                className="max-w-full max-h-[80vh] object-contain rounded-r-md shadow-2xl cursor-default"
             />
         );
     };

--- a/src/features/media/components/MediaControls.tsx
+++ b/src/features/media/components/MediaControls.tsx
@@ -165,7 +165,7 @@ const MediaControls: FunctionComponent<MediaControlsProps> = ({
 				aria-label="Record audio message"
 				aria-pressed={isRecording}
 				disabled={permissionDenied}
-				className="shadow-lg border bg-surface-utility/10 border-line-subtle hover:bg-surface-utility/20 hover:border-line-subtle hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-subtle focus-visible:ring-offset-0 active:scale-100"
+				className="shadow-lg border bg-paper-2/10 border-line-subtle hover:bg-paper-2/20 hover:border-line-subtle hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-line-subtle focus-visible:ring-offset-0 active:scale-100"
 			>
 				<Icon icon={Mic} className="w-5 h-5" aria-hidden="true"  />
 			</Button>

--- a/src/features/media/components/MediaSidebar.tsx
+++ b/src/features/media/components/MediaSidebar.tsx
@@ -107,7 +107,7 @@ const MediaRow: FunctionComponent<MediaRowProps> = ({ media, onPreview, onError 
       role="button"
       tabIndex={0}
       aria-busy={busy}
-      className="cursor-pointer transition-all duration-200 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-accent-500/50 rounded-xl"
+      className="cursor-pointer transition-all duration-200 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-accent-500/50 rounded-r-md"
       onClick={() => { void handleActivate(); }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -140,7 +140,7 @@ const MediaRow: FunctionComponent<MediaRowProps> = ({ media, onPreview, onError 
               onClick={(e) => { void handleDownload(e); }}
               title="Download file"
               disabled={busy}
-              className="p-1.5 surface-hover rounded-xl text-dim-2 hover:text-ink"
+              className="p-1.5 surface-hover rounded-r-md text-dim-2 hover:text-ink"
             >
               <Icon icon={Download} className="w-3.5 h-3.5" />
             </Button>

--- a/src/features/modals/components/CameraCaptureButton.tsx
+++ b/src/features/modals/components/CameraCaptureButton.tsx
@@ -16,7 +16,7 @@ const CameraCaptureButton: FunctionComponent<CameraCaptureButtonProps> = ({ onCl
       onClick={onClick}
       disabled={disabled}
       title="Take photo"
-      className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-utility/10 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
+      className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-paper-2/10 focus:outline-none focus:ring-2 focus:ring-accent-500 focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
       aria-label="Take photo"
     >
       <Icon icon={Camera} className="w-16 h-16 text-ink"  />

--- a/src/features/modals/components/CameraDialog.tsx
+++ b/src/features/modals/components/CameraDialog.tsx
@@ -126,7 +126,7 @@ const CameraDialog: FunctionComponent<CameraDialogProps> = ({
             <p>{error}</p>
           </div>
         )}
-        <div className="relative w-full h-full overflow-hidden bg-surface-app-frame flex-grow border-t border-line-subtle">
+        <div className="relative w-full h-full overflow-hidden bg-paper flex-grow border-t border-line-subtle">
           <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-cover" />
           <canvas ref={canvasRef} style={{ display: 'none' }} />
         </div>

--- a/src/features/onboarding/components/InfoCard.tsx
+++ b/src/features/onboarding/components/InfoCard.tsx
@@ -56,7 +56,7 @@ export const InfoCard = ({
 
   return (
     <div className={cn(
-      'rounded-xl border',
+      'rounded-r-md border',
       variantClasses[variant],
       sizeClasses[size],
       className

--- a/src/features/practice-dashboard/components/BillingActionsWidget.tsx
+++ b/src/features/practice-dashboard/components/BillingActionsWidget.tsx
@@ -43,7 +43,7 @@ export const BillingActionsWidget = ({
             <LoadingSpinner size="md" />
           </div>
         ) : error ? (
-          <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
+          <div className="rounded-r-md border border-card-border bg-card px-3 py-2 text-sm text-ink">
             {error}
           </div>
         ) : actions.length === 0 ? (
@@ -52,7 +52,7 @@ export const BillingActionsWidget = ({
           <div className="space-y-4">
             {actions.map((action) => (
               <Fragment key={action.id}>
-                <div className="rounded-xl border border-line-subtle bg-surface px-4 py-3">
+                <div className="rounded-r-md border border-line-subtle bg-surface px-4 py-3">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex gap-3">
                       <div className="text-lg" aria-hidden="true">{ICONS[action.reason]}</div>

--- a/src/features/practice-dashboard/components/DashboardSummaryCards.tsx
+++ b/src/features/practice-dashboard/components/DashboardSummaryCards.tsx
@@ -54,7 +54,7 @@ export const DashboardSummaryCards = ({ stats, loading = false }: DashboardSumma
         </div>
         <div className="flex items-start justify-end">
           {stat.changeLabel ? (
-            <span className={`mt-1 rounded-md bg-surface-utility/10 px-2 py-1 text-xs font-semibold ${changeToneClass[stat.changeTone ?? 'neutral']}`}>
+            <span className={`mt-1 rounded-md bg-paper-2/10 px-2 py-1 text-xs font-semibold ${changeToneClass[stat.changeTone ?? 'neutral']}`}>
               {stat.changeLabel}
             </span>
           ) : null}

--- a/src/features/practice-dashboard/components/OutstandingPaymentsWidget.tsx
+++ b/src/features/practice-dashboard/components/OutstandingPaymentsWidget.tsx
@@ -28,7 +28,7 @@ export const OutstandingPaymentsWidget = ({
           <LoadingSpinner size="md" />
         </div>
       ) : error ? (
-        <div className="rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
+        <div className="rounded-r-md border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : summary ? (

--- a/src/features/practice-dashboard/components/RecentActivityTable.tsx
+++ b/src/features/practice-dashboard/components/RecentActivityTable.tsx
@@ -36,9 +36,9 @@ const statusClass = (status: ActivityEntry['status']) => {
   const normalized = status.toLowerCase();
   if (normalized === 'paid') return 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300';
   if (normalized === 'overdue') return 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300';
-  if (normalized === 'draft') return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
-  if (normalized === 'sent' || normalized === 'pending') return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
-  return 'bg-surface-overlay/80 text-dim-2 ring-line-subtle';
+  if (normalized === 'draft') return 'bg-card/80 text-dim-2 ring-line-subtle';
+  if (normalized === 'sent' || normalized === 'pending') return 'bg-card/80 text-dim-2 ring-line-subtle';
+  return 'bg-card/80 text-dim-2 ring-line-subtle';
 };
 
 export const RecentActivityTable = ({ days, loading = false, error = null, onOpenInvoice }: RecentActivityTableProps) => (
@@ -98,8 +98,8 @@ export const RecentActivityTable = ({ days, loading = false, error = null, onOpe
                       <tr className="text-sm text-ink">
                         <th scope="colgroup" colSpan={3} className="relative isolate py-2 font-semibold">
                           <time dateTime={day.isoDate}>{day.label}</time>
-                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
-                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-subtle bg-surface-overlay/70" />
+                          <div className="absolute inset-y-0 right-full -z-10 w-screen border-b border-line-subtle bg-card/70" />
+                          <div className="absolute inset-y-0 left-0 -z-10 w-screen border-b border-line-subtle bg-card/70" />
                         </th>
                       </tr>
                       {day.entries.length === 0 && showEmptyRows ? (

--- a/src/features/practice-dashboard/components/RecentClientsGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentClientsGrid.tsx
@@ -9,7 +9,7 @@ import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatDate } from '@/shared/utils/dateTime';
 import type { RecentClient } from '@/features/practice-dashboard/hooks/usePracticeBillingData';
 
-const neutralTone = 'ring-line-subtle bg-surface-overlay/80 text-dim-2';
+const neutralTone = 'ring-line-subtle bg-card/80 text-dim-2';
 const statusTone: Record<string, string> = {
   paid: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   overdue: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
@@ -52,7 +52,7 @@ export const RecentClientsGrid = ({
           ))}
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
+        <div className="mt-6 rounded-r-md border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : clients.length === 0 ? (
@@ -62,14 +62,14 @@ export const RecentClientsGrid = ({
           {clients.map((client) => (
             <li
               key={client.id}
-              className="overflow-hidden rounded-xl bg-surface-overlay/80 outline outline-1 outline-line-glass/40 backdrop-blur-xl"
+              className="overflow-hidden rounded-r-md bg-card/80 outline outline-1 outline-line-glass/40 backdrop-blur-xl"
             >
-              <div className="flex items-center gap-x-4 border-b border-line-subtle bg-surface-overlay/70 p-6">
+              <div className="flex items-center gap-x-4 border-b border-line-subtle bg-card/70 p-6">
                 <Avatar 
                   src={client.avatarUrl} 
                   name={client.name} 
                   size="lg" 
-                  className="h-12 w-12 rounded-xl"
+                  className="h-12 w-12 rounded-r-md"
                 />
                 <div className="flex-1">
                   <p className="text-sm font-medium text-ink">{client.name}</p>
@@ -93,7 +93,7 @@ export const RecentClientsGrid = ({
                 </DropdownMenu>
               </div>
               {client.lastInvoice ? (
-                <dl className="-my-3 divide-y divide-line-subtle bg-surface-overlay/60 px-6 py-4 text-sm">
+                <dl className="-my-3 divide-y divide-line-subtle bg-card/60 px-6 py-4 text-sm">
                   <div className="flex justify-between gap-x-4 py-3">
                     <dt className="text-dim-2">Last invoice</dt>
                     <dd className="text-ink">

--- a/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
+++ b/src/features/practice-dashboard/components/RecentIntakesGrid.tsx
@@ -11,7 +11,7 @@ import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
 const statusTone: Record<string, string> = {
   accepted: 'bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-300',
   declined: 'bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-300',
-  pending_review: 'ring-line-subtle bg-surface-overlay/80 text-dim-2',
+  pending_review: 'ring-line-subtle bg-card/80 text-dim-2',
 };
 
 type RecentIntakesGridProps = {
@@ -56,7 +56,7 @@ export const RecentIntakesGrid = ({
           ))}
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-xl border border-card-border bg-card px-3 py-2 text-sm text-ink">
+        <div className="mt-6 rounded-r-md border border-card-border bg-card px-3 py-2 text-sm text-ink">
           {error}
         </div>
       ) : intakes.length === 0 ? (
@@ -91,7 +91,7 @@ export const RecentIntakesGrid = ({
                   <Avatar 
                     name={contactName}
                     size="lg" 
-                    className="h-12 w-12 rounded-xl"
+                    className="h-12 w-12 rounded-r-md"
                   />
                   <div className="flex-1">
                     <p className="text-sm font-medium text-ink">{title}</p>

--- a/src/features/practice-onboarding/components/ConversationalCorrection.tsx
+++ b/src/features/practice-onboarding/components/ConversationalCorrection.tsx
@@ -94,7 +94,7 @@ const ConversationalCorrection: FunctionComponent<ConversationalCorrectionProps>
       {correctionRequests.map((request, index) => (
         <div key={request.field} className="card p-4">
           <div className="flex items-start gap-3">
-            <div className="w-8 h-8 bg-accent-100 rounded-full flex items-center justify-center flex-shrink-0">
+            <div className="w-8 h-8 bg-accent/20 rounded-full flex items-center justify-center flex-shrink-0">
               <span className="text-accent-600 font-semibold text-sm">{index + 1}</span>
             </div>
             <div className="flex-1">

--- a/src/features/practice-onboarding/components/OnboardingActions.tsx
+++ b/src/features/practice-onboarding/components/OnboardingActions.tsx
@@ -100,7 +100,7 @@ const OnboardingActions: FunctionComponent<OnboardingActionsProps> = ({
         </div>
 
         {missingFields.length > 0 && (
-          <div className="rounded-xl bg-accent-warning/10 border border-accent-warning/30 p-3">
+          <div className="rounded-r-md bg-accent-warning/10 border border-accent-warning/30 p-3">
             <p className="text-sm text-yellow-800">
               <strong>Still needed:</strong> {missingFields.join(', ')}
             </p>
@@ -108,7 +108,7 @@ const OnboardingActions: FunctionComponent<OnboardingActionsProps> = ({
         )}
 
         {saveError && (
-          <div className="rounded-xl bg-accent-error/10 border border-accent-error/30 p-3">
+          <div className="rounded-r-md bg-accent-error/10 border border-accent-error/30 p-3">
             <p className="text-sm text-accent-error-foreground">
               <strong>Error:</strong> {saveError}
             </p>

--- a/src/features/practice-setup/components/StripeCheckpointCard.tsx
+++ b/src/features/practice-setup/components/StripeCheckpointCard.tsx
@@ -31,7 +31,7 @@ export function StripeCheckpointCard({
   return (
     <div className="card mt-4 space-y-4 border border-line-subtle p-4 text-ink">
       <div className="flex items-start gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-accent-500/12 text-lg text-[rgb(var(--accent-foreground))]">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-accent/12 text-lg text-[rgb(var(--accent-foreground))]">
           $
         </div>
         <div className="min-w-0 space-y-1">
@@ -39,7 +39,7 @@ export function StripeCheckpointCard({
           <p className="text-sm text-dim-2">{body}</p>
         </div>
       </div>
-      <div className="flex items-center justify-between gap-3 rounded-2xl border border-line-subtle bg-surface-utility/10 px-3 py-2">
+      <div className="flex items-center justify-between gap-3 rounded-2xl border border-line-subtle bg-paper-2/10 px-3 py-2">
         <div>
           <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-dim-2">Stripe status</div>
           <div className="text-sm font-medium">{statusLabel}</div>

--- a/src/features/practice/components/PracticeProfile.tsx
+++ b/src/features/practice/components/PracticeProfile.tsx
@@ -29,7 +29,7 @@ export default function PracticeProfile({
 					src={profileImage} 
 					name={name} 
 					size="lg" 
-					className="w-12 h-12 rounded-xl"
+					className="w-12 h-12 rounded-r-md"
 				/>
 			</div>
 

--- a/src/features/reports/components/ReportCard.tsx
+++ b/src/features/reports/components/ReportCard.tsx
@@ -40,16 +40,16 @@ export const ReportCard: FunctionComponent<ReportCardProps> = ({ definition, onC
       type="button"
       onClick={onClick}
       className={cn(
-        'flex w-full flex-col gap-2 rounded-2xl border border-line-subtle bg-surface-utility/5 p-4 text-left transition hover:bg-surface-utility/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
+        'flex w-full flex-col gap-2 rounded-2xl border border-line-subtle bg-paper-2/5 p-4 text-left transition hover:bg-paper-2/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
         className,
       )}
     >
       <div className="flex items-center justify-between">
-        <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line-subtle bg-paper-2/10">
           <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" />
         </div>
         {definition.phase === 3 ? (
-          <span className="rounded-full bg-surface-utility/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-dim-2">
+          <span className="rounded-full bg-paper-2/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-dim-2">
             Coming soon
           </span>
         ) : null}

--- a/src/features/reports/components/ReportFilters.tsx
+++ b/src/features/reports/components/ReportFilters.tsx
@@ -75,7 +75,7 @@ export const ReportFilters: FunctionComponent<ReportFiltersProps> = ({ filters, 
               <select
                 value={current}
                 onChange={(e) => set(f.id, (e.currentTarget as HTMLSelectElement).value)}
-                className="h-9 rounded-md border border-line-subtle bg-surface-utility/5 px-2 text-sm text-ink"
+                className="h-9 rounded-md border border-line-subtle bg-paper-2/5 px-2 text-sm text-ink"
               >
                 {f.options.map((o) => (
                   <option key={o.value} value={o.value}>{o.label}</option>

--- a/src/features/reports/pages/reports/DeliveriesListView.tsx
+++ b/src/features/reports/pages/reports/DeliveriesListView.tsx
@@ -84,7 +84,7 @@ export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = ({
         stickyHeader
         className="panel overflow-hidden"
         bodyClassName="bg-transparent"
-        rowClassName="transition-colors duration-150 hover:!bg-surface-card-hover"
+        rowClassName="transition-colors duration-150 hover:!bg-paper-2"
         hasMore={hasMore}
         isLoadingMore={loading && items.length > 0}
         onLoadMore={loadMore}

--- a/src/features/search/components/CommandPalette.tsx
+++ b/src/features/search/components/CommandPalette.tsx
@@ -210,7 +210,7 @@ function ScopePills({ scopes }: { scopes: SearchScope[] }) {
       {scopes.map((scope) => (
         <span
           key={scope}
-          className="text-xs font-medium px-2 py-1 rounded-md bg-surface-card-hover text-ink"
+          className="text-xs font-medium px-2 py-1 rounded-md bg-paper-2 text-ink"
         >
           in:{scope}
         </span>
@@ -249,8 +249,8 @@ function ResultGroups({
                 className={cn(
                   'w-full flex items-start gap-3 px-3 py-2 rounded-lg text-left transition-colors',
                   active
-                    ? 'bg-surface-card-hover'
-                    : 'hover:bg-surface-card-hover/60',
+                    ? 'bg-paper-2'
+                    : 'hover:bg-paper-2/60',
                   item.archived ? 'opacity-60' : '',
                 )}
               >
@@ -300,7 +300,7 @@ function SuggestionsList({
           key={`${s.source}:${s.query}`}
           type="button"
           onClick={() => onPick(s.query)}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-surface-card-hover/60"
+          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-paper-2/60"
         >
           <Search size={14} className="text-ink/40" aria-hidden="true" />
           <span className="text-sm text-ink flex-1">{s.query}</span>
@@ -354,7 +354,7 @@ function RecentsList({
           key={q}
           type="button"
           onClick={() => onPick(q)}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-surface-card-hover/60"
+          className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-paper-2/60"
         >
           <Search size={14} className="text-ink/40" aria-hidden="true" />
           <span className="text-sm text-ink">{q}</span>

--- a/src/features/settings/components/NotificationChannelSelector.tsx
+++ b/src/features/settings/components/NotificationChannelSelector.tsx
@@ -65,7 +65,7 @@ export const NotificationChannelSelector = ({
         }}
         disabled={isDisabled}
         className={cn(
-          'w-full min-w-0 sm:min-w-[180px] [&_[role=combobox]]:w-full [&_[role=combobox]]:rounded-xl'
+          'w-full min-w-0 sm:min-w-[180px] [&_[role=combobox]]:w-full [&_[role=combobox]]:rounded-r-md'
         )}
         clearable={false}
         searchable={false}

--- a/src/features/settings/components/SettingSelect.tsx
+++ b/src/features/settings/components/SettingSelect.tsx
@@ -31,7 +31,7 @@ export const SettingSelect = ({
           value={value}
           options={options}
           onChange={onChange}
-          className="w-full min-w-0 sm:min-w-[180px] [&_[role=combobox]]:w-full [&_[role=combobox]]:rounded-xl"
+          className="w-full min-w-0 sm:min-w-[180px] [&_[role=combobox]]:w-full [&_[role=combobox]]:rounded-r-md"
           clearable={false}
           searchable={false}
         />

--- a/src/features/settings/components/SettingsNotice.tsx
+++ b/src/features/settings/components/SettingsNotice.tsx
@@ -27,7 +27,7 @@ export const SettingsNotice = ({
 
   return (
     <div
-      className={cn('rounded-xl p-3 text-sm', variantClasses[variant], className)}
+      className={cn('rounded-r-md p-3 text-sm', variantClasses[variant], className)}
       role={role}
       aria-live={ariaLive}
     >

--- a/src/features/settings/components/WidgetPreviewFrame.tsx
+++ b/src/features/settings/components/WidgetPreviewFrame.tsx
@@ -71,10 +71,10 @@ export const WidgetPreviewFrame = ({
     <div className="w-full">
       {showTitle ? <h3 className="mb-3 text-sm font-semibold text-ink">{title}</h3> : null}
       <div className={cn(
-        'mx-auto w-full max-w-[380px] overflow-hidden bg-surface-card',
-        framed && 'rounded-xl border border-line-subtle shadow-glass',
+        'mx-auto w-full max-w-[380px] overflow-hidden bg-card',
+        framed && 'rounded-r-md border border-line-subtle shadow-glass',
       )}>
-        <div className={cn('relative w-full overflow-hidden bg-surface-ground', viewportClassName)}>
+        <div className={cn('relative w-full overflow-hidden bg-paper', viewportClassName)}>
           <WidgetPreviewApp
             key={previewKey}
             practiceId={previewPracticeId}

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -1025,7 +1025,7 @@ export const AccountPage = ({
                 ]}
                 onChange={handleDomainChange}
                 placeholder={t('settings:account.links.selectOption')}
-                className="border-0 bg-transparent px-3 py-1 hover:bg-surface-workspace/10 focus:ring-2 focus:ring-accent-500"
+                className="border-0 bg-transparent px-3 py-1 hover:bg-paper/10 focus:ring-2 focus:ring-accent-500"
                 searchable={false}
               />
             </SettingRow>
@@ -1035,7 +1035,7 @@ export const AccountPage = ({
               label="LinkedIn"
               labelNode={
                 <div className="flex items-center gap-3">
-                  <div className="w-4 h-4 bg-surface-app-frame rounded flex items-center justify-center">
+                  <div className="w-4 h-4 bg-paper rounded flex items-center justify-center">
                     <span className="text-[rgb(var(--accent-foreground))] text-xs font-bold">in</span>
                   </div>
                   <FormLabel>LinkedIn</FormLabel>

--- a/src/features/settings/pages/AppsPage.tsx
+++ b/src/features/settings/pages/AppsPage.tsx
@@ -32,7 +32,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
               label={app.name}
               labelNode={(
                 <div className="flex items-center gap-4">
-                  <div className="w-12 h-12 rounded-xl panel flex items-center justify-center overflow-hidden">
+                  <div className="w-12 h-12 rounded-r-md panel flex items-center justify-center overflow-hidden">
                     {app.logo ? (
                       <img
                         src={app.logo}

--- a/src/features/settings/pages/EngagementTemplatesPage.tsx
+++ b/src/features/settings/pages/EngagementTemplatesPage.tsx
@@ -182,7 +182,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
           </div>
 
           {/* Fee configuration */}
-          <div className="flex flex-col gap-3 rounded-xl border border-line-subtle bg-surface-card p-4">
+          <div className="flex flex-col gap-3 rounded-r-md border border-line-subtle bg-card p-4">
             <p className="text-sm font-semibold text-ink">Fee arrangement</p>
             <div className="flex flex-wrap gap-2">
               {(Object.keys(FEE_TYPE_LABELS) as EngagementFeeType[]).map((type) => (
@@ -193,7 +193,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                   className={cn(
                     'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
                     template.feeType === type
-                      ? 'border-accent-500 bg-accent-500/10 text-[rgb(var(--accent-foreground))]'
+                      ? 'border-accent-500 bg-accent/10 text-[rgb(var(--accent-foreground))]'
                       : 'border-line-subtle text-dim-2 hover:border-line-subtle hover:text-ink',
                   )}
                 >
@@ -291,7 +291,7 @@ function TemplateEditor({ initial, serviceOptions, onSave, onDelete, onBack, isS
                 key={key}
                 type="button"
                 onClick={() => insertPlaceholder(key)}
-                className="flex flex-col items-start rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-surface-input"
+                className="flex flex-col items-start rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-card"
               >
                 <span className="font-mono text-xs text-accent-500">{key}</span>
                 <span className="text-xs text-dim-2">{description}</span>
@@ -327,20 +327,20 @@ function TemplateListView({ templates, onNew, onEdit }: ListViewProps) {
       </div>
 
       {templates.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-line-subtle py-12 text-center">
+        <div className="flex flex-col items-center gap-3 rounded-r-md border border-dashed border-line-subtle py-12 text-center">
           <FileText className="h-8 w-8 text-dim-2" />
           <p className="text-sm font-medium text-ink">No templates yet</p>
           <p className="text-xs text-dim-2">Create your first engagement letter template to get started.</p>
           <Button icon={Plus} onClick={onNew} size="sm" variant="secondary">New template</Button>
         </div>
       ) : (
-        <div className="flex flex-col divide-y divide-line-subtle overflow-hidden rounded-xl border border-line-subtle">
+        <div className="flex flex-col divide-y divide-line-subtle overflow-hidden rounded-r-md border border-line-subtle">
           {templates.map((template) => (
             <button
               key={template.id}
               type="button"
               onClick={() => onEdit(template)}
-              className="flex items-center justify-between gap-4 px-4 py-3.5 text-left transition-colors hover:bg-surface-card"
+              className="flex items-center justify-between gap-4 px-4 py-3.5 text-left transition-colors hover:bg-card"
             >
               <div className="min-w-0">
                 <p className="truncate text-sm font-medium text-ink">{template.name}</p>

--- a/src/features/settings/pages/MFAEnrollmentPage.tsx
+++ b/src/features/settings/pages/MFAEnrollmentPage.tsx
@@ -232,17 +232,17 @@ export const MFAEnrollmentPage = ({
 
           {/* QR Code */}
           <div className="flex justify-center">
-            <div className="panel p-4 rounded-xl">
+            <div className="panel p-4 rounded-r-md">
               {/* Mock QR Code - in real app, you'd use a QR code library */}
-              <div className="w-48 h-48 bg-surface-base rounded flex items-center justify-center">
+              <div className="w-48 h-48 bg-paper rounded flex items-center justify-center">
                 <div className="text-center">
-                  <div className="w-32 h-32 bg-surface-app-frame dark:bg-surface-workspace rounded grid grid-cols-8 gap-1 p-2">
+                  <div className="w-32 h-32 bg-paper dark:bg-paper rounded grid grid-cols-8 gap-1 p-2">
                     {/* Mock QR pattern - stable pattern that doesn't flicker */}
                     {qrPattern.map((isWhite, i) => (
                       <div
                         key={i}
                         className={`w-full h-full rounded-sm ${
-                          isWhite ? 'bg-surface-workspace dark:bg-surface-app-frame' : 'bg-surface-app-frame dark:bg-surface-workspace'
+                          isWhite ? 'bg-paper dark:bg-paper' : 'bg-paper dark:bg-paper'
                         }`}
                       />
                     ))}
@@ -272,7 +272,7 @@ export const MFAEnrollmentPage = ({
               <SectionDivider className="w-full" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-surface-base text-dim-2">
+              <span className="px-2 bg-paper text-dim-2">
                 {t('settings:mfa.then')}
               </span>
             </div>

--- a/src/features/settings/pages/McpAccessPage.tsx
+++ b/src/features/settings/pages/McpAccessPage.tsx
@@ -96,7 +96,7 @@ export const McpAccessPage = ({ app, onBack }: McpAccessPageProps) => {
                     <div key={scope.id} className="space-y-1">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium text-ink">{scope.title}</span>
-                        <code className="rounded bg-surface-utility/10 px-1.5 py-0.5 font-mono text-xs text-dim-2">
+                        <code className="rounded bg-paper-2/10 px-1.5 py-0.5 font-mono text-xs text-dim-2">
                           {scope.id}
                         </code>
                       </div>

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -529,7 +529,7 @@ export const PracticePage = ({ className, onBack }: PracticePageProps) => {
                   }))}
                   disabled={isSaving}
                   aria-label={practiceText.brandColorAriaLabel}
-                  className="h-10 w-16 rounded-xl border border-line-subtle bg-surface-card p-1"
+                  className="h-10 w-16 rounded-r-md border border-line-subtle bg-card p-1"
                 />
                 <Input
                   aria-label={practiceText.brandColorHexAria}

--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -499,7 +499,7 @@ export const AcceptInvitationPage = () => {
           )}
         </div>
         {hasEmailMismatch && (
-          <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200 backdrop-blur-xl">
+          <div className="mt-4 rounded-r-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200 backdrop-blur-xl">
             You’re signed in with a different email. Switch accounts to continue with the invited email.
           </div>
         )}
@@ -599,7 +599,7 @@ export const AcceptInvitationPage = () => {
         )}
       </div>
       {hasEmailMismatch && (
-        <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200 backdrop-blur-xl">
+        <div className="mt-4 rounded-r-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200 backdrop-blur-xl">
           You’re signed in with {sessionEmail}. Switch accounts to accept with {effectiveInvitedEmail}.
         </div>
       )}

--- a/src/pages/AdminIntakeInspectorPage.tsx
+++ b/src/pages/AdminIntakeInspectorPage.tsx
@@ -142,7 +142,7 @@ const SearchEntry: FunctionComponent = () => {
           value={input}
           onInput={(e) => setInput((e.currentTarget as HTMLInputElement).value)}
           placeholder="conversation_id"
-          className="flex-1 rounded-md border border-input-border bg-surface-app px-3 py-2 text-sm"
+          className="flex-1 rounded-md border border-input-border bg-paper px-3 py-2 text-sm"
           aria-label="Conversation id"
         />
         <Button type="submit" disabled={!input.trim()}>
@@ -292,7 +292,7 @@ const IntakeTimelineRow: FunctionComponent<IntakeTimelineRowProps> = ({ turn }) 
   const provenanceLabel = PROVENANCE_LABELS[turn.provenance] ?? turn.provenance;
 
   return (
-    <li className="rounded-md border border-input-border bg-surface-app">
+    <li className="rounded-md border border-input-border bg-paper">
       <button
         type="button"
         className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left"
@@ -344,7 +344,7 @@ const ExpandedSection: FunctionComponent<{ label: string; children: ComponentChi
 }) => (
   <details className="mb-2" open>
     <summary className="cursor-pointer text-xs font-medium text-ink/70">{label}</summary>
-    <div className="mt-1 rounded bg-surface-utility/40 p-2 dark:bg-surface-utility/20">{children}</div>
+    <div className="mt-1 rounded bg-paper-2/40 p-2 dark:bg-paper-2/20">{children}</div>
   </details>
 );
 

--- a/src/pages/ApproveActionPage.tsx
+++ b/src/pages/ApproveActionPage.tsx
@@ -18,9 +18,9 @@ export default function ApproveActionPage({ jwt }: { jwt?: string }) {
   const hasToken = Boolean(jwt && jwt.trim());
 
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-surface-app px-4 py-10">
-      <div className="w-full max-w-md rounded-2xl border border-line-subtle bg-surface-card p-6 text-center shadow-sm">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
+    <div className="flex min-h-screen w-full items-center justify-center bg-paper px-4 py-10">
+      <div className="w-full max-w-md rounded-2xl border border-line-subtle bg-card p-6 text-center shadow-sm">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-paper-2/10">
           <Icon icon={ShieldCheck} className="h-6 w-6 text-ink" aria-hidden="true" />
         </div>
         <h1 className="text-lg font-semibold text-ink">Approval request</h1>

--- a/src/pages/DebugChatPage.tsx
+++ b/src/pages/DebugChatPage.tsx
@@ -198,14 +198,14 @@ export default function DebugChatPage() {
         </p>
       </header>
 
-      <section className="panel space-y-3 rounded-xl p-4">
+      <section className="panel space-y-3 rounded-r-md p-4">
         <div className="flex flex-wrap items-center gap-2">
           <Button variant="secondary" size="sm" onClick={resetState}>
             Reset chat
           </Button>
         </div>
 
-        <div className="h-[640px] overflow-hidden rounded-xl border border-input-border/60 bg-transparent">
+        <div className="h-[640px] overflow-hidden rounded-r-md border border-input-border/60 bg-transparent">
           <ChatContainer
             messages={messages}
             conversationTitle="Debug Chat"

--- a/src/pages/DebugConversationsPage.tsx
+++ b/src/pages/DebugConversationsPage.tsx
@@ -367,7 +367,7 @@ export default function DebugConversationsPage() {
                 type="button"
                 variant="icon"
                 size="icon-sm"
-                className="border border-line-subtle bg-surface-workspace/10 hover:bg-surface-workspace/15"
+                className="border border-line-subtle bg-paper/10 hover:bg-paper/15"
                 aria-label="Open conversation details"
                 onClick={() => setIsConversationDetailsOpen(true)}
               >
@@ -379,7 +379,7 @@ export default function DebugConversationsPage() {
                 type="button"
                 variant="icon"
                 size="icon-sm"
-                className="border border-line-subtle bg-surface-utility/10 hover:bg-surface-utility/20"
+                className="border border-line-subtle bg-paper-2/10 hover:bg-paper-2/20"
                 aria-label="Open conversation details"
                 onClick={() => setIsConversationDetailsOpen(true)}
               >
@@ -411,7 +411,7 @@ export default function DebugConversationsPage() {
         <div className="flex flex-wrap items-center gap-2">
           <Icon icon={MessagesSquare} className="h-6 w-6 text-accent-500" aria-hidden="true"  />
           <h1 className="text-2xl font-semibold text-ink">Debug Conversations</h1>
-          <span className="rounded-full border border-line-subtle bg-surface-panel/60 px-2.5 py-1 text-xs font-medium text-dim-2">
+          <span className="rounded-full border border-line-subtle bg-paper-2/60 px-2.5 py-1 text-xs font-medium text-dim-2">
             No API
           </span>
         </div>
@@ -470,17 +470,17 @@ export default function DebugConversationsPage() {
       >
         <DialogBody className="space-y-4 text-sm text-ink">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div className="panel rounded-xl p-3">
+            <div className="panel rounded-r-md p-3">
               <div className="text-xs uppercase tracking-wide text-dim-2">Workspace</div>
               <div className="mt-1 font-semibold capitalize">{workspaceKind}</div>
             </div>
-            <div className="panel rounded-xl p-3">
+            <div className="panel rounded-r-md p-3">
               <div className="text-xs uppercase tracking-wide text-dim-2">Conversation ID</div>
               <div className="mt-1 break-all font-mono text-xs">{activeConversationId}</div>
             </div>
           </div>
           {activeConversation?.user_info?.title ? (
-            <div className="panel rounded-xl p-3">
+            <div className="panel rounded-r-md p-3">
               <div className="text-xs uppercase tracking-wide text-dim-2">Title</div>
               <div className="mt-1 font-semibold">{String(activeConversation.user_info.title)}</div>
             </div>

--- a/src/pages/DebugDialogsPage.tsx
+++ b/src/pages/DebugDialogsPage.tsx
@@ -548,7 +548,7 @@ function InspectorPanelPreview() {
         role="dialog"
         aria-modal="true"
         aria-label="Inspector preview"
-        className="ui-surface-enter-right absolute inset-y-0 right-0 z-10 flex w-full max-w-[min(42rem,100vw)] flex-col overflow-hidden bg-surface-inspector shadow-glass"
+        className="ui-surface-enter-right absolute inset-y-0 right-0 z-10 flex w-full max-w-[min(42rem,100vw)] flex-col overflow-hidden bg-paper-2 shadow-glass"
       >
         <InspectorPanel
           entityType="invoice"
@@ -676,7 +676,7 @@ function PreviewSurface({
         <div className="mb-4 flex justify-between items-center border-b border-line-subtle pb-2">
           <span className={cn(
             "rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider",
-            theme === 'light' ? "bg-accent-500/10 text-accent-600" : "bg-accent-400/20 text-accent-300"
+            theme === 'light' ? "bg-accent/10 text-accent-600" : "bg-accent/80/20 text-accent-300"
           )}>
             {theme === 'light' ? 'Light Mode' : 'Dark Mode'}
           </span>
@@ -856,7 +856,7 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-bold text-ink">{item.name}</h2>
-          <span className="rounded-full bg-accent-500/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[rgb(var(--accent-foreground))]">
+          <span className="rounded-full bg-accent/10 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[rgb(var(--accent-foreground))]">
             {item.section}
           </span>
         </div>
@@ -886,14 +886,14 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
                 <iframe
                   key={`light-${previewNonce}`}
                   src={`${frameSrcBase}?theme=light`}
-                  className="w-full rounded-xl bg-transparent"
+                  className="w-full rounded-r-md bg-transparent"
                   style={{ height: item.frameHeight ?? 400 }}
                   title={`${item.name} Light Mode Preview`}
                   loading="lazy"
                 />
               ) : (
                 <div className="flex items-center justify-center p-8" style={{ height: item.frameHeight ?? 400 }}>
-                  <SkeletonLoader variant="rect" height="100%" width="100%" className="rounded-xl opacity-20" />
+                  <SkeletonLoader variant="rect" height="100%" width="100%" className="rounded-r-md opacity-20" />
                 </div>
               )}
             </div>
@@ -901,28 +901,28 @@ function GalleryCard({ item, previewNonce }: { item: DialogInventoryItem; previe
           <div className="space-y-2 min-h-[320px]">
             <p className="text-[10px] font-bold uppercase tracking-widest text-dim-2">Dark Mode</p>
             <div 
-              className="relative overflow-visible rounded-2xl border border-line-subtle bg-surface-workspace p-4 shadow-glass dark"
+              className="relative overflow-visible rounded-2xl border border-line-subtle bg-paper p-4 shadow-glass dark"
               style={{ isolation: 'isolate' }}
             >
               {isLoaded && frameSrcBase ? (
                 <iframe
                   key={`dark-${previewNonce}`}
                   src={`${frameSrcBase}?theme=dark`}
-                  className="w-full rounded-xl bg-transparent"
+                  className="w-full rounded-r-md bg-transparent"
                   style={{ height: item.frameHeight ?? 400 }}
                   title={`${item.name} Dark Mode Preview`}
                   loading="lazy"
                 />
               ) : (
                 <div className="flex items-center justify-center p-8" style={{ height: item.frameHeight ?? 400 }}>
-                  <SkeletonLoader variant="rect" height="100%" width="100%" className="rounded-xl opacity-10" />
+                  <SkeletonLoader variant="rect" height="100%" width="100%" className="rounded-r-md opacity-10" />
                 </div>
               )}
             </div>
           </div>
         </div>
       ) : (
-        <div className="flex h-32 items-center justify-center rounded-2xl bg-surface-utility/5 text-xs text-dim-2 italic">
+        <div className="flex h-32 items-center justify-center rounded-2xl bg-paper-2/5 text-xs text-dim-2 italic">
           No preview available
         </div>
       )}

--- a/src/pages/DebugMatterPage.tsx
+++ b/src/pages/DebugMatterPage.tsx
@@ -373,7 +373,7 @@ export default function DebugMatterPage() {
                           'transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 rounded-t-sm',
                           'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-all after:duration-150',
                           isActive
-                            ? 'text-ink after:bg-accent-500'
+                            ? 'text-ink after:bg-accent'
                             : 'text-dim-2 hover:text-ink after:bg-transparent hover:after:bg-line-glass/20'
                         ].join(' ')}
                       >

--- a/src/pages/DebugStylesPage.tsx
+++ b/src/pages/DebugStylesPage.tsx
@@ -89,15 +89,15 @@ export default function DebugStylesPage() {
         <div className="grid gap-4 md:grid-cols-3">
           <div className="card p-4">
             <p className="font-medium text-ink">card</p>
-            <p className="text-sm text-dim-2">Content cards. <code>bg-surface-card</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
+            <p className="text-sm text-dim-2">Content cards. <code>bg-card</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
           </div>
           <div className="panel p-4">
             <p className="font-medium text-ink">panel</p>
-            <p className="text-sm text-dim-2">Section containers. <code>bg-surface-section</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
+            <p className="text-sm text-dim-2">Section containers. <code>bg-paper-2</code>, <code>border-subtle</code>, <code>rounded-2xl</code>.</p>
           </div>
-          <div className="input-surface rounded-xl p-4">
+          <div className="input-surface rounded-r-md p-4">
             <p className="font-medium text-ink">input-surface</p>
-            <p className="text-sm text-dim-2">Input backgrounds. <code>bg-surface-input</code>, <code>border-subtle</code>, <code>rounded-xl</code>.</p>
+            <p className="text-sm text-dim-2">Input backgrounds. <code>bg-card</code>, <code>border-subtle</code>, <code>rounded-r-md</code>.</p>
           </div>
         </div>
       </section>
@@ -109,7 +109,7 @@ export default function DebugStylesPage() {
         </p>
         <div className="grid gap-3 md:grid-cols-2">
           {buttonVariants.map((variant) => (
-            <div key={variant} className="panel flex items-center gap-3 rounded-xl p-3">
+            <div key={variant} className="panel flex items-center gap-3 rounded-r-md p-3">
               <Button variant={variant}>{variant}</Button>
               <code className="text-xs text-dim-2">variant=&quot;{variant}&quot;</code>
             </div>
@@ -119,7 +119,7 @@ export default function DebugStylesPage() {
 
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Button Sizes</h2>
-        <div className="panel flex flex-wrap items-center gap-3 rounded-xl p-3">
+        <div className="panel flex flex-wrap items-center gap-3 rounded-r-md p-3">
           {buttonSizes.map((size) => (
             <Button key={size} size={size} variant="secondary">
               {size}
@@ -139,10 +139,10 @@ export default function DebugStylesPage() {
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Nav State Tokens</h2>
         <div className="grid gap-3 md:grid-cols-2">
-          <button type="button" className="nav-item-active rounded-xl px-3 py-2 text-left">
+          <button type="button" className="nav-item-active rounded-r-md px-3 py-2 text-left">
             Active nav item (`nav-item-active`)
           </button>
-          <button type="button" className="nav-item-inactive rounded-xl px-3 py-2 text-left">
+          <button type="button" className="nav-item-inactive rounded-r-md px-3 py-2 text-left">
             Inactive nav item (`nav-item-inactive`)
           </button>
         </div>
@@ -151,22 +151,22 @@ export default function DebugStylesPage() {
       <section className="space-y-4 pt-4">
         <h2 className="text-xs font-semibold uppercase tracking-widest text-dim-2">Status Utilities</h2>
         <p className="text-sm text-dim-2">
-          Semantic status banners for inline feedback. Uses `rounded-xl`.
+          Semantic status banners for inline feedback. Uses `rounded-r-md`.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="status-info rounded-xl p-3">
+          <div className="status-info rounded-r-md p-3">
             <p className="text-sm font-semibold">status-info</p>
             <p className="text-sm opacity-90">Information or neutral feedback.</p>
           </div>
-          <div className="status-success rounded-xl p-3">
+          <div className="status-success rounded-r-md p-3">
             <p className="text-sm font-semibold">status-success</p>
             <p className="text-sm opacity-90">Operation completed successfully.</p>
           </div>
-          <div className="status-warning rounded-xl p-3">
+          <div className="status-warning rounded-r-md p-3">
             <p className="text-sm font-semibold">status-warning</p>
             <p className="text-sm opacity-90">Warning or attention required.</p>
           </div>
-          <div className="status-error rounded-xl p-3">
+          <div className="status-error rounded-r-md p-3">
             <p className="text-sm font-semibold">status-error</p>
             <p className="text-sm opacity-90">Critical failure or invalid input.</p>
           </div>
@@ -179,11 +179,11 @@ export default function DebugStylesPage() {
           Accent-colored surfaces should use `text-[rgb(var(--accent-foreground))]` for contrast-safe text/icons.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-xl bg-accent-500 p-4 text-[rgb(var(--accent-foreground))]">
+          <div className="rounded-r-md bg-accent p-4 text-[rgb(var(--accent-foreground))]">
             <p className="font-medium">Correct: accent foreground token</p>
             <p className="text-sm opacity-90">Remains readable across accent theme changes.</p>
           </div>
-          <div className="rounded-xl bg-accent-500 p-4 text-[rgb(var(--accent-foreground))]">
+          <div className="rounded-r-md bg-accent p-4 text-[rgb(var(--accent-foreground))]">
             <p className="font-medium">Avoid: hardcoded `text-white`</p>
             <p className="text-sm opacity-90">Can fail contrast on some accent colors.</p>
           </div>
@@ -196,12 +196,12 @@ export default function DebugStylesPage() {
           Status is communicated through colored rings on the <code>input-surface</code> base.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="panel rounded-xl p-4 space-y-4">
+          <div className="panel rounded-r-md p-4 space-y-4">
             <div className="space-y-1">
               <label htmlFor="defaultInput" className="text-xs font-medium text-dim-2">Default / Focus</label>
               <input
                 id="defaultInput"
-                className="input-surface w-full rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-accent-500/30"
+                className="input-surface w-full rounded-r-md px-3 py-2 text-sm focus:ring-2 focus:ring-accent-500/30"
                 placeholder="Standard state"
               />
             </div>
@@ -209,17 +209,17 @@ export default function DebugStylesPage() {
               <label htmlFor="errorInput" className="text-xs font-medium text-dim-2">Error</label>
               <input
                 id="errorInput"
-                className="input-surface w-full rounded-xl px-3 py-2 text-sm ring-2 ring-accent-error/40 focus:ring-accent-error/60"
+                className="input-surface w-full rounded-r-md px-3 py-2 text-sm ring-2 ring-accent-error/40 focus:ring-accent-error/60"
                 placeholder="Invalid value"
               />
             </div>
           </div>
-          <div className="panel rounded-xl p-4 space-y-4">
+          <div className="panel rounded-r-md p-4 space-y-4">
             <div className="space-y-1">
               <label htmlFor="successInput" className="text-xs font-medium text-dim-2">Success</label>
               <input
                 id="successInput"
-                className="input-surface w-full rounded-xl px-3 py-2 text-sm ring-2 ring-accent-success/40 focus:ring-accent-success/60"
+                className="input-surface w-full rounded-r-md px-3 py-2 text-sm ring-2 ring-accent-success/40 focus:ring-accent-success/60"
                 placeholder="Valid value"
               />
             </div>
@@ -228,7 +228,7 @@ export default function DebugStylesPage() {
               <input
                 id="disabledInput"
                 disabled
-                className="input-surface w-full rounded-xl px-3 py-2 text-sm opacity-50 cursor-not-allowed focus:ring-0"
+                className="input-surface w-full rounded-r-md px-3 py-2 text-sm opacity-50 cursor-not-allowed focus:ring-0"
                 placeholder="Locked"
               />
             </div>
@@ -242,7 +242,7 @@ export default function DebugStylesPage() {
           Height baseline should align with Combobox for `md` controls.
         </p>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="panel rounded-xl p-4">
+          <div className="panel rounded-r-md p-4">
             <Input
               label="Input"
               value={inputValue}
@@ -250,7 +250,7 @@ export default function DebugStylesPage() {
               placeholder="Enter matter title"
             />
           </div>
-          <div className="panel rounded-xl p-4">
+          <div className="panel rounded-r-md p-4">
             <Combobox
               label="Combobox"
               value={comboboxValue}
@@ -259,7 +259,7 @@ export default function DebugStylesPage() {
               placeholder="Pick a stage"
             />
           </div>
-          <div className="panel rounded-xl p-4">
+          <div className="panel rounded-r-md p-4">
             <CurrencyInput
               label="Currency Input"
               value={currencyValue}
@@ -267,14 +267,14 @@ export default function DebugStylesPage() {
               placeholder="0"
             />
           </div>
-          <div className="panel rounded-xl p-4">
+          <div className="panel rounded-r-md p-4">
             <DatePicker
               label="Date Picker"
               value={dateValue}
               onChange={setDateValue}
             />
           </div>
-          <div className="panel rounded-xl p-4 md:col-span-2">
+          <div className="panel rounded-r-md p-4 md:col-span-2">
             <Textarea
               label="Textarea"
               rows={3}
@@ -292,7 +292,7 @@ export default function DebugStylesPage() {
           One component, four modes. `multiple` and `allowCustomValues` toggle behavior; this is not a separate component.
         </p>
         <div className="grid gap-4 md:grid-cols-2 overflow-visible">
-          <div className="panel relative z-40 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-40 rounded-r-md p-4 overflow-visible">
             <Combobox
               label="Single (dropdown mode)"
               value={selectValue}
@@ -301,7 +301,7 @@ export default function DebugStylesPage() {
               searchable={false}
             />
           </div>
-          <div className="panel relative z-40 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-40 rounded-r-md p-4 overflow-visible">
             <Combobox
               label="Single (searchable)"
               placeholder="Pick a stage"
@@ -311,7 +311,7 @@ export default function DebugStylesPage() {
               leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-dim-2')}
             />
           </div>
-          <div className="panel relative z-30 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-30 rounded-r-md p-4 overflow-visible">
             <Combobox
               label="Multi (chips)"
               placeholder="Pick one or more stages"
@@ -323,7 +323,7 @@ export default function DebugStylesPage() {
               leading={renderUserAvatar({ name: 'Demo User' }, 'xs', 'h-4 w-4 text-dim-2')}
             />
           </div>
-          <div className="panel relative z-30 rounded-xl p-4 overflow-visible">
+          <div className="panel relative z-30 rounded-r-md p-4 overflow-visible">
             <Combobox
               label="Combobox (multi + custom)"
               placeholder="Type to add tags"
@@ -344,7 +344,7 @@ export default function DebugStylesPage() {
           Five sizes (<code>xs sm md lg xl</code>) with optional <code>status</code> dot (<code>active</code> = emerald, <code>inactive</code> = amber).
           Image falls back to initials extracted from <code>name</code>.
         </p>
-        <div className="panel rounded-xl p-4">
+        <div className="panel rounded-r-md p-4">
           <div className="flex flex-wrap items-end gap-6">
             {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
               <div key={size} className="flex flex-col items-center gap-2">
@@ -371,7 +371,7 @@ export default function DebugStylesPage() {
         <p className="text-sm text-dim-2">
           Pass a <code>users</code> array and a <code>max</code> cap. Overflow renders a <code>+N</code> badge using the <code>input-surface</code> surface.
         </p>
-        <div className="panel rounded-xl p-4 flex flex-wrap items-center gap-8">
+        <div className="panel rounded-r-md p-4 flex flex-wrap items-center gap-8">
           <div className="flex flex-col gap-1">
             <StackedAvatars users={sampleUsers} size="sm" max={3} />
             <code className="text-[10px] text-dim-2">size=sm max=3</code>
@@ -398,7 +398,7 @@ export default function DebugStylesPage() {
           Pass <code>onClick</code> to make it a button (adds hover + focus ring).
         </p>
         <div className="grid gap-3 md:grid-cols-2">
-          <div className="panel rounded-xl p-1">
+          <div className="panel rounded-r-md p-1">
             <UserCard
               name="Alice Chen"
               secondary="alice@lawfirm.com"
@@ -407,7 +407,7 @@ export default function DebugStylesPage() {
               status="active"
             />
           </div>
-          <div className="panel rounded-xl p-1">
+          <div className="panel rounded-r-md p-1">
             <UserCard
               name="Bob Ramirez"
               secondary="bob@lawfirm.com"
@@ -417,7 +417,7 @@ export default function DebugStylesPage() {
               trailing={<Button size="xs" variant="ghost">Manage</Button>}
             />
           </div>
-          <div className="panel rounded-xl overflow-hidden">
+          <div className="panel rounded-r-md overflow-hidden">
             <UserCard
               name="Carol Singh"
               secondary="carol@lawfirm.com"
@@ -425,7 +425,7 @@ export default function DebugStylesPage() {
               onClick={() => alert('UserCard clicked')}
             />
           </div>
-          <div className="panel rounded-xl overflow-hidden">
+          <div className="panel rounded-r-md overflow-hidden">
             <UserCard
               name="David Kim"
               secondary="Member"

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -155,10 +155,10 @@ export default function OAuthConsentPage() {
   };
 
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-surface-app px-4 py-10">
-      <div className="w-full max-w-md rounded-2xl border border-line-subtle bg-surface-card p-6 shadow-sm">
+    <div className="flex min-h-screen w-full items-center justify-center bg-paper px-4 py-10">
+      <div className="w-full max-w-md rounded-2xl border border-line-subtle bg-card p-6 shadow-sm">
         <div className="flex flex-col items-center text-center">
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-paper-2/10">
             <Icon icon={Sparkles} className="h-6 w-6 text-ink" aria-hidden="true" />
           </div>
           <h1 className="text-lg font-semibold text-ink">Authorize access</h1>

--- a/src/pages/PaymentResultPage.tsx
+++ b/src/pages/PaymentResultPage.tsx
@@ -52,7 +52,7 @@ const OUTCOMES: Record<PaymentOutcome, OutcomeConfig> = {
     headline: 'Verifying your payment…',
     body: 'Please wait a moment while we confirm your payment status.',
     badge: 'Checking status',
-    badgeClass: 'bg-surface-utility/15 text-dim-2 border-line-subtle',
+    badgeClass: 'bg-paper-2/15 text-dim-2 border-line-subtle',
   },
 };
 
@@ -107,7 +107,7 @@ const PaymentResultPage: FunctionComponent<{ practiceSlug?: string }> = ({ pract
           
           <div className="card p-8 sm:p-10 space-y-6">
             <div className="flex justify-center">
-              <div className="rounded-full bg-surface-subtle/50 p-4 border border-line-subtle shadow-sm">
+              <div className="rounded-full bg-paper-2/50 p-4 border border-line-subtle shadow-sm">
                 <Icon className={`w-10 h-10 ${config.iconColor}`} aria-hidden="true" />
               </div>
             </div>

--- a/src/pages/PracticeHomePage.tsx
+++ b/src/pages/PracticeHomePage.tsx
@@ -371,9 +371,9 @@ const PracticeHomePage = () => {
                 </button>
               </div>
             </div>
-            <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full bg-surface-card-hover">
+            <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full bg-paper-2">
               <div
-                className="h-full rounded-full bg-accent-500 transition-[width] motion-reduce:transition-none"
+                className="h-full rounded-full bg-accent transition-[width] motion-reduce:transition-none"
                 style={{ width: `${progressPct}%` }}
                 role="progressbar"
                 aria-valuenow={completeCount}
@@ -389,11 +389,11 @@ const PracticeHomePage = () => {
                   type="button"
                   disabled={!step.href}
                   onClick={() => handleSetupStep(step)}
-                  className="flex min-h-[116px] flex-col gap-2.5 rounded-lg border border-line-subtle bg-surface-card-hover p-4 text-left transition-colors hover:bg-surface-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40 disabled:cursor-default disabled:hover:bg-surface-card-hover"
+                  className="flex min-h-[116px] flex-col gap-2.5 rounded-lg border border-line-subtle bg-paper-2 p-4 text-left transition-colors hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40 disabled:cursor-default disabled:hover:bg-paper-2"
                 >
                   <div className="flex items-center gap-2.5">
                     {step.complete ? (
-                      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-accent-500 text-[rgb(var(--accent-foreground))]">
+                      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-accent text-[rgb(var(--accent-foreground))]">
                         <Check className="h-3.5 w-3.5" strokeWidth={3} aria-hidden="true" />
                       </span>
                     ) : (
@@ -427,9 +427,9 @@ const PracticeHomePage = () => {
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {[0, 1, 2, 3].map((item) => (
                 <div key={item} className="rounded-2xl border border-card-border bg-card p-5">
-                  <div className="h-3 w-24 rounded-full bg-surface-card-hover" />
-                  <div className="mt-4 h-8 w-28 rounded-full bg-surface-card-hover" />
-                  <div className="mt-3 h-3 w-36 rounded-full bg-surface-card-hover" />
+                  <div className="h-3 w-24 rounded-full bg-paper-2" />
+                  <div className="mt-4 h-8 w-28 rounded-full bg-paper-2" />
+                  <div className="mt-3 h-3 w-36 rounded-full bg-paper-2" />
                 </div>
               ))}
             </div>
@@ -490,12 +490,12 @@ const PracticeHomePage = () => {
                     type="button"
                     onClick={() => handleIntakeOpen(row.uuid)}
                     className={[
-                      'group grid w-full grid-cols-1 gap-2 px-5 py-4 text-left transition-colors hover:bg-surface-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40 md:grid-cols-[260px_1fr_140px_110px] md:items-center md:gap-4',
+                      'group grid w-full grid-cols-1 gap-2 px-5 py-4 text-left transition-colors hover:bg-paper-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40 md:grid-cols-[260px_1fr_140px_110px] md:items-center md:gap-4',
                       idx > 0 ? 'border-t border-line-subtle' : '',
                     ].filter(Boolean).join(' ')}
                   >
                     <div className="flex min-w-0 items-center gap-2.5">
-                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-card-hover text-[11px] font-semibold text-ink">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-paper-2 text-[11px] font-semibold text-ink">
                         {initialsFor(contactName)}
                       </span>
                       <span className="truncate text-sm font-medium text-ink">{contactName}</span>
@@ -519,10 +519,10 @@ const PracticeHomePage = () => {
             <div className="overflow-hidden rounded-2xl border border-card-border bg-card">
               {[0, 1, 2].map((row) => (
                 <div key={row} className="grid grid-cols-1 gap-2 border-t border-line-subtle px-5 py-4 first:border-t-0 md:grid-cols-[260px_1fr_140px_110px] md:items-center md:gap-4">
-                  <div className="h-4 w-36 rounded-full bg-surface-card-hover" />
-                  <div className="h-4 w-48 rounded-full bg-surface-card-hover" />
-                  <div className="h-4 w-24 rounded-full bg-surface-card-hover" />
-                  <div className="h-6 w-20 rounded-full bg-surface-card-hover md:ml-auto" />
+                  <div className="h-4 w-36 rounded-full bg-paper-2" />
+                  <div className="h-4 w-48 rounded-full bg-paper-2" />
+                  <div className="h-4 w-24 rounded-full bg-paper-2" />
+                  <div className="h-6 w-20 rounded-full bg-paper-2 md:ml-auto" />
                 </div>
               ))}
             </div>

--- a/src/shared/components/AnnouncementBanner.tsx
+++ b/src/shared/components/AnnouncementBanner.tsx
@@ -21,19 +21,19 @@ interface AnnouncementBannerProps {
 
 const toneStyles: Record<AnnouncementTone, { container: string; title: string; body: string; rail: string }> = {
   warning: {
-    container: 'border-line-subtle bg-surface-panel/60 text-ink backdrop-blur-xl shadow-glass',
+    container: 'border-line-subtle bg-paper-2/60 text-ink backdrop-blur-xl shadow-glass',
     title: 'text-ink',
     body: 'text-dim-2',
     rail: 'bg-amber-500/70'
   },
   info: {
-    container: 'border-line-subtle bg-surface-panel/60 text-ink backdrop-blur-xl shadow-glass',
+    container: 'border-line-subtle bg-paper-2/60 text-ink backdrop-blur-xl shadow-glass',
     title: 'text-ink',
     body: 'text-dim-2',
     rail: 'bg-sky-500/70'
   },
   success: {
-    container: 'border-line-subtle bg-surface-panel/60 text-ink backdrop-blur-xl shadow-glass',
+    container: 'border-line-subtle bg-paper-2/60 text-ink backdrop-blur-xl shadow-glass',
     title: 'text-ink',
     body: 'text-dim-2',
     rail: 'bg-emerald-500/70'
@@ -41,9 +41,9 @@ const toneStyles: Record<AnnouncementTone, { container: string; title: string; b
 };
 
 const flatToneStyles: Record<AnnouncementTone, string> = {
-  warning: 'border border-line-subtle bg-surface-panel/40 text-ink backdrop-blur-xl',
-  info: 'border border-line-subtle bg-surface-panel/40 text-ink backdrop-blur-xl',
-  success: 'border border-line-subtle bg-surface-panel/40 text-ink backdrop-blur-xl'
+  warning: 'border border-line-subtle bg-paper-2/40 text-ink backdrop-blur-xl',
+  info: 'border border-line-subtle bg-paper-2/40 text-ink backdrop-blur-xl',
+  success: 'border border-line-subtle bg-paper-2/40 text-ink backdrop-blur-xl'
 };
 
 const AnnouncementBanner = ({

--- a/src/shared/components/AuthForm.tsx
+++ b/src/shared/components/AuthForm.tsx
@@ -412,13 +412,13 @@ const AuthForm = ({
           </div>
 
           {error && (
-            <div className="mt-4 rounded-xl panel border-accent-error/20 p-3">
+            <div className="mt-4 rounded-r-md panel border-accent-error/20 p-3">
               <p className="text-sm text-accent-error-light">{error}</p>
             </div>
           )}
 
           {message && (
-            <div className="mt-4 rounded-xl panel border-emerald-500/20 p-3">
+            <div className="mt-4 rounded-r-md panel border-emerald-500/20 p-3">
               <p className="text-sm text-emerald-400">{message}</p>
             </div>
           )}

--- a/src/shared/components/ConfirmationDialog.tsx
+++ b/src/shared/components/ConfirmationDialog.tsx
@@ -148,7 +148,7 @@ export default function ConfirmationDialog({
                 <div className="space-y-2">
                   <label htmlFor={confirmationInputId} className="block text-sm font-medium text-ink">
                     {confirmationLabel}
-                    <span className="font-mono text-xs font-bold bg-surface-utility/40 border border-line-utility/50 dark:border-white/20 px-2 py-0.5 rounded shadow-sm ml-2 text-ink inline-flex items-center">
+                    <span className="font-mono text-xs font-bold bg-paper-2/40 border border-line-utility/50 dark:border-white/20 px-2 py-0.5 rounded shadow-sm ml-2 text-ink inline-flex items-center">
                       {confirmationValue}
                     </span>
                   </label>
@@ -162,7 +162,7 @@ export default function ConfirmationDialog({
                     onMouseDown={(e) => e.stopPropagation()}
                     placeholder={`Type "${confirmationValue}" to confirm`}
                     className={cn(
-                      'input-surface w-full rounded-xl px-3 py-2 text-sm',
+                      'input-surface w-full rounded-r-md px-3 py-2 text-sm',
                       error ? 'isError' : ''
                     )}
                     aria-invalid={Boolean(error)}
@@ -178,7 +178,7 @@ export default function ConfirmationDialog({
 
                 {/* Success Message */}
                 {showSuccessMessage && successMessage && (
-                  <div className="status-success rounded-xl py-2.5 px-3 text-sm">
+                  <div className="status-success rounded-r-md py-2.5 px-3 text-sm">
                     {successMessage.title && (
                       <p className="mb-1 text-sm font-semibold">
                         {successMessage.title}
@@ -206,7 +206,7 @@ export default function ConfirmationDialog({
                       onMouseDown={(e) => e.stopPropagation()}
                       placeholder={passwordPlaceholder}
                       className={cn(
-                        'input-surface w-full rounded-xl px-3 py-2 text-sm',
+                        'input-surface w-full rounded-r-md px-3 py-2 text-sm',
                         passwordError ? 'isError' : ''
                       )}
                       aria-invalid={Boolean(passwordError)}

--- a/src/shared/components/DebugOverlay.tsx
+++ b/src/shared/components/DebugOverlay.tsx
@@ -239,8 +239,8 @@ export const DebugOverlay: FunctionComponent<DebugOverlayProps> = ({ isVisible =
         {isExpanded && (
           <div className="mt-2 pt-2 border-t border-line-subtle" role="region" aria-label="Additional debug information">
             <div className="text-xs text-dim-2">
-              <div>Press <kbd className="bg-surface-utility/40 px-1 rounded">Esc</kbd> to collapse</div>
-              <div>Press <kbd className="bg-surface-utility/40 px-1 rounded">Enter</kbd> or <kbd className="bg-surface-utility/40 px-1 rounded">Space</kbd> to toggle</div>
+              <div>Press <kbd className="bg-paper-2/40 px-1 rounded">Esc</kbd> to collapse</div>
+              <div>Press <kbd className="bg-paper-2/40 px-1 rounded">Enter</kbd> or <kbd className="bg-paper-2/40 px-1 rounded">Space</kbd> to toggle</div>
             </div>
           </div>
         )}

--- a/src/shared/components/Toast.tsx
+++ b/src/shared/components/Toast.tsx
@@ -65,7 +65,7 @@ const ToastComponent: FunctionComponent<ToastProps> = ({ toast, onRemove }) => {
   };
 
   return (
-    <div className={`max-w-sm w-full ${getStatusClass()} rounded-xl p-4 relative animate-toast-in`}>
+    <div className={`max-w-sm w-full ${getStatusClass()} rounded-r-md p-4 relative animate-toast-in`}>
       <div className="flex items-start">
         <div className="flex-shrink-0">
           {getIcon()}

--- a/src/shared/ui/Accordion.tsx
+++ b/src/shared/ui/Accordion.tsx
@@ -105,7 +105,7 @@ const Accordion: FunctionComponent<AccordionProps> = ({
     <AccordionContext.Provider value={contextValue}>
       <div 
         data-slot="accordion" 
-        className={cn("w-full border border-line-subtle rounded-xl", className)}
+        className={cn("w-full border border-line-subtle rounded-r-md", className)}
       >
         {children}
       </div>
@@ -173,7 +173,7 @@ const AccordionTrigger: FunctionComponent<AccordionTriggerProps> = ({
         aria-expanded={isOpen}
         aria-controls={contentId}
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center justify-between gap-4 px-4 py-3 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 rounded-xl",
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center justify-between gap-4 px-4 py-3 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 rounded-r-md",
           className
         )}
         onClick={handleClick}

--- a/src/shared/ui/DragDropOverlay.tsx
+++ b/src/shared/ui/DragDropOverlay.tsx
@@ -50,7 +50,7 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
     <div
       ref={overlayRef}
       tabIndex={-1}
-      className="pointer-events-none fixed inset-0 flex items-center justify-center bg-surface-app-frame/40 backdrop-blur-[2px]"
+      className="pointer-events-none fixed inset-0 flex items-center justify-center bg-paper/40 backdrop-blur-[2px]"
       style={{ zIndex: THEME.zIndex.modal }}
       role="status"
       aria-label="Drop files to add to the conversation"
@@ -61,13 +61,13 @@ const DragDropOverlay: FunctionComponent<DragDropOverlayProps> = ({ isVisible, o
         {/* Icon stack — overlapping "talk + image + doc" tiles to mirror the
             reference. Tilted at slight angles so they read as a sticker stack. */}
         <div className="relative h-16 w-20">
-          <div className="absolute left-1 top-1 flex h-12 w-12 -rotate-12 items-center justify-center rounded-2xl bg-accent-500/90 shadow-lg ring-1 ring-line-subtle">
+          <div className="absolute left-1 top-1 flex h-12 w-12 -rotate-12 items-center justify-center rounded-2xl bg-accent/90 shadow-lg ring-1 ring-line-subtle">
             <Icon icon={MessageSquare} className="h-6 w-6 text-[rgb(var(--accent-foreground))]" aria-hidden="true" />
           </div>
           <div className="absolute right-0 top-0 flex h-12 w-12 rotate-6 items-center justify-center rounded-2xl bg-input-text/85 shadow-lg ring-1 ring-line-subtle">
             <Icon icon={FileText} className="h-6 w-6 text-surface-app-frame" aria-hidden="true" />
           </div>
-          <div className="absolute bottom-0 left-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-accent-500 shadow-lg ring-1 ring-line-subtle">
+          <div className="absolute bottom-0 left-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-accent shadow-lg ring-1 ring-line-subtle">
             <Icon icon={Image} className="h-6 w-6 text-[rgb(var(--accent-foreground))]" aria-hidden="true" />
           </div>
         </div>

--- a/src/shared/ui/Kbd.tsx
+++ b/src/shared/ui/Kbd.tsx
@@ -9,7 +9,7 @@ interface KbdProps {
 export const Kbd = ({ children, className }: KbdProps) => (
   <kbd
     className={cn(
-      'inline-flex min-w-[1.5em] items-center justify-center rounded border border-line-subtle bg-surface-utility/40 px-1.5 py-0.5 font-mono text-xs text-ink',
+      'inline-flex min-w-[1.5em] items-center justify-center rounded border border-line-subtle bg-paper-2/40 px-1.5 py-0.5 font-mono text-xs text-ink',
       className
     )}
   >

--- a/src/shared/ui/activity/ActivityTimeline.tsx
+++ b/src/shared/ui/activity/ActivityTimeline.tsx
@@ -170,14 +170,14 @@ export const ActivityTimeline = ({
                     name={item.person.name}
                     src={item.person.imageUrl}
                     size="md"
-                    className="ring-1 ring-line-utility/30 bg-surface-utility/10 text-ink"
+                    className="ring-1 ring-line-utility/30 bg-paper-2/10 text-ink"
                   />
-                  <span className="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full bg-surface-overlay text-ink ring-1 ring-line-utility/30 shadow-sm sm:h-5 sm:w-5">
+                  <span className="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full bg-card text-ink ring-1 ring-line-utility/30 shadow-sm sm:h-5 sm:w-5">
                     <Icon icon={MessagesSquare} className="h-2.5 w-2.5 sm:h-3 sm:w-3" aria-hidden="true"  />
                   </span>
                 </div>
               ) : (
-                <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-overlay text-ink ring-1 ring-line-subtle shadow-sm">
+                <div className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-card text-ink ring-1 ring-line-subtle shadow-sm">
                   {item.type === 'paid' ? (
                     <Icon icon={CheckCircle2} aria-hidden="true" className="h-5 w-5 text-accent-success"  />
                   ) : TYPE_ICONS[item.type] ? (
@@ -351,7 +351,7 @@ export const ActivityTimeline = ({
           name={composerPerson?.name ?? 'You'}
           src={composerPerson?.imageUrl ?? null}
           size="sm"
-          className="ring-1 ring-line-subtle bg-surface-utility/10 text-ink dark:ring-line-subtle sm:mt-1"
+          className="ring-1 ring-line-subtle bg-paper-2/10 text-ink dark:ring-line-subtle sm:mt-1"
         />
         <form className="flex-auto space-y-2" onSubmit={handleSubmit}>
           <MarkdownUploadTextarea

--- a/src/shared/ui/address/AddressExperienceForm.tsx
+++ b/src/shared/ui/address/AddressExperienceForm.tsx
@@ -309,7 +309,7 @@ export const AddressExperienceForm = ({
   const containerClasses = cn(
     variant === 'plain'
       ? 'w-full'
-      : 'panel rounded-xl p-6',
+      : 'panel rounded-r-md p-6',
     className
   );
 

--- a/src/shared/ui/address/AddressFields.tsx
+++ b/src/shared/ui/address/AddressFields.tsx
@@ -245,9 +245,9 @@ export const AddressFields = forwardRef<HTMLDivElement, AddressFieldsProps>(
               aria-label="Address suggestions"
               data-testid="autocomplete-dropdown"
               className={cn(
-                'absolute z-50 mt-1 w-full overflow-y-auto rounded-xl',
+                'absolute z-50 mt-1 w-full overflow-y-auto rounded-r-md',
                 'max-h-60 border border-white/10',
-                'bg-surface-overlay/95 backdrop-blur-2xl shadow-glass',
+                'bg-card/95 backdrop-blur-2xl shadow-glass',
               )}
             >
               {streetAddressProps.suggestions.length > 0 ? (
@@ -278,8 +278,8 @@ export const AddressFields = forwardRef<HTMLDivElement, AddressFieldsProps>(
                           className={cn(
                             'w-full px-3 py-2 text-left text-sm transition-colors duration-150',
                             isActive
-                              ? 'bg-accent-500/15 text-accent-400'
-                              : 'text-ink hover:bg-surface-utility/10'
+                              ? 'bg-accent/15 text-accent-400'
+                              : 'text-ink hover:bg-paper-2/10'
                           )}
                         >
                           {s.formatted}

--- a/src/shared/ui/cards/InfoCard.tsx
+++ b/src/shared/ui/cards/InfoCard.tsx
@@ -23,7 +23,7 @@ export const InfoCard = ({
 }: InfoCardProps) => (
   <section
     className={cn(
-      'card flex flex-col rounded-xl p-5',
+      'card flex flex-col rounded-r-md p-5',
       bodyGap === 'sm' ? 'gap-3' : 'gap-4',
       className
     )}

--- a/src/shared/ui/collection/CollectionToolbar.tsx
+++ b/src/shared/ui/collection/CollectionToolbar.tsx
@@ -36,7 +36,7 @@ export const CollectionToolbar = ({
   return (
     <section
       className={cn(
-        'rounded-2xl border border-line-subtle bg-surface-panel/70 backdrop-blur-xl',
+        'rounded-2xl border border-line-subtle bg-paper-2/70 backdrop-blur-xl',
         compact ? 'p-3' : 'p-4 sm:p-5',
         className
       )}

--- a/src/shared/ui/dialog/DialogHeader.tsx
+++ b/src/shared/ui/dialog/DialogHeader.tsx
@@ -56,7 +56,7 @@ export const DialogHeader: FunctionComponent<DialogHeaderProps> = ({
           size="icon-xs"
           onClick={onClose}
           aria-label="Close"
-          className="mt-0.5 shrink-0 rounded-full text-dim-2 hover:bg-surface-hover hover:text-ink"
+          className="mt-0.5 shrink-0 rounded-full text-dim-2 hover:bg-paper-2 hover:text-ink"
           icon={<Icon icon={X} className="h-4 w-4" />}
         />
       )}

--- a/src/shared/ui/dialog/Fullscreen.tsx
+++ b/src/shared/ui/dialog/Fullscreen.tsx
@@ -116,7 +116,7 @@ export const Fullscreen: FunctionComponent<FullscreenProps> = ({
             size="icon-xs"
             onClick={onClose}
             aria-label="Close"
-            className="absolute right-4 top-4 z-10 rounded-full text-dim-2 hover:bg-surface-hover hover:text-ink"
+            className="absolute right-4 top-4 z-10 rounded-full text-dim-2 hover:bg-paper-2 hover:text-ink"
             icon={<Icon icon={X} className="h-4 w-4" />}
           />
         )}

--- a/src/shared/ui/dialog/InfoListDialog.tsx
+++ b/src/shared/ui/dialog/InfoListDialog.tsx
@@ -86,7 +86,7 @@ export const InfoListDialog: FunctionComponent<InfoListDialogProps> = ({
         {items.map((item, index) => (
           <div key={item.id}>
             <div className="flex items-start gap-3 py-1">
-              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-surface-utility/10">
+              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-paper-2/10">
                 <Icon icon={item.icon} className={item.iconClassName ?? 'h-5 w-5 text-ink'} aria-hidden="true" />
               </div>
               <div className="min-w-0 space-y-1">

--- a/src/shared/ui/dropdown/DropdownMenuCheckboxItem.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuCheckboxItem.tsx
@@ -42,7 +42,7 @@ export const DropdownMenuCheckboxItem = ({
     <div 
       className={cn(
         'flex items-center justify-between px-2 py-1.5 text-sm text-ink',
-        'hover:bg-surface-utility/10',
+        'hover:bg-paper-2/10',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent-500/50',
         'dark:focus-visible:ring-accent-400/40',
         disabled && 'opacity-50 cursor-not-allowed',

--- a/src/shared/ui/dropdown/DropdownMenuContent.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuContent.tsx
@@ -113,7 +113,7 @@ export const DropdownMenuContent = ({
       role="menu"
       ref={(node) => setContentRef(node)}
       className={cn(
-        'fixed z-50 min-w-max overflow-hidden rounded-xl border border-white/10 bg-surface-overlay shadow-glass text-ink',
+        'fixed z-50 min-w-max overflow-hidden rounded-r-md border border-white/10 bg-card shadow-glass text-ink',
         centerTransform,
         className,
       )}

--- a/src/shared/ui/dropdown/DropdownMenuItem.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuItem.tsx
@@ -34,7 +34,7 @@ export const DropdownMenuItem = ({
       disabled={disabled}
       className={cn(
         'w-full text-left px-2 py-1.5 text-sm text-ink',
-        'hover:bg-surface-utility/10 focus:outline-none focus:bg-surface-utility/20',
+        'hover:bg-paper-2/10 focus:outline-none focus:bg-paper-2/20',
         disabled && 'opacity-50 cursor-not-allowed',
         className
       )}

--- a/src/shared/ui/dropdown/DropdownMenuTrigger.tsx
+++ b/src/shared/ui/dropdown/DropdownMenuTrigger.tsx
@@ -144,8 +144,8 @@ export const DropdownMenuTrigger = ({
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       className={cn(
-        'flex items-center gap-2 px-3 py-1 text-sm text-ink rounded-xl',
-        'hover:bg-surface-utility/10 focus:outline-none focus:ring-2 focus:ring-accent-500',
+        'flex items-center gap-2 px-3 py-1 text-sm text-ink rounded-r-md',
+        'hover:bg-paper-2/10 focus:outline-none focus:ring-2 focus:ring-accent-500',
         className
       )}
       aria-haspopup="menu"

--- a/src/shared/ui/input/Combobox.tsx
+++ b/src/shared/ui/input/Combobox.tsx
@@ -105,11 +105,11 @@ function Chip({
   return (
     <span
       className={cn(
-        'inline-flex max-w-full items-center gap-1 rounded-xl border text-xs font-medium',
+        'inline-flex max-w-full items-center gap-1 rounded-r-md border text-xs font-medium',
         compact ? 'min-h-8 px-3 py-1 text-sm' : 'px-2 py-0.5',
         isCustom
-          ? 'border-accent-500/25 bg-accent-500/12 text-accent-utility'
-          : 'border-line-subtle bg-surface-utility/10 text-ink'
+          ? 'border-accent-500/25 bg-accent/12 text-accent-utility'
+          : 'border-line-subtle bg-paper-2/10 text-ink'
       )}
     >
       <span className="truncate">{label}</span>
@@ -167,8 +167,8 @@ function DropdownOption({
         'group relative flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-all',
         option.disabled && 'cursor-not-allowed opacity-45',
         isSelected || isFocused
-          ? 'bg-accent-500/15 text-ink'
-          : 'text-ink hover:bg-surface-utility/10 dark:hover:bg-surface-utility/20',
+          ? 'bg-accent/15 text-ink'
+          : 'text-ink hover:bg-paper-2/10 dark:hover:bg-paper-2/20',
         option.disabled && 'hover:bg-transparent dark:hover:bg-transparent'
       )}
     >
@@ -580,7 +580,7 @@ export function Combobox({
           onClick={() => (isOpen ? close() : open())}
           onKeyDown={handleKeyDown}
           className={cn(
-            'input-surface relative flex w-full gap-2 rounded-xl px-3 py-2.5 transition-all duration-200',
+            'input-surface relative flex w-full gap-2 rounded-r-md px-3 py-2.5 transition-all duration-200',
             isOpen && 'isOpen',
             'items-center',
             !disabled && 'cursor-pointer'
@@ -601,8 +601,8 @@ export function Combobox({
           tabIndex={-1}
           onMouseDown={(e) => e.preventDefault()}
           className={cn(
-            'z-[60] w-full overflow-hidden rounded-xl absolute',
-            'bg-surface-overlay shadow-glass border border-line-subtle',
+            'z-[60] w-full overflow-hidden rounded-r-md absolute',
+            'bg-card shadow-glass border border-line-subtle',
             hideTrigger ? 'top-0 mt-1' : (direction === 'up' ? 'bottom-full mb-1 top-auto' : 'top-full mt-1')
           )}
         >
@@ -620,7 +620,7 @@ export function Combobox({
                 }}
                 onKeyDown={handleKeyDown}
                 className={cn(
-                  'w-full rounded-xl bg-surface-utility/10 px-3 py-1.5 text-sm text-ink',
+                  'w-full rounded-r-md bg-paper-2/10 px-3 py-1.5 text-sm text-ink',
                   'placeholder:text-dim-2/60',
                   'focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500/30'
                 )}
@@ -647,11 +647,11 @@ export function Combobox({
                 className={cn(
                   'flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors',
                   clampedFocus === 0
-                    ? 'bg-accent-500/15 text-ink'
-                    : 'text-ink hover:bg-surface-utility/10 focus:bg-surface-utility/20'
+                    ? 'bg-accent/15 text-ink'
+                    : 'text-ink hover:bg-paper-2/10 focus:bg-paper-2/20'
                 )}
               >
-                <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-accent-500/20 text-accent-utility">
+                <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-accent/20 text-accent-utility">
                   <Icon icon={Plus} className="h-3.5 w-3.5"  />
                 </span>
                 <span>
@@ -701,7 +701,7 @@ export function Combobox({
             </div>
           ) : allowCustomValues && filteredOptions.length === 0 && !showAddRow ? (
             <div className="flex items-center gap-2 border-t border-line-subtle px-3 py-2 text-xs text-dim-2">
-              <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded bg-accent-500/20 text-accent-utility">
+              <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded bg-accent/20 text-accent-utility">
                 <Icon icon={Plus} className="h-3 w-3" />
               </span>
               <span>Type a name and press Enter to add a new option.</span>

--- a/src/shared/ui/input/CurrencyInput.tsx
+++ b/src/shared/ui/input/CurrencyInput.tsx
@@ -82,7 +82,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-ink placeholder:text-dim-2',
+    'w-full rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],

--- a/src/shared/ui/input/DatePicker.tsx
+++ b/src/shared/ui/input/DatePicker.tsx
@@ -113,7 +113,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
   };
 
   const inputClasses = cn(
-    'w-full min-h-[44px] rounded-xl text-ink placeholder:text-dim-2',
+    'w-full min-h-[44px] rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'appearance-none input-surface border-none',
     sizeClasses[size],

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -103,7 +103,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-ink placeholder:text-dim-2',
+    'w-full rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],

--- a/src/shared/ui/input/FileInput.tsx
+++ b/src/shared/ui/input/FileInput.tsx
@@ -159,9 +159,9 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(({
         aria-label={displayLabel || "File upload area"}
         aria-disabled={disabled}
         className={cn(
-          'relative border-2 border-dashed rounded-xl transition-colors',
+          'relative border-2 border-dashed rounded-r-md transition-colors',
           'hover:border-accent-400 dark:hover:border-accent-500',
-          isDragOver ? 'border-accent-500 bg-accent-50 dark:bg-accent-900/20' : 'border-input-border',
+          isDragOver ? 'border-accent-500 bg-accent/10 dark:bg-accent-deep/20' : 'border-input-border',
           variantClasses[variant],
           disabled && 'opacity-50 cursor-not-allowed',
           className

--- a/src/shared/ui/input/LogoUploadInput.tsx
+++ b/src/shared/ui/input/LogoUploadInput.tsx
@@ -137,7 +137,7 @@ export const LogoUploadInput = forwardRef<HTMLInputElement, LogoUploadInputProps
             className="h-full w-full object-cover"
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center bg-surface-utility/10">
+          <div className="flex h-full w-full items-center justify-center bg-paper-2/10">
             <Icon icon={User} className="h-1/2 w-1/2 text-dim-2"  />
           </div>
         )}

--- a/src/shared/ui/input/MarkdownUploadTextarea.tsx
+++ b/src/shared/ui/input/MarkdownUploadTextarea.tsx
@@ -274,16 +274,16 @@ export const MarkdownUploadTextarea = ({
         </label>
       ) : null}
 
-      <div className="overflow-hidden rounded-2xl border border-line-subtle bg-surface-panel/80 shadow-glass backdrop-blur-xl dark:bg-surface-overlay/70">
+      <div className="overflow-hidden rounded-2xl border border-line-subtle bg-paper-2/80 shadow-glass backdrop-blur-xl dark:bg-card/70">
         {showTabs ? (
-          <div className="flex items-center justify-between gap-3 border-b border-line-subtle bg-surface-panel/70 px-2 py-2 dark:bg-surface-overlay/80">
+          <div className="flex items-center justify-between gap-3 border-b border-line-subtle bg-paper-2/70 px-2 py-2 dark:bg-card/80">
             <div className="flex min-w-0 items-center gap-2 @xl:flex @xl:flex-none @xl:items-center @xl:gap-1">
               <button
                 type="button"
                 className={cn(
-                  'rounded-xl px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
+                  'rounded-r-md px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'write'
-                    ? 'bg-surface-workspace/90 text-ink shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
+                    ? 'bg-paper/90 text-ink shadow-sm ring-1 ring-line-subtle dark:bg-card/90'
                     : 'text-dim-2 hover:text-ink'
                 )}
                 onClick={() => setActiveTab('write')}
@@ -293,9 +293,9 @@ export const MarkdownUploadTextarea = ({
               <button
                 type="button"
                 className={cn(
-                  'rounded-xl px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
+                  'rounded-r-md px-3 py-2 text-sm font-medium transition-colors @xl:px-3 @xl:py-1.5',
                   activeTab === 'preview'
-                    ? 'bg-surface-workspace/90 text-ink shadow-sm ring-1 ring-line-subtle dark:bg-surface-overlay/90'
+                    ? 'bg-paper/90 text-ink shadow-sm ring-1 ring-line-subtle dark:bg-card/90'
                     : 'text-dim-2 hover:text-ink'
                 )}
                 onClick={() => setActiveTab('preview')}
@@ -308,7 +308,7 @@ export const MarkdownUploadTextarea = ({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-line-subtle bg-surface-overlay/40 text-dim-2 transition-colors hover:text-ink"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-r-md border border-line-subtle bg-card/40 text-dim-2 transition-colors hover:text-ink"
                     aria-label="Formatting options"
                   >
                     <Icon icon={MoreVertical} className="h-4 w-4" aria-hidden="true" />
@@ -317,63 +317,63 @@ export const MarkdownUploadTextarea = ({
                 <DropdownMenuContent align="end" className="w-64 p-1.5">
                   <DropdownMenuItem
                     onSelect={() => prependToLine('# ', 'Heading')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-surface-overlay/50 text-xs font-semibold">H</span>
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-card/50 text-xs font-semibold">H</span>
                     <span>Heading</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => replaceSelection('**', '**', 'bold text')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-surface-overlay/50 text-xs font-semibold">B</span>
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-card/50 text-xs font-semibold">B</span>
                     <span>Bold</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => replaceSelection('*', '*', 'italic text')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-surface-overlay/50 text-xs italic font-semibold">I</span>
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-line-subtle bg-card/50 text-xs italic font-semibold">I</span>
                     <span>Italic</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => prependToLine('> ', 'Quoted text')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
                     <Icon icon={PanelLeft} className="h-4 w-4" aria-hidden="true" />
                     <span>Quote</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => replaceSelection('```\n', '\n```', 'code')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
                     <Icon icon={Code} className="h-4 w-4" aria-hidden="true" />
                     <span>Code</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => replaceSelection('[', '](https://)', 'link text')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
                     <Icon icon={Link} className="h-4 w-4" aria-hidden="true" />
                     <span>Link</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => prependToLine('- ', 'List item')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
                     <Icon icon={List} className="h-4 w-4" aria-hidden="true" />
                     <span>Bulleted list</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => prependToLine('1. ', 'List item')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
                     <Icon icon={ListOrdered} className="h-4 w-4" aria-hidden="true" />
                     <span>Numbered list</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => prependToLine('- [ ] ', 'Task')}
-                    className="flex items-center gap-2 rounded-xl px-3 py-2"
+                    className="flex items-center gap-2 rounded-r-md px-3 py-2"
                   >
                     <Icon icon={FileText} className="h-4 w-4" aria-hidden="true" />
                     <span>Task list</span>
@@ -425,7 +425,7 @@ export const MarkdownUploadTextarea = ({
           <div
             className={cn(
               'relative border border-transparent transition-colors',
-              isDragActive ? 'border-accent-500/60 bg-accent-500/5' : ''
+              isDragActive ? 'border-accent-500/60 bg-accent/5' : ''
             )}
           >
             <textarea
@@ -468,7 +468,7 @@ export const MarkdownUploadTextarea = ({
               }}
             />
             {isDragActive && (
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-surface-overlay/70 text-sm font-medium text-ink">
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-card/70 text-sm font-medium text-ink">
                 Drop files to upload and insert links
               </div>
             )}
@@ -493,7 +493,7 @@ export const MarkdownUploadTextarea = ({
                     {value}
                   </ReactMarkdown>
                 ) : (
-                  <div className="mt-2 flex justify-center rounded border border-line-subtle bg-surface-panel p-2 dark:border-line-subtle dark:bg-surface-panel/40">
+                  <div className="mt-2 flex justify-center rounded border border-line-subtle bg-paper-2 p-2 dark:border-line-subtle dark:bg-paper-2/40">
                     <LoadingSpinner size="sm" ariaLabel="Loading preview" />
                   </div>
                 )}
@@ -543,7 +543,7 @@ export const MarkdownUploadTextarea = ({
       ) : null}
 
       {uploadItems.length > 0 && (
-        <div className="space-y-1 rounded-xl border border-line-subtle bg-surface-overlay/50 px-3 py-2">
+        <div className="space-y-1 rounded-r-md border border-line-subtle bg-card/50 px-3 py-2">
           {uploadItems.map((item) => (
             <div key={item.id} className="flex items-center gap-2 text-xs text-dim-2">
               <Icon icon={FileText} className="h-4 w-4" aria-hidden="true"  />

--- a/src/shared/ui/input/NumberInput.tsx
+++ b/src/shared/ui/input/NumberInput.tsx
@@ -90,7 +90,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-ink placeholder:text-dim-2',
+    'w-full rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -187,7 +187,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
               disabled={disabled || !canIncrement}
               className={cn(
                 'flex items-center justify-center border-l border-input-border',
-                'input-surface hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
+                'input-surface hover:bg-paper-2/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 controlSizeClasses[size],
                 'rounded-tr-xl'
@@ -201,7 +201,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
               disabled={disabled || !canDecrement}
               className={cn(
                 'flex items-center justify-center border-l border-t border-input-border',
-                'input-surface hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
+                'input-surface hover:bg-paper-2/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 controlSizeClasses[size],
                 'rounded-br-xl'

--- a/src/shared/ui/input/PINInput.tsx
+++ b/src/shared/ui/input/PINInput.tsx
@@ -117,7 +117,7 @@ export function PINInput({
           disabled={disabled}
           aria-label={`Digit ${i + 1}`}
           className={cn(
-            'input-surface text-center font-medium rounded-xl',
+            'input-surface text-center font-medium rounded-r-md',
             sizeClasses[size],
             'focus-visible:outline-none',
             error && 'input-surface isError',

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -93,7 +93,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-ink placeholder:text-dim-2',
+    'w-full rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -372,7 +372,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
   const isInvalid = Boolean(error) || showInvalidValidation;
 
   const inputClasses = cn(
-    'w-full rounded-xl text-ink placeholder:text-dim-2',
+    'w-full rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],
@@ -417,7 +417,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
               aria-haspopup="listbox"
               aria-label={`Select country. Current: ${currentCountry.name} (+${currentCountry.callingCode})`}
               className={cn(
-                'inline-flex items-center rounded-l-xl rounded-r-none text-ink hover:bg-surface-utility/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500 transition-colors input-surface border-r border-line-subtle',
+                'inline-flex items-center rounded-l-xl rounded-r-none text-ink hover:bg-paper-2/40 focus:outline-none focus:ring-2 ring-inset focus:ring-accent-500 transition-colors input-surface border-r border-line-subtle',
                 sizeClasses[size],
                 disabled && 'opacity-50 cursor-not-allowed',
               )}
@@ -429,7 +429,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
 
             {isDropdownOpen && (
               <div
-                className="absolute z-10 panel border border-line-subtle rounded-xl shadow-glass w-64 top-full left-0 mt-1"
+                className="absolute z-10 panel border border-line-subtle rounded-r-md shadow-glass w-64 top-full left-0 mt-1"
                 role="dialog"
               >
                 <div className="p-2 border-b border-line-subtle">
@@ -475,8 +475,8 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
                         onClick={() => selectCountry(country)}
                         onMouseEnter={() => setFocusedIndex(index)}
                         className={cn(
-                          'inline-flex w-full px-3 py-2 text-sm text-ink hover:bg-surface-utility/40 focus:outline-none',
-                          index === focusedIndex && 'bg-surface-utility/60',
+                          'inline-flex w-full px-3 py-2 text-sm text-ink hover:bg-paper-2/40 focus:outline-none',
+                          index === focusedIndex && 'bg-paper-2/60',
                           country.iso === selectedIso && 'font-medium',
                         )}
                         tabIndex={-1}
@@ -527,7 +527,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(({
             data-testid={dataTestId}
             className={cn(
               inputClasses,
-              showCountryCode ? 'rounded-l-none border-l-0' : 'rounded-xl',
+              showCountryCode ? 'rounded-l-none border-l-0' : 'rounded-r-md',
               'rounded-r-xl',
             )}
           />

--- a/src/shared/ui/input/RadioGroupWithDescriptions.tsx
+++ b/src/shared/ui/input/RadioGroupWithDescriptions.tsx
@@ -36,8 +36,8 @@ export const RadioGroupWithDescriptions = ({
               !isFirst && 'border-t border-line-subtle',
               'focus-within:outline-none focus-within:ring-2 ring-inset focus-within:ring-accent-500/50 focus-within:ring-inset',
               isSelected
-                ? 'bg-surface-panel/40 ring-1 ring-inset ring-accent-500/45 text-ink'
-                : 'text-ink hover:bg-surface-panel/10'
+                ? 'bg-paper-2/40 ring-1 ring-inset ring-accent-500/45 text-ink'
+                : 'text-ink hover:bg-paper-2/10'
             )}
           >
             <input
@@ -53,12 +53,12 @@ export const RadioGroupWithDescriptions = ({
               className={cn(
                 'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border',
                 isSelected
-                  ? 'border-accent-500/50 bg-accent-500/20'
-                  : 'border-line-subtle bg-surface-panel/20'
+                  ? 'border-accent-500/50 bg-accent/20'
+                  : 'border-line-subtle bg-paper-2/20'
               )}
               aria-hidden="true"
             >
-              {isSelected && <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />}
+              {isSelected && <span className="h-1.5 w-1.5 rounded-full bg-accent" />}
             </span>
             <span className="flex flex-col">
               <span className="block text-sm font-medium text-ink">

--- a/src/shared/ui/input/Slider.tsx
+++ b/src/shared/ui/input/Slider.tsx
@@ -103,15 +103,15 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(function Slider(
           className={cn(
             'w-full appearance-none bg-transparent cursor-pointer',
             'disabled:opacity-45 disabled:cursor-not-allowed',
-            '[&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-surface-utility/10',
+            '[&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-paper-2/10',
             track,
-            '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-accent-500 [&::-webkit-slider-thumb]:shadow-md [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-surface-card',
+            '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-accent [&::-webkit-slider-thumb]:shadow-md [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-surface-card',
             thumb,
             thumbOffset,
             'focus-visible:outline-none [&:focus-visible::-webkit-slider-thumb]:ring-2 [&:focus-visible::-webkit-slider-thumb]:ring-accent-500/50 [&:focus-visible::-webkit-slider-thumb]:ring-offset-2',
             '[&:focus-visible::-moz-range-thumb]:ring-2 [&:focus-visible::-moz-range-thumb]:ring-accent-500/50 [&:focus-visible::-moz-range-thumb]:ring-offset-2',
-            '[&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-surface-utility/10',
-            '[&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-accent-500 [&::-moz-range-thumb]:shadow-md [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-surface-card',
+            '[&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-paper-2/10',
+            '[&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-accent [&::-moz-range-thumb]:shadow-md [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-surface-card',
           )}
           style={{
             background: disabled

--- a/src/shared/ui/input/URLInput.tsx
+++ b/src/shared/ui/input/URLInput.tsx
@@ -121,7 +121,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
   };
 
   const inputClasses = cn(
-    'w-full rounded-xl text-ink placeholder:text-dim-2',
+    'w-full rounded-r-md text-ink placeholder:text-dim-2',
     'focus:outline-none transition-all duration-200',
     'input-surface border-none',
     sizeClasses[size],

--- a/src/shared/ui/inspector/InspectorPrimitives.tsx
+++ b/src/shared/ui/inspector/InspectorPrimitives.tsx
@@ -68,7 +68,7 @@ export const InspectorGroup = ({
               disabled={disabled}
               aria-expanded={isOpen}
               aria-label="Toggle group options"
-              className={`flex h-7 w-7 items-center justify-center rounded-md text-dim-2 transition hover:bg-surface-app-frame/60 dark:hover:bg-surface-panel/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-surface-app-frame/60 dark:bg-surface-panel/40 text-ink' : ''}`}
+              className={`flex h-7 w-7 items-center justify-center rounded-md text-dim-2 transition hover:bg-paper/60 dark:hover:bg-paper-2/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-paper/60 dark:bg-paper-2/40 text-ink' : ''}`}
             >
               <Settings className="h-4 w-4" />
             </button>
@@ -131,7 +131,7 @@ export const InspectorEditableRow = ({
             onClick={onToggle}
             disabled={disabled}
             aria-expanded={isOpen}
-            className={`flex-shrink-0 ${label ? '-mt-1' : 'mt-0.5'} inline-flex h-7 w-7 items-center justify-center rounded-md text-dim-2 transition hover:bg-surface-app-frame/60 dark:hover:bg-surface-panel/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-surface-app-frame/60 dark:bg-surface-panel/40 text-ink' : ''}`}
+            className={`flex-shrink-0 ${label ? '-mt-1' : 'mt-0.5'} inline-flex h-7 w-7 items-center justify-center rounded-md text-dim-2 transition hover:bg-paper/60 dark:hover:bg-paper-2/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50 ${isOpen ? 'bg-paper/60 dark:bg-paper-2/40 text-ink' : ''}`}
             aria-label={`${isOpen ? 'Close' : 'Open'} ${label} controls`}
           >
             <Settings className="h-4 w-4" />
@@ -165,7 +165,7 @@ export const InspectorHeaderPerson = ({
         name={name} 
         size="xl" 
         className="h-14 w-14"
-        bgClassName="bg-surface-app-frame/60 dark:bg-white/[0.08]"
+        bgClassName="bg-paper/60 dark:bg-white/[0.08]"
       />
       <p className="mt-3 text-[15px] font-semibold text-ink">{name}</p>
       {secondaryLine ? (
@@ -227,7 +227,7 @@ export const InspectorHeaderHero = ({
             name={name} 
             size="xl" 
             className="h-24 w-24"
-            bgClassName="bg-surface-workspace/10 shadow-2xl ring-1 ring-white/10 ring-inset"
+            bgClassName="bg-paper/10 shadow-2xl ring-1 ring-white/10 ring-inset"
           />
           <div className="absolute inset-0 rounded-full border border-[rgb(var(--surface-workspace))]/10 pointer-events-none" />
         </div>

--- a/src/shared/ui/inspector/MatterFilesSection.tsx
+++ b/src/shared/ui/inspector/MatterFilesSection.tsx
@@ -99,7 +99,7 @@ export const MatterFilesSection = ({ practiceId, matterId }: MatterFilesSectionP
       />
 
       {error ? (
-        <div className="rounded-xl border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+        <div className="rounded-r-md border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-200">
           {error}
         </div>
       ) : null}

--- a/src/shared/ui/inspector/SetupInspectorContent.tsx
+++ b/src/shared/ui/inspector/SetupInspectorContent.tsx
@@ -187,7 +187,7 @@ export function SetupInspectorContent({
               <div className="flex justify-end">
                 <button
                   type="button"
-                  className="rounded-md bg-surface-panel/40 px-3 py-1.5 text-xs font-semibold text-ink transition hover:bg-surface-panel/60 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-paper-2/40 px-3 py-1.5 text-xs font-semibold text-ink transition hover:bg-paper-2/60 disabled:cursor-not-allowed disabled:opacity-50"
                   disabled={isReadOnly}
                   onClick={() => { void commitDraft('address', '', true); }}
                 >

--- a/src/shared/ui/layout/AppShell.tsx
+++ b/src/shared/ui/layout/AppShell.tsx
@@ -97,7 +97,7 @@ export const AppShell = ({
 
   return (
     <div
-      className={cn('relative grid h-full min-h-full w-full bg-surface-app-frame', gridClassName, className)}
+      className={cn('relative grid h-full min-h-full w-full bg-paper', gridClassName, className)}
       style={{ '--app-md-grid-cols': mdGridCols, '--app-lg-grid-cols': lgGridCols, '--app-xl-grid-cols': xlGridCols } as JSX.CSSProperties}
     >
       {backgroundDecor && (
@@ -127,7 +127,7 @@ export const AppShell = ({
       {hasListPanel && (
         <aside
           className={cn(
-            'relative z-10 p-2 row-start-2 min-h-0 overflow-y-auto bg-surface-collection hidden md:block',
+            'relative z-10 p-2 row-start-2 min-h-0 overflow-y-auto bg-paper-2 hidden md:block',
             listPanelColStartClass,
             listPanelClassName
           )}
@@ -138,7 +138,7 @@ export const AppShell = ({
 
       <main
         className={cn(
-          'relative z-10 row-start-2 min-h-0 h-full flex flex-col bg-surface-workspace',
+          'relative z-10 row-start-2 min-h-0 h-full flex flex-col bg-paper',
           mainColStartClass,
           mainClassName
         )}
@@ -149,7 +149,7 @@ export const AppShell = ({
       {hasInspector && (
         <aside
           className={cn(
-            'relative z-10 row-start-2 min-h-0 overflow-y-auto bg-surface-nav-secondary hidden xl:block',
+            'relative z-10 row-start-2 min-h-0 overflow-y-auto bg-paper-2 hidden xl:block',
             inspectorColStartClass,
             inspectorClassName
           )}

--- a/src/shared/ui/layout/ContentWithBuilder.tsx
+++ b/src/shared/ui/layout/ContentWithBuilder.tsx
@@ -29,7 +29,7 @@ export function ContentWithBuilder({
     >
       <aside
         className={cn(
-          'min-h-0 overflow-x-visible overflow-y-auto bg-surface-navigation px-4 py-4',
+          'min-h-0 overflow-x-visible overflow-y-auto bg-paper-2 px-4 py-4',
           sidebarClassName
         )}
       >
@@ -40,7 +40,7 @@ export function ContentWithBuilder({
       </main>
       <aside
         className={cn(
-          'min-h-0 overflow-y-auto bg-surface-utility px-4 py-4',
+          'min-h-0 overflow-y-auto bg-paper-2 px-4 py-4',
           inspectorClassName
         )}
       >

--- a/src/shared/ui/layout/ContentWithPreview.tsx
+++ b/src/shared/ui/layout/ContentWithPreview.tsx
@@ -58,7 +58,7 @@ export function ContentWithPreview({
       </div>
       <div
         className={cn(
-          'bg-surface-panel min-h-0 overflow-y-auto border-l border-line-subtle',
+          'bg-paper-2 min-h-0 overflow-y-auto border-l border-line-subtle',
           previewClassName
         )}
       >

--- a/src/shared/ui/layout/DirectShell.tsx
+++ b/src/shared/ui/layout/DirectShell.tsx
@@ -24,7 +24,7 @@ export const DirectShell: FunctionComponent<DirectShellProps> = ({ children }) =
 
   return (
     <>
-      <div className="relative flex min-h-[100dvh] w-full flex-col bg-surface-app-frame">
+      <div className="relative flex min-h-[100dvh] w-full flex-col bg-paper">
         <div className="relative mx-auto flex w-full max-w-3xl flex-1 flex-col">
           {children}
         </div>

--- a/src/shared/ui/layout/FormItem.tsx
+++ b/src/shared/ui/layout/FormItem.tsx
@@ -24,7 +24,7 @@ export const LayoutFormItem = ({
     <div className={cn(
       'flex items-start gap-3 text-left transition-colors w-full',
       variantClasses[variant],
-      hover && 'hover:bg-surface-panel/10',
+      hover && 'hover:bg-paper-2/10',
       className
     )}>
       {children}

--- a/src/shared/ui/layout/InteractiveListItem.tsx
+++ b/src/shared/ui/layout/InteractiveListItem.tsx
@@ -48,7 +48,7 @@ export const InteractiveListItem = ({
   const itemClassName = cn(
     'flex flex-wrap items-start justify-between gap-4 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40',
     padding,
-    isSelected ? SELECTED_ACCENT_SURFACE_CLASS : (isClickable && !disabled && 'hover:bg-surface-utility/40 cursor-pointer'),
+    isSelected ? SELECTED_ACCENT_SURFACE_CLASS : (isClickable && !disabled && 'hover:bg-paper-2/40 cursor-pointer'),
     disabled && 'opacity-60 cursor-not-allowed',
     className
   );

--- a/src/shared/ui/layout/LazyRouteBoundary.tsx
+++ b/src/shared/ui/layout/LazyRouteBoundary.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/shared/ui/Button';
 import { RouteFallback } from './RouteFallback';
 
 export const ChunkLoadFallback = () => (
-  <div className="m-6 rounded-xl border border-accent-error/30 bg-accent-error/5 p-6 text-sm text-ink">
+  <div className="m-6 rounded-r-md border border-accent-error/30 bg-accent-error/5 p-6 text-sm text-ink">
     <p className="font-semibold">This page failed to load.</p>
     <p className="mt-1 text-dim-2">
       A code chunk could not be downloaded. Reload to try again.

--- a/src/shared/ui/layout/MarketingShell.tsx
+++ b/src/shared/ui/layout/MarketingShell.tsx
@@ -23,8 +23,8 @@ export const MarketingShell: FunctionComponent<MarketingShellProps> = ({ childre
 
   return (
     <>
-      <div className="min-h-screen bg-surface-app-frame p-4 md:p-8 flex items-center justify-center">
-        <div className="relative mx-auto max-w-2xl w-full bg-surface-workspace rounded-2xl shadow-glass md:mt-8 min-h-[600px] md:min-h-[700px]">
+      <div className="min-h-screen bg-paper p-4 md:p-8 flex items-center justify-center">
+        <div className="relative mx-auto max-w-2xl w-full bg-paper rounded-2xl shadow-glass md:mt-8 min-h-[600px] md:min-h-[700px]">
           {children}
         </div>
       </div>

--- a/src/shared/ui/layout/SetupShell.tsx
+++ b/src/shared/ui/layout/SetupShell.tsx
@@ -34,7 +34,7 @@ export const SetupShell = ({
     : null;
 
   return (
-    <div className={cn('relative min-h-screen w-full overflow-hidden bg-surface-app-frame', className)}>
+    <div className={cn('relative min-h-screen w-full overflow-hidden bg-paper', className)}>
       {resolvedAccentClasses && (
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <div className={resolvedAccentClasses.gradientClassName} />

--- a/src/shared/ui/layout/SkeletonLoader.tsx
+++ b/src/shared/ui/layout/SkeletonLoader.tsx
@@ -16,8 +16,8 @@ const SKELETON_DEFAULTS: Record<SkeletonVariant, { width: string; height: string
   text: { width: 'w-20', height: 'h-3', rounded: 'rounded' },
   title: { width: 'w-32', height: 'h-4', rounded: 'rounded' },
   avatar: { width: 'w-9', height: 'h-9', rounded: 'rounded-full' },
-  button: { width: 'w-24', height: 'h-9', rounded: 'rounded-xl' },
-  input: { width: 'w-full', height: 'h-9', rounded: 'rounded-xl' },
+  button: { width: 'w-24', height: 'h-9', rounded: 'rounded-r-md' },
+  input: { width: 'w-full', height: 'h-9', rounded: 'rounded-r-md' },
   chip: { width: 'w-16', height: 'h-6', rounded: 'rounded-full' },
   rect: { width: 'w-full', height: 'h-4', rounded: 'rounded' }
 };

--- a/src/shared/ui/layout/WorkspacePlaceholderState.tsx
+++ b/src/shared/ui/layout/WorkspacePlaceholderState.tsx
@@ -48,7 +48,7 @@ export const WorkspacePlaceholderState = ({
   <div className={cn('flex h-full items-center justify-center p-6', className)}>
     <div className="panel w-full max-w-lg rounded-[28px] border border-line-subtle px-8 py-8 text-center shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-xl">
       {icon ? (
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-surface-utility/10">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-line-subtle bg-paper-2/10">
           <Icon icon={icon} className="h-6 w-6 text-dim-2" aria-hidden="true" />
         </div>
       ) : null}

--- a/src/shared/ui/layout/selectionStyles.ts
+++ b/src/shared/ui/layout/selectionStyles.ts
@@ -1,4 +1,4 @@
 export const SELECTED_ACCENT_SURFACE_CLASS =
-  'bg-accent-500/10 dark:bg-accent-500/12';
+  'bg-accent/10 dark:bg-accent/12';
 
 export const SELECTED_ACCENT_TEXT_CLASS = 'text-[rgb(var(--accent-foreground))]';

--- a/src/shared/ui/list/EntityList.tsx
+++ b/src/shared/ui/list/EntityList.tsx
@@ -98,7 +98,7 @@ export function EntityList<T extends { id: string }>({
               type="button"
               className={cn(
                 'w-full text-left transition-colors duration-150 border-b border-line-subtle',
-                isSelected ? SELECTED_ACCENT_SURFACE_CLASS : 'hover:bg-surface-utility/40',
+                isSelected ? SELECTED_ACCENT_SURFACE_CLASS : 'hover:bg-paper-2/40',
                 onSelect && 'cursor-pointer'
               )}
               onClick={onSelect ? () => onSelect(item) : undefined}

--- a/src/shared/ui/list/List.tsx
+++ b/src/shared/ui/list/List.tsx
@@ -30,8 +30,8 @@ export function ListItem({
       type={onClick ? 'button' : undefined}
       onClick={onClick}
       className={cn(
-        'flex items-center gap-3 px-3 py-2.5 w-full text-left rounded-xl transition-colors',
-        onClick && 'hover:bg-surface-utility/10 cursor-pointer',
+        'flex items-center gap-3 px-3 py-2.5 w-full text-left rounded-r-md transition-colors',
+        onClick && 'hover:bg-paper-2/10 cursor-pointer',
         className,
       )}
     >

--- a/src/shared/ui/markdown/markdownComponents.tsx
+++ b/src/shared/ui/markdown/markdownComponents.tsx
@@ -82,7 +82,7 @@ export const markdownComponents: Components = {
 
   table({ children, ...props }) {
     return (
-      <div className="overflow-x-auto my-4 rounded-xl" style={{ boxShadow: 'var(--glass-rim-subtle)' }}>
+      <div className="overflow-x-auto my-4 rounded-r-md" style={{ boxShadow: 'var(--glass-rim-subtle)' }}>
         <table className="min-w-full text-sm border-collapse" {...props}>
           {children}
         </table>
@@ -147,7 +147,7 @@ export const markdownComponents: Components = {
       <div className="group relative my-3 max-w-full min-w-0">
         {copyableText ? <CopyButton text={copyableText} /> : null}
         <pre
-          className="max-w-full min-w-0 overflow-x-auto rounded-xl p-4 bg-[rgb(var(--surface-app-frame))]/40 backdrop-blur-sm text-[rgb(var(--input-foreground))] text-sm leading-relaxed"
+          className="max-w-full min-w-0 overflow-x-auto rounded-r-md p-4 bg-[rgb(var(--surface-app-frame))]/40 backdrop-blur-sm text-[rgb(var(--input-foreground))] text-sm leading-relaxed"
           style={{ boxShadow: 'var(--glass-rim-subtle)' }}
           {...props}
         >

--- a/src/shared/ui/media/Carousel.tsx
+++ b/src/shared/ui/media/Carousel.tsx
@@ -40,7 +40,7 @@ export function Carousel({
     <div className={cn('relative group', className)} aria-roledescription="carousel">
       <div
         ref={trackRef}
-        className="flex overflow-x-auto snap-x snap-mandatory scrollbar-none rounded-xl"
+        className="flex overflow-x-auto snap-x snap-mandatory scrollbar-none rounded-r-md"
         onScroll={(e) => {
           const el = e.target as HTMLDivElement;
           const idx = Math.round(el.scrollLeft / el.clientWidth);
@@ -92,8 +92,8 @@ export function Carousel({
               className={cn(
                 'w-1.5 h-1.5 rounded-full transition-all',
                 i === current
-                  ? 'bg-accent-500 w-4'
-                  : 'bg-surface-utility/15',
+                  ? 'bg-accent w-4'
+                  : 'bg-paper-2/15',
               )}
             />
           ))}

--- a/src/shared/ui/media/Image.tsx
+++ b/src/shared/ui/media/Image.tsx
@@ -42,7 +42,7 @@ export function Image({
   return (
     <div
       className={cn(
-        'relative overflow-hidden bg-surface-utility/5 rounded-xl',
+        'relative overflow-hidden bg-paper-2/5 rounded-r-md',
         containerClassName,
       )}
       style={{ aspectRatio, width, height }}
@@ -56,7 +56,7 @@ export function Image({
         />
       )}
       {status === 'loading' && !blurPlaceholder && (
-        <div className="absolute inset-0 animate-pulse bg-surface-utility/10" />
+        <div className="absolute inset-0 animate-pulse bg-paper-2/10" />
       )}
       {status === 'error' ? (
         <div className="absolute inset-0 flex items-center justify-center text-dim-2/50">

--- a/src/shared/ui/nav/OrgSwitcherMenu.tsx
+++ b/src/shared/ui/nav/OrgSwitcherMenu.tsx
@@ -188,8 +188,8 @@ export const OrgSwitcherMenu: FunctionComponent<OrgSwitcherMenuProps> = ({
           aria-label="Switch practice"
           className={
             collapsed
-              ? 'z-50 w-72 rounded-xl border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
-              : 'absolute left-0 right-0 top-full z-50 mt-2 rounded-xl border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
+              ? 'z-50 w-72 rounded-r-md border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
+              : 'absolute left-0 right-0 top-full z-50 mt-2 rounded-r-md border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
           }
           style={collapsed ? fixedStyle : undefined}
         >

--- a/src/shared/ui/nav/SidebarProfileMenu.tsx
+++ b/src/shared/ui/nav/SidebarProfileMenu.tsx
@@ -134,8 +134,8 @@ export const SidebarProfileMenu: FunctionComponent<SidebarProfileMenuProps> = ({
           aria-label="Profile menu"
           className={
             collapsed
-              ? 'z-50 w-60 rounded-xl border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
-              : 'absolute bottom-full left-0 right-0 z-50 mb-2 rounded-xl border p-1 shadow-[0_-4px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
+              ? 'z-50 w-60 rounded-r-md border p-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
+              : 'absolute bottom-full left-0 right-0 z-50 mb-2 rounded-r-md border p-1 shadow-[0_-4px_24px_rgba(0,0,0,0.4)] bg-[rgb(var(--sidebar-menu-bg))] border-[rgb(var(--sidebar-menu-border))]'
           }
           style={collapsed ? fixedStyle : undefined}
         >

--- a/src/shared/ui/navigation/Pagination.tsx
+++ b/src/shared/ui/navigation/Pagination.tsx
@@ -64,7 +64,7 @@ export function Pagination({
               'btn rounded-lg font-medium',
               btnSize,
               page === currentPage
-                ? 'bg-accent-500/12 text-accent-600 dark:text-accent-400'
+                ? 'bg-accent/12 text-accent-600 dark:text-accent-400'
                 : 'btn-ghost text-ink',
             )}
           >

--- a/src/shared/ui/navigation/Stepper.tsx
+++ b/src/shared/ui/navigation/Stepper.tsx
@@ -49,7 +49,7 @@ export function Stepper({
                 <div
                   className={cn(
                     orientation === 'horizontal' ? 'flex-1 h-0.5' : 'w-0.5 h-6',
-                    status === 'upcoming' ? 'bg-surface-utility/10' : 'bg-accent-500',
+                    status === 'upcoming' ? 'bg-paper-2/10' : 'bg-accent',
                     'transition-colors',
                   )}
                 />
@@ -61,9 +61,9 @@ export function Stepper({
                 className={cn(
                   'shrink-0 flex items-center justify-center rounded-full transition-all',
                   'w-8 h-8 text-xs font-medium',
-                  status === 'completed' && 'bg-accent-500 text-[rgb(var(--accent-foreground))]',
-                  status === 'active' && 'bg-accent-500/15 text-accent-600 dark:text-accent-400 ring-2 ring-accent-500/30',
-                  status === 'upcoming' && 'bg-surface-utility/10 text-dim-2',
+                  status === 'completed' && 'bg-accent text-[rgb(var(--accent-foreground))]',
+                  status === 'active' && 'bg-accent/15 text-accent-600 dark:text-accent-400 ring-2 ring-accent-500/30',
+                  status === 'upcoming' && 'bg-paper-2/10 text-dim-2',
                 )}
               >
                 {status === 'completed' ? (
@@ -77,7 +77,7 @@ export function Stepper({
                 <div
                   className={cn(
                     'flex-1 h-0.5',
-                    i < currentStep ? 'bg-accent-500' : 'bg-surface-utility/10',
+                    i < currentStep ? 'bg-accent' : 'bg-paper-2/10',
                     'transition-colors',
                   )}
                 />

--- a/src/shared/ui/overlays/ContextMenu.tsx
+++ b/src/shared/ui/overlays/ContextMenu.tsx
@@ -47,7 +47,7 @@ export function ContextMenu({ children, items, className }: ContextMenuProps) {
         <div
           ref={menuRef}
           role="menu"
-          className="fixed z-[100] min-w-[160px] rounded-xl panel py-1.5 shadow-lg"
+          className="fixed z-[100] min-w-[160px] rounded-r-md panel py-1.5 shadow-lg"
           style={{ top: position.y, left: position.x }}
         >
           {items.map((item, i) => {
@@ -66,7 +66,7 @@ export function ContextMenu({ children, items, className }: ContextMenuProps) {
                 }}
                 className={cn(
                   'flex w-full items-center gap-2.5 px-3 py-1.5 text-sm text-left transition-colors',
-                  'hover:bg-surface-utility/10',
+                  'hover:bg-paper-2/10',
                   'disabled:opacity-45 disabled:cursor-not-allowed',
                   item.destructive && 'text-red-500',
                   !item.destructive && 'text-ink',

--- a/src/shared/ui/overlays/Popover.tsx
+++ b/src/shared/ui/overlays/Popover.tsx
@@ -88,7 +88,7 @@ export function Popover({
       {isOpen && (
         <div
           className={cn(
-            'absolute z-[100] min-w-[200px] rounded-xl panel p-3',
+            'absolute z-[100] min-w-[200px] rounded-r-md panel p-3',
             'shadow-lg',
             sideStyles[placement] ?? sideStyles['bottom-start'],
             className,

--- a/src/shared/ui/profile/molecules/ProfileButton.tsx
+++ b/src/shared/ui/profile/molecules/ProfileButton.tsx
@@ -34,7 +34,7 @@ export const ProfileButton = ({
     <div className={`flex items-center gap-2 min-w-0 w-full max-w-full ${className}`}>
       <button
         onClick={onClick}
-        className="flex items-center gap-2 flex-1 min-w-0 text-left hover:bg-[rgb(var(--surface-utility))]/60 rounded-xl p-3 transition-colors overflow-hidden"
+        className="flex items-center gap-2 flex-1 min-w-0 text-left hover:bg-[rgb(var(--surface-utility))]/60 rounded-r-md p-3 transition-colors overflow-hidden"
         aria-label={`User profile for ${name}`}
       >
         <Avatar src={image} name={name} size="md" />

--- a/src/shared/ui/profile/molecules/ProfileDropdown.tsx
+++ b/src/shared/ui/profile/molecules/ProfileDropdown.tsx
@@ -32,7 +32,7 @@ export const ProfileDropdown = ({
       role="menu"
       aria-orientation="vertical"
       aria-label="Profile menu"
-      className={`absolute bottom-full right-0 mb-2 w-full max-w-xs rounded-xl shadow-glass border border-line-subtle py-2 z-50 bg-surface-overlay ${className}`}
+      className={`absolute bottom-full right-0 mb-2 w-full max-w-xs rounded-r-md shadow-glass border border-line-subtle py-2 z-50 bg-card ${className}`}
     >
       {/* Settings */}
       <ProfileMenuItem

--- a/src/shared/ui/profile/molecules/UserCard.tsx
+++ b/src/shared/ui/profile/molecules/UserCard.tsx
@@ -80,14 +80,14 @@ export const UserCard = ({
           onClick={onClick}
           aria-label={ariaLabel ?? `Select ${name}`}
           className={cn(
-            'flex-1 text-left rounded-xl px-3 py-2 transition-colors hover:bg-[rgb(var(--surface-utility)/0.06)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--accent-500))]',
+            'flex-1 text-left rounded-r-md px-3 py-2 transition-colors hover:bg-[rgb(var(--surface-utility)/0.06)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--accent-500))]',
             className
           )}
         >
           {clickableBody}
         </button>
       ) : (
-        <div className={cn('flex-1 rounded-xl px-3 py-2', className)}>{clickableBody}</div>
+        <div className={cn('flex-1 rounded-r-md px-3 py-2', className)}>{clickableBody}</div>
       )}
       {trailing && <div className="shrink-0">{trailing}</div>}
     </div>

--- a/src/shared/ui/profile/organisms/UserProfileDisplay.tsx
+++ b/src/shared/ui/profile/organisms/UserProfileDisplay.tsx
@@ -180,7 +180,7 @@ export const UserProfileDisplay = ({
       <div className="p-2 w-full">
         <button
           onClick={handleSignIn}
-          className={`flex items-center w-full rounded-xl text-left transition-colors text-[rgb(var(--input-foreground))] hover:bg-[rgb(var(--surface-utility))]/5 ${
+          className={`flex items-center w-full rounded-r-md text-left transition-colors text-[rgb(var(--input-foreground))] hover:bg-[rgb(var(--surface-utility))]/5 ${
             isCollapsed 
               ? 'justify-center py-2' 
               : 'gap-3 px-3 py-2'

--- a/src/shared/ui/table/ColumnEditor.tsx
+++ b/src/shared/ui/table/ColumnEditor.tsx
@@ -144,7 +144,7 @@ const ToggleColumnRow = ({
     onClick={onToggle}
     className={cn(
       'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
-      'hover:bg-surface-utility/10',
+      'hover:bg-paper-2/10',
       'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50',
       checked ? 'text-ink' : 'text-dim-2',
     )}
@@ -154,7 +154,7 @@ const ToggleColumnRow = ({
       className={cn(
         'inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors',
         checked
-          ? 'border-accent-500 bg-accent-500 text-accent-foreground'
+          ? 'border-accent-500 bg-accent text-accent-foreground'
           : 'border-input-border bg-input-bg',
       )}
     >

--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -228,7 +228,7 @@ export const DataTable = ({
       <table className={cn('min-w-full', tableClassName)}>
         {caption ? <caption className="sr-only">{caption}</caption> : null}
         <thead>
-          <tr className={cn('border-b border-line-subtle', stickyHeader && 'sticky top-0 z-10 bg-surface-workspace')}>
+          <tr className={cn('border-b border-line-subtle', stickyHeader && 'sticky top-0 z-10 bg-paper')}>
             {columns.map((column, index) => {
               const isPrimary = column.id === primaryColumn?.id || (index === 0 && !primaryColumn);
               const isLast = index === columns.length - 1;
@@ -262,7 +262,7 @@ export const DataTable = ({
             })}
           </tr>
         </thead>
-        <tbody className={cn('bg-surface-workspace divide-y divide-line-subtle', bodyClassName)}>
+        <tbody className={cn('bg-paper divide-y divide-line-subtle', bodyClassName)}>
           {(() => {
             const renderRows = rowsOverride ?? paddedRows;
             const sourceRows = rowsOverride ?? rows;

--- a/src/shared/ui/upload/atoms/FileIcon.tsx
+++ b/src/shared/ui/upload/atoms/FileIcon.tsx
@@ -38,7 +38,7 @@ export const FileIcon = ({
 
   return (
     <div className={cn(
-      'rounded-xl flex items-center justify-center',
+      'rounded-r-md flex items-center justify-center',
       config.color,
       sizeClasses[size],
       className

--- a/src/shared/ui/upload/molecules/FileCard.tsx
+++ b/src/shared/ui/upload/molecules/FileCard.tsx
@@ -66,7 +66,7 @@ export const FileCard = ({
   if (variant === 'tile') {
     const fileType = getFileTypeConfig(fileName, mimeType);
     const tileClassName = cn(
-      'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-surface-card text-left transition-all',
+      'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-card text-left transition-all',
       onClick ? 'cursor-pointer hover:border-line-subtle hover:shadow-md focus:outline-none focus:ring-2 focus:ring-accent-500' : '',
       className
     );
@@ -93,7 +93,7 @@ export const FileCard = ({
     ) : null;
     const renderTileContent = () => (
       <>
-        <div className="relative flex aspect-[4/3] w-full items-center justify-center overflow-hidden bg-surface-panel">
+        <div className="relative flex aspect-[4/3] w-full items-center justify-center overflow-hidden bg-paper-2">
           {isImage && imageUrl ? (
             <img
               src={imageUrl}
@@ -107,7 +107,7 @@ export const FileCard = ({
             </div>
           )}
           {shouldShowTileStatus ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-input-text/45 px-4 text-center text-surface-card backdrop-blur-[1px] dark:bg-surface-app-frame/75">
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-input-text/45 px-4 text-center text-surface-card backdrop-blur-[1px] dark:bg-paper/75">
               {status === 'uploading' || status === 'processing' || status === 'analyzing' ? (
                 <LoadingSpinner size="sm" ariaLabel={tileStatusLabel ?? 'File status'} />
               ) : null}
@@ -115,9 +115,9 @@ export const FileCard = ({
                 <span className="text-xs font-semibold">{tileStatusLabel}</span>
               ) : null}
               {status === 'uploading' || progress !== undefined ? (
-                <div className="h-1.5 w-full max-w-32 overflow-hidden rounded-full bg-surface-card/30">
+                <div className="h-1.5 w-full max-w-32 overflow-hidden rounded-full bg-card/30">
                   <div
-                    className="h-full rounded-full bg-accent-500"
+                    className="h-full rounded-full bg-accent"
                     style={{ width: `${Math.min(100, Math.max(0, resolvedProgress))}%` }}
                   />
                 </div>

--- a/src/shared/ui/upload/molecules/UploadQueueRow.tsx
+++ b/src/shared/ui/upload/molecules/UploadQueueRow.tsx
@@ -32,7 +32,7 @@ export const UploadQueueRow = ({
   const resolvedProgress = clampProgress(progress);
 
   return (
-    <div className="rounded-xl border border-line-subtle bg-surface-utility/35 px-3 py-2">
+    <div className="rounded-r-md border border-line-subtle bg-paper-2/35 px-3 py-2">
       <div className="flex items-start gap-3">
         <FileIcon fileName={fileName} mimeType={mimeType} size="sm" />
         <div className="min-w-0 flex-1">
@@ -83,7 +83,7 @@ export const UploadQueueRow = ({
       {status === 'uploading' ? (
         <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-line-glass/20">
           <div
-            className="h-full rounded-full bg-accent-500 transition-[width] duration-200"
+            className="h-full rounded-full bg-accent transition-[width] duration-200"
             style={{ width: `${resolvedProgress}%` }}
           />
         </div>

--- a/src/shared/ui/upload/organisms/UploadDropzone.tsx
+++ b/src/shared/ui/upload/organisms/UploadDropzone.tsx
@@ -45,9 +45,9 @@ export const UploadDropzone = ({
       aria-label={label}
       aria-disabled={disabled}
       className={cn(
-        'rounded-xl border-2 border-dashed transition-colors',
+        'rounded-r-md border-2 border-dashed transition-colors',
         'relative flex min-h-[160px] items-center justify-center px-4 py-5',
-        isDragOver ? 'border-accent-500 bg-accent-500/10' : 'border-line-subtle',
+        isDragOver ? 'border-accent-500 bg-accent/10' : 'border-line-subtle',
         disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:border-line-subtle',
         className
       )}

--- a/src/shared/ui/upload/organisms/UploadSurface.tsx
+++ b/src/shared/ui/upload/organisms/UploadSurface.tsx
@@ -64,7 +64,7 @@ export const UploadSurface = ({
           ))}
         </div>
       ) : emptyStateLabel ? (
-        <div className="mt-3 rounded-xl border border-line-subtle px-3 py-4 text-center text-sm text-dim-2">
+        <div className="mt-3 rounded-r-md border border-line-subtle px-3 py-4 text-center text-sm text-dim-2">
           {emptyStateLabel}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Second mechanical sweep in the Commit 8 ladder. Combines all 4 remaining token-utility violation families per the audit. Net diff: **exactly +542 / -542** across 185 files — one substitution per occurrence.

| Pattern family | Count | Mapping |
|---|---:|---|
| `rounded-xl` | 225 | → `rounded-r-md` (8px DS card radius, vs. 12px Tailwind default) |
| `font-display` | 8 | → `font-serif` (Source Serif 4) |
| `bg-accent-{500,600}` | 55 | → `bg-accent` |
| `bg-accent-900` | 1 | → `bg-accent-deep` |
| `bg-accent-{50,100,400}` | 3 | → `bg-accent/{10,20,80}` (alpha variants) |
| `bg-surface-card` / `-card-raised` / `-overlay` / `-input` | 96 | → `bg-card` |
| `bg-surface-card-hover` / `-utility` / `-panel` / `-hover` / `-navigation` / `-collection` / `-section` / `-nav-secondary` / `-inspector` / `-subtle` | 196 | → `bg-paper-2` |
| `bg-surface-workspace` / `-app` / `-app-frame` / `-ground` / `-base` | 56 | → `bg-paper` |

## ⚠️ One real-CSS pattern: `rounded-xl`

Same dead-classes story as PR #656 for **all but one** of these families — `rounded-xl` was *actually working today* (Tailwind built-in = 0.75rem / 12px). This sweep **tightens corners by ~4px everywhere** to the canonical DS card radius `--r-md` = 8px. That's an intentional visual change per spec, not a no-op rename. Expect cards / inputs / dropdowns to look subtly tighter.

The other three families (`font-display`, `bg-accent-N`, `bg-surface-*`) were dead like `text-input-*`. Their replacements (`font-serif`, `bg-accent`, `bg-paper`/`bg-paper-2`/`bg-card`) generate real CSS for the first time.

**CSS bundle: 149.34 → 155.71 kB (+6 kB)** — combined with PR #656's +5 kB, that's ~13 kB of utility CSS that previously didn't paint anywhere.

## Commits

1. **`9acfe6ca`** — `chore(ds): sweep rounded-xl + font-display + bg-accent-N + bg-surface-* (8.1b/c/d)` — the mechanical sweep via `grep -rl ... | xargs sed -i` with **longest-prefix-first ordering** on the substitution chain (e.g. `bg-surface-card-raised` before `bg-surface-card`, `bg-accent-500` before `bg-accent-50`) to avoid clobbering.
2. **`e219a779`** — `docs(ds): mark 8.1b/c/d complete in audit ladder`.

## Mapping rationale (`bg-surface-*` decisions)

Per the DS philosophy in `tokens.css`:
- `--paper` = main background (`#f6f3ea`)
- `--paper-2` = subtle elevation (`#ece6d3`)
- `--card` = raised surfaces (`#ffffff`)

So:
- `workspace`/`app`/`app-frame`/`ground`/`base` → `bg-paper` (these are app-shell backgrounds)
- `utility`/`panel`/`hover`/`card-hover`/`navigation`/`collection`/`section`/`nav-secondary`/`inspector`/`subtle` → `bg-paper-2` (these are mid-elevation panel-like surfaces)
- `card`/`card-raised`/`overlay`/`input` → `bg-card` (these are raised "white card" surfaces)

If any mapping turns out to be wrong for a given call site, it's still strictly better than the previous no-op styling — the call site was rendering inherited browser default before.

## Out of scope (discovered while planning)

The audit measured `bg-` prefix only. The same dead-class problem exists for related prefixes:
- `text-accent-N` (~160 occurrences)
- `ring-accent-N` (~70)
- `border-accent-N` (~30)
- Plus semantic variants: `text-accent-error` / `-error-light` / `-error-foreground` / `-success` / `-foreground` / `-utility`

These have **semantic mapping nuance** (error → `text-neg`, success → `text-pos`, foreground → `text-accent-ink`) that doesn't fit a pure mechanical sweep. They deserve a focused PR — not bundled here.

## Test plan

- [x] `grep -rE "(rounded-xl|font-display|bg-accent-[0-9]+|bg-surface-[a-z])" src/` returns zero matches
- [x] Net diff: exactly `+542 / -542` across `185 files changed`
- [x] `npm run build` green
- [x] `npm run type-check` 0 errors
- [x] `npm run lint:src` baseline preserved (`OAuthConsentPage.tsx:187` pre-existing error)
- [ ] Visual smoke at `https://local.blawby.com`:
  - [ ] Cards / inputs / dropdowns tighter (8px vs 12px corners)
  - [ ] Backgrounds finally painting their intended `bg-paper` / `bg-paper-2` / `bg-card` colors instead of inheriting

## What's next

After this lands, **PR-15** is the DataTable audit — 7 actual call sites to convert from `<table>` to CSS grid (per the audit, keep `<table>` only for `InvoicesTable` line items).

Then PR-16 (SegmentedToggle), PR-17/18 (`.status-*` + `.input-surface` alias sweeps), PR-19 (a11y + final grep gates).

A separate **PR-19a** could pick up the discovered dead families: `text-accent-N`, `ring-accent-N`, `border-accent-N`, `*-accent-error/-success/-foreground`. Adding to the ladder for future planning.