### PR TITLE
feat(queues): emit intake-conversation events from ChatRoom and conversations route

### DIFF
--- a/worker/durable-objects/ChatRoom.ts
+++ b/worker/durable-objects/ChatRoom.ts
@@ -905,6 +905,21 @@ export class ChatRoom {
 
     await this.state.storage.delete(pendingKey);
 
+    void this.env.INTAKE_CONVERSATION_EVENTS?.send({
+      type: 'message.completed',
+      id: messageId,
+      conversation_id: conversationId,
+      organization_id: practiceId,
+      user_id: userId ?? null,
+      role,
+      content,
+      seq: pending.allocated_seq,
+      client_id: clientId,
+      token_count: null,
+      metadata: sanitizedMetadata ?? null,
+      created_at: serverTs,
+    });
+
     if (role === 'user') {
       void this.maybeUpdateConversationTitle(conversationId, content);
     }

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -481,6 +481,17 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       lifecycleStatus: staffInitiated ? 'visible' : 'pending_visibility',
     }, request);
 
+    void env.INTAKE_CONVERSATION_EVENTS?.send({
+      type: 'conversation.created',
+      id: conversation.id,
+      organization_id: conversation.practice_id,
+      client_user_id: conversation.user_id ?? userId,
+      is_anonymous: conversation.is_anonymous ?? false,
+      status: conversation.status,
+      priority: conversation.priority ?? 'normal',
+      created_at: new Date().toISOString(),
+    });
+
     return createJsonResponse(conversation);
   }
 
@@ -738,6 +749,14 @@ export async function handleConversations(request: Request, env: Env): Promise<R
     const conversation = trimmedMatterId === null
       ? await conversationService.detachMatter(conversationId, practiceId)
       : await conversationService.attachMatter(conversationId, practiceId, trimmedMatterId);
+
+    void env.INTAKE_CONVERSATION_EVENTS?.send({
+      type: 'conversation.matter_linked',
+      id: conversation.id,
+      organization_id: conversation.practice_id,
+      matter_id: conversation.matter_id ?? null,
+      updated_at: new Date().toISOString(),
+    });
 
     return createJsonResponse(conversation);
   }
@@ -1102,6 +1121,19 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       },
       { request }
     );
+
+    if (body.status !== undefined) {
+      void env.INTAKE_CONVERSATION_EVENTS?.send({
+        type: 'conversation.status_changed',
+        id: conversation.id,
+        organization_id: conversation.practice_id,
+        status: conversation.status,
+        intake_mode_activated_at: conversation.intake_mode_activated_at ?? null,
+        ai_failed_at: conversation.ai_failed_at ?? null,
+        closed_at: null,
+        updated_at: new Date().toISOString(),
+      });
+    }
 
     // Mark intake-mode-activated when the consultation transition indicates the
     // slim-contact-form flow completed (or any intake-active state). Idempotent:

--- a/worker/routes/conversations.ts
+++ b/worker/routes/conversations.ts
@@ -489,7 +489,7 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       is_anonymous: conversation.is_anonymous ?? false,
       status: conversation.status,
       priority: conversation.priority ?? 'normal',
-      created_at: new Date().toISOString(),
+      created_at: conversation.created_at,
     });
 
     return createJsonResponse(conversation);
@@ -755,7 +755,7 @@ export async function handleConversations(request: Request, env: Env): Promise<R
       id: conversation.id,
       organization_id: conversation.practice_id,
       matter_id: conversation.matter_id ?? null,
-      updated_at: new Date().toISOString(),
+      updated_at: conversation.updated_at,
     });
 
     return createJsonResponse(conversation);
@@ -1130,8 +1130,8 @@ export async function handleConversations(request: Request, env: Env): Promise<R
         status: conversation.status,
         intake_mode_activated_at: conversation.intake_mode_activated_at ?? null,
         ai_failed_at: conversation.ai_failed_at ?? null,
-        closed_at: null,
-        updated_at: new Date().toISOString(),
+        closed_at: conversation.closed_at ?? null,
+        updated_at: conversation.updated_at,
       });
     }
 


### PR DESCRIPTION
Wire INTAKE_CONVERSATION_EVENTS.send() calls so conversation.created, conversation.matter_linked, conversation.status_changed, and message.completed events actually flow into the queue for the consumer to process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event tracking for message completions, including message and conversation details.
  * Added conversation lifecycle event tracking for conversation creation, matter link/unlink updates, and status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->