### PR TITLE
fix(mcp): use backend API URL for MCP resource and pass oauth_query on consent

### DIFF
--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -102,7 +102,10 @@ export default function OAuthConsentPage() {
     }
     setSubmitting(accept ? 'accept' : 'deny');
     try {
-      const { data, error } = await authClient.oauth2.consent({ accept });
+      const { data, error } = await authClient.oauth2.consent({
+        accept,
+        oauth_query: window.location.search.slice(1),
+      });
       if (error) {
         const message =
           error.message

--- a/src/shared/lib/mcpOAuth.ts
+++ b/src/shared/lib/mcpOAuth.ts
@@ -84,7 +84,7 @@ export function buildMcpSettingsReturnPath(basePath: string, status: 'success' |
 }
 
 export function getMcpResourceUrl(): string {
-  return `${getBackendApiUrl()}/mcp`;
+  return `${getBackendApiUrl().replace(/\/+$/, '')}/mcp`;
 }
 
 export async function exchangeMcpAuthorizationCode(code: string, verifier: string): Promise<Response> {

--- a/src/shared/lib/mcpOAuth.ts
+++ b/src/shared/lib/mcpOAuth.ts
@@ -1,4 +1,4 @@
-import { getWorkerApiUrl } from '@/config/urls';
+import { getWorkerApiUrl, getBackendApiUrl } from '@/config/urls';
 import { MCP_SCOPES } from '@/shared/config/mcpScopes';
 
 export const MCP_OAUTH_CLIENT_ID = 'blawby-claude-mcp';
@@ -84,7 +84,7 @@ export function buildMcpSettingsReturnPath(basePath: string, status: 'success' |
 }
 
 export function getMcpResourceUrl(): string {
-  return `${getWorkerApiUrl()}/api/mcp`;
+  return `${getBackendApiUrl()}/mcp`;
 }
 
 export async function exchangeMcpAuthorizationCode(code: string, verifier: string): Promise<Response> {


### PR DESCRIPTION
## Summary

- `getMcpResourceUrl()` now uses `getBackendApiUrl()` instead of `window.location.origin + /api/mcp`. The `resource` param in the token exchange must match `validAudiences` on the backend (`${VITE_BACKEND_API_URL}/mcp`), not the FE proxy origin.
- `OAuthConsentPage` now passes `oauth_query: window.location.search.slice(1)` to `authClient.oauth2.consent()` — without this the backend has no authorization state to redirect back with the code.

## Test plan

- [ ] Click Connect Claude in MCP settings
- [ ] Consent page appears, click Allow
- [ ] Redirected to `/oauth/callback` without `invalid_request` error
- [ ] Settings page shows Connected status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated OAuth consent handling to properly preserve original query parameters during the authorization flow
  * Adjusted MCP resource endpoint routing to use the backend API instead of the worker API for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->