### PR TITLE
ds: PR-15 — convert FilesList + DeliveriesListView to EntityList (8.2a)

### DIFF
--- a/docs/design-system-commit-8-audit.md
+++ b/docs/design-system-commit-8-audit.md
@@ -202,6 +202,9 @@ In dependency order (each can be its own PR):
 2. ~~**PR-13**: `chore(ds): replace text-input-* family (8.1a)` — big mechanical PR.~~ ✅ **landed in PR #656 (commit `054c0cf9`).** Net +1446/-1446 across 244 files. Note: `text-input-*` was actually dead (missing from tailwind config); replacement with `text-ink` / `text-dim-2` is a real visual change. CSS bundle grew ~5 kB.
 3. ~~**PR-14**: `chore(ds): replace bg-surface-* + bg-accent-N + font-display + rounded-xl (8.1b/c/d combined)` — second mechanical sweep.~~ ✅ **landed in PR #657 (commit `9acfe6ca`).** Net +542/-542 across 185 files. CSS bundle 149→156 kB. Discovered additional dead families (text-accent-N, ring-accent-N, border-accent-N, *-error/*-success/*-foreground variants) out of scope here — those go in a dedicated PR with semantic mapping.
 4. **PR-15**: `refactor(ds): DataTable → CSS grid for 6 non-invoice tables (8.2)`.
+   - ✅ **8.2a landed in PR #658 (commit `81558f59`)** — FilesList + DeliveriesListView converted to EntityList.
+   - Revised: ReportDataTable kept as `<table>` (genuinely tabular report data — same justification as InvoicesTable line items).
+   - **Remaining 4 conversions** (IntakeTemplatesPage, PracticeMattersPage, IntakesPage, EngagementsPage) deferred to a follow-up PR; each touches a larger file (385–2260 LOC) and deserves its own focused review.
 5. **PR-16**: `refactor(ds): migrate SegmentedToggle callers to Seg; delete SegmentedToggle (8.3)`.
 6. **PR-17**: `refactor(ds): migrate .status-* callers to <Pill>; delete alias (8.4b/d-partial)`.
 7. **PR-18**: `refactor(ds): migrate .input-surface callers to DS Input; delete alias (8.4c/d-partial)`.

--- a/src/features/files/components/FilesList.tsx
+++ b/src/features/files/components/FilesList.tsx
@@ -1,7 +1,7 @@
 import type { ComponentChildren } from 'preact';
 
 import { Icon } from '@/shared/ui/Icon';
-import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
+import { EntityList } from '@/shared/ui/list/EntityList';
 import { formatFileSize } from '@/shared/utils/mediaAggregation';
 import { getFileTypeConfig } from '@/shared/utils/fileTypeUtils';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
@@ -14,56 +14,44 @@ interface FilesListProps {
   onFileClick?: (file: OrgFile) => void;
 }
 
-const COLUMNS: DataTableColumn[] = [
-  { id: 'name', label: 'Name', isPrimary: true },
-  { id: 'source', label: 'Source', hideAt: 'md' },
-  { id: 'type', label: 'Type', hideAt: 'lg' },
-  { id: 'size', label: 'Size', align: 'right', hideAt: 'sm' },
-  { id: 'added', label: 'Added', align: 'right', hideAt: 'md' },
-];
-
 export const FilesList = ({
   files,
   isLoading = false,
   emptyState,
   onFileClick,
-}: FilesListProps) => {
-  const rows: DataTableRow[] = files.map((file) => {
-    const fileType = getFileTypeConfig(file.fileName, file.mimeType);
-    const association = folderForFile(file);
-    const sourceLabel = association.kind === 'loose' ? 'Loose file' : association.label;
-    return {
-      id: file.id,
-      onClick: onFileClick ? () => onFileClick(file) : undefined,
-      cells: {
-        name: (
-          <div className="flex min-w-0 items-center gap-3">
+}: FilesListProps) => (
+  <EntityList
+    items={files}
+    onSelect={(file) => onFileClick?.(file)}
+    isLoading={isLoading}
+    emptyState={emptyState}
+    className="panel overflow-hidden"
+    renderItem={(file) => {
+      const fileType = getFileTypeConfig(file.fileName, file.mimeType);
+      const association = folderForFile(file);
+      const sourceLabel = association.kind === 'loose' ? 'Loose file' : association.label;
+      return (
+        <div className="flex w-full items-center gap-4 px-4 py-3 hover:bg-paper-2/10">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
             <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-paper-2 text-dim-2">
               <Icon icon={fileType.icon} className="h-4 w-4" />
             </span>
-            <span className="min-w-0 truncate" title={file.fileName}>{file.fileName}</span>
+            <span className="min-w-0 truncate text-sm text-ink" title={file.fileName}>
+              {file.fileName}
+            </span>
           </div>
-        ),
-        source: sourceLabel,
-        type: fileType.label,
-        size: formatFileSize(file.fileSize),
-        added: file.createdAt ? formatRelativeTime(file.createdAt) : '—',
-      },
-    };
-  });
-
-  return (
-    <DataTable
-      columns={COLUMNS}
-      rows={rows}
-      loading={isLoading}
-      emptyState={emptyState}
-      stickyHeader
-      density="compact"
-      className="panel overflow-hidden"
-      bodyClassName="bg-transparent"
-    />
-  );
-};
+          <span className="hidden min-w-[100px] text-sm text-dim-2 md:block">{sourceLabel}</span>
+          <span className="hidden min-w-[80px] text-sm text-dim-2 lg:block">{fileType.label}</span>
+          <span className="hidden min-w-[64px] text-right text-sm tabular-nums text-dim-2 sm:block">
+            {formatFileSize(file.fileSize)}
+          </span>
+          <span className="hidden min-w-[80px] text-right text-sm text-dim-2 md:block">
+            {file.createdAt ? formatRelativeTime(file.createdAt) : '—'}
+          </span>
+        </div>
+      );
+    }}
+  />
+);
 
 export default FilesList;

