### PR TITLE
[codex] Fix onboarding practice creation payload

### DIFF
--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -452,17 +452,17 @@ const OnboardingFlowImpl = ({
                 lede={
                   <>
                     Your practice is the workspace your team and clients see. Pick a
-                    name + slug now; jurisdiction and bar # help us tune your assistant
-                    to your state.
+                    name now; jurisdiction and service areas help Blawby screen
+                    incoming leads against the work and locations you accept.
                   </>
                 }
               />
               <AssistantTurn trail="grounding context">
                 <p style={{ margin: 0 }}>
                   {firstName ? <>Got it, <strong>{firstName}</strong>. </> : 'Got it. '}
-                  Let&apos;s name your practice. If you&apos;re solo,
-                  &ldquo;Law Offices of {firstName || 'Your Name'}&rdquo; is common —
-                  but anything works. You can change the public slug later.
+                  Add the practice name clients should see. We&apos;ll use the
+                  jurisdiction, service areas, and practice type to qualify leads
+                  before they reach your workspace.
                 </p>
               </AssistantTurn>
               <PracticeStep draft={draft} onChange={handleDraftChange} />
@@ -642,8 +642,12 @@ export const OnboardingFlow = ({
           name,
           slug: slugify(name),
           description: draft.description ?? undefined,
+          supportedStates: draft.jurisdiction
+            ? [{ country: 'US', states: [draft.jurisdiction] }]
+            : [],
           metadata: {
             practiceAreas: draft.practiceAreas ?? [],
+            practiceTypes: draft.practiceTypes ?? [],
             barNumber: draft.barNumber ?? '',
             jurisdictions: draft.jurisdiction ? [draft.jurisdiction] : [],
           },

--- a/src/features/onboarding/steps/PracticeStep.tsx
+++ b/src/features/onboarding/steps/PracticeStep.tsx
@@ -1,8 +1,11 @@
-import { Building2 } from 'lucide-preact';
+import { useState } from 'preact/hooks';
+import { Building2, Plus } from 'lucide-preact';
 import { Chip } from '@/design-system/primitives';
+import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { slugify } from '@/shared/lib/orgCreation';
 import { getPublicFormOrigin } from '@/config/urls';
+import { STATE_OPTIONS } from '@/shared/ui/address/AddressFields';
 import type { OnboardingDraft } from '../types';
 
 interface PracticeStepProps {
@@ -10,33 +13,56 @@ interface PracticeStepProps {
   onChange: (patch: Partial<OnboardingDraft>) => void;
 }
 
-const JURISDICTIONS: ReadonlyArray<{ value: string; label: string }> = [
-  { value: 'NC', label: 'NC · North Carolina' },
-  { value: 'SC', label: 'SC · South Carolina' },
-  { value: 'GA', label: 'GA · Georgia' },
-  { value: 'TX', label: 'TX · Texas' },
-  { value: 'NY', label: 'NY · New York' },
-  { value: 'CA', label: 'CA · California' },
-  { value: 'FL', label: 'FL · Florida' },
-  { value: 'IL', label: 'IL · Illinois' },
-  { value: 'WA', label: 'WA · Washington' },
-  { value: 'MA', label: 'MA · Massachusetts' }
+const PRACTICE_SERVICE_GROUPS: ReadonlyArray<{
+  type: string;
+  services: readonly string[];
+}> = [
+  {
+    type: 'Transactional',
+    services: [
+      'Contract drafting',
+      'Contract review',
+      'Business formation',
+      'Mergers and acquisitions',
+      'Real estate transactions',
+      'Estate planning',
+      'Employment agreements',
+      'Intellectual property licensing',
+      'Nonprofit formation'
+    ]
+  },
+  {
+    type: 'Regulatory',
+    services: [
+      'Compliance counseling',
+      'Licensing and permitting',
+      'Tax',
+      'Immigration',
+      'Privacy and data security',
+      'Health care compliance',
+      'Environmental regulation',
+      'Securities regulation',
+      'Education compliance'
+    ]
+  },
+  {
+    type: 'Litigation',
+    services: [
+      'Family law',
+      'Personal injury',
+      'Employment disputes',
+      'Criminal defense',
+      'Business disputes',
+      'Probate disputes',
+      'Landlord-tenant disputes',
+      'Consumer protection',
+      'Appeals'
+    ]
+  }
 ];
 
-const PRACTICE_AREAS: readonly string[] = [
-  'Family law',
-  'Civil litigation',
-  'Estate planning',
-  'Personal injury',
-  'Small business',
-  'Real estate',
-  'Employment',
-  'Immigration',
-  'Criminal defense',
-  'Tax',
-  'Intellectual property',
-  'Bankruptcy'
-];
+const PRACTICE_TYPES = PRACTICE_SERVICE_GROUPS.map((group) => group.type);
+const CATALOG_PRACTICE_AREAS = PRACTICE_SERVICE_GROUPS.flatMap((group) => group.services);
 
 /**
  * Step 2 body — practice identity plus grounding fields. All fields are sent
@@ -45,18 +71,58 @@ const PRACTICE_AREAS: readonly string[] = [
  * Slug is auto-derived from firm name and is not user-editable.
  */
 export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
+  const [otherPracticeArea, setOtherPracticeArea] = useState('');
+  const [otherPracticeType, setOtherPracticeType] = useState(PRACTICE_TYPES[0] ?? '');
   const computedSlug = slugify(draft.practiceName ?? '');
   const selectedAreas = new Set(draft.practiceAreas ?? []);
+  const selectedTypes = new Set(draft.practiceTypes ?? []);
   const publicOrigin = (() => { try { return getPublicFormOrigin(); } catch { return ''; } })();
 
-  const togglePracticeArea = (area: string) => {
+  const setPracticeAreas = (areas: string[]) => {
+    const uniqueAreas = Array.from(new Set(areas.map((area) => area.trim()).filter(Boolean)));
+    onChange({ practiceAreas: uniqueAreas });
+  };
+
+  const setPracticeTypes = (types: string[]) => {
+    const uniqueTypes = Array.from(new Set(types.map((type) => type.trim()).filter(Boolean)));
+    onChange({ practiceTypes: uniqueTypes });
+  };
+
+  const togglePracticeType = (type: string) => {
+    const next = new Set(selectedTypes);
+    if (next.has(type)) {
+      next.delete(type);
+    } else {
+      next.add(type);
+    }
+    setPracticeTypes(Array.from(next));
+  };
+
+  const togglePracticeArea = (area: string, practiceType?: string) => {
     const next = new Set(selectedAreas);
+    const isAdding = !next.has(area);
     if (next.has(area)) {
       next.delete(area);
     } else {
       next.add(area);
     }
-    onChange({ practiceAreas: Array.from(next) });
+    const nextAreas = Array.from(next);
+    const nextTypes = practiceType && isAdding
+      ? Array.from(new Set([...(draft.practiceTypes ?? []), practiceType]))
+      : (draft.practiceTypes ?? []);
+
+    onChange({
+      practiceAreas: nextAreas,
+      practiceTypes: nextTypes
+    });
+  };
+
+  const addOtherPracticeArea = () => {
+    const nextArea = otherPracticeArea.trim();
+    if (!nextArea) return;
+    setPracticeAreas([...(draft.practiceAreas ?? []), nextArea]);
+    setPracticeTypes([...(draft.practiceTypes ?? []), otherPracticeType]);
+    setOtherPracticeArea('');
   };
 
   return (
@@ -87,7 +153,7 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
               required
               value={draft.practiceName ?? ''}
               onChange={(value) => onChange({ practiceName: value })}
-              placeholder="Law Offices of Sarah Chen"
+              placeholder="Your practice name"
               icon={Building2}
               iconClassName="h-5 w-5 text-dim-2"
             />
@@ -103,15 +169,15 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
             <select
               id="onboarding-jurisdiction"
               value={draft.jurisdiction ?? ''}
-              onChange={(event) =>
+              onInput={(event) =>
                 onChange({ jurisdiction: (event.target as HTMLSelectElement).value })
               }
               className="select"
             >
               <option value="">Select…</option>
-              {JURISDICTIONS.map((j) => (
-                <option key={j.value} value={j.value}>
-                  {j.label}
+              {STATE_OPTIONS.map((state) => (
+                <option key={state.value} value={state.value}>
+                  {state.value} · {state.label}
                 </option>
               ))}
             </select>
@@ -132,22 +198,90 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
         </div>
 
         <div className="mt-6">
-          <p className="label mb-2 block" id="practice-areas-label">
-            Practice areas
+          <p className="label mb-2 block" id="practice-services-label">
+            Services by practice type
           </p>
-          <div className="flex flex-wrap gap-2">
-            {PRACTICE_AREAS.map((area) => {
-              const isSelected = selectedAreas.has(area);
+          <div className="flex flex-col gap-5">
+            {PRACTICE_SERVICE_GROUPS.map((group) => {
+              const hasSelectedService = group.services.some((service) => selectedAreas.has(service));
+              const isTypeSelected = selectedTypes.has(group.type) || hasSelectedService;
               return (
+                <div key={group.type}>
+                  <div className="mb-2 flex items-center gap-2">
+                    <Chip
+                      variant={isTypeSelected ? 'accent' : 'default'}
+                      onClick={() => togglePracticeType(group.type)}
+                    >
+                      {group.type}
+                    </Chip>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {group.services.map((area) => {
+                      const isSelected = selectedAreas.has(area);
+                      return (
+                        <Chip
+                          key={area}
+                          variant={isSelected ? 'accent' : 'default'}
+                          onClick={() => togglePracticeArea(area, group.type)}
+                        >
+                          {area}
+                        </Chip>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+            {(draft.practiceAreas ?? [])
+              .filter((area) => !CATALOG_PRACTICE_AREAS.includes(area))
+              .map((area) => (
                 <Chip
                   key={area}
-                  variant={isSelected ? 'accent' : 'default'}
+                  variant="accent"
                   onClick={() => togglePracticeArea(area)}
+                  onRemove={() => togglePracticeArea(area)}
+                  removeAriaLabel={`Remove ${area}`}
                 >
                   {area}
                 </Chip>
-              );
-            })}
+              ))}
+          </div>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+            <select
+              id="onboarding-practice-area-other-type"
+              value={otherPracticeType}
+              onInput={(event) => setOtherPracticeType((event.target as HTMLSelectElement).value)}
+              className="select sm:max-w-[180px]"
+              aria-label="Practice type for custom area"
+            >
+              {PRACTICE_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+            <Input
+              id="onboarding-practice-area-other"
+              type="text"
+              value={otherPracticeArea}
+              onChange={setOtherPracticeArea}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  addOtherPracticeArea();
+                }
+              }}
+              placeholder="Other practice area"
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              icon={Plus}
+              onClick={addOtherPracticeArea}
+              disabled={otherPracticeArea.trim().length === 0}
+            >
+              Add
+            </Button>
           </div>
         </div>
 

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -22,6 +22,7 @@ export interface OnboardingDraft {
   jurisdiction?: string;
   barNumber?: string;
   practiceAreas?: string[];
+  practiceTypes?: string[];
   description?: string;
   /** Set once createPractice() has succeeded so we don't re-create on back/forward. */
   createdOrganizationId?: string | null;

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -606,6 +606,7 @@ export interface CreatePracticeRequest {
   logo?: string;
   description?: string;
   metadata?: PracticeMetadata;
+  supportedStates?: SupportedStateEntry[] | null;
   businessPhone?: string;
   businessEmail?: string;
   consultationFee?: MajorAmount;
@@ -1151,7 +1152,8 @@ export async function createPractice(
   payload: CreatePracticeRequest,
   config?: ApiRequestConfig
 ): Promise<Practice> {
-  const response = await apiClient.post('/api/practice', payload, {
+  const normalized = normalizePracticeCreatePayload(payload);
+  const response = await apiClient.post('/api/practice', normalized, {
     signal: config?.signal
   });
   return unwrapPracticeResponse(response.data);
@@ -1869,6 +1871,19 @@ function normalizePracticeUpdatePayload(payload: UpdatePracticeRequest): Record<
   return normalized;
 }
 
+function normalizePracticeCreatePayload(payload: CreatePracticeRequest): Record<string, unknown> {
+  const normalized: Record<string, unknown> = { ...payload };
+
+  if ('supportedStates' in payload) {
+    delete normalized.supportedStates;
+    if (payload.supportedStates !== undefined) {
+      normalized.supported_states = normalizeSupportedStates(payload.supportedStates);
+    }
+  }
+
+  return normalized;
+}
+
 function unwrapPublicPracticePayload(payload: unknown): Record<string, unknown> | null {
   if (!isRecord(payload)) return null;
 
@@ -2077,32 +2092,7 @@ function normalizePracticeDetailsPayload(payload: PracticeDetailsUpdate): Record
   }
 
   if ('supportedStates' in payload && payload.supportedStates !== undefined) {
-    if (Array.isArray(payload.supportedStates)) {
-      normalized.supported_states = payload.supportedStates
-        .map((entry) => {
-          if (!isRecord(entry) || typeof entry.country !== 'string') {
-            return null;
-          }
-          const country = entry.country.trim().toUpperCase();
-          if (!country) {
-            return null;
-          }
-          const result: Record<string, unknown> = { country };
-          if (Array.isArray(entry.states)) {
-            const states = entry.states
-              .filter((state): state is string => typeof state === 'string')
-              .map((state) => state.trim().toUpperCase())
-              .filter(Boolean);
-            if (states.length > 0) {
-              result.states = states;
-            }
-          }
-          return result;
-        })
-        .filter((entry): entry is Record<string, unknown> => entry !== null);
-    } else {
-      normalized.supported_states = payload.supportedStates;
-    }
+    normalized.supported_states = normalizeSupportedStates(payload.supportedStates);
   }
 
   // NOTE: Persist `services_by_state` inside `settings` (opaque JSON string).
@@ -2111,6 +2101,35 @@ function normalizePracticeDetailsPayload(payload: PracticeDetailsUpdate): Record
   // create a top-level `services_by_state` field — the backend does not accept it.
 
   return normalized;
+}
+
+function normalizeSupportedStates(
+  supportedStates: SupportedStateEntry[] | null
+): Record<string, unknown>[] | null {
+  if (supportedStates === null) return null;
+
+  return supportedStates
+    .map((entry) => {
+      if (!isRecord(entry) || typeof entry.country !== 'string') {
+        return null;
+      }
+      const country = entry.country.trim().toUpperCase();
+      if (!country) {
+        return null;
+      }
+      const result: Record<string, unknown> = { country };
+      if (Array.isArray(entry.states)) {
+        const states = entry.states
+          .filter((state): state is string => typeof state === 'string')
+          .map((state) => state.trim().toUpperCase())
+          .filter(Boolean);
+        if (states.length > 0) {
+          result.states = states;
+        }
+      }
+      return result;
+    })
+    .filter((entry): entry is Record<string, unknown> => entry !== null);
 }
 
 export function normalizePracticeDetailsResponse(payload: unknown): PracticeDetails | null {

--- a/tests/component/onboarding-flow-subscription-order.test.tsx
+++ b/tests/component/onboarding-flow-subscription-order.test.tsx
@@ -109,6 +109,27 @@ describe('OnboardingFlow subscription ordering', () => {
     fireEvent.input(document.querySelector('#onboarding-firmName') as HTMLInputElement, {
       target: { value: 'E2E Practice' },
     });
+    const jurisdictionSelect = document.getElementById('onboarding-jurisdiction') as unknown as HTMLSelectElement;
+    const jurisdictionOptions = Array.from(jurisdictionSelect.options).map((option) => option.value);
+    expect(jurisdictionOptions).toContain('DC');
+    expect(jurisdictionOptions).toContain('VT');
+    expect(screen.queryByText('Civil litigation')).not.toBeInTheDocument();
+    expect(screen.getByText('Business formation')).toBeInTheDocument();
+    expect(screen.getByText('Compliance counseling')).toBeInTheDocument();
+    expect(screen.getByText('Business disputes')).toBeInTheDocument();
+
+    jurisdictionSelect.value = 'VT';
+    fireEvent.input(jurisdictionSelect);
+    fireEvent.change(jurisdictionSelect);
+    const otherTypeSelect = document.getElementById('onboarding-practice-area-other-type') as unknown as HTMLSelectElement;
+    otherTypeSelect.value = 'Litigation';
+    fireEvent.input(otherTypeSelect);
+    fireEvent.change(otherTypeSelect);
+    fireEvent.input(document.querySelector('#onboarding-practice-area-other') as HTMLInputElement, {
+      target: { value: 'Aviation law' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Business disputes' }));
     fireEvent.click(screen.getByRole('button', { name: /Continue → Get Business/i }));
 
     await waitFor(() => {
@@ -116,6 +137,12 @@ describe('OnboardingFlow subscription ordering', () => {
         expect.objectContaining({
           name: 'E2E Practice',
           slug: 'e2e-practice',
+          supportedStates: [{ country: 'US', states: ['VT'] }],
+          metadata: expect.objectContaining({
+            practiceAreas: expect.arrayContaining(['Aviation law', 'Business disputes']),
+            practiceTypes: ['Litigation'],
+            jurisdictions: ['VT'],
+          }),
         })
       );
     });

--- a/tests/e2e/practice-member-registration.spec.ts
+++ b/tests/e2e/practice-member-registration.spec.ts
@@ -132,12 +132,27 @@ test.describe('New practice member registration → dashboard', () => {
     await expect(page.getByText(/Step 2 of 6 · Your practice/i)).toBeVisible();
     await page.locator('#onboarding-firmName').fill(practice.name);
     await page.locator('#onboarding-jurisdiction').selectOption(practice.jurisdiction);
+    await expect(page.locator('#onboarding-jurisdiction')).toContainText('WY · Wyoming');
+    await expect(page.getByText('Civil litigation')).toHaveCount(0);
 
+    const createPracticeRequest = page.waitForRequest(
+      (request) => request.url().includes('/api/practice') && request.method() === 'POST',
+      { timeout: 30000 }
+    );
     const createPracticeResponse = page.waitForResponse(
       (response) => response.url().includes('/api/practice') && response.request().method() === 'POST',
       { timeout: 30000 }
     );
     await page.getByRole('button', { name: /Continue → Get Business/i }).click();
+    const practiceRequest = await createPracticeRequest;
+    const practicePayload = practiceRequest.postDataJSON() as {
+      supported_states?: Array<{ country?: string; states?: string[] }>;
+      metadata?: { jurisdictions?: string[] };
+    };
+    expect(practicePayload.supported_states).toEqual([
+      { country: 'US', states: [practice.jurisdiction] },
+    ]);
+    expect(practicePayload.metadata?.jurisdictions).toEqual([practice.jurisdiction]);
     const practiceResponse = await createPracticeResponse;
     expect(practiceResponse.ok()).toBe(true);
     practiceCreated = true;


### PR DESCRIPTION
## Summary

- Normalize onboarding practice creation to send `supported_states` in the backend wire format so practice creation does not fail with a missing/empty supported states insert path.
- Expand jurisdiction selection to all US states plus DC and remove the misleading firm-name suggestion copy.
- Rework practice services into Transactional, Regulatory, and Litigation groups with an Other practice area input.
- Add component and browser e2e assertions for the practice creation payload and onboarding service/jurisdiction UI.

## Validation

- `npx vitest run -c config/vitest/vitest.config.ts --project component tests/component/onboarding-flow-subscription-order.test.tsx`
- `npm run type-check`
- `npx eslint src/features/onboarding/steps/PracticeStep.tsx src/features/onboarding/components/OnboardingFlow.tsx src/features/onboarding/types.ts src/shared/lib/apiClient.ts --max-warnings 0`
- `E2E_BASE_URL=https://dev.blawby.com npx playwright test -c playwright.public.config.ts --project=chromium tests/e2e/practice-member-registration.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated onboarding to guide users through choosing practice type, practice areas, and jurisdiction in a more structured way.
  * Added support for custom “other” practice areas during setup.
  * Expanded practice setup to capture supported states and practice types when creating a practice.

* **Bug Fixes**
  * Improved onboarding data handling so selected jurisdictions and practice details are saved more reliably.
  * Refined setup copy and field labels for clearer practice-profile entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->