### PR TITLE
[codex] fix service worker lazy chunk precache

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -238,9 +238,19 @@ export default defineConfig(({ mode }: ConfigEnv) => {
 					skipWaiting: false,
 					clientsClaim: false,
 					cleanupOutdatedCaches: true,
-					// Precache the SPA shell used by Workbox's navigation fallback plus
-					// app JS/CSS. Widget pages/assets are still excluded by the denylist.
-					globPatterns: ['index.html', 'assets/**/*.{js,css}'],
+					// Precache only the SPA shell and shared entry/vendor bundles.
+					// Lazy route/dialog chunks are cached on first real use below.
+					globPatterns: [
+						'index.html',
+						'assets/main-*.js',
+						'assets/prerenderEntry-*.js',
+						'assets/vendor-*.js',
+						'assets/i18n-*.js',
+						'assets/icons-*.js',
+						'assets/stripe-*.js',
+						'assets/markdown-*.js',
+						'assets/*.css'
+					],
 					globIgnores: [],
 					navigateFallbackDenylist: [
 						// Never route API or auth requests through the SPA
@@ -250,7 +260,15 @@ export default defineConfig(({ mode }: ConfigEnv) => {
 						/\/widget-[^/]+$/,
 						/\.html$/,
 					],
-					runtimeCaching: []
+					runtimeCaching: [
+						{
+							urlPattern: /\/assets\/.*\.js$/,
+							handler: 'StaleWhileRevalidate',
+							options: {
+								cacheName: 'lazy-chunks'
+							}
+						}
+					]
 				}
 			}),
 			// Process HTML with critical CSS extraction


### PR DESCRIPTION
## Summary

Fixes #695 by restoring lazy-route code splitting behavior in the production service worker:

- Narrows Workbox precache from `assets/**/*.{js,css}` to the shell/shared entry patterns only.
- Keeps the SPA shell, entry/modulepreload bundles, manually split shared bundles, and CSS precached.
- Adds a `StaleWhileRevalidate` runtime cache named `lazy-chunks` for remaining `assets/*.js` route/dialog chunks, so they cache on first real use instead of on SW install.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run build`
- Confirmed generated `dist/sw.js` precache dropped to 11 entries and no longer precaches issue examples like `WorkspacePage`, `PracticeTrustPage`, `SendInvoiceDialog`, `VoidInvoiceConfirmDialog`, `WelcomeDialog`, or `PricingPage`; `lazy-chunks` runtime caching is present.