### PR TITLE
[codex] fix dashboard request bursts

### DIFF
--- a/src/features/chat/components/PracticeAssistantBriefing.tsx
+++ b/src/features/chat/components/PracticeAssistantBriefing.tsx
@@ -267,15 +267,16 @@ export function PracticeAssistantBriefing({
     { enabled: Boolean(practiceId) },
   );
 
+  const mattersData = useMattersData(practiceId ?? '', [], {
+    enabled: Boolean(practiceId),
+  });
+
   const { summaryStats, loading: practiceBillingLoading } = usePracticeBillingData({
     practiceId,
     enabled: Boolean(practiceId),
     matterLimit: 25,
     windowSize: '7d',
-  });
-
-  const mattersData = useMattersData(practiceId ?? '', [], {
-    enabled: Boolean(practiceId),
+    matters: mattersData.items,
   });
 
   const [stripeStatus, setStripeStatus] = useState<StripeStatus>(null);

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from 'preact';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
 import { Copy, X, MessagesSquare, Plus, User, Phone } from 'lucide-preact';
 
@@ -29,12 +29,10 @@ import {
   updateUserDetailMemo,
   deleteUserDetailMemo,
   getUserDetail,
-  getUserDetailAddressById,
   type UserDetailMemoRecord
 } from '@/shared/lib/apiClient';
 import {
   formatUserDetailAddressDisplay,
-  hasRenderableUserDetailAddress,
   readUserDetailAddress,
 } from '@/shared/lib/userDetailAddress';
 import {
@@ -567,11 +565,6 @@ export const PracticeContactsPage = ({
   const [memoSubmitting, setMemoSubmitting] = useState(false);
   const [memoActionId, setMemoActionId] = useState<string | null>(null);
   const [sendMessagePending, setSendMessagePending] = useState(false);
-  const [hydratedAddressByDetailId, setHydratedAddressByDetailId] = useState<Record<string, unknown>>({});
-  // Transient in-flight / failed trackers — use refs to avoid effect self-canceling
-  const hydrationInFlightRef = useRef<Record<string, true>>({});
-  const hydrationFailedRef = useRef<Record<string, true>>({});
-
   // ── chat-first list controls ─────────────────────────────────────────
   const [activeFilter, setActiveFilter] = useState<ContactFilterId>('all');
   const [sortMode, setSortMode] = useState<ContactSortId>('recent_activity');
@@ -647,90 +640,6 @@ export const PracticeContactsPage = ({
       return { ...prev, [activePracticeId]: updated };
     });
   }, [activePracticeId]);
-  useEffect(() => {
-    if (!activePracticeId) return;
-
-    const candidates = prefetchedItems.filter((detail) => {
-      if (hydratedAddressByDetailId[detail.id] || hydrationInFlightRef.current[detail.id] || hydrationFailedRef.current[detail.id]) return false;
-      const hasAddressId = Boolean((detail as Record<string, unknown>).address_id ?? (detail as Record<string, unknown>).addressId);
-      if (!hasAddressId) return false;
-      const inlineAddress = readUserDetailAddress(detail);
-      return !inlineAddress;
-    });
-
-    if (candidates.length === 0) return;
-
-    let cancelled = false;
-    // mark in-flight in the ref (transient)
-    hydrationInFlightRef.current = { ...hydrationInFlightRef.current };
-    candidates.forEach((detail) => {
-      hydrationInFlightRef.current[detail.id] = true;
-    });
-    void Promise.allSettled(
-      candidates.map(async (detail) => {
-        const hydrated = await getUserDetail(activePracticeId, detail.id);
-        let resolved = hydrated ? readUserDetailAddress(hydrated) : null;
-        if (hydrated && !resolved) {
-          const hydratedRecord = hydrated as unknown as Record<string, unknown>;
-          const addressId = typeof hydratedRecord.address_id === 'string'
-            ? hydratedRecord.address_id
-            : (typeof hydratedRecord.addressId === 'string' ? hydratedRecord.addressId : '');
-          if (addressId.trim().length > 0) {
-            const fetchedAddress = await getUserDetailAddressById(activePracticeId, addressId.trim());
-            if (fetchedAddress && hasRenderableUserDetailAddress(fetchedAddress)) {
-              resolved = readUserDetailAddress(fetchedAddress);
-            }
-          }
-        }
-        if (!resolved) return null;
-        return { id: detail.id, address: resolved };
-      })
-    ).then((results) => {
-      if (cancelled) return;
-      const updates: Record<string, unknown> = {};
-      results.forEach((result, index) => {
-        const detailId = candidates[index]?.id;
-        if (result.status === 'rejected') {
-          console.error('[Contacts] Failed to hydrate contact address', {
-            detailId,
-            reason: result.reason
-          });
-          if (detailId) {
-            hydrationFailedRef.current = { ...hydrationFailedRef.current };
-            hydrationFailedRef.current[detailId] = true;
-          }
-          return;
-        }
-        if (!result.value) {
-          if (detailId) {
-            hydrationFailedRef.current = { ...hydrationFailedRef.current };
-            hydrationFailedRef.current[detailId] = true;
-          }
-          return;
-        }
-        updates[result.value.id] = result.value.address;
-      });
-      if (Object.keys(updates).length === 0) return;
-      setHydratedAddressByDetailId((prev) => ({ ...prev, ...updates }));
-    }).finally(() => {
-      // remove in-flight flags for completed candidates, even if the effect was cancelled
-      hydrationInFlightRef.current = { ...hydrationInFlightRef.current };
-      candidates.forEach((detail) => {
-        delete hydrationInFlightRef.current[detail.id];
-      });
-    });
-
-    return () => {
-      // clear any in-flight markers we set for these candidates so they can
-      // be retried on the next effect run instead of being permanently blocked
-      hydrationInFlightRef.current = { ...hydrationInFlightRef.current };
-      candidates.forEach((detail) => {
-        delete hydrationInFlightRef.current[detail.id];
-      });
-      cancelled = true;
-    };
-  }, [activePracticeId, prefetchedItems, hydratedAddressByDetailId]);
-
   const teamMembers = useMemo<DirectoryRecord[]>(() => {
     return teamMembersData.map<DirectoryRecord>((member) => ({
         id: `team:${member.userId}`,
@@ -776,8 +685,7 @@ export const PracticeContactsPage = ({
   const clients = useMemo<DirectoryRecord[]>(() => {
     const peopleItems: DirectoryRecord[] = prefetchedItems.map((detail) => {
       const name = detail.user?.name?.trim() || detail.user?.email?.trim() || 'Unknown contact';
-      const hydratedAddress = hydratedAddressByDetailId[detail.id];
-      const resolvedAddress = readUserDetailAddress(hydratedAddress) ?? readUserDetailAddress(detail);
+      const resolvedAddress = readUserDetailAddress(detail);
       const userId = detail.user_id;
       const matters = userId ? (mattersByUserId.get(userId) ?? []) : [];
       const primaryMatter = pickPrimaryMatter(matters);
@@ -812,7 +720,7 @@ export const PracticeContactsPage = ({
       return activePeople;
     }
     return teamMembersLoaded ? [...activePeople, ...teamMembers] : activePeople;
-  }, [hydratedAddressByDetailId, isArchivedListRoute, isClientsListRoute, isTeamListRoute, mattersByUserId, now, pickPrimaryMatter, prefetchedItems, statusFilter, teamMembers, teamMembersLoaded]);
+  }, [isArchivedListRoute, isClientsListRoute, isTeamListRoute, mattersByUserId, now, pickPrimaryMatter, prefetchedItems, statusFilter, teamMembers, teamMembersLoaded]);
 
   const pendingClientInvitations = useMemo(
     () => practiceInvitations.filter((invitation) => normalizePracticeRole(invitation.role) === 'client' && invitation.status === 'pending'),
@@ -1026,8 +934,7 @@ export const PracticeContactsPage = ({
           return;
         }
         const name = detail.user?.name?.trim() || detail.user?.email?.trim() || 'Unknown contact';
-        const hydratedAddress = hydratedAddressByDetailId[detail.id];
-        const resolvedAddress = readUserDetailAddress(hydratedAddress) ?? readUserDetailAddress(detail);
+        const resolvedAddress = readUserDetailAddress(detail);
         const userId = detail.user_id;
         const matters = userId ? (mattersByUserId.get(userId) ?? []) : [];
         const primaryMatter = pickPrimaryMatter(matters);
@@ -1054,7 +961,7 @@ export const PracticeContactsPage = ({
         setSelectedClientRemote(null);
       });
     return () => controller.abort();
-  }, [activePracticeId, hydratedAddressByDetailId, mattersByUserId, now, pickPrimaryMatter, selectedClientFromList, selectedClientIdFromPath, teamMembersLoaded]);
+  }, [activePracticeId, mattersByUserId, now, pickPrimaryMatter, selectedClientFromList, selectedClientIdFromPath, teamMembersLoaded]);
 
   const handleMemoSubmit = useCallback(async (text: string) => {
     if (!activePracticeId || !selectedClient || selectedClient.kind !== 'client') return;

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -796,7 +796,7 @@ export const PracticeMattersPage = ({
   useEffect(() => {
     if (!activePracticeId) return;
     if (practiceDetailsRequestedRef.current === activePracticeId) return;
-    if (practiceDetails && hasPracticeDetails) {
+    if (hasPracticeDetails) {
       practiceDetailsRequestedRef.current = activePracticeId;
       return;
     }
@@ -805,7 +805,7 @@ export const PracticeMattersPage = ({
     fetchPracticeDetails()
       .catch((error) => console.warn('[PracticeMattersPage] Failed to load practice services', error))
       .finally(() => setServicesLoading(false));
-  }, [activePracticeId, fetchPracticeDetails, hasPracticeDetails, practiceDetails]);
+  }, [activePracticeId, fetchPracticeDetails, hasPracticeDetails]);
 
   useEffect(() => {
     if (!convertIntakeUuid || !activePracticeId) {

--- a/src/features/matters/services/mattersApi.ts
+++ b/src/features/matters/services/mattersApi.ts
@@ -33,6 +33,7 @@ import type {
   BackendMatterExpense,
   BackendMatterMilestone,
   BackendMatterTask,
+  BackendPracticeTask,
   TaskStatus,
   TaskPriority,
 } from '@/shared/types/wire';
@@ -45,6 +46,7 @@ export type {
   BackendMatterExpense,
   BackendMatterMilestone,
   BackendMatterTask,
+  BackendPracticeTask,
   TaskStatus,
   TaskPriority,
 };
@@ -258,6 +260,9 @@ const extractMilestonesArray = (payload: unknown): BackendMatterMilestone[] =>
 
 const extractTasksArray = (payload: unknown): BackendMatterTask[] =>
   pluckCollection<BackendMatterTask>(unwrapApiResponse<unknown>(payload), ['tasks']);
+
+const extractPracticeTasksArray = (payload: unknown): BackendPracticeTask[] =>
+  pluckCollection<BackendPracticeTask>(unwrapApiResponse<unknown>(payload), ['tasks']);
 
 const extractTask = (payload: unknown): BackendMatterTask | null =>
   pluckRecord<BackendMatterTask>(unwrapApiResponse<unknown>(payload), ['task']);
@@ -900,6 +905,38 @@ export const listMatterTasks = async (
     'Failed to load tasks'
   );
   return extractTasksArray(payload);
+};
+
+export const listPracticeTasks = async (
+  practiceId: string,
+  filters: ListMatterTaskFilters & { due_before?: string; page?: number; limit?: number } = {},
+  options: FetchOptions = {}
+): Promise<BackendPracticeTask[]> => {
+  if (!practiceId) {
+    return [];
+  }
+
+  const params = new URLSearchParams();
+  if (filters.task_id) params.set('task_id', filters.task_id);
+  if (filters.assignee_id) params.set('assignee_id', filters.assignee_id);
+  if (filters.status) params.set('status', filters.status);
+  if (filters.priority) params.set('priority', filters.priority);
+  if (filters.stage) params.set('stage', filters.stage);
+  if (filters.due_before) params.set('due_before', filters.due_before);
+  if (filters.page) params.set('page', String(filters.page));
+  if (filters.limit) params.set('limit', String(filters.limit));
+
+  const payload = await requestData(
+    apiClient.get(
+      `/api/tasks/${encodeURIComponent(practiceId)}`,
+      {
+        params: Object.fromEntries(params.entries()),
+        signal: options.signal
+      }
+    ),
+    'Failed to load tasks'
+  );
+  return extractPracticeTasksArray(payload);
 };
 
 export const createMatterTask = async (

--- a/src/features/tasks/services/useTasks.ts
+++ b/src/features/tasks/services/useTasks.ts
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   createMatterTask,
   deleteMatterTask,
+  listPracticeTasks,
   listMatters,
-  listMatterTasks,
   updateMatterTask,
   type BackendMatter,
+  type BackendPracticeTask,
   type CreateMatterTaskPayload,
   type UpdateMatterTaskPayload
 } from '@/features/matters/services/mattersApi';
@@ -14,14 +15,50 @@ import type { CreateTaskInput, Task, UpdateTaskInput } from '@/features/tasks/ty
 
 const PAGE_SIZE = 50;
 
-const buildMatterTitle = (matter: BackendMatter): string => {
-  const raw = (matter.title ?? '').toString().trim();
-  return raw.length > 0 ? raw : 'Untitled matter';
-};
-
 const isMatterUrgent = (matter: BackendMatter): boolean => {
   const urgency = (matter.urgency ?? '').toString().toLowerCase();
   return urgency === 'emergency' || urgency === 'time_sensitive';
+};
+
+const normalizeStatus = (status: BackendPracticeTask['status']) =>
+  status === 'pending' || status === 'in_progress' || status === 'completed' || status === 'blocked'
+    ? status
+    : 'pending';
+
+const normalizePriority = (priority: BackendPracticeTask['priority']) =>
+  priority === 'low' || priority === 'normal' || priority === 'high' || priority === 'urgent'
+    ? priority
+    : 'normal';
+
+const isPracticeTaskUrgent = (task: BackendPracticeTask): boolean => {
+  const record = task as BackendPracticeTask & { matter?: BackendMatter | null; matter_urgency?: string | null };
+  const urgency = (record.matter?.urgency ?? record.matter_urgency ?? '').toString().toLowerCase();
+  return urgency === 'emergency' || urgency === 'time_sensitive';
+};
+
+const getPracticeTaskMatterTitle = (task: BackendPracticeTask, matter?: BackendMatter): string => {
+  const record = task as BackendPracticeTask & { matter?: BackendMatter | null; matter_title?: string | null };
+  const title = record.matter?.title ?? record.matter_title ?? matter?.title ?? '';
+  const raw = title.toString().trim();
+  return raw.length > 0 ? raw : 'Untitled matter';
+};
+
+const toTask = (task: BackendPracticeTask, matter?: BackendMatter): Task | null => {
+  if (!task.matter_id) return null;
+  const base = toMatterTask({
+    ...task,
+    matter_id: task.matter_id,
+    name: task.name ?? 'Untitled task',
+    status: normalizeStatus(task.status),
+    priority: normalizePriority(task.priority),
+    stage: task.stage ?? '',
+  });
+  return {
+    ...base,
+    matterTitle: getPracticeTaskMatterTitle(task, matter),
+    matterStatus: matter?.status ?? null,
+    matterUrgent: matter ? isMatterUrgent(matter) : isPracticeTaskUrgent(task)
+  };
 };
 
 type UseTasksResult = {
@@ -39,15 +76,10 @@ type UseTasksResult = {
 /**
  * Cross-matter Tasks aggregation hook.
  *
- * The Tasks API is matter-scoped (`/api/matters/:practice/:matter/tasks`), so
- * the cross-matter Tasks screen must fan-out across the practice's matters and
- * merge each matter-row task list with its parent-matter context (title,
- * status, urgency) — this hook owns that fan-out + the per-task mutations.
- *
- * No top-level `/api/practices/:id/tasks` endpoint is exposed on the worker;
- * a `BackendPracticeTask` shape exists for the internal ReportService but it
- * is not surfaced to the frontend. If/when a real aggregation endpoint ships,
- * swap the fan-out below for a single fetch.
+ * The practice-wide Tasks API returns tasks across the organization in one
+ * request while the matters list supplies create-task options and row context.
+ * Each aggregate task is merged with its parent matter metadata (title,
+ * status, urgency) without per-matter task fan-out.
  */
 export const useTasks = (practiceId: string | null | undefined): UseTasksResult => {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -88,32 +120,15 @@ export const useTasks = (practiceId: string | null | undefined): UseTasksResult 
         }
         setMatters(allMatters);
 
-        // 2. Fan-out task fetches per matter, tolerating individual failures
-        //    so one missing matter doesn't blank the whole screen.
-        const settled = await Promise.allSettled(
-          allMatters.map((matter) =>
-            listMatterTasks(practiceId, matter.id, {}, { signal })
-          )
-        );
+        // 2. Fetch practice-wide tasks in a single request.
+        const practiceTasks = await listPracticeTasks(practiceId, {}, { signal });
         if (signal.aborted) return;
 
+        const matterById = new Map(allMatters.map((matter) => [matter.id, matter]));
         const merged: Task[] = [];
-        settled.forEach((result, index) => {
-          const matter = allMatters[index];
-          if (!matter) return;
-          if (result.status !== 'fulfilled') return;
-          const matterTitle = buildMatterTitle(matter);
-          const matterStatus = matter.status ?? null;
-          const matterUrgent = isMatterUrgent(matter);
-          for (const wireTask of result.value) {
-            const base = toMatterTask(wireTask);
-            merged.push({
-              ...base,
-              matterTitle,
-              matterStatus,
-              matterUrgent
-            });
-          }
+        practiceTasks.forEach((wireTask) => {
+          const task = toTask(wireTask, wireTask.matter_id ? matterById.get(wireTask.matter_id) : undefined);
+          if (task) merged.push(task);
         });
 
         setTasks(merged);

--- a/src/shared/types/wire.ts
+++ b/src/shared/types/wire.ts
@@ -90,6 +90,14 @@ export {
   SubscriptionLifecycleStatusSchema,
 } from '../../../worker/types/wire/practice';
 
+// Reports / practice-wide aggregates
+export type {
+  BackendPracticeTask,
+} from '../../../worker/types/wire/reports';
+export {
+  BackendPracticeTaskSchema,
+} from '../../../worker/types/wire/reports';
+
 // ── Conversation ──────────────────────────────────────────────────────────
 export type {
   ChatMessage,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -82,6 +82,7 @@ const workerEndpoints = [
 	'subscription',
 	'engagement-contracts',
 	'matters',
+	'tasks',
 	'uploads',
 	'widget',
 	'presence',

--- a/worker/routes/authProxy.ts
+++ b/worker/routes/authProxy.ts
@@ -38,6 +38,7 @@ const BACKEND_PATH_PREFIXES = [
   '/api/preferences',
   '/api/subscriptions',
   '/api/subscription',
+  '/api/tasks',
   '/api/uploads',
   '/api/clients'
 ];


### PR DESCRIPTION
## Summary

Fixes part of #694 by removing confirmed frontend request burst sources:

- Reuses the dashboard matters fetch inside `usePracticeBillingData` so the briefing no longer issues the duplicate `/api/matters/:practiceId` request.
- Removes Contacts page per-contact address hydration and reads the inline `address` returned by the clients list response.
- Replaces the cross-matter Tasks page N+1 task fan-out with the practice-wide `/api/tasks/:practiceId` endpoint, including local/prod worker proxy routing for `/api/tasks`.
- Tightens the Practice Matters practice-details effect dependency to avoid rerunning on details object identity changes.

## Notes

I did not change the suspected duplicate invoice path because current `staging` gates the workspace invoice-existence check to `view === 'invoices'`, so it no longer appears to be part of the dashboard mount burst without a fresh reproduction.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build`