### PR TITLE
[codex] Reduce API load and improve empty states

### DIFF
--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.

--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -22,7 +22,7 @@ Review files for compliance with Web Interface Guidelines.
 
 Fetch fresh guidelines before each review:
 
-```
+```text
 https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
 ```
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<link rel="icon" type="image/png" href="/blawby-favicon-iframe.png" />
 	<link rel="apple-touch-icon" href="/blawby-favicon-iframe.png" />
 	<link rel="shortcut icon" href="/blawby-favicon-iframe.png" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta name="color-scheme" content="light dark" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -18,6 +18,10 @@
 				var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 				if (saved === 'dark' || (!saved && prefersDark)) {
 					document.documentElement.setAttribute('data-theme', 'midnight');
+					document.documentElement.style.colorScheme = 'dark';
+					document.querySelector('meta[name="theme-color"]')?.setAttribute('content', '#050c1c');
+				} else {
+					document.documentElement.style.colorScheme = 'light';
 				}
 			} catch (e) { /* localStorage unavailable (private mode, iframe restrictions) */ }
 		})();

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -18,6 +18,12 @@
       "sourceType": "github",
       "skillPath": ".claude/skills/ui-ux-pro-max/SKILL.md",
       "computedHash": "6337038fe1fe6bbe1b9f252ab678ee575859190bab6f0f246f4061824eb40875"
+    },
+    "web-design-guidelines": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/web-design-guidelines/SKILL.md",
+      "computedHash": "f3bc47f890f42a44db1007ab390709ec368e4b8c089baee6b0007182236ac474"
     }
   }
 }

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -972,31 +972,12 @@ export function MainApp({
             <PracticeContactsPage
               practiceId={practiceId}
               basePath={practiceContactsPath}
-              renderMode={layoutMode === 'desktop' ? 'detailOnly' : 'full'}
               statusFilter={statusFilter}
               prefetchedItems={prefetchData?.contactsData?.items}
               prefetchedLoading={prefetchData?.contactsData?.isLoading}
               prefetchedError={prefetchData?.contactsData?.error}
-              onRefetchList={prefetchData?.contactsData?.refetch}
 
               detailHeaderLeadingAction={detailHeaderLeadingAction}
-              showDetailBackButton={showWorkspaceDetailBack}
-            />
-          </LazyRouteBoundary>
-        )
-        : undefined}
-      contactsListContent={isPracticeWorkspace && layoutMode === 'desktop' && practiceContactsPath != null
-        ? (statusFilter, prefetchData) => (
-          <LazyRouteBoundary>
-            <PracticeContactsPage
-              practiceId={practiceId}
-              basePath={practiceContactsPath}
-              renderMode="listOnly"
-              statusFilter={statusFilter}
-              prefetchedItems={prefetchData?.contactsData?.items}
-              prefetchedLoading={prefetchData?.contactsData?.isLoading}
-              prefetchedError={prefetchData?.contactsData?.error}
-              onRefetchList={prefetchData?.contactsData?.refetch}
               showDetailBackButton={showWorkspaceDetailBack}
             />
           </LazyRouteBoundary>

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -21,6 +21,7 @@ import { setupGlobalKeyboardListeners } from '@/shared/utils/keyboard';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { resolveConversationContactName, resolveConversationDisplayTitle } from '@/shared/utils/conversationDisplay';
 import { usePracticeDetails } from '@/shared/hooks/usePracticeDetails';
+import { applyHtmlTheme } from '@/shared/hooks/useTheme';
 import { practiceDetailsStore } from '@/shared/stores/practiceDetailsStore';
 import { useStore } from '@nanostores/preact';
 import { LeftRail, type LeftRailItem } from '@/design-system/layout';
@@ -644,7 +645,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
 
   useEffect(() => {
     // Widget shell is always rendered with the midnight (dark) theme.
-    document.documentElement.setAttribute('data-theme', 'midnight');
+    applyHtmlTheme(true);
   }, []);
 
   const handleSlimFormDismiss = useCallback(() => {

--- a/src/design-system/tokens.css
+++ b/src/design-system/tokens.css
@@ -14,7 +14,7 @@
    ========================================================= */
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
 
   /* ---- Surface ---- */
   --paper:        #f6f3ea;
@@ -45,6 +45,21 @@
   --rule-soft:    rgba(15,30,54,0.08);
   --rule-rgb:     211 214 223;
 
+  /* ---- Line utilities ----
+     Used by Tailwind `border-line-*`, `divide-line-*`, `ring-line-*`, and
+     `bg-line-*` utilities. Subtle lines are ink-derived so dense table/list
+     dividers stay quieter than container rules in every theme. */
+  --line-subtle-rgb:     var(--ink-rgb);
+  --line-subtle-alpha:   0.08;
+  --line-default-rgb:    var(--rule-rgb);
+  --line-default-alpha:  0.72;
+  --line-utility-rgb:    var(--rule-rgb);
+  --line-utility-alpha:  1;
+  --line-emphasized-rgb: var(--ink-3-rgb);
+  --line-emphasized-alpha: 0.48;
+  --line-glass-rgb:      var(--ink-rgb);
+  --line-glass-alpha:    0.12;
+
   /* ---- Accent (gold) ---- */
   --accent:       oklch(0.72 0.13 82);
   --accent-soft:  oklch(0.72 0.13 82 / 0.14);
@@ -64,20 +79,79 @@
   --warn-rgb:     201 137 30;
   --neg-rgb:      189  68 40;
 
+  /* ---- Compatibility aliases ----
+     Page, input, inspector, markdown, and upload components consume these
+     semantic names. Keep them aliased to the canonical palette so every
+     surface follows the active theme without page-level overrides. */
+  --surface-page:       var(--paper-rgb);
+  --surface-base:       var(--paper-rgb);
+  --surface-workspace:  var(--paper-2-rgb);
+  --surface-card:       var(--card-rgb);
+  --surface-card-hover: var(--paper-2-rgb);
+  --surface-panel:      var(--paper-2-rgb);
+  --surface-overlay:    var(--card-rgb);
+  --surface-app-frame:  var(--paper-rgb);
+  --surface-utility:    var(--ink-rgb);
+
+  --text-primary:   var(--ink-rgb);
+  --text-secondary: var(--ink-2-rgb);
+  --text-muted:     var(--dim-rgb);
+  --border-subtle:  var(--rule-rgb);
+
+  --header-bg:         var(--card-rgb);
+  --input-text:        var(--ink-rgb);
+  --input-foreground:  var(--ink-rgb);
+  --input-placeholder: var(--dim-rgb);
+  --error-foreground:  var(--neg-rgb);
+  --gray-500:          107 114 128;
+  --line-glass:        var(--line-glass-rgb);
+
+  --glass-bg-top:    rgb(var(--card-rgb) / 0.92);
+  --glass-bg-mid:    rgb(var(--card-rgb) / 0.86);
+  --glass-bg-bottom: rgb(var(--paper-rgb) / 0.82);
+  --glass-rim-subtle: 0 0 0 1px rgb(var(--line-glass-rgb) / 0.12), 0 18px 48px -32px rgb(var(--ink-rgb) / 0.32);
+
   /* ---- Sidebar (rail) ----
      Aliased onto the theme palette so each data-theme below inherits
      these automatically through CSS variable resolution. Active state
-     uses the inverse paper/ink pair so the selected row reads as a
-     high-contrast pill against the rail surface; the `before:bg-accent`
-     stripe and `[&_svg]:text-accent` icon supply the brand cue on top. */
+     stays tonal rather than inverted; the accent stripe and icon carry
+     the brand cue while the row remains quiet enough for dense navigation. */
   --sidebar-bg:             var(--paper-2-rgb);
   --sidebar-text:           var(--ink-rgb);
   --sidebar-text-secondary: var(--ink-3-rgb);
   --sidebar-hover-bg:       var(--paper-edge-rgb);
-  --sidebar-active-bg:      var(--ink-rgb);
-  --sidebar-active-text:    var(--paper-rgb);
+  --sidebar-active-bg:      220 211 186;
+  --sidebar-active-text:    var(--ink-rgb);
   --sidebar-border:         var(--rule-rgb);
-  --sidebar-badge-bg:       var(--neg-rgb);
+  --sidebar-badge-bg:       145 100 16;
+  --sidebar-badge-text:     255 255 255;
+  --sidebar-divider:        var(--rule-rgb);
+  --sidebar-section-label:  var(--dim-rgb);
+  --sidebar-menu-border:    var(--rule-rgb);
+
+  /* ---- Upload file chips ---- */
+  --light-file-type-pdf:         220 38 38;
+  --light-file-type-image:       22 163 74;
+  --light-file-type-video:       124 58 237;
+  --light-file-type-audio:       217 119 6;
+  --light-file-type-code:        37 99 235;
+  --light-file-type-archive:     100 116 139;
+  --light-file-type-spreadsheet: 5 150 105;
+  --light-file-type-document:    14 116 144;
+  --light-file-type-default:     71 85 105;
+  --dark-file-type-pdf:          248 113 113;
+  --dark-file-type-image:        74 222 128;
+  --dark-file-type-video:        167 139 250;
+  --dark-file-type-audio:        251 191 36;
+  --dark-file-type-code:         96 165 250;
+  --dark-file-type-archive:      148 163 184;
+  --dark-file-type-spreadsheet:  52 211 153;
+  --dark-file-type-document:     34 211 238;
+  --dark-file-type-default:      148 163 184;
+  --light-file-progress-bg:      211 214 223;
+  --light-file-progress-fill:    var(--accent-rgb);
+  --dark-file-progress-bg:       21 32 59;
+  --dark-file-progress-fill:     var(--accent-rgb);
 
   /* ---- Type ---- */
   --serif: "Source Serif 4", "Source Serif Pro", Georgia, serif;
@@ -110,6 +184,8 @@
    ========================================================= */
 
 html[data-theme="dark"] {
+  color-scheme: dark;
+
   --paper:        #0c1830;
   --paper-2:      #142142;
   --paper-edge:   #1d2c4f;
@@ -144,9 +220,24 @@ html[data-theme="dark"] {
   --accent-rgb:      221 184 70;
   --accent-deep-rgb: 173 137 35;
   --accent-ink-rgb:   42  34  0;
+
+  --sidebar-bg:             14  24  48;
+  --sidebar-text:           var(--ink-rgb);
+  --sidebar-text-secondary: 183 191 211;
+  --sidebar-hover-bg:       22  34  62;
+  --sidebar-active-bg:      30  45  76;
+  --sidebar-active-text:    var(--ink-rgb);
+  --sidebar-border:         34  49  82;
+  --sidebar-badge-bg:       145 100 16;
+  --sidebar-badge-text:     255 255 255;
+  --sidebar-divider:        34  49  82;
+  --sidebar-section-label:  130 141 166;
+  --sidebar-menu-border:    34  49  82;
 }
 
 html[data-theme="midnight"] {
+  color-scheme: dark;
+
   --paper:        #050c1c;
   --paper-2:      #0c142a;
   --paper-edge:   #15203b;
@@ -181,9 +272,24 @@ html[data-theme="midnight"] {
   --accent-rgb:      232 196 80;
   --accent-deep-rgb: 173 137 35;
   --accent-ink-rgb:   42  34  0;
+
+  --sidebar-bg:             8   16  34;
+  --sidebar-text:           var(--ink-rgb);
+  --sidebar-text-secondary: 183 191 211;
+  --sidebar-hover-bg:       16  27  52;
+  --sidebar-active-bg:      25  38  65;
+  --sidebar-active-text:    var(--ink-rgb);
+  --sidebar-border:         28  42  72;
+  --sidebar-badge-bg:       145 100 16;
+  --sidebar-badge-text:     255 255 255;
+  --sidebar-divider:        28  42  72;
+  --sidebar-section-label:  130 141 166;
+  --sidebar-menu-border:    28  42  72;
 }
 
 html[data-theme="parchment"] {
+  color-scheme: light;
+
   --paper:        #f0eadb;
   --paper-2:      #e2dabf;
   --paper-edge:   #cdc9b8;

--- a/src/features/chat/pages/WorkspacePage.tsx
+++ b/src/features/chat/pages/WorkspacePage.tsx
@@ -38,6 +38,7 @@ import { useWorkspaceConversations } from './hooks/useWorkspaceConversations';
 import { useWorkspaceNavigation } from './hooks/useWorkspaceNavigation';
 import { resolveConsultationState } from '@/shared/utils/consultationState';
 import { resolveConversationContactName, resolveConversationDisplayTitle } from '@/shared/utils/conversationDisplay';
+import { useMatterDetail } from '@/shared/hooks/useMatterDetail';
 import { useWorkspaceSetup } from './hooks/useWorkspaceSetup';
 import { useWorkspaceData } from './hooks/useWorkspaceData';
 import { useConversationPreviews } from './hooks/useConversationPreviews';
@@ -114,7 +115,7 @@ const getRailItemMatchScore = (currentPath: string, item: LeftRailItem): number 
   return bestScore;
 };
 
-const SECTION_SIDEBAR_WORKSPACE_SECTIONS = new Set(['settings', 'reports', 'conversations', 'assistant', 'tasks', 'calendar'] as const);
+const SECTION_SIDEBAR_WORKSPACE_SECTIONS = new Set(['settings', 'reports', 'conversations', 'assistant', 'matters', 'tasks', 'calendar'] as const);
 
 interface WorkspacePageProps {
   view: WorkspaceView;
@@ -161,7 +162,6 @@ interface WorkspacePageProps {
   mattersView?: ComponentChildren | ((statusFilter: string[], prefetchData?: WorkspacePrefetchData, onDetailInspector?: (() => void), detailInspectorOpen?: boolean, detailHeaderLeadingAction?: ComponentChildren) => ComponentChildren);
   mattersListContent?: ComponentChildren | ((statusFilter: string[], prefetchData?: WorkspacePrefetchData) => ComponentChildren);
   contactsView?: ComponentChildren | ((statusFilter: UserDetailStatus | null, prefetchData?: WorkspacePrefetchData, onDetailInspector?: (() => void), detailInspectorOpen?: boolean, detailHeaderLeadingAction?: ComponentChildren) => ComponentChildren);
-  contactsListContent?: ComponentChildren | ((statusFilter: UserDetailStatus | null, prefetchData?: WorkspacePrefetchData) => ComponentChildren);
   invoicesView?: ComponentChildren | ((statusFilter: string[], onDetailInspector?: (() => void), detailInspectorOpen?: boolean, detailHeaderLeadingAction?: ComponentChildren) => ComponentChildren);
   invoicesListContent?: ComponentChildren | ((statusFilter: string[]) => ComponentChildren);
   reportsView?: ComponentChildren | ((title: string, reportType: string, deliveryId: string | null) => ComponentChildren);
@@ -243,7 +243,6 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   mattersView,
   mattersListContent,
   contactsView,
-  contactsListContent,
   invoicesView,
   invoicesListContent,
   intakesView,
@@ -1144,14 +1143,6 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     && !mattersDataForView.error
     && mattersDataForView.items.length === 0
   );
-  const shouldShowDesktopContactsListPanel = !(
-    layoutMode === 'desktop'
-    && view === 'contacts'
-    && activeSecondaryFilter !== 'contacts-pending'
-    && !contactsData.isLoading
-    && !contactsData.error
-    && contactsData.items.length === 0
-  );
   const shouldShowDesktopInvoicesListPanel = view === 'invoices' && hasDesktopInvoiceListItems !== false;
   const matterListIsEmpty = layoutMode === 'desktop'
     && view === 'matters'
@@ -1340,9 +1331,6 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   const matterListPanel = layoutMode === 'desktop' && (isPracticeWorkspace || isClientWorkspace) && view === 'matters' && shouldShowDesktopMattersListPanel
     ? resolveViewContent(mattersListContent, [mattersStatusFilter, workspacePrefetchData] as const)
     : undefined;
-  const contactsListPanel = layoutMode === 'desktop' && isPracticeWorkspace && view === 'contacts' && shouldShowDesktopContactsListPanel
-    ? resolveViewContent(contactsListContent, [contactsStatusFilter, workspacePrefetchData] as const)
-    : undefined;
   const invoicesListPanel = layoutMode === 'desktop' && (isPracticeWorkspace || isClientWorkspace) && view === 'invoices' && shouldShowDesktopInvoicesListPanel
     ? resolveViewContent(invoicesListContent, [invoicesStatusFilter] as const)
     : undefined;
@@ -1453,10 +1441,12 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
   // dedicated three-section panel (Contact / Linked Matter / Recent Activity)
   // instead of the generic InspectorPanel surface. Other entity types keep
   // using InspectorPanel.
-  const linkedMatter = useMemo(() => {
-    if (!selectedConversation?.matter_id) return null;
-    return mattersData.items.find((m) => m.id === selectedConversation.matter_id) ?? null;
-  }, [mattersData.items, selectedConversation?.matter_id]);
+  const linkedMatterId = isPracticeWorkspace && workspaceSection === 'conversations'
+    ? selectedConversation?.matter_id ?? null
+    : null;
+  const { data: linkedMatter } = useMatterDetail(practiceId, linkedMatterId, {
+    enabled: Boolean(linkedMatterId),
+  });
   const conversationContextPanel = isPracticeWorkspace
     && inspectorTarget?.entityType === 'conversation'
     ? (
@@ -1545,7 +1535,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
       || workspaceSection === 'conversations'
       || workspaceSection === 'assistant')
     && currentSectionRailItem
-    && SECTION_SIDEBAR_WORKSPACE_SECTIONS.has(workspaceSection as 'settings' | 'reports' | 'conversations' | 'assistant' | 'tasks' | 'calendar')
+    && SECTION_SIDEBAR_WORKSPACE_SECTIONS.has(workspaceSection as 'settings' | 'reports' | 'conversations' | 'assistant' | 'matters' | 'tasks' | 'calendar')
   );
   const staticSectionSidebarSections = useMemo(() => (
     (navConfig.secondary ?? []).map((section, index) => ({
@@ -1558,13 +1548,13 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
           label: item.label,
           icon: item.icon as IconComponent | undefined,
           href: item.href,
-          badge: typeof item.badge === 'number' ? item.badge : null,
+          badge: sidebarCounts?.[item.id] ?? (typeof item.badge === 'number' ? item.badge : null),
           variant: item.variant,
           isAction: item.isAction,
-          isActive: workspaceSection === 'conversations'
+          isActive: workspaceSection === 'conversations' || workspaceSection === 'matters'
             ? item.id === activeSecondaryFilter
             : undefined,
-          onClick: workspaceSection === 'conversations'
+          onClick: workspaceSection === 'conversations' || workspaceSection === 'matters'
             ? () => handleSecondaryFilterSelect(item.id)
             : undefined,
           prefetch: item.prefetch,
@@ -1575,6 +1565,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
     currentSectionRailItem?.id,
     handleSecondaryFilterSelect,
     navConfig.secondary,
+    sidebarCounts,
     workspaceSection,
   ]);
   const sectionSidebarSections = useMemo(() => (
@@ -1710,7 +1701,7 @@ const WorkspacePage: FunctionComponent<WorkspacePageProps> = ({
         <AppShell
           className="flex-1 min-w-0 bg-transparent"
           accentBackdropVariant="none"
-          listPanel={isFullscreenEditorRoute ? undefined : (matterListPanel ?? contactsListPanel ?? invoicesListPanel)}
+          listPanel={isFullscreenEditorRoute ? undefined : (matterListPanel ?? invoicesListPanel)}
           inspector={activeInspector ?? undefined}
           inspectorMobileOpen={detailInspectorOpen && (isMobileLayout || !isXlViewport)}
           onInspectorMobileClose={() => setIsInspectorOpen(false)}

--- a/src/features/chat/pages/hooks/useWorkspaceAutoNavigation.tsx
+++ b/src/features/chat/pages/hooks/useWorkspaceAutoNavigation.tsx
@@ -121,6 +121,35 @@ export function useWorkspaceAutoNavigation(
     workspaceSection,
   ]);
 
+  // Practice workspace on desktop mirrors the client split-view behavior:
+  // entering Messages opens the most recently updated visible thread.
+  useEffect(() => {
+    if (!isPracticeWorkspace || layoutMode !== 'desktop') return;
+    if (workspaceSection !== 'conversations' || view !== 'list') return;
+    if (activeConversationId || hasAutoNavigatedRef.current) return;
+    if (resolvedConversationsLoading || navigationInitiatedRef.current) return;
+
+    const mostRecentConversationId = filteredConversations
+      .slice()
+      .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())[0]?.id;
+    if (!mostRecentConversationId) return;
+
+    navigationInitiatedRef.current = true;
+    hasAutoNavigatedRef.current = true;
+    handleSelectConversation(mostRecentConversationId);
+  }, [
+    activeConversationId,
+    filteredConversations,
+    handleSelectConversation,
+    hasAutoNavigatedRef,
+    isPracticeWorkspace,
+    layoutMode,
+    navigationInitiatedRef,
+    resolvedConversationsLoading,
+    view,
+    workspaceSection,
+  ]);
+
   // Client workspace on desktop, conversations section: pick the first
   // conversation if none is active. Gated on workspaceSection so the home tab
   // can render the client dashboard instead of bouncing straight to messages.

--- a/src/features/chat/pages/hooks/useWorkspaceConversations.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceConversations.ts
@@ -45,7 +45,12 @@ export function useWorkspaceConversations({
       ? (activeSecondaryFilter ? PRACTICE_CONVERSATIONS_ASSIGNED_TO_MAP[activeSecondaryFilter] : null)
       : (isClientWorkspace && activeSecondaryFilter ? CLIENT_CONVERSATIONS_ASSIGNED_TO_MAP[activeSecondaryFilter] : null))
     : null;
-  const shouldListConversations = isPracticeWorkspace ? true : view !== 'conversation';
+  const shouldListConversations =
+    workspaceSection === 'conversations' ||
+    workspaceSection === 'assistant' ||
+    view === 'home' ||
+    view === 'setup' ||
+    Boolean(activeConversationId);
 
   const {
     conversations,

--- a/src/features/chat/pages/hooks/useWorkspaceData.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceData.ts
@@ -26,27 +26,47 @@ type UseWorkspaceDataInput = {
   sessionUserId: string | null;
 };
 
+const MATTERS_FILTER_STATUS_MAP: Record<string, string[]> = {
+  new: ['first_contact', 'intake_pending', 'conflict_check', 'eligibility'],
+  active: ['consultation_scheduled', 'engagement_pending', 'active', 'pleadings_filed', 'discovery', 'mediation', 'pre_trial', 'trial'],
+  closing: ['order_entered', 'appeal_pending'],
+  closed: ['closed'],
+  declined: ['declined', 'conflicted', 'referred'],
+};
+
 export function useWorkspaceData({
   practiceId,
   isPracticeWorkspace,
   isClientWorkspace,
   view,
   layoutMode,
+  workspaceSection,
+  activeSecondaryFilter,
   selectedMatterIdFromPath,
   sessionUserId,
 }: UseWorkspaceDataInput) {
-  const mattersStatusFilter = useMemo<string[]>(() => [], []);
+  const mattersStatusFilter = useMemo<string[]>(() => {
+    if (!activeSecondaryFilter || activeSecondaryFilter === 'all') return [];
+    return MATTERS_FILTER_STATUS_MAP[activeSecondaryFilter] ?? [];
+  }, [activeSecondaryFilter]);
 
   const contactsStatusFilter = useMemo<UserDetailStatus | null>(() => null, []);
 
   const invoicesStatusFilter = useMemo<string[]>(() => [], []);
 
-  // Always fetch the full unfiltered matters list so the inspector can use it.
-  // The mattersStore handles deduplication — this fires once and caches.
+  const shouldFetchMatters =
+    (isPracticeWorkspace || isClientWorkspace) &&
+    (
+      workspaceSection === 'matters' ||
+      Boolean(selectedMatterIdFromPath)
+    );
+
+  // Fetch the full unfiltered matters list only where matter rows are rendered.
+  // The matters store still deduplicates and caches the sections that opt in.
   const mattersData = useMattersData(
     practiceId,
     [], // no status filter — fetch all, filter at display time
-    { enabled: isPracticeWorkspace || isClientWorkspace }
+    { enabled: shouldFetchMatters }
   );
 
   // Filtered view for the matters list page (status filter applied after fetch)

--- a/src/features/chat/pages/hooks/useWorkspaceNavigation.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceNavigation.ts
@@ -232,6 +232,11 @@ export function useWorkspaceNavigation({
       setSecondaryFilterBySection((prev) => ({ ...prev, [workspaceSection]: id }));
       return;
     }
+    if (workspaceSection === 'matters') {
+      navigate(`${basePath}/matters`);
+      setSecondaryFilterBySection((prev) => ({ ...prev, [workspaceSection]: id }));
+      return;
+    }
     setSecondaryFilterBySection((prev) => ({ ...prev, [workspaceSection]: id }));
   }, [navigate, normalizedBase, workspaceSection]);
 

--- a/src/features/chat/pages/hooks/useWorkspaceSetup.ts
+++ b/src/features/chat/pages/hooks/useWorkspaceSetup.ts
@@ -203,11 +203,22 @@ export const useWorkspaceSetup = ({
   const [previewReloadKey, setPreviewReloadKey] = useState(0);
 
   const workspacePracticeId = practiceId ?? currentPractice?.id ?? null;
+  const shouldLoadSetupDetails = view === 'setup';
+  const shouldLoadTeam =
+    isPracticeWorkspace &&
+    Boolean(workspacePracticeId) &&
+    (
+      view === 'setup' ||
+      workspaceSection === 'conversations' ||
+      workspaceSection === 'assistant' ||
+      workspaceSection === 'matters'
+    );
 
   useEffect(() => {
+    if (!shouldLoadSetupDetails) return;
     if (!currentPractice?.id) return;
     void fetchSetupDetails();
-  }, [currentPractice?.id, fetchSetupDetails]);
+  }, [currentPractice?.id, fetchSetupDetails, shouldLoadSetupDetails]);
 
   const forcePreviewReload = useCallback(() => {
     setPreviewReloadKey(prev => prev + 1);
@@ -336,7 +347,7 @@ export const useWorkspaceSetup = ({
   const { members: practiceMembers } = usePracticeTeam(
     workspacePracticeId,
     session?.user?.id ?? null,
-    { enabled: isPracticeWorkspace && Boolean(workspacePracticeId) }
+    { enabled: shouldLoadTeam }
   );
 
   const conversationMemberOptions = useMemo(

--- a/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
+++ b/src/features/client-dashboard/components/ClientRecentInvoicesTable.tsx
@@ -97,7 +97,7 @@ export const ClientRecentInvoicesTable = ({
                       {day.entries.length === 0 && showEmptyRows ? (
                         <tr>
                           <td colSpan={3} className="relative py-5 text-sm text-dim-2">
-                            No invoice activity yet.
+                            No invoice activity found. New invoices and payments from your firm will appear here.
                             <div className="absolute right-full bottom-0 h-px w-screen bg-line-glass/20" />
                             <div className="absolute bottom-0 left-0 h-px w-screen bg-line-glass/20" />
                           </td>

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
@@ -8,10 +7,9 @@ import { DetailHeader } from '@/shared/ui/layout/DetailHeader';
 import { ResponsiveDefinitionGrid } from '@/shared/ui/layout/ResponsiveDefinitionGrid';
 import { Panel } from '@/shared/ui/layout/Panel';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
-import { LoadingBlock, InteractiveListItem } from '@/shared/ui/layout';
 import { Button } from '@/shared/ui/Button';
 import { Avatar } from '@/shared/ui/profile';
-import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { DataTable, type DataTableColumn, type DataTableRow } from '@/shared/ui/table';
 import { cn } from '@/shared/utils/cn';
 import { ActivityTimeline, type TimelineItem } from '@/shared/ui/activity/ActivityTimeline';
 import { formatDate } from '@/shared/utils/dateTime';
@@ -53,13 +51,10 @@ import {
   MatterChip,
   type StatStripCell,
 } from '@/design-system/patterns';
-import { SignalPill, type SignalPillSignal } from '@/design-system/primitives';
+import { Pill, SignalPill, type PillTone, type SignalPillSignal } from '@/design-system/primitives';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
-import {
-  ClientDirectoryRow,
-  readRetainerAmount,
-} from '@/features/clients/components/ClientDirectoryRow';
+import { readRetainerAmount } from '@/features/clients/components/ClientDirectoryRow';
 import {
   SENTIMENT_RANK,
   computeLastContactDays,
@@ -101,16 +96,56 @@ const formatPhoneNumber = (phone?: string | null) => {
   return phone;
 };
 
+const contactStatusPillTone = (status?: ContactRelationshipStatus | null): PillTone | undefined => {
+  switch (status) {
+    case 'active':
+      return 'live';
+    case 'lead':
+      return 'warn';
+    case 'inactive':
+    case 'archived':
+      return 'dim';
+    default:
+      return undefined;
+  }
+};
+
+const formatMatterCount = (count: number) => {
+  if (count === 0) return 'No matters';
+  if (count === 1) return '1 matter';
+  return `${count} matters`;
+};
+
+const ContactTableEmptyState = ({
+  title,
+  description,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) => (
+  <div className="flex flex-col items-center justify-center gap-3 px-4 py-8 text-center">
+    <div>
+      <p className="text-sm font-medium text-ink">{title}</p>
+      <p className="mt-1 max-w-md text-sm text-dim-2">{description}</p>
+    </div>
+    {actionLabel && onAction ? (
+      <Button variant="secondary" size="sm" icon={Plus} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    ) : null}
+  </div>
+);
+
 const PendingEmptyState = ({ onInviteClient }: { onInviteClient: () => void }) => (
-  <WorkspacePlaceholderState
-    icon={User}
-    title="No pending invites"
-    description="Contact invites you send will appear here until they are accepted."
-    primaryAction={{
-      label: 'New Contact',
-      onClick: onInviteClient,
-      icon: Plus,
-    }}
+  <ContactTableEmptyState
+    title="No pending invitations found"
+    description="Create a contact invitation and it will stay here until the person accepts it."
+    actionLabel="Create Contact"
+    onAction={onInviteClient}
   />
 );
 
@@ -502,30 +537,25 @@ export const PracticeContactsPage = ({
   practiceId: routePracticeId,
   basePath = '/practice/contacts',
   conversationsPath,
-  renderMode = 'full',
   statusFilter = null,
   prefetchedItems = [],
   prefetchedLoading = false,
   prefetchedLoadingMore = false,
   prefetchedError = null,
-  onRefetchList: _onRefetchList,
   detailHeaderLeadingAction,
   showDetailBackButton = true,
 }: {
   practiceId?: string | null;
   basePath?: string;
   conversationsPath?: string | null;
-  renderMode?: 'full' | 'listOnly' | 'detailOnly';
   statusFilter?: ContactRelationshipStatus | null;
   prefetchedItems?: ContactRecord[];
   prefetchedLoading?: boolean;
   prefetchedLoadingMore?: boolean;
   prefetchedError?: string | null;
-  onRefetchList?: (signal?: AbortSignal) => Promise<void>;
   detailHeaderLeadingAction?: ComponentChildren;
   showDetailBackButton?: boolean;
 }) => {
-  const { t } = useTranslation();
   const location = useLocation();
   const { currentPractice } = usePracticeManagement();
   const { session } = useSessionContext();
@@ -1237,150 +1267,180 @@ export const PracticeContactsPage = ({
     { id: 'risk', label: 'Risk' },
   ];
 
-  // ── List panes ───────────────────────────────────────────────────────
-  const directoryListPane = (
-    <div className="h-full overflow-y-auto">
-      {/* Header row — desktop only */}
-      <div className="hidden border-b border-line-subtle bg-paper-2 px-[18px] py-2.5 font-mono text-[10px] uppercase tracking-[0.12em] text-dim md:grid md:grid-cols-[28px_minmax(0,1.8fr)_minmax(0,1.6fr)_minmax(0,1fr)_110px_100px] md:gap-4">
-        <div />
-        <div>Client</div>
-        <div>Retainer</div>
-        <div>Primary matter</div>
-        <div>Last contact</div>
-        <div>Signal</div>
-      </div>
+  // ── Table rows ───────────────────────────────────────────────────────
+  const contactColumns = useMemo<DataTableColumn[]>(() => [
+    { id: 'contact', label: 'Contact', isPrimary: true },
+    { id: 'status', label: 'Status', hideAt: 'sm' },
+    { id: 'matters', label: 'Matters', hideAt: 'md' },
+    { id: 'retainer', label: 'Retainer', hideAt: 'lg', align: 'right' },
+    { id: 'lastContact', label: 'Last contact', hideAt: 'md' },
+    { id: 'signal', label: 'Signal', hideAt: 'sm' },
+    { id: 'actions', label: '', align: 'right', isAction: true, disableCellWrap: true },
+  ], []);
 
-      {sortedClients.length === 0 ? (
-        <div className="flex h-full min-h-[200px] items-center justify-center px-6 py-12 text-center">
-          <p className="text-sm text-dim-2">
-            {activeFilter === 'all'
-              ? 'No contacts found.'
-              : 'No contacts match this filter.'}
-          </p>
-        </div>
-      ) : (
-        sortedClients.map((client) => {
-          const isSelected = client.id === selectedClient?.id;
-          if (client.kind === 'team') {
-            // Team rows use the simpler legacy row — directory grid is for clients.
-            const nameParts = splitName(client.name);
-            const normalizedTeamRole = normalizePracticeRole(client.teamRole);
-            return (
-              <InteractiveListItem
-                key={client.id}
-                onClick={() => handleSelectClient(client)}
-                isSelected={isSelected}
-                padding="px-4 py-3.5"
-                className="flex-nowrap gap-4 rounded-none h-auto border-b border-line-subtle"
-              >
-                <Avatar name={client.name} size="md" className="text-ink" />
-                <div className="min-w-0 flex-1 text-left">
-                  <p className="text-sm text-ink truncate">
-                    {nameParts.first ? (
-                      <>
-                        <span>{nameParts.first} </span>
-                        <span className="font-semibold">{nameParts.last}</span>
-                      </>
-                    ) : (
-                      <span className="font-semibold">{nameParts.last}</span>
-                    )}
-                  </p>
-                  <p className="mt-0.5 text-xs text-dim-2 truncate">
-                    Team member{normalizedTeamRole ? ` • ${getPracticeRoleLabel(normalizedTeamRole)}` : ''}
-                  </p>
-                </div>
-              </InteractiveListItem>
-            );
-          }
-          const matters = client.matters ?? [];
-          const retainerMatter = matters.find((m) => readRetainerAmount(m) !== null) ?? client.primaryMatter ?? null;
-          const retainerAmount = readRetainerAmount(retainerMatter);
-          // We don't have a real retainer cap exposed yet — use a placeholder
-          // percent so the bar still gives a sense of presence.
-          // TODO(backend): expose retainer cap + current balance per matter
-          // so this bar can become exact instead of presence-only.
-          const retainerPercent = retainerAmount !== null ? 60 : null;
-          const lastContactSource = client.lastContactDays !== null && client.primaryMatter?.updated_at
-            ? `via ${formatRelativeTime(client.primaryMatter.updated_at)}`
-            : null;
-          const practiceArea = client.primaryMatter?.matter_type ?? null;
-          return (
-            <ClientDirectoryRow
-              key={client.id}
-              id={client.id}
-              name={client.name}
-              matterCount={matters.length}
-              primaryMatter={client.primaryMatter ?? null}
-              practiceArea={practiceArea}
-              retainerAmount={retainerAmount}
-              retainerPercent={retainerPercent}
-              lastContactDays={client.lastContactDays ?? null}
-              lastContactSource={lastContactSource}
-              signal={client.signal ?? 'calm'}
-              isSelected={isSelected}
-              isUrgent={client.signal === 'frustrated'}
-              onSelect={() => handleSelectClient(client)}
-              onMessage={() => { void handleSendMessage(client); }}
-              onCall={client.phone ? () => { window.location.href = `tel:${client.phone}`; } : undefined}
-              onOpenMatters={(() => {
-                const primary = client.primaryMatter;
-                return primary ? () => handleOpenMatter(primary.id) : undefined;
-              })()}
-              onOpenPrimaryMatter={(matterId) => handleOpenMatter(matterId)}
+  const contactRows = useMemo<DataTableRow[]>(() => sortedClients.map((client) => {
+    const matters = client.matters ?? [];
+    const primaryMatter = client.primaryMatter ?? null;
+    const retainerMatter = matters.find((matter) => readRetainerAmount(matter) !== null) ?? primaryMatter;
+    const retainerAmount = readRetainerAmount(retainerMatter);
+    const normalizedTeamRole = normalizePracticeRole(client.teamRole);
+    const roleLabel = normalizedTeamRole ? getPracticeRoleLabel(normalizedTeamRole) : 'Team member';
+    const isClientRecord = client.kind === 'client';
+    const statusLabel = isClientRecord
+      ? (client.status ? STATUS_LABELS[client.status] : 'Contact')
+      : roleLabel;
+    const signal = client.signal ?? 'calm';
+    const lastContactSource = isClientRecord && client.lastContactDays !== null && primaryMatter?.updated_at
+      ? `via ${formatRelativeTime(primaryMatter.updated_at)}`
+      : null;
+
+    return {
+      id: client.id,
+      onClick: () => handleSelectClient(client),
+      className: signal === 'frustrated' ? 'bg-[color-mix(in_oklab,var(--neg)_3%,transparent)]' : undefined,
+      cells: {
+        contact: (
+          <div className="flex min-w-0 items-center gap-3">
+            <Avatar name={client.name} size="md" className={cn('shrink-0 text-ink', signal === 'frustrated' && 'ring-1 ring-neg')} />
+            <div className="min-w-0">
+              <div className="truncate font-[family-name:var(--serif)] text-[17px] leading-tight text-ink">
+                {client.name}
+              </div>
+              <div className="mt-1 truncate text-xs text-dim-2">
+                {isClientRecord ? client.email : `Team member · ${client.email}`}
+              </div>
+            </div>
+          </div>
+        ),
+        status: isClientRecord ? (
+          <Pill tone={contactStatusPillTone(client.status)}>{statusLabel}</Pill>
+        ) : (
+          <Pill tone="dim">{roleLabel}</Pill>
+        ),
+        matters: (
+          <div className="min-w-0">
+            <div className="truncate text-sm text-ink-2">{formatMatterCount(matters.length)}</div>
+            {primaryMatter ? (
+              <div className="mt-1 max-w-full truncate text-xs text-accent">
+                {primaryMatter.title ?? 'Untitled matter'}
+              </div>
+            ) : null}
+          </div>
+        ),
+        retainer: retainerAmount !== null ? (
+          <span className="font-mono tabular-nums text-ink">
+            {retainerAmount.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}
+          </span>
+        ) : (
+          <span className="text-dim-2">—</span>
+        ),
+        lastContact: (
+          <span className="font-mono text-xs uppercase tracking-wider text-ink-2">
+            {isClientRecord ? formatLastContact(client.lastContactDays ?? null) : '—'}
+            {lastContactSource ? <span className="mt-0.5 block text-[10px] normal-case tracking-normal text-dim">{lastContactSource}</span> : null}
+          </span>
+        ),
+        signal: isClientRecord ? (
+          <SignalPill signal={signal} label={signalLabel(signal)} />
+        ) : (
+          <span className="font-mono text-[10.5px] uppercase tracking-wider text-dim-2">Team</span>
+        ),
+        actions: (
+          <div className="flex justify-end gap-1">
+            {isClientRecord ? (
+              <Button
+                variant="icon"
+                size="icon-sm"
+                icon={MessagesSquare}
+                iconClassName="h-4 w-4"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void handleSendMessage(client);
+                }}
+                disabled={!client.userId || sendMessagePending}
+                aria-label={`Message ${client.name}`}
+                title={!client.userId ? 'Messaging requires a linked portal account.' : 'Message'}
+              />
+            ) : null}
+            {isClientRecord && client.phone ? (
+              <Button
+                variant="icon"
+                size="icon-sm"
+                icon={Phone}
+                iconClassName="h-4 w-4"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  window.location.href = `tel:${client.phone}`;
+                }}
+                aria-label={`Call ${client.name}`}
+                title="Call"
+              />
+            ) : null}
+          </div>
+        ),
+      },
+    };
+  }), [handleSelectClient, handleSendMessage, sendMessagePending, sortedClients]);
+
+  const pendingInvitationColumns = useMemo<DataTableColumn[]>(() => [
+    { id: 'invitee', label: 'Invitee', isPrimary: true },
+    { id: 'role', label: 'Role', hideAt: 'sm' },
+    { id: 'status', label: 'Status', hideAt: 'md' },
+    { id: 'expires', label: 'Expires', hideAt: 'sm' },
+    { id: 'actions', label: '', align: 'right', isAction: true, disableCellWrap: true },
+  ], []);
+
+  const pendingInvitationRows = useMemo<DataTableRow[]>(() => sortedPendingInvitations.map((invitation) => {
+    const roleLabel = getPracticeRoleLabel(normalizePracticeRole(invitation.role) ?? 'client');
+    return {
+      id: invitation.id,
+      onClick: () => handleSelectPendingInvitation(invitation),
+      cells: {
+        invitee: (
+          <div className="flex min-w-0 items-center gap-3">
+            <Avatar name={invitation.email} size="md" className="shrink-0 text-ink" />
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-ink">{invitation.email}</div>
+              <div className="mt-1 truncate text-xs text-dim-2">Pending contact invitation</div>
+            </div>
+          </div>
+        ),
+        role: roleLabel,
+        status: <Pill tone="warn">Pending</Pill>,
+        expires: formatDate(new Date(invitation.expiresAt)),
+        actions: (
+          <div className="flex justify-end gap-1">
+            <Button
+              variant="icon"
+              size="icon-sm"
+              icon={Copy}
+              iconClassName="h-4 w-4"
+              onClick={(event) => {
+                event.stopPropagation();
+                void handleCopyPendingInvitationLink(invitation.id);
+              }}
+              aria-label={`Copy invite link for ${invitation.email}`}
+              title="Copy invite link"
             />
-          );
-        })
-      )}
-
-      {prefetchedLoadingMore ? (
-        <div className="px-4 py-3 text-xs text-dim-2 text-center">
-          <LoadingSpinner size="sm" ariaLabel={t('clients.loadingMore', { defaultValue: 'Loading more contacts' })} />
-        </div>
-      ) : null}
-    </div>
-  );
-
-  const pendingInvitationListPane = (
-    <div className="relative h-full min-h-0 overflow-hidden">
-      <div className="h-full overflow-y-auto">
-        <ul className="divide-y divide-line-subtle">
-          {sortedPendingInvitations.map((invitation) => {
-            const isSelected = invitation.id === selectedPendingInvitationFromList?.id;
-            const roleLabel = getPracticeRoleLabel(normalizePracticeRole(invitation.role) ?? 'client');
-            return (
-              <li key={invitation.id}>
-                <InteractiveListItem
-                  onClick={() => handleSelectPendingInvitation(invitation)}
-                  isSelected={isSelected}
-                  padding="px-4 py-3.5"
-                  className="flex-nowrap gap-4 rounded-none h-auto"
-                >
-                  <Avatar
-                    name={invitation.email}
-                    size="md"
-                    className="text-ink"
-                  />
-                  <div className="min-w-0 flex-1 text-left">
-                    <p className="truncate text-sm font-medium text-ink">
-                      {invitation.email}
-                    </p>
-                    <p className="mt-0.5 truncate text-xs text-dim-2">
-                      {roleLabel} invitation • Expires {formatDate(new Date(invitation.expiresAt))}
-                    </p>
-                  </div>
-                </InteractiveListItem>
-              </li>
-            );
-          })}
-          {sortedPendingInvitations.length === 0 ? (
-            <li className="p-6">
-              <PendingEmptyState onInviteClient={handleOpenAddClient} />
-            </li>
-          ) : null}
-        </ul>
-      </div>
-    </div>
-  );
+            {isAdmin ? (
+              <Button
+                variant="icon"
+                size="icon-sm"
+                icon={X}
+                iconClassName="h-4 w-4"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void handleCancelPendingInvitation(invitation.id);
+                }}
+                aria-label={`Cancel invite for ${invitation.email}`}
+                title="Cancel invitation"
+              />
+            ) : null}
+          </div>
+        ),
+      },
+    };
+  }), [handleCancelPendingInvitation, handleCopyPendingInvitationLink, handleSelectPendingInvitation, isAdmin, sortedPendingInvitations]);
 
   const clientDetailBody = selectedClient ? (
     <ClientDetailPanel
@@ -1477,41 +1537,10 @@ export const PracticeContactsPage = ({
     </div>
   ) : null;
 
-  const renderCenteredState = (children: ComponentChildren) => (
-    <div className="h-full flex items-center justify-center">
-      {children}
+  const renderErrorState = (message: string | null) => (
+    <div className="flex min-h-[160px] items-center justify-center px-6 py-10">
+      <p className="text-sm text-dim-2">{message}</p>
     </div>
-  );
-
-  const renderLoadingState = () => renderCenteredState(
-    <LoadingBlock label={t('clients.loading', { defaultValue: 'Loading contacts...' })} />
-  );
-
-  const renderErrorState = (message: string | null) => renderCenteredState(
-    <p className="text-sm text-dim-2">{message}</p>
-  );
-
-  const renderListPanel = ({
-    loading,
-    error,
-    content,
-    useEmptyMinHeight = false,
-  }: {
-    loading: boolean;
-    error: string | null;
-    content: ComponentChildren;
-    useEmptyMinHeight?: boolean;
-  }) => (
-    <Panel className={cn(
-      'list-panel-card-gradient min-h-0 flex-1 overflow-hidden',
-      useEmptyMinHeight && 'min-h-[520px]'
-    )}>
-      {loading
-        ? renderLoadingState()
-        : error
-          ? renderErrorState(error)
-          : content}
-    </Panel>
   );
 
   const renderDetailShell = ({
@@ -1721,13 +1750,26 @@ export const PracticeContactsPage = ({
 
           {/* ── Directory ───────────────────────────────────────────── */}
           <div className="mt-0 overflow-hidden rounded-b-md border border-t-0 border-line-subtle bg-card">
-            {clientsLoading ? (
-              <div className="p-6">{renderLoadingState()}</div>
-            ) : clientsError ? (
-              <div className="p-6">{renderErrorState(clientsError)}</div>
-            ) : (
-              directoryListPane
-            )}
+            <DataTable
+              columns={contactColumns}
+              rows={contactRows}
+              loading={clientsLoading}
+              isLoadingMore={prefetchedLoadingMore}
+              errorState={clientsError ? renderErrorState(clientsError) : undefined}
+              emptyState={(
+                <ContactTableEmptyState
+                  title={activeFilter === 'all' ? 'No contacts found' : 'No contacts found for this filter'}
+                  description={activeFilter === 'all'
+                    ? 'Create a contact to track client details, matters, retainers, and recent communication.'
+                    : 'Adjust the contact filters or create a new contact if this person is not in your directory.'}
+                  actionLabel="Create Contact"
+                  onAction={handleOpenAddClient}
+                />
+              )}
+              density="compact"
+              className="gap-0"
+              tableClassName="bg-card"
+            />
           </div>
 
           {/* Foot summary */}
@@ -1747,52 +1789,7 @@ export const PracticeContactsPage = ({
     );
   };
 
-  const listPanelContent = isPendingListRoute
-    ? {
-        content: <div className="min-h-0 flex-1">{pendingInvitationListPane}</div>,
-        useEmptyMinHeight: true,
-      }
-    : {
-        content: <div className="min-h-0 flex-1 overflow-y-auto">{directoryListPane}</div>,
-        useEmptyMinHeight: sortedClients.length === 0 || clientsLoading || Boolean(clientsError),
-      };
-
   const hasSelectedDetail = Boolean(selectedPendingInvitationIdFromPath || selectedClientIdFromPath);
-
-  if (renderMode === 'listOnly') {
-    if (!isPendingListRoute && !clientsLoading && !clientsError && sortedClients.length === 0) {
-      return null;
-    }
-
-    return (
-      <div className="h-full min-h-0 overflow-hidden flex flex-col gap-2">
-        {/* Filter row above the list when in listOnly (split view's left pane). */}
-        {!isPendingListRoute ? (
-          <div className="px-3 pt-2 sm:px-4">
-            {renderFilterRow()}
-          </div>
-        ) : null}
-        {renderListPanel({
-          loading: clientsLoading,
-          error: clientsError,
-          ...listPanelContent,
-        })}
-      </div>
-    );
-  }
-
-  if (renderMode === 'detailOnly') {
-    return (
-      <>
-        {renderDetailShell({
-          title: detailConfig.title,
-          body: detailConfig.body,
-          leadingAction: detailHeaderLeadingAction,
-          actions: detailHeaderActions,
-        })}
-      </>
-    );
-  }
 
   if (hasSelectedDetail) {
     return (
@@ -1809,22 +1806,45 @@ export const PracticeContactsPage = ({
     );
   }
 
-  // ── chat-first full-page (no selection, full renderMode) ──────────────
+  // ── chat-first full-page (no selection) ──────────────────────────────
   if (!isPendingListRoute) {
     return renderChatFirstListPage();
   }
 
-  // Pending invitations: preserve legacy panel-list rendering.
   return (
-    <>
-      <div className="h-full min-h-0 overflow-hidden flex flex-col gap-2">
-        {renderListPanel({
-          loading: clientsLoading,
-          error: clientsError,
-          content: listPanelContent.content,
-          useEmptyMinHeight: listPanelContent.useEmptyMinHeight,
-        })}
+    <div className="flex h-full min-h-0 flex-col overflow-auto">
+      <div className="mx-auto w-full max-w-[1280px] px-4 pb-12 pt-6 sm:px-8 sm:pt-7 md:px-10">
+        <header className="flex flex-wrap items-end justify-between gap-3 border-b border-line-subtle pb-5 sm:gap-4">
+          <div className="min-w-0">
+            <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-dim">
+              Contacts · {sortedPendingInvitations.length} pending
+            </div>
+            <h1 className="mt-1.5 font-[family-name:var(--serif)] text-[32px] font-normal leading-[1.05] tracking-[-0.022em] text-ink sm:text-[44px] sm:leading-none lg:text-[56px]">
+              Pending invitations
+            </h1>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="secondary" size="sm" onClick={handleOpenTeamInvite}>
+              Invite Team Member
+            </Button>
+            <Button variant="primary" size="sm" icon={Plus} onClick={handleOpenAddClient}>
+              New Contact
+            </Button>
+          </div>
+        </header>
+        <div className="mt-5 overflow-hidden rounded-md border border-line-subtle bg-card">
+          <DataTable
+            columns={pendingInvitationColumns}
+            rows={pendingInvitationRows}
+            loading={clientsLoading}
+            errorState={clientsError ? renderErrorState(clientsError) : undefined}
+            emptyState={<PendingEmptyState onInviteClient={handleOpenAddClient} />}
+            density="compact"
+            className="gap-0"
+            tableClassName="bg-card"
+          />
+        </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/src/features/engagements/api/engagementsApi.ts
+++ b/src/features/engagements/api/engagementsApi.ts
@@ -49,6 +49,18 @@ type PatchEngagementContractPayload = {
 const mutationError = (error: unknown, defaultMessage: string): Error => {
   if (isHttpError(error)) {
     const data = error.response.data as { message?: string; error?: string } | undefined;
+    console.error('[engagementsApi] Engagement request failed', {
+      status: error.response.status,
+      data: error.response.data,
+    });
+    try {
+      console.error(`[engagementsApi] Engagement request failed details ${JSON.stringify({
+        status: error.response.status,
+        data: error.response.data,
+      })}`);
+    } catch {
+      // The structured log above still carries the response body if stringifying fails.
+    }
     const message = data?.message ?? data?.error;
     return new Error(message ? String(message) : `${defaultMessage} (HTTP ${error.response.status})`);
   }
@@ -69,62 +81,127 @@ const requireString = (data: Record<string, unknown>, field: string): string => 
 const optionalString = (value: unknown): string | null =>
   typeof value === 'string' && value.length > 0 ? value : null;
 
+const optionalNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+const requireRecord = (
+  data: Record<string, unknown>,
+  field: string,
+  engagementId: string
+): Record<string, unknown> => {
+  const value = data[field];
+  if (!value || typeof value !== 'object') {
+    throw new Error(`Engagement ${engagementId} is missing ${field}`);
+  }
+  return value as Record<string, unknown>;
+};
+
+const logInvalidEngagementContract = (raw: unknown, error: Error) => {
+  if (typeof console === 'undefined') return;
+  const data = asRecord(raw);
+  const proposalData = asRecord(data.proposal_data);
+  const clientSummary = asRecord(proposalData.client_summary);
+  const fees = asRecord(proposalData.fees);
+  const details = {
+    error: error.message,
+    id: data.id,
+    keys: Object.keys(data),
+    proposalDataKeys: Object.keys(proposalData),
+    clientSummaryKeys: Object.keys(clientSummary),
+    feesKeys: Object.keys(fees),
+  };
+  console.error('[engagementsApi] Invalid engagement contract payload', details);
+  console.error(`[engagementsApi] Invalid engagement contract payload details ${JSON.stringify(details)}`);
+};
+
 const parseContractListPayload = (raw: unknown): EngagementContractListPayload => {
   const data = asRecord(raw);
-  if (!Array.isArray(data.data)) {
+  const list = data.data;
+  if (!Array.isArray(list)) {
     throw new Error('Engagement contract list is missing data');
   }
+
   const pagination = asRecord(data.pagination);
-  if (
-    typeof pagination.page !== 'number'
-    || typeof pagination.limit !== 'number'
-    || typeof pagination.total !== 'number'
-  ) {
+  const page = optionalNumber(pagination.page);
+  const limit = optionalNumber(pagination.limit);
+  const total = optionalNumber(pagination.total);
+
+  if (page === null || limit === null || total === null) {
     throw new Error('Engagement contract list is missing pagination');
   }
+
   return {
-    data: data.data,
+    data: list,
     pagination: {
-      page: pagination.page,
-      limit: pagination.limit,
-      total: pagination.total,
+      page,
+      limit,
+      total,
     },
   };
 };
 
 const normalizeEngagementContract = (raw: unknown): EngagementDetail => {
-  const data = asRecord(raw);
-  if (!data.id) throw new Error('Engagement not found');
-  if (typeof data.status !== 'string' || !ENGAGEMENT_STATUSES.includes(data.status as EngagementStatus)) {
-    throw new Error('Engagement has an invalid status');
+  try {
+    const data = asRecord(raw);
+    const id = requireString(data, 'id');
+    if (typeof data.status !== 'string' || !ENGAGEMENT_STATUSES.includes(data.status as EngagementStatus)) {
+      throw new Error(`Engagement ${id} has an invalid status`);
+    }
+
+    const proposalData = requireRecord(data, 'proposal_data', id) as unknown as ProposalData;
+    const proposalRecord = proposalData as unknown as Record<string, unknown>;
+    const clientSummary = requireRecord(proposalRecord, 'client_summary', id);
+    requireRecord(proposalRecord, 'fees', id);
+    const sourceSnapshot = proposalData.source_snapshot;
+    const clientName = requireString(clientSummary, 'client_name');
+    const matterSummary = requireString(clientSummary, 'matter_summary');
+
+    return {
+      ...(data as unknown as EngagementDetail),
+      id,
+      matter_id: optionalString(data.matter_id),
+      intake_id: requireString(data, 'intake_id'),
+      organization_id: requireString(data, 'organization_id'),
+      status: data.status as EngagementStatus,
+      proposal_data: proposalData,
+      client_name: clientName,
+      client_email: optionalString(data.client_email),
+      title: matterSummary,
+      description: matterSummary,
+      conversation_id: sourceSnapshot?.conversation_id ?? optionalString(data.conversation_id),
+      practice_area: sourceSnapshot?.practice_area ?? optionalString(data.practice_area),
+      urgency: sourceSnapshot?.urgency ?? optionalString(data.urgency),
+      opposing_party: sourceSnapshot?.opposing_party ?? optionalString(data.opposing_party),
+      desired_outcome: sourceSnapshot?.desired_outcome ?? optionalString(data.desired_outcome),
+      created_at: requireString(data, 'created_at'),
+      updated_at: optionalString(data.updated_at),
+    };
+  } catch (error) {
+    const normalizedError = error instanceof Error ? error : new Error('Engagement contract payload is invalid');
+    logInvalidEngagementContract(raw, normalizedError);
+    throw normalizedError;
+  }
+};
+
+const normalizeEngagementContractList = (
+  data: EngagementContractListPayload,
+  allowedStatuses: Set<string>,
+): { items: EngagementDetail[]; rejectedCount: number } => {
+  const items: EngagementDetail[] = [];
+  let rejectedCount = 0;
+
+  for (const rawItem of data.data) {
+    try {
+      const item = normalizeEngagementContract(rawItem);
+      if (allowedStatuses.has(item.status)) {
+        items.push(item);
+      }
+    } catch {
+      rejectedCount += 1;
+    }
   }
 
-  const proposalData = data.proposal_data && typeof data.proposal_data === 'object'
-    ? data.proposal_data as ProposalData
-    : null;
-  const clientSummary = proposalData?.client_summary;
-  const sourceSnapshot = proposalData?.source_snapshot;
-
-  return {
-    ...(data as unknown as EngagementDetail),
-    id: requireString(data, 'id'),
-    matter_id: optionalString(data.matter_id),
-    intake_id: requireString(data, 'intake_id'),
-    organization_id: requireString(data, 'organization_id'),
-    status: data.status as EngagementStatus,
-    proposal_data: proposalData,
-    client_name: clientSummary?.client_name ?? null,
-    client_email: optionalString(data.client_email),
-    title: clientSummary?.matter_summary ?? null,
-    description: clientSummary?.matter_summary ?? null,
-    conversation_id: sourceSnapshot?.conversation_id ?? null,
-    practice_area: sourceSnapshot?.practice_area ?? null,
-    urgency: sourceSnapshot?.urgency ?? null,
-    opposing_party: sourceSnapshot?.opposing_party ?? null,
-    desired_outcome: sourceSnapshot?.desired_outcome ?? null,
-    created_at: requireString(data, 'created_at'),
-    updated_at: optionalString(data.updated_at),
-  };
+  return { items, rejectedCount };
 };
 
 const invalidateEngagementLifecycleCaches = (practiceId: string, engagement?: EngagementDetail | null) => {
@@ -189,9 +266,8 @@ export async function listEngagements(
   }
 
   const data = parseContractListPayload(raw);
-  const allItems = data.data.map(normalizeEngagementContract);
-  const items = allItems.filter((item) => allowedStatuses.has(item.status));
-  const total = data.pagination.total;
+  const { items, rejectedCount } = normalizeEngagementContractList(data, allowedStatuses);
+  const total = Math.max(0, data.pagination.total - rejectedCount);
   const total_pages = Math.max(1, Math.ceil(total / requestedLimit));
 
   return {

--- a/src/features/engagements/pages/EngagementsPage.tsx
+++ b/src/features/engagements/pages/EngagementsPage.tsx
@@ -5,9 +5,9 @@ import { Briefcase, Plus } from 'lucide-preact';
 
 import { Button } from '@/shared/ui/Button';
 import { Seg } from '@/design-system/patterns';
-import { EntityList } from '@/shared/ui/list/EntityList';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { InfiniteScroll } from '@/shared/ui/layout/InfiniteScroll';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
 import { queryCache } from '@/shared/lib/queryCache';
 import { policyTtl } from '@/shared/lib/cachePolicy';
@@ -74,8 +74,7 @@ const StatusPill: FunctionComponent<{ status: EngagementStatus | string | undefi
 const getMatterLabel = (item: EngagementListItem): string => {
   const proposalSummary = item.proposal_data?.client_summary?.matter_summary;
   if (proposalSummary && proposalSummary.trim()) return proposalSummary;
-  if (item.title && item.title.trim()) return item.title;
-  return '—';
+  throw new Error(`Engagement ${item.id} is missing proposal_data.client_summary.matter_summary`);
 };
 
 const getBillingLabel = (fees: ProposalFees | null | undefined): string => {
@@ -104,7 +103,10 @@ const EngagementMobileCard: FunctionComponent<{
   item: EngagementListItem;
   onClick: () => void;
 }> = ({ item, onClick }) => {
-  const name = item.client_name || 'Unknown Client';
+  const name = item.client_name;
+  if (!name) {
+    throw new Error(`Engagement ${item.id} is missing client_name`);
+  }
   const matter = getMatterLabel(item);
   const retainer = getRetainerLabel(item.proposal_data?.fees);
 
@@ -178,13 +180,8 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
       // reuses the result instead of re-hitting the backend. Keyed by practice
       // + status filter + page; invalidated on create/action handlers below.
       //
-      // We intentionally do NOT forward usePaginatedList's per-mount abort
-      // signal into the cached fetch. usePaginatedList runs its fetch effect
-      // twice on mount (its reset effect bumps a counter), aborting the first
-      // run; coalesceGet's single-flight would then tie the surviving second
-      // call to the first (aborted) promise, leaving the list permanently
-      // empty. Letting the request finish also warms the cache for the next
-      // visit — stale results are ignored by usePaginatedList's requestId guard.
+      // Let the cached request finish even if this list unmounts quickly; the
+      // result warms the cache for the next visit and avoids a repeat page load.
       const cacheKey = `engagement:list:${practiceId}:${activeTab}:p${page}`;
       const result = await queryCache.coalesceGet(
         cacheKey,
@@ -259,10 +256,13 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
     );
   }
 
-  const showEmpty = !isLoading && !error && engagements.length === 0 && !hasMore;
+  const showEmpty = !isLoading && !error && engagements.length === 0;
+  const emptyTitle = activeTab === 'all'
+    ? 'No engagements found'
+    : `No ${activeTab} engagements found`;
   const emptyMessage = activeTab === 'all'
-    ? 'When you accept an intake and begin drafting an engagement letter, it will appear here.'
-    : `No ${activeTab} engagements yet.`;
+    ? 'Create an engagement to draft, send, and track a client engagement letter.'
+    : `Create an engagement or switch filters to see ${activeTab} engagement letters.`;
 
   return (
     <div className="flex h-full flex-col min-h-0 bg-paper">
@@ -291,45 +291,62 @@ export const EngagementsPage: FunctionComponent<EngagementsPageProps> = ({
         ) : showEmpty ? (
           <WorkspacePlaceholderState
             icon={Briefcase}
-            title="No engagements yet"
+            title={emptyTitle}
             description={emptyMessage}
-            primaryAction={{ label: 'New Engagement', onClick: handleOpenCreate, icon: Plus, disabled: !practiceId }}
+            primaryAction={{ label: 'Create Engagement', onClick: handleOpenCreate, icon: Plus, disabled: !practiceId }}
             className="p-8"
           />
         ) : (
           <>
             {/* Desktop table */}
             <div className="hidden md:block px-6 py-4">
-              <EntityList
-                items={engagements}
-                onSelect={handleSelectEngagement}
-                isLoading={isLoading && engagements.length === 0}
-                isLoadingMore={isLoadingMore}
-                onLoadMore={hasMore ? loadMore : undefined}
-                className="panel overflow-hidden"
-                renderItem={(item) => (
-                  <div className="flex w-full items-center gap-4 px-4 py-3">
-                    <span className="min-w-[160px] flex-1 truncate text-sm font-medium text-ink">
-                      {item.client_name || 'Unknown Client'}
-                    </span>
-                    <span className="min-w-[160px] flex-1 truncate text-sm text-dim-2">
-                      {getMatterLabel(item)}
-                    </span>
-                    <span className="hidden min-w-[100px] text-sm text-dim-2 md:block">
-                      {getBillingLabel(item.proposal_data?.fees)}
-                    </span>
-                    <span className="min-w-[80px] text-sm">
-                      <StatusPill status={item.status} />
-                    </span>
-                    <span className="hidden min-w-[100px] text-right text-sm tabular-nums text-dim-2 lg:block">
-                      {item.sent_at ? formatRelativeTime(item.sent_at) : '—'}
-                    </span>
-                    <span className="min-w-[100px] text-right text-sm font-medium tabular-nums text-ink">
-                      {getRetainerLabel(item.proposal_data?.fees)}
-                    </span>
+              <div className="panel overflow-hidden">
+                {isLoading && engagements.length === 0 ? (
+                  <div className="flex justify-center px-4 py-6">
+                    <LoadingSpinner size="sm" ariaLabel="Loading engagements" announce={false} />
                   </div>
+                ) : (
+                  <>
+                    {engagements.map((item) => (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => handleSelectEngagement(item)}
+                        className="flex w-full items-center gap-4 border-b border-line-subtle px-4 py-3 text-left transition-colors hover:bg-paper-2/40"
+                      >
+                        <span className="min-w-[160px] flex-1 truncate text-sm font-medium text-ink">
+                          {item.client_name}
+                        </span>
+                        <span className="min-w-[160px] flex-1 truncate text-sm text-dim-2">
+                          {getMatterLabel(item)}
+                        </span>
+                        <span className="hidden min-w-[100px] text-sm text-dim-2 md:block">
+                          {getBillingLabel(item.proposal_data?.fees)}
+                        </span>
+                        <span className="min-w-[80px] text-sm">
+                          <StatusPill status={item.status} />
+                        </span>
+                        <span className="hidden min-w-[100px] text-right text-sm tabular-nums text-dim-2 lg:block">
+                          {item.sent_at ? formatRelativeTime(item.sent_at) : '-'}
+                        </span>
+                        <span className="min-w-[100px] text-right text-sm font-medium tabular-nums text-ink">
+                          {getRetainerLabel(item.proposal_data?.fees)}
+                        </span>
+                      </button>
+                    ))}
+                    {isLoadingMore ? (
+                      <div className="flex justify-center px-4 py-3">
+                        <LoadingSpinner size="sm" ariaLabel="Loading more engagements" announce={false} />
+                      </div>
+                    ) : null}
+                    {hasMore && !isLoadingMore ? (
+                      <div className="border-t border-line-subtle px-4 py-3 text-center">
+                        <Button variant="secondary" onClick={loadMore}>Load More</Button>
+                      </div>
+                    ) : null}
+                  </>
                 )}
-              />
+              </div>
             </div>
 
             {/* Mobile cards */}

--- a/src/features/engagements/types/engagement.ts
+++ b/src/features/engagements/types/engagement.ts
@@ -19,8 +19,8 @@ export type JurisdictionStatus = 'supported' | 'unsupported' | 'unknown';
 export interface RiskReview {
   conflict_status: ConflictStatus;
   jurisdiction_status: JurisdictionStatus;
-  risk_notes?: string[] | null;
-  open_questions?: string[] | null;
+  risk_notes: string[];
+  open_questions: string[];
   conflict_note?: string | null;
 }
 
@@ -28,28 +28,28 @@ export interface RiskReview {
 
 export interface ProposalRepresentation {
   scope_summary: string;
-  included_services?: string[] | null;
-  excluded_services?: string[] | null;
-  client_identity_notes?: string | null;
-  jurisdiction_notes?: string | null;
+  included_services: string[];
+  excluded_services: string[];
+  client_identity_notes: string;
+  jurisdiction_notes: string;
 }
 
 export interface ProposalFees {
-  billing_type?: string | null;
+  billing_type: string;
   fixed_fee_amount?: number | null;
   hourly_rate_attorney?: number | null;
   hourly_rate_admin?: number | null;
   contingency_percentage?: number | null;
   retainer_amount?: number | null;
   payment_frequency?: string | null;
-  fee_notes?: string | null;
+  fee_notes: string;
 }
 
 export interface ProposalClientSummary {
-  matter_summary?: string | null;
-  location_summary?: string | null;
-  goals_summary?: string | null;
-  client_name?: string | null;
+  matter_summary: string;
+  location_summary: string;
+  goals_summary: string;
+  client_name: string;
   co_clients?: string[] | null;
   non_clients?: string[] | null;
 }
@@ -67,13 +67,13 @@ export interface ProposalData {
   client_summary: ProposalClientSummary;
   draft_meta: ProposalDraftMeta;
   source_snapshot?: {
-    intake_uuid?: string | null;
-    conversation_id?: string | null;
-    matter_id?: string | null;
-    practice_area?: string | null;
-    urgency?: string | null;
-    desired_outcome?: string | null;
-    opposing_party?: string | null;
+    intake_uuid: string;
+    conversation_id: string;
+    matter_id: string;
+    practice_area: string;
+    urgency: string;
+    desired_outcome: string;
+    opposing_party: string;
     court_date?: string | null;
   } | null;
   acknowledgment_language?: string | null;

--- a/src/features/engagements/utils/engagementDraft.ts
+++ b/src/features/engagements/utils/engagementDraft.ts
@@ -85,6 +85,8 @@ const nullableString = (value: string): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
+const requiredString = (value: string): string => value.trim();
+
 const numberOrNull = (value: string): number | null => {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -92,13 +94,11 @@ const numberOrNull = (value: string): number | null => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 
-const lines = (value: string): string[] | null => {
-  const entries = value
+const lineEntries = (value: string): string[] =>
+  value
     .split('\n')
     .map((entry) => entry.trim())
     .filter(Boolean);
-  return entries.length > 0 ? entries : null;
-};
 
 const firstString = (...values: unknown[]): string => {
   for (const value of values) {
@@ -168,45 +168,45 @@ export const buildEngagementDraftFormFromIntake = (
 
 export const buildProposalDataFromDraft = (form: EngagementDraftForm): ProposalData => {
   const fees: ProposalFees = {
-    billing_type: nullableString(form.billingType),
+    billing_type: requiredString(form.billingType),
     fixed_fee_amount: numberOrNull(form.fixedFeeAmount),
     hourly_rate_attorney: numberOrNull(form.hourlyRateAttorney),
     hourly_rate_admin: numberOrNull(form.hourlyRateAdmin),
     contingency_percentage: numberOrNull(form.contingencyPercentage),
     retainer_amount: numberOrNull(form.retainerAmount),
     payment_frequency: nullableString(form.paymentFrequency),
-    fee_notes: nullableString(form.feeNotes),
+    fee_notes: requiredString(form.feeNotes),
   };
 
   return {
     client_summary: {
-      client_name: nullableString(form.clientName),
-      matter_summary: nullableString(form.matterSummary),
-      location_summary: nullableString(form.locationSummary),
-      goals_summary: nullableString(form.goalsSummary),
+      client_name: requiredString(form.clientName),
+      matter_summary: requiredString(form.matterSummary),
+      location_summary: requiredString(form.locationSummary),
+      goals_summary: requiredString(form.goalsSummary),
     },
     representation: {
       scope_summary: form.scopeSummary.trim(),
-      included_services: lines(form.includedServices),
-      excluded_services: lines(form.excludedServices),
-      client_identity_notes: nullableString(form.clientIdentityNotes),
-      jurisdiction_notes: nullableString(form.jurisdictionNotes),
+      included_services: lineEntries(form.includedServices),
+      excluded_services: lineEntries(form.excludedServices),
+      client_identity_notes: requiredString(form.clientIdentityNotes),
+      jurisdiction_notes: requiredString(form.jurisdictionNotes),
     },
     fees,
     risk_review: {
       conflict_status: form.conflictStatus,
       jurisdiction_status: form.jurisdictionStatus,
-      risk_notes: lines(form.riskNotes),
-      open_questions: lines(form.openQuestions),
+      risk_notes: lineEntries(form.riskNotes),
+      open_questions: lineEntries(form.openQuestions),
     },
     source_snapshot: {
-      intake_uuid: nullableString(form.intakeId),
-      conversation_id: nullableString(form.conversationId),
-      matter_id: nullableString(form.matterId),
-      practice_area: nullableString(form.practiceArea),
-      urgency: nullableString(form.urgency),
-      desired_outcome: nullableString(form.desiredOutcome),
-      opposing_party: nullableString(form.opposingParty),
+      intake_uuid: requiredString(form.intakeId),
+      conversation_id: requiredString(form.conversationId),
+      matter_id: requiredString(form.matterId),
+      practice_area: requiredString(form.practiceArea),
+      urgency: requiredString(form.urgency),
+      desired_outcome: requiredString(form.desiredOutcome),
+      opposing_party: requiredString(form.opposingParty),
       court_date: nullableString(form.courtDate),
     },
     draft_meta: {
@@ -223,8 +223,8 @@ export const buildDeterministicContractBody = (form: EngagementDraftForm): strin
   const scopeSummary = form.scopeSummary.trim() || matterSummary;
   const goalsSummary = form.goalsSummary.trim();
   const feeNotes = form.feeNotes.trim();
-  const included = lines(form.includedServices);
-  const excluded = lines(form.excludedServices);
+  const included = lineEntries(form.includedServices);
+  const excluded = lineEntries(form.excludedServices);
 
   return [
     `Engagement Letter for ${clientName}`,
@@ -233,8 +233,8 @@ export const buildDeterministicContractBody = (form: EngagementDraftForm): strin
     '',
     'Scope of Representation',
     scopeSummary,
-    included ? `Included services:\n${included.map((item) => `- ${item}`).join('\n')}` : '',
-    excluded ? `Excluded services:\n${excluded.map((item) => `- ${item}`).join('\n')}` : '',
+    included.length ? `Included services:\n${included.map((item) => `- ${item}`).join('\n')}` : '',
+    excluded.length ? `Excluded services:\n${excluded.map((item) => `- ${item}`).join('\n')}` : '',
     goalsSummary ? `Client goals:\n${goalsSummary}` : '',
     '',
     'Fees and Billing',

--- a/src/features/invoices/components/InvoicesTable.tsx
+++ b/src/features/invoices/components/InvoicesTable.tsx
@@ -286,7 +286,7 @@ export const InvoicesTable: FunctionComponent<InvoicesTableProps> = ({
         rows={rows}
         caption="Invoices"
         toolbar={toolbar}
-        emptyState={emptyMessage ?? 'No invoices found'}
+        emptyState={emptyMessage ?? 'No invoices found. Create an invoice to bill a client or matter.'}
         errorState={error ? (
           <div className="panel rounded-r-md p-4 text-sm text-red-300">
             Failed to load invoices: {error}

--- a/src/features/invoices/pages/ClientInvoicesPage.tsx
+++ b/src/features/invoices/pages/ClientInvoicesPage.tsx
@@ -27,9 +27,9 @@ const CLIENT_INVOICE_TAB_OPTIONS: ReadonlyArray<{ value: ClientInvoiceTabId; lab
 
 const InvoicesEmptyState = ({ hasFilters }: { hasFilters: boolean }) => (
   <WorkspacePlaceholderState
-    title={hasFilters ? 'No invoices match these filters' : 'No invoices yet'}
+    title={hasFilters ? 'No invoices found for these filters' : 'No invoices found'}
     description={hasFilters
-      ? 'Try adjusting your filters to see more invoices.'
+      ? 'Adjust the invoice filters to look for paid, unpaid, or open invoices.'
       : 'Invoices shared with you will appear here.'}
     className="p-8"
   />

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -69,11 +69,11 @@ const InvoicesEmptyState = ({
   onCreateInvoice?: () => void;
 }) => (
   <WorkspacePlaceholderState
-    title={hasFilters ? 'No invoices match these filters' : 'No invoices yet'}
+    title={hasFilters ? 'No invoices found for these filters' : 'No invoices found'}
     description={hasFilters
-      ? 'Try adjusting your filters to see more invoices.'
+      ? 'Adjust the invoice filters or create a new invoice if this bill has not been started.'
       : 'Create your first invoice here, or link one to a matter later.'}
-    primaryAction={hasFilters ? undefined : (onCreateInvoice ? { label: 'New Invoice', onClick: onCreateInvoice } : undefined)}
+    primaryAction={hasFilters ? undefined : (onCreateInvoice ? { label: 'Create Invoice', onClick: onCreateInvoice } : undefined)}
     className="p-8"
   />
 );
@@ -474,7 +474,7 @@ export function PracticeInvoicesPage({
             hasMore={hasMore}
             onLoadMore={loadMore}
             error={error}
-            emptyMessage={hasFilters ? 'No invoices match these filters.' : undefined}
+            emptyMessage={hasFilters ? 'No invoices found for these filters. Adjust the filters or create a new invoice.' : undefined}
             onRowClick={handleRowClick}
             onViewCustomer={handleViewCustomer}
             onSendInvoice={handleSendInvoice}

--- a/src/features/matters/components/MatterAskCard.tsx
+++ b/src/features/matters/components/MatterAskCard.tsx
@@ -23,12 +23,12 @@ export interface MatterAskCardProps {
  * MatterAskCard — pinned chat card scoped to a single matter
  * (per design_handoff_blawby_chat_first/screens/Matter.html ".ask-card").
  *
- * Dark-ink card rendered in the right rail of the matter detail. Distinct
+ * Theme-aware card rendered in the right rail of the matter detail. Distinct
  * from `AIAskBar`:
  *   - `AIAskBar` is the global one-off ask on list views (paper card, sticky
  *     bottom, suggestions as pills).
  *   - `MatterAskCard` is permanently scoped to one matter and lives in the
- *     right rail (ink card, suggestions as tappable underlined links).
+ *     right rail (card surface, suggestions as tappable underlined links).
  *
  * TODO(backend): wire onSubmit to `/api/practice/:id/matters/:matterId/ask`
  * once the scoped-context practice-assistant route exists. Today the stub
@@ -74,7 +74,7 @@ export const MatterAskCard = ({
   return (
     <section
       aria-label="Ask about this matter"
-      className="rounded-md bg-[color:var(--ink)] p-4 text-[color:var(--paper)] shadow-[var(--shadow-2)]"
+      className="card flex flex-col gap-3 p-4 text-ink"
     >
       <div className="flex items-center gap-2.5">
         <div
@@ -84,18 +84,17 @@ export const MatterAskCard = ({
           B
         </div>
         <div className="min-w-0 leading-tight">
-          <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-[color-mix(in_oklab,var(--paper)_50%,transparent)]">
+          <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-dim-2">
             {contextLabel}
           </div>
-          <h4 className="font-[family-name:var(--serif)] text-base font-normal text-[color:var(--paper)]">
+          <h4 className="font-[family-name:var(--serif)] text-base font-normal text-ink">
             Ask about this matter
           </h4>
         </div>
       </div>
 
-      <form onSubmit={handleSubmit} className="mt-3 flex flex-col gap-3" role="search">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3" role="search">
         <Composer
-          className="composer--inverse"
           placeholder={placeholder}
           value={value}
           inputMode="single-line"
@@ -124,7 +123,7 @@ export const MatterAskCard = ({
                 <button
                   type="button"
                   onClick={() => submit(suggestion)}
-                  className="flex w-full items-center gap-2 py-1 text-left font-[family-name:var(--sans)] text-[12.5px] text-[color:var(--accent)] transition-colors hover:text-[color-mix(in_oklab,var(--accent)_80%,white)]"
+                  className="flex w-full items-center gap-2 py-1 text-left font-[family-name:var(--sans)] text-[12.5px] text-accent-deep transition-colors hover:text-accent dark:text-accent dark:hover:text-accent-deep"
                 >
                   <span aria-hidden="true" className="font-[family-name:var(--serif)] italic opacity-70">
                     ›

--- a/src/features/matters/components/billing/InvoicesSection.tsx
+++ b/src/features/matters/components/billing/InvoicesSection.tsx
@@ -75,7 +75,7 @@ export const InvoicesSection = ({
       invoices={summaries}
       loading={loading}
       error={error}
-      emptyMessage="No invoices yet for this matter."
+      emptyMessage="No invoices found for this matter. Create an invoice from this matter when there is work to bill."
       onRowClick={(invoice) => {
         const sourceInvoice = invoiceById.get(invoice.id);
         if (sourceInvoice) {

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -162,6 +162,19 @@ const FILTER_CHIP_OPTIONS: ReadonlyArray<{ id: MatterRiskFilter; label: string }
   { id: 'assigned_me', label: 'Assigned to me' },
 ];
 
+const filterChipBaseClass =
+  'relative inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 font-mono text-[10.5px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50';
+const filterChipActiveClass =
+  `${filterChipBaseClass} border border-[rgb(var(--sidebar-border))] bg-[rgb(var(--sidebar-active-bg))] pl-3 text-ink before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-0.5 before:rounded-full before:bg-accent before:content-['']`;
+const filterChipInactiveClass =
+  `${filterChipBaseClass} border border-dashed border-line-utility bg-transparent text-dim hover:border-line-emphasized hover:bg-[rgb(var(--sidebar-hover-bg))] hover:text-ink-2`;
+const mobileFilterChipBaseClass =
+  'relative flex w-full items-center justify-between rounded-lg border px-4 py-3 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50';
+const mobileFilterChipActiveClass =
+  `${mobileFilterChipBaseClass} border-[rgb(var(--sidebar-border))] bg-[rgb(var(--sidebar-active-bg))] pl-5 text-ink before:absolute before:left-2 before:top-3 before:bottom-3 before:w-0.5 before:rounded-full before:bg-accent before:content-['']`;
+const mobileFilterChipInactiveClass =
+  `${mobileFilterChipBaseClass} border-line-subtle bg-paper-2 text-ink-2 hover:bg-[rgb(var(--sidebar-hover-bg))] hover:text-ink`;
+
 // Risk signal derivation from matter data. We only have urgency + updated_at
 // in the prefetched list payload — per-row event counts and retainer % live in
 // the matter detail and don't fan out to the list (would be N+1). So:
@@ -2505,12 +2518,8 @@ export const PracticeMattersPage = ({
                   type="button"
                   onClick={() => toggleFilter(chip.id)}
                   aria-pressed={isOn}
-                  className={
-                    isOn
-                      ? 'inline-flex items-center gap-1.5 rounded-[2px] border border-solid bg-[var(--accent-soft)] px-2.5 py-1 font-mono text-[10.5px] uppercase tracking-wider text-[var(--accent-deep)] transition-colors'
-                      : 'inline-flex items-center gap-1.5 rounded-[2px] border border-dashed border-line-utility bg-transparent px-2.5 py-1 font-mono text-[10.5px] uppercase tracking-wider text-dim transition-colors hover:border-line-emphasized hover:text-ink-2'
-                  }
-                  style={isOn ? { borderColor: 'color-mix(in oklab, var(--accent) 40%, var(--rule))' } : undefined}
+                  className={isOn ? filterChipActiveClass : filterChipInactiveClass}
+                  style={isOn ? { color: 'var(--ink)' } : undefined}
                 >
                   {chip.label}
                   {isOn ? <span className="text-dim-2">×</span> : null}
@@ -2648,11 +2657,8 @@ export const PracticeMattersPage = ({
                   type="button"
                   onClick={() => toggleFilter(chip.id)}
                   aria-pressed={isOn}
-                  className={`flex w-full items-center justify-between rounded-md border px-4 py-3 text-sm transition-colors ${
-                    isOn
-                      ? 'border-line-emphasized bg-[var(--accent-soft)] text-ink'
-                      : 'border-line-subtle bg-paper-2 text-ink-2 hover:bg-rule-soft'
-                  }`}
+                  className={isOn ? mobileFilterChipActiveClass : mobileFilterChipInactiveClass}
+                  style={isOn ? { color: 'var(--ink)' } : undefined}
                 >
                   <span>{chip.label}</span>
                   {isOn ? <span className="font-mono text-xs text-dim-2">×</span> : null}

--- a/src/features/practice-onboarding/components/OnboardingDialogs.tsx
+++ b/src/features/practice-onboarding/components/OnboardingDialogs.tsx
@@ -53,7 +53,7 @@ interface ContactFormValues {
   address?: Partial<Address>;
 }
 
-const getBasicsDraft = (practice: Practice | null, details: PracticeDetails | null): BasicsFormValues => ({
+const getBasicsDraft = (practice: Practice | null): BasicsFormValues => ({
   name: practice?.name ?? '',
   slug: practice?.slug ?? '',
 });
@@ -100,13 +100,13 @@ const OnboardingDialogs = forwardRef<OnboardingDialogsRef, OnboardingDialogsProp
 }, ref) => {
   const [basicsModalOpen, setBasicsModalOpen] = useState(false);
   const [contactModalOpen, setContactModalOpen] = useState(false);
-  const [basicsDraft, setBasicsDraft] = useState<BasicsFormValues>(() => getBasicsDraft(practice, details));
+  const [basicsDraft, setBasicsDraft] = useState<BasicsFormValues>(() => getBasicsDraft(practice));
   const [contactDraft, setContactDraft] = useState<ContactFormValues>(() => getContactDraft(practice, details));
 
   const openBasicsModal = useCallback(() => {
-    setBasicsDraft(getBasicsDraft(practice, details));
+    setBasicsDraft(getBasicsDraft(practice));
     setBasicsModalOpen(true);
-  }, [practice, details]);
+  }, [practice]);
 
   const openContactModal = useCallback(() => {
     setContactDraft(getContactDraft(practice, details));

--- a/src/features/reports/components/ReportDataTable.tsx
+++ b/src/features/reports/components/ReportDataTable.tsx
@@ -45,7 +45,7 @@ export const ReportDataTable: FunctionComponent<ReportDataTableProps> = ({
     stickyHeader
     className="panel overflow-hidden"
     bodyClassName="bg-transparent"
-    emptyState={emptyState ?? <span className="text-sm text-dim-2">No data</span>}
+    emptyState={emptyState ?? <span className="text-sm text-dim-2">No report rows found.</span>}
   />
 );
 

--- a/src/features/reports/components/ReportPageShell.tsx
+++ b/src/features/reports/components/ReportPageShell.tsx
@@ -28,6 +28,9 @@ const defaultFilterValues = (definition: ReportDefinition): ReportFilterValues =
   return values;
 };
 
+const reportEmptyMessage = (title: string) =>
+  `No ${title.toLowerCase()} rows found for these filters. Try a different date range or add the records that feed this report.`;
+
 export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ definition, practiceId }) => {
   const [filters, setFilters] = useState<ReportFilterValues>(() => defaultFilterValues(definition));
   const [scheduleOpen, setScheduleOpen] = useState(false);
@@ -112,6 +115,7 @@ export const ReportPageShell: FunctionComponent<ReportPageShellProps> = ({ defin
         columns={definition.columns}
         rows={(data?.items as Record<string, unknown>[]) ?? []}
         loading={loading && !data}
+        emptyState={<span className="text-sm text-dim-2">{reportEmptyMessage(definition.title)}</span>}
       />
 
       <ScheduleModal

--- a/src/features/settings/pages/AuditLogPage.tsx
+++ b/src/features/settings/pages/AuditLogPage.tsx
@@ -150,7 +150,14 @@ export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => {
             </div>
           </SettingsCard>
         ) : (
-          <p className="py-8 text-center text-sm text-dim">No events match your filters.</p>
+          <SettingsCard className="max-w-[860px]">
+            <div className="py-8 text-center">
+              <p className="text-sm font-medium text-ink">No audit events found</p>
+              <p className="mx-auto mt-1 max-w-md text-sm text-dim">
+                Adjust the audit filters to find logged changes, sign-ins, assistant actions, or record updates.
+              </p>
+            </div>
+          </SettingsCard>
         )}
 
         {/* Pagination */}

--- a/src/features/settings/pages/GeneralPage.tsx
+++ b/src/features/settings/pages/GeneralPage.tsx
@@ -112,12 +112,12 @@ export const GeneralPage = () => {
   const applyThemePreference = useCallback((value: 'light' | 'dark' | 'system') => {
     if (value === 'dark') {
       applyHtmlTheme(true);
-      localStorage.setItem('theme', 'dark');
+      try { localStorage.setItem('theme', 'dark'); } catch { /* ignore */ }
       return;
     }
     if (value === 'light') {
       applyHtmlTheme(false);
-      localStorage.setItem('theme', 'light');
+      try { localStorage.setItem('theme', 'light'); } catch { /* ignore */ }
       return;
     }
     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
@@ -125,7 +125,7 @@ export const GeneralPage = () => {
     } else {
       applyHtmlTheme(false);
     }
-    localStorage.removeItem('theme');
+    try { localStorage.removeItem('theme'); } catch { /* ignore */ }
   }, []);
 
   useEffect(() => {

--- a/src/features/settings/pages/GeneralPage.tsx
+++ b/src/features/settings/pages/GeneralPage.tsx
@@ -14,6 +14,7 @@ import { SettingsCard } from '@/features/settings/components/SettingsCard';
 import { getPreferencesCategory, preferencesApi } from '@/shared/lib/preferencesApi';
 import type { GeneralPreferences } from '@/shared/types/preferences';
 import { cn } from '@/shared/utils/cn';
+import { applyHtmlTheme } from '@/shared/hooks/useTheme';
 
 // ---------------------------------------------------------------------------
 // Theme card — uses app's .card CSS class + design-token border + shadow
@@ -110,19 +111,19 @@ export const GeneralPage = () => {
 
   const applyThemePreference = useCallback((value: 'light' | 'dark' | 'system') => {
     if (value === 'dark') {
-      document.documentElement.setAttribute('data-theme', 'midnight');
+      applyHtmlTheme(true);
       localStorage.setItem('theme', 'dark');
       return;
     }
     if (value === 'light') {
-      document.documentElement.removeAttribute('data-theme');
+      applyHtmlTheme(false);
       localStorage.setItem('theme', 'light');
       return;
     }
     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      document.documentElement.setAttribute('data-theme', 'midnight');
+      applyHtmlTheme(true);
     } else {
-      document.documentElement.removeAttribute('data-theme');
+      applyHtmlTheme(false);
     }
     localStorage.removeItem('theme');
   }, []);

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
 
   body {
     @apply min-h-screen m-0;
+
     background-color: var(--paper);
     color: var(--ink);
     font-family: var(--sans);
@@ -2802,10 +2803,8 @@
 
   /* §3.20 Numbered Section — step indicator with done/now/next states */
   .numbered-section {
-    display: grid;
-    grid-template-columns: 28px 1fr;
-    gap: 14px;
-    align-items: flex-start;
+    --numbered-section-indent: 42px;
+    display: block;
   }
   .numbered-section-indicator {
     width: 24px;
@@ -2820,40 +2819,44 @@
     margin-top: 2px;
     flex-shrink: 0;
   }
-  .numbered-section-indicator-done {
+  .numbered-section-done .numbered-section-indicator {
     background: var(--accent);
     color: var(--accent-ink);
     border: 1px solid var(--accent);
   }
-  .numbered-section-indicator-now {
+  .numbered-section-now .numbered-section-indicator {
     background: var(--card);
     color: var(--accent-deep);
     border: 2px solid var(--accent);
     box-shadow: 0 0 0 3px var(--accent-soft);
   }
-  .numbered-section-indicator-next {
+  .numbered-section-next .numbered-section-indicator {
     background: var(--card);
     color: var(--dim);
     border: 1px solid var(--rule);
   }
   .numbered-section-body {
+    margin-left: var(--numbered-section-indent);
+    margin-top: 12px;
     min-width: 0;
   }
   .numbered-section-title {
+    display: grid;
+    grid-template-columns: 28px minmax(0, 1fr);
+    column-gap: 14px;
+    align-items: flex-start;
     font-family: var(--serif);
     font-size: 18px;
     color: var(--ink);
     line-height: 1.3;
     margin: 0;
   }
-  .numbered-section-description {
+  .numbered-section-desc {
     font-family: var(--mono);
     font-size: 11px;
     color: var(--dim);
-    margin-top: 4px;
-  }
-  .numbered-section-content {
-    margin-top: 12px;
+    line-height: 1.45;
+    margin: 4px 0 0 var(--numbered-section-indent);
   }
 
   /* §3.21 Signal Pill — semantic risk/sentiment pill */

--- a/src/index.css
+++ b/src/index.css
@@ -5,11 +5,29 @@
 @tailwind utilities;
 
 @layer base {
+  html {
+    background-color: var(--paper);
+  }
+
   body {
     @apply min-h-screen m-0;
     background-color: var(--paper);
     color: var(--ink);
     font-family: var(--sans);
+  }
+
+  input,
+  textarea,
+  select {
+    background-color: var(--card);
+    color: var(--ink);
+    caret-color: var(--accent);
+  }
+
+  select,
+  option {
+    background-color: var(--card);
+    color: var(--ink);
   }
 
   .widget-shell-gradient {
@@ -2526,12 +2544,14 @@
      final consolidation is part of Commit 8 feature sweep. */
   .seg {
     display: inline-flex;
-    border: 1px solid var(--rule);
-    border-radius: var(--r-xs);
+    border: 1px solid rgb(var(--sidebar-border));
+    border-radius: var(--r-sm);
     background: var(--card);
+    overflow: hidden;
   }
   .seg button {
     appearance: none;
+    position: relative;
     border: none;
     background: transparent;
     padding: 5px 10px;
@@ -2539,22 +2559,30 @@
     font-size: 12px;
     color: var(--ink-2);
     cursor: pointer;
-    border-right: 1px solid var(--rule);
+    border-right: 1px solid rgb(var(--sidebar-border));
     line-height: 1.4;
+    transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
   }
   .seg button:last-child {
     border-right: none;
   }
   .seg button:hover:not(:disabled) {
-    background: var(--rule-soft);
+    background: rgb(var(--sidebar-hover-bg));
+    color: var(--ink);
+  }
+  .seg button:focus-visible {
+    outline: none;
+    z-index: 1;
+    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--accent) 62%, transparent);
   }
   .seg button:disabled {
     cursor: not-allowed;
     opacity: 0.5;
   }
   .seg button.seg-on {
-    background: var(--ink);
-    color: var(--accent);
+    background: rgb(var(--sidebar-active-bg));
+    color: rgb(var(--sidebar-active-text));
+    box-shadow: inset 0 -2px 0 var(--accent);
   }
 
   /* §3.16 AI Ask Bar — sticky pill composer for one-off asks on list views */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { hydrate, prerender as ssr, Router, Route, useLocation, LocationProvider } from 'preact-iso';
+import { render } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { Suspense } from 'preact/compat';
 import { I18nextProvider } from 'react-i18next';
@@ -43,7 +44,7 @@ import { registerSWWithUpdatePrompt } from '@/shared/lib/swUpdate';
 import { UpdateAvailableToast } from '@/shared/ui/UpdateAvailableToast';
 import { consumePostAuthConversationContext } from '@/shared/utils/anonymousIdentity';
 import { isWidgetRuntimeContext as _isWidgetRuntimeContext } from '@/shared/utils/widgetAuth';
-import { useTheme } from '@/shared/hooks/useTheme';
+import { applyHtmlTheme, useTheme } from '@/shared/hooks/useTheme';
 import { lazy } from 'preact/compat';
 // Top-level pages are lazy so they don't bloat the entry chunk. Each page
 // loads its own bundle on demand the first time the matching route renders.
@@ -82,6 +83,20 @@ const reloadPage = () => {
   if (typeof window !== 'undefined') {
     window.location.reload();
   }
+};
+
+const mountApp = (mountEl: HTMLElement) => {
+  if (import.meta.env.DEV) {
+    render(<AppWithProviders />, mountEl);
+    return;
+  }
+
+  const hasPrerenderedContent = mountEl.childNodes.length > 0;
+  if (hasPrerenderedContent) {
+    hydrate(<AppWithProviders />, mountEl);
+    return;
+  }
+  render(<AppWithProviders />, mountEl);
 };
 
 const buildRetryAction = () => ({
@@ -939,7 +954,11 @@ function PracticeAppRoute({
   }
 
   if (!session?.user) {
-    return <AuthPage />;
+    return (
+      <Suspense fallback={<LoadingScreen />}>
+        <AuthPage />
+      </Suspense>
+    );
   }
 
   if (!canAccessPractice) {
@@ -1186,9 +1205,11 @@ function ClientPracticeRoute({
 function AppWithProviders() {
   return (
     <I18nextProvider i18n={i18n}>
-      <Suspense fallback={<LoadingScreen />}>
-        <App />
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<LoadingScreen />}>
+          <App />
+        </Suspense>
+      </ErrorBoundary>
     </I18nextProvider>
   );
 }
@@ -1205,7 +1226,9 @@ async function mountClientApp() {
   const shouldBeDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
 
   if (shouldBeDark) {
-    document.documentElement.setAttribute('data-theme', 'midnight');
+    applyHtmlTheme(true);
+  } else {
+    applyHtmlTheme(false);
   }
 
 
@@ -1219,14 +1242,16 @@ async function mountClientApp() {
     .then(() => {
       {
         const mountEl = document.getElementById('app');
-        if (mountEl) hydrate(<AppWithProviders />, mountEl);
+        if (mountEl) {
+          mountApp(mountEl);
+        }
       }
     })
     .catch((_error) => {
       console.error('Failed to initialize i18n:', _error);
       {
         const mountEl = document.getElementById('app');
-        if (mountEl) hydrate(<AppWithProviders />, mountEl);
+        if (mountEl) mountApp(mountEl);
       }
     });
 }

--- a/src/shared/config/navConfig.ts
+++ b/src/shared/config/navConfig.ts
@@ -388,6 +388,20 @@ const buildConversationsSecondary = (basePath: string, workspace: 'practice' | '
   }];
 };
 
+const buildMattersSecondary = (basePath: string): NavSection[] => [
+  {
+    label: 'Matters',
+    items: [
+      { id: 'all', label: 'All', href: `${basePath}/matters` },
+      { id: 'new', label: 'New', href: `${basePath}/matters` },
+      { id: 'active', label: 'Active', href: `${basePath}/matters` },
+      { id: 'closing', label: 'Closing', href: `${basePath}/matters` },
+      { id: 'closed', label: 'Closed', href: `${basePath}/matters` },
+      { id: 'declined', label: 'Declined', href: `${basePath}/matters` },
+    ],
+  },
+];
+
 const buildReportsSecondary = (basePath: string, workspace: 'practice' | 'client'): NavSection[] | undefined => {
   if (workspace !== 'practice') return undefined;
   const reportItems: SecondaryNavItem[] = REPORT_DEFINITIONS.map((def) => ({
@@ -491,6 +505,8 @@ const buildSecondary = (basePath: string, section: WorkspaceSection, workspace: 
       return workspace === 'practice' ? buildContactsSecondary(basePath) : undefined;
     case 'conversations':
       return buildConversationsSecondary(basePath, workspace);
+    case 'matters':
+      return buildMattersSecondary(basePath);
     case 'tasks':
       return workspace === 'practice' ? buildTasksSecondary(basePath) : undefined;
     case 'calendar':

--- a/src/shared/hooks/usePaginatedList.ts
+++ b/src/shared/hooks/usePaginatedList.ts
@@ -34,6 +34,7 @@ export function usePaginatedList<T extends { id: string }>(
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const fetchRequestIdRef = useRef(0);
   const fetchPageRef = useRef(fetchPage);
+  const resetDepsRef = useRef<unknown[] | null>(null);
 
   useEffect(() => {
     fetchPageRef.current = fetchPage;
@@ -42,6 +43,14 @@ export function usePaginatedList<T extends { id: string }>(
   const [resetCounter, setResetCounter] = useState(0);
 
   useEffect(() => {
+    const previousDeps = resetDepsRef.current;
+    resetDepsRef.current = deps;
+    if (!previousDeps || (
+      previousDeps.length === deps.length
+      && previousDeps.every((value, index) => Object.is(value, deps[index]))
+    )) {
+      return;
+    }
     setResetCounter((c) => c + 1);
     setPage(1);
     setItems([]);
@@ -54,7 +63,6 @@ export function usePaginatedList<T extends { id: string }>(
   }, deps);
 
   useEffect(() => {
-    if (!hasMore && page > 1) return;
     const controller = new AbortController();
     const requestId = ++fetchRequestIdRef.current;
     setError(null);
@@ -83,7 +91,7 @@ export function usePaginatedList<T extends { id: string }>(
       });
 
     return () => controller.abort();
-  }, [hasMore, page, resetCounter]);
+  }, [page, resetCounter]);
 
   const canObserve = useMemo(() => hasMore && !isLoading && !isLoadingMore, [hasMore, isLoading, isLoadingMore]);
 

--- a/src/shared/hooks/useTheme.ts
+++ b/src/shared/hooks/useTheme.ts
@@ -1,12 +1,25 @@
 import { useState, useEffect, useRef } from 'preact/hooks';
 
-const applyHtmlTheme = (dark: boolean): void => {
+const updateThemeMeta = (): void => {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  const themeColorMeta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!themeColorMeta) return;
+  const paper = window.getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+  if (paper) {
+    themeColorMeta.setAttribute('content', paper);
+  }
+};
+
+export const applyHtmlTheme = (dark: boolean): void => {
   if (typeof document === 'undefined') return;
   if (dark) {
     document.documentElement.setAttribute('data-theme', 'midnight');
+    document.documentElement.style.colorScheme = 'dark';
   } else {
     document.documentElement.removeAttribute('data-theme');
+    document.documentElement.style.colorScheme = 'light';
   }
+  updateThemeMeta();
 };
 
 export const useTheme = () => {

--- a/src/shared/hooks/useWorkspaceRouting.ts
+++ b/src/shared/hooks/useWorkspaceRouting.ts
@@ -51,6 +51,7 @@ import { getWorkspaceConversationsPath, getWorkspaceMattersPath, getWorkspaceCon
 import type { LayoutMode } from '@/app/MainApp';
 import { useMobileDetection } from '@/shared/hooks/useMobileDetection';
 import type { AuthSessionPayload } from '@/shared/types/user';
+import type { PracticeDetails } from '@/shared/lib/apiClient';
 
 // ─── types ────────────────────────────────────────────────────────────────────
 
@@ -60,8 +61,6 @@ interface CurrentPractice {
   logo?: string | null;
   metadata?: Record<string, unknown> | null;
 }
-
-interface PracticeDetails {}
 
 export interface UseWorkspaceRoutingOptions {
   practiceId: string;
@@ -92,7 +91,6 @@ export const useWorkspaceRouting = ({
   routeConversationId,
   isWidget = false,
   currentPractice,
-  practiceDetails,
   activeMemberRole,
   session,
 }: UseWorkspaceRoutingOptions) => {

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -112,6 +112,27 @@ type ApiFetchConfig = {
   acceptStatuses?: number[];
 };
 
+async function parseResponseBody(response: Response, responseHeaders: Headers, isErrorResponse: boolean): Promise<unknown> {
+  const contentType = responseHeaders.get?.('content-type') ?? '';
+  const isJson = contentType.toLowerCase().includes('application/json');
+  if (isJson || (!contentType && typeof response.json === 'function')) {
+    const jsonSource = typeof response.clone === 'function' ? response.clone() : response;
+    try {
+      return await jsonSource.json() as unknown;
+    } catch (error) {
+      if (!isErrorResponse || typeof response.text !== 'function') {
+        throw error;
+      }
+      try {
+        return await response.text();
+      } catch {
+        throw error;
+      }
+    }
+  }
+  return await response.text();
+}
+
 const composeAbortSignals = (signal: AbortSignal | undefined, timeout: number | undefined): { signal: AbortSignal | undefined; cleanup: () => void } => {
   if (timeout == null) return { signal, cleanup: () => {} };
   const controller = new AbortController();
@@ -184,13 +205,7 @@ async function apiFetch<T>(
     return { data: null as T, status: response.status, headers: responseHeaders };
   }
 
-  const contentType = responseHeaders.get?.('content-type') ?? '';
-  // Heuristic for environments without a proper Headers instance (some test
-  // mocks): if `json()` is callable, prefer JSON.
-  const preferJson = contentType.includes('application/json') || typeof response.json === 'function';
-  const data: unknown = preferJson
-    ? await response.json() as unknown
-    : await response.text();
+  const data = await parseResponseBody(response, responseHeaders, !response.ok && !isAccepted);
 
   if (!response.ok && !isAccepted) {
     throw new HttpError(response.status, data, extractFetchErrorMessage(data, `HTTP ${response.status}`));

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -409,14 +409,8 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(
             </div>
           )}
 
-          <div
+          <label
             className="relative flex-1 min-w-0"
-            onMouseDown={(event) => {
-              if (event.target === event.currentTarget) {
-                event.preventDefault();
-                inputElementRef.current?.focus();
-              }
-            }}
           >
             {!showCountryCode ? (
               <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
@@ -462,7 +456,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(
                 )}
               </div>
             )}
-          </div>
+          </label>
         </div>
 
         {error && (

--- a/src/shared/ui/nav/SidebarProfileMenu.tsx
+++ b/src/shared/ui/nav/SidebarProfileMenu.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './Sidebar';
 import { Avatar } from '@/shared/ui/profile';
 import { Icon, type IconComponent } from '@/shared/ui/Icon';
 import { cn } from '@/shared/utils/cn';
+import { applyHtmlTheme } from '@/shared/hooks/useTheme';
 
 type ThemeChoice = 'light' | 'dark' | 'system';
 
@@ -20,11 +21,7 @@ const readStoredTheme = (): ThemeChoice => {
 };
 
 const setHtmlTheme = (dark: boolean) => {
-  if (dark) {
-    document.documentElement.setAttribute('data-theme', 'midnight');
-  } else {
-    document.documentElement.removeAttribute('data-theme');
-  }
+  applyHtmlTheme(dark);
 };
 
 const applyTheme = (choice: ThemeChoice) => {

--- a/src/shared/ui/table/DataTable.tsx
+++ b/src/shared/ui/table/DataTable.tsx
@@ -270,7 +270,7 @@ export const DataTable = ({
               return (
                 <tr>
                   <td colSpan={columns.length} className="px-4 py-6 text-sm text-dim-2">
-                    {emptyState ?? 'No results'}
+                    {emptyState ?? 'No table rows found.'}
                   </td>
                 </tr>
               );

--- a/src/shared/utils/workspaceShell.ts
+++ b/src/shared/utils/workspaceShell.ts
@@ -216,6 +216,9 @@ export const getWorkspaceDefaultSecondaryFilter = ({
   if (workspaceSection === 'conversations' && (isPracticeWorkspace || isClientWorkspace)) {
     return 'all';
   }
+  if (workspaceSection === 'matters' && (isPracticeWorkspace || isClientWorkspace)) {
+    return 'all';
+  }
   if (workspaceSection === 'home' && isPracticeWorkspace) {
     return 'overview';
   }
@@ -260,6 +263,9 @@ export const getWorkspaceActiveSecondaryFilter = ({
   if (workspaceSection === 'conversations' && (isPracticeWorkspace || isClientWorkspace)) {
     return secondaryFilterBySection[workspaceSection] ?? defaultSecondaryFilterId;
   }
+  if (workspaceSection === 'matters' && (isPracticeWorkspace || isClientWorkspace)) {
+    return secondaryFilterBySection[workspaceSection] ?? defaultSecondaryFilterId;
+  }
   if (workspaceSection === 'home' && isPracticeWorkspace) {
     return 'overview';
   }
@@ -279,7 +285,7 @@ export const getWorkspaceActiveSecondaryFilter = ({
   if (workspaceSection === 'intakes' && isPracticeWorkspace) {
     return 'responses';
   }
-  if (workspaceSection === 'matters' || workspaceSection === 'invoices') return null;
+  if (workspaceSection === 'invoices') return null;
   return secondaryFilterBySection[workspaceSection] ?? defaultSecondaryFilterId;
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,10 @@
+const lineColor = (rgbVar, alphaVar) => ({ opacityValue } = {}) => {
+  if (opacityValue === undefined) {
+    return `rgb(var(${rgbVar}) / var(${alphaVar}))`;
+  }
+  return `rgb(var(${rgbVar}) / calc(${opacityValue} * var(${alphaVar})))`;
+};
+
 /**
  * Responsive breakpoint conventions
  * ---------------------------------
@@ -45,6 +52,15 @@ module.exports = {
         'paper-2': 'rgb(var(--paper-2-rgb) / <alpha-value>)',
         'paper-edge': 'rgb(var(--paper-edge-rgb) / <alpha-value>)',
         card: 'rgb(var(--card-rgb) / <alpha-value>)',
+        'surface-page': 'rgb(var(--surface-page) / <alpha-value>)',
+        'surface-base': 'rgb(var(--surface-base) / <alpha-value>)',
+        'surface-workspace': 'rgb(var(--surface-workspace) / <alpha-value>)',
+        'surface-card': 'rgb(var(--surface-card) / <alpha-value>)',
+        'surface-card-hover': 'rgb(var(--surface-card-hover) / <alpha-value>)',
+        'surface-panel': 'rgb(var(--surface-panel) / <alpha-value>)',
+        'surface-overlay': 'rgb(var(--surface-overlay) / <alpha-value>)',
+        'surface-app-frame': 'rgb(var(--surface-app-frame) / <alpha-value>)',
+        'surface-utility': 'rgb(var(--surface-utility) / <alpha-value>)',
 
         // Ink (text) tokens
         ink: 'rgb(var(--ink-rgb) / <alpha-value>)',
@@ -52,9 +68,23 @@ module.exports = {
         'ink-3': 'rgb(var(--ink-3-rgb) / <alpha-value>)',
         dim: 'rgb(var(--dim-rgb) / <alpha-value>)',
         'dim-2': 'rgb(var(--dim-2-rgb) / <alpha-value>)',
+        'text-primary': 'rgb(var(--text-primary) / <alpha-value>)',
+        'text-secondary': 'rgb(var(--text-secondary) / <alpha-value>)',
+        'text-muted': 'rgb(var(--text-muted) / <alpha-value>)',
+        'input-text': 'rgb(var(--input-text) / <alpha-value>)',
+        'input-foreground': 'rgb(var(--input-foreground) / <alpha-value>)',
+        'input-placeholder': 'rgb(var(--input-placeholder) / <alpha-value>)',
 
         // Rule (border)
         rule: 'rgb(var(--rule-rgb) / <alpha-value>)',
+        'rule-soft': 'var(--rule-soft)',
+        'border-subtle': 'rgb(var(--border-subtle) / <alpha-value>)',
+        'line-subtle': lineColor('--line-subtle-rgb', '--line-subtle-alpha'),
+        'line-default': lineColor('--line-default-rgb', '--line-default-alpha'),
+        'line-utility': lineColor('--line-utility-rgb', '--line-utility-alpha'),
+        'line-emphasized': lineColor('--line-emphasized-rgb', '--line-emphasized-alpha'),
+        'line-glass': lineColor('--line-glass-rgb', '--line-glass-alpha'),
+        primary: 'rgb(var(--accent-rgb) / <alpha-value>)',
 
         // Accent — single gold
         accent: 'rgb(var(--accent-rgb) / <alpha-value>)',
@@ -65,6 +95,31 @@ module.exports = {
         pos: 'rgb(var(--pos-rgb) / <alpha-value>)',
         warn: 'rgb(var(--warn-rgb) / <alpha-value>)',
         neg: 'rgb(var(--neg-rgb) / <alpha-value>)',
+        'error-foreground': 'rgb(var(--error-foreground) / <alpha-value>)',
+
+        // Upload file color tokens
+        'light-file-type-pdf': 'rgb(var(--light-file-type-pdf) / <alpha-value>)',
+        'light-file-type-image': 'rgb(var(--light-file-type-image) / <alpha-value>)',
+        'light-file-type-video': 'rgb(var(--light-file-type-video) / <alpha-value>)',
+        'light-file-type-audio': 'rgb(var(--light-file-type-audio) / <alpha-value>)',
+        'light-file-type-code': 'rgb(var(--light-file-type-code) / <alpha-value>)',
+        'light-file-type-archive': 'rgb(var(--light-file-type-archive) / <alpha-value>)',
+        'light-file-type-spreadsheet': 'rgb(var(--light-file-type-spreadsheet) / <alpha-value>)',
+        'light-file-type-document': 'rgb(var(--light-file-type-document) / <alpha-value>)',
+        'light-file-type-default': 'rgb(var(--light-file-type-default) / <alpha-value>)',
+        'dark-file-type-pdf': 'rgb(var(--dark-file-type-pdf) / <alpha-value>)',
+        'dark-file-type-image': 'rgb(var(--dark-file-type-image) / <alpha-value>)',
+        'dark-file-type-video': 'rgb(var(--dark-file-type-video) / <alpha-value>)',
+        'dark-file-type-audio': 'rgb(var(--dark-file-type-audio) / <alpha-value>)',
+        'dark-file-type-code': 'rgb(var(--dark-file-type-code) / <alpha-value>)',
+        'dark-file-type-archive': 'rgb(var(--dark-file-type-archive) / <alpha-value>)',
+        'dark-file-type-spreadsheet': 'rgb(var(--dark-file-type-spreadsheet) / <alpha-value>)',
+        'dark-file-type-document': 'rgb(var(--dark-file-type-document) / <alpha-value>)',
+        'dark-file-type-default': 'rgb(var(--dark-file-type-default) / <alpha-value>)',
+        'light-file-progress-bg': 'rgb(var(--light-file-progress-bg) / <alpha-value>)',
+        'light-file-progress-fill': 'rgb(var(--light-file-progress-fill) / <alpha-value>)',
+        'dark-file-progress-bg': 'rgb(var(--dark-file-progress-bg) / <alpha-value>)',
+        'dark-file-progress-fill': 'rgb(var(--dark-file-progress-fill) / <alpha-value>)',
       },
       borderRadius: {
         'r-xs': 'var(--r-xs)',
@@ -76,6 +131,7 @@ module.exports = {
         '1': 'var(--shadow-1)',
         '2': 'var(--shadow-2)',
         '3': 'var(--shadow-3)',
+        glass: 'var(--glass-rim-subtle)',
       },
     },
   },

--- a/tests/e2e/engagements-create-page.spec.ts
+++ b/tests/e2e/engagements-create-page.spec.ts
@@ -32,7 +32,7 @@ const validDraftEngagement = {
       scope_summary: 'Draft an engagement letter for proper E2E data.',
       included_services: ['Initial consultation', 'Document review'],
       excluded_services: ['Trial representation'],
-      client_identity_notes: null,
+      client_identity_notes: '',
       jurisdiction_notes: 'Texas',
     },
     fees: {
@@ -68,11 +68,11 @@ const validDraftEngagement = {
     source_snapshot: {
       intake_uuid: 'e2e-intake-valid-draft',
       conversation_id: 'e2e-conversation-valid-draft',
-      matter_id: null,
+      matter_id: '',
       practice_area: 'business',
       urgency: 'routine',
       desired_outcome: 'Validate engagement list rendering',
-      opposing_party: null,
+      opposing_party: '',
       court_date: null,
     },
     acknowledgment_language: 'Client acknowledges the scope.',

--- a/tests/e2e/engagements-create-page.spec.ts
+++ b/tests/e2e/engagements-create-page.spec.ts
@@ -2,13 +2,165 @@ import { expect, test } from './fixtures.auth';
 import { loadE2EConfig } from './helpers/e2eConfig';
 
 const e2eConfig = loadE2EConfig();
-const PRACTICE_SLUG = e2eConfig?.practice.slug ?? process.env.E2E_PRACTICE_SLUG ?? 'demo-owner-local';
+const resolvePracticeSlug = (value: string | null | undefined): string => {
+  if (!value) return 'demo-owner-local';
+  try {
+    const url = new URL(value);
+    const segments = url.pathname.split('/').filter(Boolean);
+    return segments[segments.length - 1] ?? 'demo-owner-local';
+  } catch {
+    return value;
+  }
+};
+
+const PRACTICE_SLUG = resolvePracticeSlug(e2eConfig?.practice.slug ?? process.env.E2E_PRACTICE_SLUG);
 const ENGAGEMENTS_BASE = `/practice/${encodeURIComponent(PRACTICE_SLUG)}/engagements`;
 const CREATE_PATH = `${ENGAGEMENTS_BASE}/new`;
+
+const validDraftEngagement = {
+  id: 'e2e-engagement-valid-draft',
+  intake_id: 'e2e-intake-valid-draft',
+  matter_id: null,
+  organization_id: e2eConfig?.practice.id ?? 'e2e-practice',
+  status: 'draft',
+  client_name: 'E2E Proper Client',
+  client_email: 'proper-client@test-blawby.com',
+  contract_body: 'Engagement agreement body for E2E proper data.',
+  billing_snapshot: null,
+  proposal_data: {
+    representation: {
+      scope_summary: 'Draft an engagement letter for proper E2E data.',
+      included_services: ['Initial consultation', 'Document review'],
+      excluded_services: ['Trial representation'],
+      client_identity_notes: null,
+      jurisdiction_notes: 'Texas',
+    },
+    fees: {
+      billing_type: 'flat_fee',
+      fixed_fee_amount: 2500,
+      hourly_rate_attorney: null,
+      hourly_rate_admin: null,
+      contingency_percentage: null,
+      retainer_amount: 1000,
+      payment_frequency: 'upfront',
+      fee_notes: 'E2E fee terms',
+    },
+    risk_review: {
+      conflict_status: 'clear',
+      jurisdiction_status: 'supported',
+      risk_notes: [],
+      open_questions: [],
+      conflict_note: null,
+    },
+    client_summary: {
+      client_name: 'E2E Proper Client',
+      matter_summary: 'E2E Proper Matter',
+      location_summary: 'Austin, Texas',
+      goals_summary: 'Confirm the UI renders valid engagement data.',
+      co_clients: [],
+      non_clients: [],
+    },
+    draft_meta: {
+      version: 1,
+      generated_at: '2026-06-20T00:00:00.000Z',
+      generated_by: 'e2e',
+    },
+    source_snapshot: {
+      intake_uuid: 'e2e-intake-valid-draft',
+      conversation_id: 'e2e-conversation-valid-draft',
+      matter_id: null,
+      practice_area: 'business',
+      urgency: 'routine',
+      desired_outcome: 'Validate engagement list rendering',
+      opposing_party: null,
+      court_date: null,
+    },
+    acknowledgment_language: 'Client acknowledges the scope.',
+    no_guarantee_language: 'No outcome is guaranteed.',
+  },
+  engagement_notes: 'E2E note',
+  sent_at: null,
+  accepted_at: null,
+  declined_at: null,
+  signed_pdf_s3_key: null,
+  created_by: 'e2e-owner',
+  created_at: '2026-06-20T00:00:00.000Z',
+  updated_at: '2026-06-20T00:00:00.000Z',
+};
+
+const malformedDraftEngagement = {
+  id: 'e2e-engagement-malformed-draft',
+  intake_id: 'e2e-intake-malformed-draft',
+  matter_id: null,
+  organization_id: e2eConfig?.practice.id ?? 'e2e-practice',
+  status: 'draft',
+  contract_body: 'Malformed E2E engagement body.',
+  billing_snapshot: null,
+  proposal_data: {
+    draft_meta: {
+      version: 1,
+      generated_at: '2026-06-20T00:00:00.000Z',
+      generated_by: 'e2e',
+    },
+    source_snapshot: {
+      intake_uuid: 'e2e-intake-malformed-draft',
+    },
+  },
+  created_by: 'e2e-owner',
+  created_at: '2026-06-20T00:00:00.000Z',
+  updated_at: '2026-06-20T00:00:00.000Z',
+};
 
 test.describe('engagements create page', () => {
   // Raise the per-test budget — staging API responses can be slow.
   test.setTimeout(60000);
+
+  test('list renders proper engagement data and drops malformed rows', async ({ ownerPage }) => {
+    await ownerPage.setViewportSize({ width: 1440, height: 900 });
+
+    const engagementRequests: string[] = [];
+    const engagementErrors: string[] = [];
+    ownerPage.on('console', (message) => {
+      if (message.type() === 'error' && message.text().includes('[engagementsApi]')) {
+        engagementErrors.push(message.text());
+      }
+    });
+
+    await ownerPage.route('**/api/engagement-contracts/**', async (route) => {
+      const url = new URL(route.request().url());
+      engagementRequests.push(`${url.pathname}${url.search}`);
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [validDraftEngagement, malformedDraftEngagement],
+          pagination: {
+            page: Number(url.searchParams.get('page') ?? '1'),
+            limit: Number(url.searchParams.get('limit') ?? '20'),
+            total: 2,
+          },
+        }),
+      });
+    });
+
+    await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });
+
+    await expect(ownerPage.getByText('E2E Proper Client').filter({ visible: true })).toBeVisible({ timeout: 20000 });
+    await expect(ownerPage.getByText('E2E Proper Matter').filter({ visible: true })).toBeVisible();
+    await expect(ownerPage.getByText('Flat fee').filter({ visible: true })).toBeVisible();
+    await expect(ownerPage.getByText('$1,000').filter({ visible: true })).toBeVisible();
+    await expect(ownerPage.getByText('No engagements found')).not.toBeVisible();
+    await expect(ownerPage.getByText('e2e-engagement-malformed-draft')).not.toBeVisible();
+    expect(engagementErrors.some((entry) => entry.includes('e2e-engagement-malformed-draft'))).toBe(true);
+
+    await ownerPage.getByRole('button', { name: 'Draft' }).click();
+
+    await expect(ownerPage.getByText('E2E Proper Client').filter({ visible: true })).toBeVisible({ timeout: 20000 });
+    await expect(ownerPage.getByText('No draft engagements found')).not.toBeVisible();
+    expect(engagementRequests.filter((request) => request.includes('/api/engagement-contracts/'))).toHaveLength(2);
+    expect(engagementRequests.some((request) => request.includes('status=draft'))).toBe(true);
+  });
 
   test('New Engagement button navigates to /new route', async ({ ownerPage }) => {
     await ownerPage.goto(ENGAGEMENTS_BASE, { waitUntil: 'domcontentloaded' });

--- a/tests/unit/engagements/engagementDraft.test.ts
+++ b/tests/unit/engagements/engagementDraft.test.ts
@@ -60,25 +60,25 @@ describe('engagementDraft', () => {
     });
     expect(proposal.representation.scope_summary).toBe('Custody consultation');
     expect(proposal.fees).toMatchObject({
-      billing_type: null,
+      billing_type: '',
       fixed_fee_amount: null,
       hourly_rate_attorney: null,
       hourly_rate_admin: null,
       contingency_percentage: null,
       retainer_amount: null,
       payment_frequency: null,
-      fee_notes: null,
+      fee_notes: '',
     });
     expect(proposal.risk_review).toMatchObject({
       conflict_status: 'unknown',
       jurisdiction_status: 'unknown',
-      risk_notes: null,
-      open_questions: null,
+      risk_notes: [],
+      open_questions: [],
     });
     expect(proposal.source_snapshot).toMatchObject({
       intake_uuid: 'intake-123',
       conversation_id: 'conversation-123',
-      matter_id: null,
+      matter_id: '',
       practice_area: 'Family Law',
       urgency: 'time_sensitive',
       desired_outcome: 'Protect weekday parenting time',
@@ -94,7 +94,7 @@ describe('engagementDraft', () => {
     vi.useRealTimers();
   });
 
-  it('keeps missing optional fields null or empty', () => {
+  it('serializes missing required string fields as empty strings and arrays', () => {
     const form = buildEngagementDraftFormFromIntake({
       ...acceptedIntake,
       conversation_id: null,
@@ -107,10 +107,14 @@ describe('engagementDraft', () => {
     });
     const proposal = buildProposalDataFromDraft(form);
 
-    expect(proposal.client_summary.client_name).toBeNull();
-    expect(proposal.client_summary.location_summary).toBeNull();
-    expect(proposal.source_snapshot?.conversation_id).toBeNull();
-    expect(proposal.source_snapshot?.practice_area).toBeNull();
+    expect(proposal.client_summary.client_name).toBe('');
+    expect(proposal.client_summary.location_summary).toBe('');
+    expect(proposal.representation.included_services).toEqual([]);
+    expect(proposal.risk_review.open_questions).toEqual([]);
+    expect(proposal.source_snapshot?.conversation_id).toBe('');
+    expect(proposal.source_snapshot?.matter_id).toBe('');
+    expect(proposal.source_snapshot?.practice_area).toBe('');
+    expect(proposal.source_snapshot?.urgency).toBe('');
     expect(proposal.source_snapshot?.court_date).toBeNull();
   });
 

--- a/tests/unit/engagements/engagementsApi.test.ts
+++ b/tests/unit/engagements/engagementsApi.test.ts
@@ -52,22 +52,36 @@ const proposalData: ProposalData = {
   client_summary: {
     client_name: 'Jane Client',
     matter_summary: 'Custody consultation',
+    location_summary: '',
+    goals_summary: '',
   },
   representation: {
     scope_summary: 'Limited scope representation.',
+    included_services: [],
+    excluded_services: [],
+    client_identity_notes: '',
+    jurisdiction_notes: '',
   },
   fees: {
     billing_type: 'fixed',
     fixed_fee_amount: 1500,
+    fee_notes: '',
   },
   risk_review: {
     conflict_status: 'unknown',
     jurisdiction_status: 'unknown',
+    risk_notes: [],
+    open_questions: [],
   },
   source_snapshot: {
     intake_uuid: 'intake-123',
     conversation_id: 'conversation-123',
-    matter_id: null,
+    matter_id: '',
+    practice_area: '',
+    urgency: '',
+    desired_outcome: '',
+    opposing_party: '',
+    court_date: null,
   },
   draft_meta: {
     generated_at: '2026-05-22T10:00:00.000Z',

--- a/tests/unit/engagements/engagementsApi.test.ts
+++ b/tests/unit/engagements/engagementsApi.test.ts
@@ -13,6 +13,20 @@ vi.mock('@/shared/lib/apiClient', () => ({
   apiClient: mockApiClient,
   isHttpError: (error: unknown): error is { response: { status: number; data: unknown } } =>
     typeof error === 'object' && error !== null && 'response' in error,
+  unwrapApiResponse: <T,>(payload: unknown, fallbackMessage = 'Request failed'): T => {
+    if (payload && typeof payload === 'object' && 'success' in payload) {
+      const envelope = payload as { success: boolean; data?: unknown; error?: unknown; message?: unknown };
+      if (envelope.success === false) {
+        throw new Error(
+          typeof envelope.error === 'string' ? envelope.error :
+            typeof envelope.message === 'string' ? envelope.message :
+              fallbackMessage,
+        );
+      }
+      return envelope.data as T;
+    }
+    return payload as T;
+  },
 }));
 
 vi.mock('@/shared/lib/queryCache', () => ({
@@ -24,6 +38,8 @@ vi.mock('@/shared/lib/queryCache', () => ({
 import {
   acceptEngagement,
   createEngagementContract,
+  getEngagement,
+  listEngagements,
   patchEngagementContract,
   sendEngagementToClient,
 } from '@/features/engagements/api/engagementsApi';
@@ -102,6 +118,247 @@ describe('engagementsApi', () => {
       },
       { signal: undefined },
     );
+  });
+
+  it('lists engagements from the documented data envelope', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        data: [engagementPayload],
+        pagination: { page: 1, limit: 20, total: 1 },
+      },
+    });
+
+    const result = await listEngagements(practiceId, { page: 1, limit: 20 });
+
+    expect(mockApiClient.get).toHaveBeenCalledWith(
+      `/api/engagement-contracts/${practiceId}?page=1&limit=20`,
+      { signal: undefined },
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.id).toBe(contractId);
+    expect(result.total).toBe(1);
+  });
+
+  it('fast-fails list responses that use non-documented aliases', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        contracts: [engagementPayload],
+        page: 1,
+        limit: 20,
+        total: 1,
+      },
+    });
+
+    await expect(listEngagements(practiceId, { page: 1, limit: 20 }))
+      .rejects.toThrow('Engagement contract list is missing data');
+  });
+
+  it('logs HTTP error response bodies when engagement list fetch fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const responseBody = {
+        success: false,
+        error: 'Malformed engagement contract response',
+        details: {
+          issues: [{ id: contractId, missing: ['proposal_data.client_summary'] }],
+        },
+      };
+      mockApiClient.get.mockRejectedValueOnce({
+        response: {
+          status: 500,
+          data: responseBody,
+        },
+      });
+
+      await expect(listEngagements(practiceId, { page: 1, limit: 20 }))
+        .rejects.toThrow('Malformed engagement contract response');
+
+      expect(consoleError).toHaveBeenCalledWith(
+        '[engagementsApi] Engagement request failed',
+        {
+          status: 500,
+          data: responseBody,
+        },
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('[engagementsApi] Engagement request failed details '),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('drops and logs list records when proposal data is omitted', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          data: [{
+            ...engagementPayload,
+            proposal_data: null,
+            client_name: 'Top Level Client',
+            title: 'Top level matter summary',
+            description: 'Top level description',
+            conversation_id: 'top-level-conversation',
+            practice_area: 'Family',
+          }],
+          pagination: { page: 1, limit: 20, total: 1 },
+        },
+      });
+
+      const result = await listEngagements(practiceId, { page: 1, limit: 20 });
+
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(consoleError).toHaveBeenCalledWith(
+        '[engagementsApi] Invalid engagement contract payload',
+        expect.objectContaining({
+          id: contractId,
+          error: `Engagement ${contractId} is missing proposal_data`,
+          proposalDataKeys: [],
+          clientSummaryKeys: [],
+          feesKeys: [],
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('drops and logs list records that lack client summary fields', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          data: [{
+            ...engagementPayload,
+            proposal_data: {
+              draft_meta: proposalData.draft_meta,
+              source_snapshot: {
+                intake_uuid: 'intake-123',
+                opposing_party: 'Jane Doe',
+              },
+            },
+          }],
+          pagination: { page: 1, limit: 20, total: 1 },
+        },
+      });
+
+      const result = await listEngagements(practiceId, { page: 1, limit: 20 });
+
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(consoleError).toHaveBeenCalledWith(
+        '[engagementsApi] Invalid engagement contract payload',
+        expect.objectContaining({
+          id: contractId,
+          error: `Engagement ${contractId} is missing client_summary`,
+          proposalDataKeys: expect.arrayContaining(['draft_meta', 'source_snapshot']),
+          clientSummaryKeys: [],
+          feesKeys: [],
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('drops and logs list records that lack fees', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          data: [{
+            ...engagementPayload,
+            proposal_data: {
+              ...proposalData,
+              fees: undefined,
+            },
+          }],
+          pagination: { page: 1, limit: 20, total: 1 },
+        },
+      });
+
+      const result = await listEngagements(practiceId, { page: 1, limit: 20 });
+
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(consoleError).toHaveBeenCalledWith(
+        '[engagementsApi] Invalid engagement contract payload',
+        expect.objectContaining({
+          id: contractId,
+          error: `Engagement ${contractId} is missing fees`,
+          proposalDataKeys: expect.arrayContaining(['client_summary', 'fees']),
+          feesKeys: [],
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('keeps valid list records while dropping malformed records', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      mockApiClient.get.mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              ...engagementPayload,
+              id: 'malformed-contract',
+              proposal_data: {
+                draft_meta: proposalData.draft_meta,
+                source_snapshot: proposalData.source_snapshot,
+              },
+            },
+            engagementPayload,
+          ],
+          pagination: { page: 1, limit: 20, total: 2 },
+        },
+      });
+
+      const result = await listEngagements(practiceId, { page: 1, limit: 20 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe(contractId);
+      expect(result.total).toBe(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        '[engagementsApi] Invalid engagement contract payload',
+        expect.objectContaining({
+          id: 'malformed-contract',
+          error: 'Engagement malformed-contract is missing client_summary',
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('fast-fails list responses wrapped in an undocumented success envelope', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          contracts: [engagementPayload],
+          pagination: { page: 1, limit: 20, total: 1 },
+        },
+      },
+    });
+
+    await expect(listEngagements(practiceId, { page: 1, limit: 20 }))
+      .rejects.toThrow('Engagement contract list is missing data');
+  });
+
+  it('fast-fails engagement details wrapped in an undocumented success envelope', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: engagementPayload,
+      },
+    });
+
+    await expect(getEngagement(practiceId, contractId))
+      .rejects.toThrow('Engagement is missing id');
   });
 
   it('updates a draft with the documented PATCH body', async () => {

--- a/tests/unit/hooks/usePaginatedList.test.ts
+++ b/tests/unit/hooks/usePaginatedList.test.ts
@@ -59,4 +59,30 @@ describe('usePaginatedList', () => {
       expect(fetchPage).toHaveBeenCalledTimes(2);
     });
   });
+
+  it('does not reset or reload when deps rerender with equivalent values', async () => {
+    const fetchPage = vi.fn(async () => ({
+      items: [{ id: 'item-1' }],
+      hasMore: false,
+    }));
+
+    const { rerender, result } = renderHook(
+      ({ practiceId }) =>
+        usePaginatedList<Item>({
+          fetchPage,
+          deps: [practiceId],
+        }),
+      { initialProps: { practiceId: 'practice-1' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([{ id: 'item-1' }]);
+    });
+
+    await act(async () => {
+      rerender({ practiceId: 'practice-1' });
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/hooks/usePaginatedList.test.ts
+++ b/tests/unit/hooks/usePaginatedList.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
+
+type Item = { id: string };
+
+describe('usePaginatedList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the first page once on initial mount', async () => {
+    const fetchPage = vi.fn(async () => ({
+      items: [{ id: 'item-1' }],
+      hasMore: false,
+    }));
+
+    const { result } = renderHook(() =>
+      usePaginatedList<Item>({
+        fetchPage,
+        deps: ['practice-1'],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([{ id: 'item-1' }]);
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith(1, expect.any(AbortSignal));
+  });
+
+  it('resets and reloads when deps change after mount', async () => {
+    const fetchPage = vi.fn(async () => ({
+      items: [{ id: 'item-1' }],
+      hasMore: false,
+    }));
+
+    const { rerender, result } = renderHook(
+      ({ practiceId }) =>
+        usePaginatedList<Item>({
+          fetchPage,
+          deps: [practiceId],
+        }),
+      { initialProps: { practiceId: 'practice-1' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual([{ id: 'item-1' }]);
+    });
+
+    await act(async () => {
+      rerender({ practiceId: 'practice-2' });
+    });
+
+    await waitFor(() => {
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/lib/apiClient.test.ts
+++ b/tests/unit/lib/apiClient.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient, isHttpError } from '@/shared/lib/apiClient';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('apiClient', () => {
+  it('surfaces non-JSON error responses as HttpError instead of JSON parse errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('<!DOCTYPE html><title>Bad Gateway</title>', {
+        status: 502,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+
+    try {
+      await apiClient.get('https://worker.test/api/engagement-contracts/practice-1');
+      throw new Error('Expected apiClient.get to throw');
+    } catch (error) {
+      expect(isHttpError(error)).toBe(true);
+      if (!isHttpError(error)) throw error;
+      expect(error.response.status).toBe(502);
+      expect(error.message).toContain('<!DOCTYPE html>');
+    }
+  });
+});

--- a/tests/unit/worker/route-table.test.ts
+++ b/tests/unit/worker/route-table.test.ts
@@ -11,7 +11,7 @@
  * If a route ordering changes (e.g. `/api/ai/chat` accidentally matches
  * before `/api/ai/intent`), this test fails.
  */
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import type { Env } from '../../../worker/types.js';
 
 let findRoute: typeof import('../../../worker/index.js').findRoute;
@@ -55,6 +55,7 @@ describe('worker route table', () => {
     expectRoute('/api/onboarding', 'proxy');
     expectRoute('/api/matters', 'proxy');
     expectRoute('/api/matters/m-1', 'proxy');
+    expectRoute('/api/engagement-contracts/practice-1', 'proxy');
     expectRoute('/api/invoices', 'proxy');
     expectRoute('/api/practice-client-intakes', 'proxy');
     expectRoute('/api/clients', 'proxy');

--- a/tests/unit/worker/routes/authProxy-engagement-contracts.test.ts
+++ b/tests/unit/worker/routes/authProxy-engagement-contracts.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleBackendProxy } from '../../../../worker/routes/authProxy.js';
+import type { Env } from '../../../../worker/types.js';
+
+const practiceId = 'practice-1';
+
+const buildEnv = (): Env => ({
+  NODE_ENV: 'test',
+  BACKEND_API_URL: 'https://backend.test',
+  IDEMPOTENCY_SALT: 'test-salt',
+} as Env);
+
+const buildRequest = (path: string): Request =>
+  new Request(`https://worker.test${path}`, {
+    method: 'GET',
+    headers: { Cookie: 'session=present' },
+  });
+
+const validEngagement = {
+  id: 'engagement-1',
+  intake_id: 'intake-1',
+  organization_id: practiceId,
+  status: 'draft',
+  proposal_data: {
+    client_summary: {
+      client_name: 'Client Name',
+      matter_summary: 'Draft engagement matter',
+    },
+    fees: {
+      billing_type: 'hourly',
+    },
+  },
+  created_at: '2026-06-20T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('handleBackendProxy engagement contract validation', () => {
+  it('passes through valid engagement contract list responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      Response.json({
+        data: [validEngagement],
+        pagination: { page: 1, limit: 20, total: 1 },
+      }),
+    );
+
+    const response = await handleBackendProxy(
+      buildRequest(`/api/engagement-contracts/${practiceId}?page=1&limit=20`),
+      buildEnv(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: [validEngagement],
+    });
+  });
+
+  it('passes through empty engagement contract lists', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      Response.json({
+        data: [],
+        pagination: { page: 1, limit: 20, total: 0 },
+      }),
+    );
+
+    const response = await handleBackendProxy(
+      buildRequest(`/api/engagement-contracts/${practiceId}?page=1&limit=20`),
+      buildEnv(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: [],
+      pagination: { total: 0 },
+    });
+  });
+
+  it('passes through engagement contract lists that use backend aliases', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      Response.json({
+        contracts: [validEngagement],
+        page: 1,
+        limit: 20,
+        total: 1,
+      }),
+    );
+
+    const response = await handleBackendProxy(
+      buildRequest(`/api/engagement-contracts/${practiceId}?page=1&limit=20`),
+      buildEnv(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      contracts: [validEngagement],
+    });
+  });
+
+  it('passes through malformed engagement contract records from upstream', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      Response.json({
+        data: [{
+          ...validEngagement,
+          proposal_data: {
+            draft_meta: {},
+            source_snapshot: {},
+          },
+        }],
+        pagination: { page: 1, limit: 20, total: 1 },
+      }),
+    );
+
+    const response = await handleBackendProxy(
+      buildRequest(`/api/engagement-contracts/${practiceId}?page=1&limit=20`),
+      buildEnv(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: [{
+        ...validEngagement,
+        proposal_data: {
+          draft_meta: {},
+          source_snapshot: {},
+        },
+      }],
+      pagination: { page: 1, limit: 20, total: 1 },
+    });
+  });
+
+  it('fast-fails upstream HTML errors with JSON diagnostics', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('<!DOCTYPE html><title>502: Bad gateway</title>', {
+        status: 502,
+        headers: { 'Content-Type': 'text/html; charset=UTF-8' },
+      }),
+    );
+
+    const response = await handleBackendProxy(
+      buildRequest(`/api/engagement-contracts/${practiceId}?page=1&limit=20`),
+      buildEnv(),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Engagement contract upstream request failed',
+      details: {
+        path: `/api/engagement-contracts/${practiceId}`,
+        status: 502,
+        contentType: 'text/html; charset=UTF-8',
+        bodyPreview: expect.stringContaining('Bad gateway'),
+      },
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      '[ERROR] [engagement-contracts] Upstream request failed with non-JSON response',
+      expect.objectContaining({
+        path: `/api/engagement-contracts/${practiceId}`,
+        status: 502,
+        contentType: 'text/html; charset=UTF-8',
+      }),
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/* global URL */
 import { type ConfigEnv, type ProxyOptions, defineConfig, loadEnv } from 'vite';
 import preact from '@preact/preset-vite';
 import { resolve } from 'path';
@@ -79,6 +80,7 @@ const workerEndpoints = [
 	'reports',
 	'subscriptions',
 	'subscription',
+	'engagement-contracts',
 	'matters',
 	'uploads',
 	'widget',

--- a/worker/routes/aiChatIntake.ts
+++ b/worker/routes/aiChatIntake.ts
@@ -21,7 +21,6 @@ import {
 } from '../../src/shared/utils/intakeOrchestration.js';
 
 const MAX_SERVICES_IN_PROMPT = 20;
-const MAX_SERVICES_IN_CONVERSATION_PROMPT = 8;
 type IntakePromptService = { name: string; uuid: string };
 
 const US_STATE_NAME_TO_CODE: Record<string, string> = {
@@ -402,9 +401,6 @@ export const handleSaveCaseDetails = (
   const merged = mergeIntakeState(storedIntakeState, patch);
   const isSubmittable = isIntakeSubmittable(merged, submissionGate);
 
-  const completenessScore = submissionGate.activeTemplate && merged
-    ? computeCompletenessScore(submissionGate.activeTemplate, merged as Record<string, unknown>)
-    : 0;
 
   // Template fee presence takes precedence over practice details — allow zero values.
   const templatePaymentConfigured = typeof submissionGate.templateConsultationFee === 'number';

--- a/worker/routes/authProxy.ts
+++ b/worker/routes/authProxy.ts
@@ -26,6 +26,7 @@ type CachedProxyResponse = {
   body: ArrayBuffer;
   hasSetCookie: boolean;
 };
+
 const BACKEND_PATH_PREFIXES = [
   '/api/onboarding',
   '/api/matters',
@@ -55,6 +56,90 @@ export async function handleAuthProxy(request: Request, env: Env): Promise<Respo
 
 const isBackendProxyPath = (path: string): boolean =>
   BACKEND_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+
+const jsonResponse = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+
+const validateEngagementContractProxyResponse = async (
+  request: Request,
+  response: Response,
+): Promise<Response | null> => {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith('/api/engagement-contracts')) return null;
+  if (request.method.toUpperCase() === 'HEAD') return null;
+
+  const contentType = response.headers.get('Content-Type') ?? '';
+  const isJson = contentType.toLowerCase().includes('application/json');
+
+  if (!isJson) {
+    const bodyPreview = await response.clone().text()
+      .then((text) => text.slice(0, 500))
+      .catch((error) => `Unable to read response body: ${error instanceof Error ? error.message : String(error)}`);
+
+    if (response.status < 200 || response.status >= 300) {
+      Logger.error('[engagement-contracts] Upstream request failed with non-JSON response', {
+        path: url.pathname,
+        status: response.status,
+        contentType,
+        bodyPreview,
+      });
+      return jsonResponse({
+        success: false,
+        error: 'Engagement contract upstream request failed',
+        details: {
+          path: url.pathname,
+          status: response.status,
+          contentType,
+          bodyPreview,
+        },
+      }, 500);
+    }
+
+    Logger.error('[engagement-contracts] Upstream returned non-JSON response', {
+      path: url.pathname,
+      status: response.status,
+      contentType,
+      bodyPreview,
+    });
+    return jsonResponse({
+      success: false,
+      error: 'Malformed engagement contract response',
+      details: {
+        path: url.pathname,
+        reason: 'Upstream returned non-JSON response',
+        contentType,
+        bodyPreview,
+      },
+    }, 500);
+  }
+
+  try {
+    await response.clone().json();
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    Logger.error('[engagement-contracts] Upstream returned non-JSON response', {
+      path: url.pathname,
+      status: response.status,
+      error: errorMessage,
+    });
+    return jsonResponse({
+      success: false,
+      error: 'Malformed engagement contract response',
+      details: {
+        path: url.pathname,
+        reason: 'Upstream returned invalid JSON',
+      },
+    }, 500);
+  }
+
+  return null;
+};
 
 const getPracticeIdForDetailsCacheInvalidation = (pathname: string): string | null => {
   const segments = pathname.split('/').filter(Boolean);
@@ -186,6 +271,10 @@ export async function handleBackendProxy(
     transformUrl,
     onBeforeFetch,
   });
+  const engagementContractError = await validateEngagementContractProxyResponse(request, result.response);
+  if (engagementContractError) {
+    return engagementContractError;
+  }
 
   // Mutations on practice routes — invalidate the practice-details cache.
   if (result.status >= 200 && result.status < 300 && method !== 'GET' && method !== 'HEAD') {


### PR DESCRIPTION
## Summary

- reduce repeated API load by tightening request coalescing/cache behavior across workspace data and engagement flows
- make engagement lists fast-fail malformed rows with explicit console diagnostics while rendering valid rows or targeted empty states
- add empty-state coverage for data tables and engagement tabs, plus unit/E2E coverage for proper and malformed engagement data
- include related UI cleanup and lint fixes needed for the full branch to pass quality gates

## Validation

- npm run lint
- npm run type-check

## Notes

The targeted live E2E run against dev.blawby.com was blocked by `/api/auth/get-session` returning 429 before the mocked engagement endpoint could be reached. The new engagement E2E fixture is included, and the requested lint/type gates pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated mobile viewport scaling (removed zoom restrictions)
  * Auto-navigation selects the most recently updated conversation on desktop practice workspaces
  * Added a Matters secondary section to the workspace sidebar
  * Redesigned Practice Contacts into a chat-first table directory (including pending invitations)

* **Improvements**
  * Improved theme switching (theme color updates and more consistent dark/light styling)
  * Clearer empty-state messaging across invoices, engagements, reports, and audit logs
  * Improved workspace navigation, filtering, and list/panel composition
<!-- end of auto-generated comment: release notes by coderabbit.ai -->