--- a/src/features/reports/pages/reports/DeliveriesListView.tsx
+++ b/src/features/reports/pages/reports/DeliveriesListView.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'preact';
 import { Inbox } from 'lucide-preact';
 
-import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table/DataTable';
+import { EntityList } from '@/shared/ui/list/EntityList';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { useNavigation } from '@/shared/utils/navigation';
 import { useReportDeliveries } from '@/features/reports/hooks/useReportDeliveries';
@@ -17,13 +17,6 @@ interface DeliveriesListViewProps {
 
 const DEFINITIONS_BY_ID = new Map<string, ReportDefinition>(REPORT_DEFINITIONS.map((d) => [d.id, d]));
 
-const COLUMNS: DataTableColumn[] = [
-  { id: 'createdAt', label: 'Created', isPrimary: true },
-  { id: 'reportType', label: 'Report' },
-  { id: 'status', label: 'Status' },
-  { id: 'recipients', label: 'Recipients' },
-];
-
 const STATUS_BADGE: Record<string, string> = {
   pending: 'text-amber-400',
   completed: 'text-emerald-400',
@@ -34,19 +27,10 @@ export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = ({
   const { items, loading, error, hasMore, loadMore, refetch } = useReportDeliveries(practiceId);
   const { navigate } = useNavigation();
 
-  const rows: DataTableRow[] = items.map((d) => ({
-    id: d.id,
-    onClick: () => {
-      if (!practiceSlug) return;
-      navigate(`/practice/${encodeURIComponent(practiceSlug)}/reports/deliveries/${encodeURIComponent(d.id)}`);
-    },
-    cells: {
-      createdAt: new Date(d.createdAt).toLocaleString(),
-      reportType: DEFINITIONS_BY_ID.get(d.reportType)?.title ?? d.reportType,
-      status: <span className={STATUS_BADGE[d.status] ?? ''}>{d.status}</span>,
-      recipients: d.recipients.length > 0 ? `${d.recipients.length} recipient${d.recipients.length === 1 ? '' : 's'}` : '—',
-    },
-  }));
+  const handleSelect = (delivery: typeof items[number]) => {
+    if (!practiceSlug) return;
+    navigate(`/practice/${encodeURIComponent(practiceSlug)}/reports/deliveries/${encodeURIComponent(delivery.id)}`);
+  };
 
   if (!loading && items.length === 0 && !error) {
     return (
@@ -76,18 +60,31 @@ export const DeliveriesListView: FunctionComponent<DeliveriesListViewProps> = ({
           {error} <button type="button" className="ml-2 underline" onClick={refetch}>Retry</button>
         </div>
       ) : null}
-      <DataTable
-        columns={COLUMNS}
-        rows={rows}
-        loading={loading && items.length === 0}
-        density="compact"
-        stickyHeader
-        className="panel overflow-hidden"
-        bodyClassName="bg-transparent"
-        rowClassName="transition-colors duration-150 hover:!bg-paper-2"
-        hasMore={hasMore}
+      <EntityList
+        items={items}
+        onSelect={handleSelect}
+        isLoading={loading && items.length === 0}
         isLoadingMore={loading && items.length > 0}
-        onLoadMore={loadMore}
+        onLoadMore={hasMore ? loadMore : undefined}
+        className="panel overflow-hidden"
+        renderItem={(delivery) => (
+          <div className="flex w-full items-center gap-4 px-4 py-3 hover:bg-paper-2/10">
+            <span className="min-w-[160px] flex-1 truncate text-sm text-ink">
+              {new Date(delivery.createdAt).toLocaleString()}
+            </span>
+            <span className="hidden min-w-[140px] truncate text-sm text-dim-2 sm:block">
+              {DEFINITIONS_BY_ID.get(delivery.reportType)?.title ?? delivery.reportType}
+            </span>
+            <span className={`min-w-[80px] text-sm ${STATUS_BADGE[delivery.status] ?? 'text-dim-2'}`}>
+              {delivery.status}
+            </span>
+            <span className="hidden min-w-[120px] text-right text-sm text-dim-2 md:block">
+              {delivery.recipients.length > 0
+                ? `${delivery.recipients.length} recipient${delivery.recipients.length === 1 ? '' : 's'}`
+                : '—'}
+            </span>
+          </div>
+        )}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

First slice of the DataTable audit (Commit 8 §8.2). Two non-tabular list views move off `DataTable` to `EntityList`, per `DESIGN_SYSTEM §2.10`: *"Use `<table>` for invoice line items only; other lists use card-grids or EntityList."*

Net diff: **+60 / -75** across 2 files (plus 1 doc update).

## Commits

1. **`81558f59`** — `refactor(ds): convert FilesList + DeliveriesListView from DataTable to EntityList (8.2a)`
2. **`204584c4`** — `docs(ds): mark 8.2a complete; revise ladder for ReportDataTable exemption`

## Per-file changes

### `src/features/files/components/FilesList.tsx`

- Replaced `DataTable` with `EntityList` + a flex `renderItem` row
- Dropped `COLUMNS: DataTableColumn[]` + `rows: DataTableRow[]` builder
- Responsive column hiding (was `hideAt: 'sm' | 'md' | 'lg'`) reimplemented as Tailwind `hidden sm:block` / `md:block` / `lg:block` per field
- Kept: file-type icon thumbnail, name truncation with `title` attribute, tabular-nums for file size, "Loose file" / folder source label, relative-time `Added` column
- Click handler routes through `EntityList.onSelect`

### `src/features/reports/pages/reports/DeliveriesListView.tsx`

- Same pattern — `DataTable` → `EntityList` + inline flex `renderItem`
- Dropped `COLUMNS` + `rows: DataTableRow[]` builder
- Kept: status colored span (amber/emerald/red per status), recipient count, `onLoadMore` pagination via `hasMore ? loadMore : undefined`
- Kept the early-return for the empty state (separate `WorkspacePlaceholderState` rendering)

## ⚠️ ReportDataTable revised — staying as `<table>`

PR-15 was originally scoped as "3 small DataTable conversions": FilesList, DeliveriesListView, **ReportDataTable**. After reading ReportDataTable, I'm leaving it as `<table>` for the same reason `InvoicesTable` stays:

**It's genuinely tabular data.** ReportDataTable is a generic wrapper that takes column metadata (`ColumnSpec` with `kind: 'currency' | 'date' | 'number'`, etc.) and renders formatted rows. The data is a numerical/textual report — rows × typed columns — which is *exactly* what `<table>` semantics exist for.

Forcing this through `EntityList` (which has no concept of columns) would either:
- Drop the column-spec abstraction (each ReportPageShell would inline its own row layout per report type), or
- Require building a new column-aware non-`<table>` primitive

Neither is justified by the spec right now. The Reports.html chat-first screen rebuild will re-evaluate the table format on its own merits. Until then, this stays.

## Remaining DataTable callers (after this PR)

| File | Status |
|---|---|
| `InvoicesTable` (313 LOC) | **Kept** — invoice line items are tabular |
| `ReportDataTable` (52 LOC) | **Kept** — generic report tabular data, see above |
| `ReportPageShell` (uses `ReportDataTable`) | **Kept** — chain consumer |
| `IntakesPage` (385 LOC) | Pending — follow-up PR |
| `EngagementsPage` (388 LOC) | Pending — follow-up PR |
| `IntakeTemplatesPage` (2260 LOC) | Pending — large file, focused PR |
| `PracticeMattersPage` (2247 LOC) | Pending — large file, focused PR |
| `DataTable.tsx` (424 LOC) | Stays as long as Invoices/Reports use it |

`DataTable.tsx` won't be deleted in Commit 8; it survives as the primitive backing `InvoicesTable` and `ReportDataTable`.

## Test plan

- [x] `npm run build` green
- [x] `npm run type-check` 0 errors
- [x] `npm run lint:src` baseline preserved (pre-existing `OAuthConsentPage.tsx:187`)
- [ ] Visual smoke at `https://local.blawby.com`:
  - [ ] Files page list renders rows with file icon + name + size + added timestamp; columns hide correctly on sm/md
  - [ ] Reports → Deliveries page renders deliveries with status pill colors + recipient count; pagination triggers near scroll bottom

## What's next

- **PR-16**: SegmentedToggle → Seg sweep (13 callers; mechanical per-site judgment)
- **PR-17/18**: `.status-*` and `.input-surface` alias caller sweeps + alias deletion
- **PR-19**: a11y + final grep gates
- **Future**: DataTable conversion for the 4 larger files (IntakesPage, EngagementsPage, IntakeTemplatesPage, PracticeMattersPage) — each gets its own focused PR
- **Future (PR-19a)**: dead `text-accent-N` / `ring-accent-N` / `border-accent-N` families with semantic mappings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized file list view with streamlined component rendering, improving visual consistency and overall application performance.
  * Enhanced deliveries list view with optimized component architecture and rendering efficiency for better responsiveness and user experience.

* **Documentation**
  * Updated design system audit documentation to reflect recent component modernization efforts and architecture improvements across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-ai-chatbot/pull/658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->