### PR TITLE
[codex] Fix onboarding subscription return and previews

### DIFF
--- a/src/app/PublicWorkspaceRoute.tsx
+++ b/src/app/PublicWorkspaceRoute.tsx
@@ -13,6 +13,7 @@ import MarketingShell from '@/shared/ui/layout/MarketingShell';
 import { SEOHead } from '@/app/SEOHead';
 import { normalizePracticeDetailsResponse } from '@/shared/lib/apiClient';
 import { setPracticeDetailsEntry } from '@/shared/stores/practiceDetailsStore';
+import { useSessionContext } from '@/shared/contexts/SessionContext';
 import type { WidgetPreviewConfig, WidgetPreviewMessage, WidgetPreviewScenario } from '@/shared/types/widgetPreview';
 import { toMinorUnitsValue } from '@/shared/utils/money';
 
@@ -43,6 +44,7 @@ export const PublicWorkspaceRoute: FunctionComponent<PublicWorkspaceRouteProps> 
   shell,
 }) => {
   const location = useLocation();
+  const { session } = useSessionContext();
   const slug = (practiceSlug ?? '').trim();
   const searchParams = getSearchParams(location.url);
 
@@ -54,6 +56,12 @@ export const PublicWorkspaceRoute: FunctionComponent<PublicWorkspaceRouteProps> 
 
   const isPreviewRequested = isPreviewQuery(searchParams);
   const isEmbed = isEmbedQuery(searchParams);
+  const isOwnerPreview = searchParams.get('ownerPreview') === '1';
+  const previewBanner = (isOwnerPreview || (session?.user && !session.user.is_anonymous)) && !isEmbed ? (
+    <div className="border-b border-line-subtle bg-paper-2 px-4 py-2 text-xs text-dim">
+      Preview mode: you are logged in as {session?.user?.email ?? 'your account'}. Clients do not see this banner.
+    </div>
+  ) : null;
 
   const initialScenario = useMemo<WidgetPreviewScenario>(() => {
     const params = getSearchParams(location.url);
@@ -116,7 +124,12 @@ export const PublicWorkspaceRoute: FunctionComponent<PublicWorkspaceRouteProps> 
   }, [data, resolvedPracticeId]);
 
   if (isLoading) {
-    return <LoadingScreen />;
+    return (
+      <>
+        {previewBanner}
+        <LoadingScreen />
+      </>
+    );
   }
 
   if (!data || error || !practiceConfig || !resolvedPracticeId) {
@@ -144,6 +157,7 @@ export const PublicWorkspaceRoute: FunctionComponent<PublicWorkspaceRouteProps> 
     return (
       <>
         <SEOHead practiceConfig={practiceConfig} currentUrl={currentUrl} />
+        {previewBanner}
         <WidgetPreviewApp
           practiceId={resolvedPracticeId}
           practiceConfig={practiceConfig}
@@ -166,7 +180,10 @@ export const PublicWorkspaceRoute: FunctionComponent<PublicWorkspaceRouteProps> 
   return (
     <>
       <SEOHead practiceConfig={practiceConfig} currentUrl={currentUrl} />
-      <Shell>{widgetApp}</Shell>
+      <Shell>
+        {previewBanner}
+        {widgetApp}
+      </Shell>
     </>
   );
 };

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -38,13 +38,18 @@ interface OnboardingFlowProps {
   active?: boolean;
   className?: string;
   testId?: string;
+  initialStep?: OnboardingStep;
+  initialHasActiveSubscription?: boolean;
+  subscriptionSuccessPracticeId?: string | null;
 }
 
 interface OnboardingFlowRuntimeProps extends OnboardingFlowProps {
   initialStep?: OnboardingStep;
   initialDraft?: OnboardingDraft;
   initialHasActiveSubscription?: boolean;
+  subscriptionSuccessPracticeId?: string | null;
   sessionUserName: string;
+  sessionUserEmail: string;
   sessionUserId?: string | null;
   requiresNameCollection: boolean;
   firstExistingMembership?: ExistingMembership;
@@ -99,7 +104,9 @@ const OnboardingFlowImpl = ({
   initialStep = 1,
   initialDraft,
   initialHasActiveSubscription = false,
+  subscriptionSuccessPracticeId = null,
   sessionUserName,
+  sessionUserEmail,
   sessionUserId,
   requiresNameCollection,
   firstExistingMembership,
@@ -123,7 +130,12 @@ const OnboardingFlowImpl = ({
     return {
       fullName: stored?.fullName ?? initialDraft?.fullName ?? sessionUserName,
       ...(initialDraft ?? {}),
-      ...(stored ?? {})
+      ...(stored ?? {}),
+      createdOrganizationId:
+        subscriptionSuccessPracticeId
+          ?? stored?.createdOrganizationId
+          ?? initialDraft?.createdOrganizationId
+          ?? undefined
     };
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -496,7 +508,10 @@ const OnboardingFlowImpl = ({
                   this second, you can come back and complete verification there.
                 </p>
               </AssistantTurn>
-              <PaymentsStep draft={draft} />
+              <PaymentsStep
+                draft={draft}
+                practiceEmail={sessionUserEmail}
+              />
               <StageFooter
                 onSkip={handleSkip}
                 onBack={handleBack}
@@ -582,7 +597,10 @@ export const OnboardingFlow = ({
   onComplete,
   active = true,
   className = '',
-  testId
+  testId,
+  initialStep,
+  initialHasActiveSubscription = false,
+  subscriptionSuccessPracticeId = null
 }: OnboardingFlowProps) => {
   const { session } = useSessionContext();
 
@@ -616,10 +634,14 @@ export const OnboardingFlow = ({
       className={className}
       testId={testId}
       sessionUserName={sessionUserName}
+      sessionUserEmail={session?.user?.email ?? ''}
       sessionUserId={sessionUserId}
       requiresNameCollection={requiresNameCollection}
       firstExistingMembership={firstExistingMembership}
       persistDraft
+      initialStep={initialStep}
+      initialHasActiveSubscription={initialHasActiveSubscription}
+      subscriptionSuccessPracticeId={subscriptionSuccessPracticeId}
       loadPreferences={() => getPreferencesCategory<OnboardingPreferences>('onboarding')}
       loadSubscription={async () => Boolean(await getCurrentSubscription())}
       createOrganization={async (draft, membership) => {
@@ -701,6 +723,7 @@ export const DebugOnboardingFlow = ({
       initialDraft={initialDraft}
       initialHasActiveSubscription={hasActiveSubscription}
       sessionUserName={sessionUserName}
+      sessionUserEmail="sarah@example.com"
       pricingPlanOverride={pricingPlanOverride}
       sessionUserId={null}
       requiresNameCollection={false}

--- a/src/features/onboarding/steps/IntakeFormStep.tsx
+++ b/src/features/onboarding/steps/IntakeFormStep.tsx
@@ -72,6 +72,7 @@ export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
 
   const requiredFields = template.fields.filter((f) => (f.phase ?? (f.required ? 'required' : 'enrichment')) === 'required');
   const enrichmentFields = template.fields.filter((f) => (f.phase ?? (f.required ? 'required' : 'enrichment')) === 'enrichment');
+  const standardContactFields = ['Name', 'Email', 'Phone'];
 
   return (
     <div className="flex flex-col gap-4">
@@ -88,6 +89,20 @@ export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
             {template.introMessage}
           </p>
         )}
+      </div>
+
+      <div className="card" style={{ padding: '22px' }}>
+        <div style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--dim)', marginBottom: 14 }}>
+          Collected on every intake
+        </div>
+        <ul style={{ display: 'flex', flexDirection: 'column', gap: 10, margin: 0, padding: 0, listStyle: 'none' }}>
+          {standardContactFields.map((label) => (
+            <li key={label} style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+              <Icon icon={CheckCircle2} className="h-4 w-4 shrink-0 mt-0.5" style={{ color: 'var(--pos)' }} />
+              <span style={{ fontSize: 14, color: 'var(--ink)' }}>{label}</span>
+            </li>
+          ))}
+        </ul>
       </div>
 
       {/* Required fields */}
@@ -131,7 +146,7 @@ export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
       )}
 
       <p style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--dim)', letterSpacing: '0.02em' }}>
-        You can rename this form and add custom questions from{' '}
+        You can rename this form, edit these questions, and add custom questions from{' '}
         <strong style={{ color: 'var(--ink-2)' }}>Settings → Intake forms</strong>{' '}
         any time after setup.
       </p>

--- a/src/features/onboarding/steps/PaymentsStep.tsx
+++ b/src/features/onboarding/steps/PaymentsStep.tsx
@@ -1,23 +1,73 @@
+import { useState } from 'preact/hooks';
 import { CheckCircle2 } from 'lucide-preact';
+import { Button } from '@/shared/ui/Button';
 import { Icon } from '@/shared/ui/Icon';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { createConnectedAccount } from '@/shared/lib/apiClient';
+import { getValidatedStripeOnboardingUrl } from '@/shared/utils/stripeOnboarding';
 import type { OnboardingDraft } from '../types';
 
 interface PaymentsStepProps {
   draft: OnboardingDraft;
+  practiceEmail: string;
+  redirectToStripe?: (url: string) => void;
 }
 
-/**
- * Step 4 body — Stripe Connect handoff.
- *
- * TODO(stripe): wiring Stripe Connect inside onboarding requires the org to
- * exist before the connected-account API can be called (createConnectedAccount
- * needs a practiceUuid). The existing flow at /practice/:slug/setup mints the
- * account *after* org creation. To keep onboarding linear and non-blocking,
- * step 4 renders an explainer + handoff: payouts get set up immediately after
- * the user lands in their workspace, via the existing StripeCheckpointCard.
- * Reusing that surface unmodified avoids forking Stripe state machines.
- */
-export const PaymentsStep = (_: PaymentsStepProps) => {
+const defaultRedirectToStripe = (url: string): void => {
+  if (typeof window === 'undefined') return;
+  window.location.href = url;
+};
+
+export const PaymentsStep = ({
+  draft,
+  practiceEmail,
+  redirectToStripe = defaultRedirectToStripe,
+}: PaymentsStepProps) => {
+  const { showError } = useToastContext();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const organizationId = draft.createdOrganizationId ?? null;
+
+  const handleStartStripe = async () => {
+    if (!organizationId) {
+      showError('Payouts', 'Missing practice context.');
+      return;
+    }
+    if (!practiceEmail) {
+      showError('Payouts', 'Add an email before starting Stripe verification.');
+      return;
+    }
+    if (typeof window === 'undefined') {
+      showError('Payouts', 'Unable to start Stripe onboarding in this environment.');
+      return;
+    }
+
+    const baseUrl = `${window.location.origin}${window.location.pathname}`;
+    const returnUrl = new URL(baseUrl);
+    returnUrl.searchParams.set('stripe', 'return');
+    const refreshUrl = new URL(baseUrl);
+    refreshUrl.searchParams.set('stripe', 'refresh');
+
+    setIsSubmitting(true);
+    try {
+      const connectedAccount = await createConnectedAccount({
+        practiceEmail,
+        practiceUuid: organizationId,
+        returnUrl: returnUrl.toString(),
+        refreshUrl: refreshUrl.toString(),
+      });
+      const validatedUrl = getValidatedStripeOnboardingUrl(connectedAccount.onboardingUrl);
+      if (!validatedUrl) {
+        showError('Payouts', 'Stripe onboarding link was not provided. Please try again.');
+        return;
+      }
+      redirectToStripe(validatedUrl);
+    } catch (error) {
+      showError('Payouts', error instanceof Error ? error.message : 'Failed to start Stripe onboarding');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <section className="card" style={{ padding: '28px' }}>
       <h2
@@ -35,7 +85,7 @@ export const PaymentsStep = (_: PaymentsStepProps) => {
       </h2>
 
       <div
-        className="flex items-center gap-4 rounded-md border p-4"
+        className="flex flex-col gap-4 rounded-md border p-4 sm:flex-row sm:items-center"
         style={{
           background: 'var(--card)',
           borderColor: 'var(--rule)',
@@ -73,6 +123,14 @@ export const PaymentsStep = (_: PaymentsStepProps) => {
             receive payouts.
           </p>
         </div>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => void handleStartStripe()}
+          disabled={isSubmitting || !organizationId || !practiceEmail}
+        >
+          {isSubmitting ? 'Preparing Stripe...' : 'Start Stripe setup'}
+        </Button>
       </div>
 
       <div
@@ -84,8 +142,8 @@ export const PaymentsStep = (_: PaymentsStepProps) => {
           color: 'var(--ink-2)'
         }}
       >
-        You&apos;ll finish Stripe setup from your workspace after onboarding. We&apos;ll
-        take you there next so you can start or resume verification.
+        Stripe opens a secure hosted flow for business and representative
+        verification. You can return here after Stripe sends you back.
       </div>
 
       <ul className="mt-6 flex flex-col gap-3 text-sm" style={{ color: 'var(--ink-2)' }}>
@@ -99,14 +157,13 @@ export const PaymentsStep = (_: PaymentsStepProps) => {
         </li>
         <li className="flex items-start gap-2">
           <Icon icon={CheckCircle2} className="h-4 w-4 mt-0.5" style={{ color: 'var(--pos)' }} />
-          <span>You can start or finish setup from the workspace banner when you&apos;re ready</span>
+          <span>You can also finish setup later from Payouts &amp; billing settings</span>
         </li>
       </ul>
     </section>
   );
 };
 
-/** Step 4 is always continueable — Stripe is handed off post-onboarding. */
 export const isPaymentsComplete = (_draft: OnboardingDraft): boolean => true;
 
 export default PaymentsStep;

--- a/src/features/onboarding/steps/ShareIntakeStep.tsx
+++ b/src/features/onboarding/steps/ShareIntakeStep.tsx
@@ -42,7 +42,9 @@ export const ShareIntakeStep = ({ draft }: ShareIntakeStepProps) => {
 
   const handleOpenPreview = () => {
     if (typeof window === 'undefined') return;
-    window.open(intakeUrl, '_blank', 'noopener,noreferrer');
+    const previewUrl = new URL(intakeUrl);
+    previewUrl.searchParams.set('ownerPreview', '1');
+    window.open(previewUrl.toString(), '_blank', 'noopener,noreferrer');
   };
 
   const practiceAreaCount = draft.practiceAreas?.length ?? 0;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,6 +84,19 @@ const reloadPage = () => {
   }
 };
 
+function PublicShortLinkRoute({ practiceSlug }: { practiceSlug?: string }) {
+  const location = useLocation();
+  const hasPaymentResultParams =
+    typeof location.query.session_id === 'string' ||
+    typeof location.query.uuid === 'string';
+
+  if (hasPaymentResultParams) {
+    return <PaymentResultPage practiceSlug={practiceSlug} />;
+  }
+
+  return <PublicWorkspaceRoute practiceSlug={practiceSlug} />;
+}
+
 const mountApp = (mountEl: HTMLElement) => {
   if (import.meta.env.DEV) {
     render(<AppWithProviders />, mountEl);
@@ -302,7 +315,7 @@ function AppShell() {
     Boolean(session?.user) &&
     !session?.user?.is_anonymous &&
     session?.user?.onboarding_complete !== true;
-  const isPublicRoute = location.path.startsWith('/public/');
+  const isPublicRoute = location.path.startsWith('/public/') || location.path.startsWith('/p/');
   const isAuthRoute = location.path.startsWith('/auth');
   const isPricingRoute = location.path.startsWith('/pricing');
   const isClientRoute = location.path.startsWith('/client/');
@@ -352,6 +365,7 @@ function AppShell() {
     const isDebugRoute = import.meta.env.DEV && location.path.startsWith('/debug');
     const isPublicIntakeRoute =
       location.path.startsWith('/public/') ||
+      location.path.startsWith('/p/') ||
       location.path.startsWith('/client/');
     const bypassOnboardingForRoute = isPublicIntakeRoute || isDebugRoute;
 
@@ -569,7 +583,7 @@ function AppShell() {
           <Route path="/practice/:practiceSlug/settings/audit-log" component={PracticeAppRoute} workspaceView="settings" settingsView="audit-log" />
           <Route path="/practice/:practiceSlug/settings/export-data" component={PracticeAppRoute} workspaceView="settings" settingsView="export-data" />
           <Route path="/practice/:practiceSlug/settings/help" component={PracticeAppRoute} workspaceView="settings" settingsView="help" />
-          <Route path="/p/:practiceSlug" component={({ practiceSlug }: { practiceSlug?: string }) => <PaymentResultPage practiceSlug={practiceSlug} />} />
+          <Route path="/p/:practiceSlug" component={PublicShortLinkRoute} />
           {/* U10: engineer-only intake inspector. The worker route is gated by
               the engineer email allowlist; this page surfaces a friendly
               "not authorized" message when the API returns 403. */}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -19,6 +19,18 @@ const isSafeRedirectPath = (path: string | null | undefined): path is string => 
   }
 };
 
+const getSubscriptionSuccessPracticeId = (path: string | null): string | null => {
+  if (!path) return null;
+  try {
+    const url = new URL(path, 'http://local.dev');
+    if (url.searchParams.get('subscription') !== 'success') return null;
+    const practiceId = url.searchParams.get('practiceId')?.trim();
+    return practiceId || null;
+  } catch {
+    return null;
+  }
+};
+
 const OnboardingPage = () => {
   const { session, isPending } = useSessionContext();
   const { navigate } = useNavigation();
@@ -38,6 +50,15 @@ const OnboardingPage = () => {
   // RootRoute owns the post-onboarding destination decision. Returning to `/`
   // is safe now because root routing fails fast and sends no-practice users to pricing.
   const fallbackPath: string = isSafeRedirectPath(rawReturnTo) ? rawReturnTo : '/';
+  const subscriptionSuccessPracticeId = getSubscriptionSuccessPracticeId(fallbackPath);
+  const completionPath = subscriptionSuccessPracticeId ? '/' : fallbackPath;
+  const handleComplete = () => {
+    if (typeof window !== 'undefined') {
+      window.location.assign(completionPath);
+      return;
+    }
+    navigate(completionPath, true);
+  };
 
   const userId = session?.user?.id;
   const userIsAnonymous = session?.user?.is_anonymous;
@@ -50,10 +71,10 @@ const OnboardingPage = () => {
       return;
     }
     if (userOnboardingComplete) {
-      navigate(fallbackPath, true);
+      navigate(completionPath, true);
     }
   }, [
-    fallbackPath,
+    completionPath,
     isPending,
     navigate,
     userId,
@@ -81,8 +102,11 @@ const OnboardingPage = () => {
   // directly without SetupShell's extra accent backdrop.
   return (
     <OnboardingFlow
-      onClose={() => navigate(fallbackPath, true)}
-      onComplete={() => navigate(fallbackPath, true)}
+      onClose={() => navigate(completionPath, true)}
+      onComplete={handleComplete}
+      initialStep={subscriptionSuccessPracticeId ? 4 : undefined}
+      initialHasActiveSubscription={Boolean(subscriptionSuccessPracticeId)}
+      subscriptionSuccessPracticeId={subscriptionSuccessPracticeId}
       active
     />
   );

--- a/tests/component/onboarding-flow-subscription-order.test.tsx
+++ b/tests/component/onboarding-flow-subscription-order.test.tsx
@@ -2,8 +2,10 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/preact
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createPracticeMock = vi.fn();
+const createConnectedAccountMock = vi.fn();
 const getCurrentSubscriptionMock = vi.fn();
 const setActiveMock = vi.fn();
+const listIntakeTemplatesMock = vi.fn();
 let organizationsMock: unknown[] = [];
 
 vi.mock('@/shared/i18n/hooks', () => ({
@@ -26,6 +28,7 @@ vi.mock('@/shared/contexts/SessionContext', () => ({
       user: {
         id: 'user-1',
         name: 'E2E Owner',
+        email: 'owner@example.com',
       },
     },
   }),
@@ -40,7 +43,12 @@ vi.mock('@/shared/contexts/ToastContext', () => ({
 
 vi.mock('@/shared/lib/apiClient', () => ({
   createPractice: (...args: unknown[]) => createPracticeMock(...args),
+  createConnectedAccount: (...args: unknown[]) => createConnectedAccountMock(...args),
   getCurrentSubscription: (...args: unknown[]) => getCurrentSubscriptionMock(...args),
+}));
+
+vi.mock('@/features/intake/api/intakeTemplatesApi', () => ({
+  listIntakeTemplates: (...args: unknown[]) => listIntakeTemplatesMock(...args),
 }));
 
 vi.mock('@/shared/lib/preferencesApi', () => ({
@@ -74,17 +82,42 @@ vi.mock('@/features/pricing/components/PricingView', () => ({
 }));
 
 import { OnboardingFlow } from '@/features/onboarding/components/OnboardingFlow';
+import PaymentsStep from '@/features/onboarding/steps/PaymentsStep';
+import IntakeFormStep from '@/features/onboarding/steps/IntakeFormStep';
 
 describe('OnboardingFlow subscription ordering', () => {
   beforeEach(() => {
     localStorage.clear();
     createPracticeMock.mockReset();
+    createConnectedAccountMock.mockReset();
     getCurrentSubscriptionMock.mockReset();
     setActiveMock.mockReset();
+    listIntakeTemplatesMock.mockReset();
     organizationsMock = [];
     createPracticeMock.mockResolvedValue({ id: 'practice-123', slug: 'e2e-practice' });
+    createConnectedAccountMock.mockResolvedValue({
+      practiceUuid: 'practice-123',
+      stripeAccountId: 'acct_123',
+      clientSecret: null,
+      onboardingUrl: 'https://connect.stripe.com/setup/s/acct_123',
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      detailsSubmitted: false,
+    });
     getCurrentSubscriptionMock.mockResolvedValue(null);
     setActiveMock.mockResolvedValue(undefined);
+    listIntakeTemplatesMock.mockResolvedValue([
+      {
+        id: 'template-1',
+        key: 'general',
+        name: 'General consultation',
+        is_default: true,
+        fields: [
+          { key: 'summary', label: 'Brief summary', required: true, phase: 'required' },
+          { key: 'timeline', label: 'Important dates', required: false, phase: 'enrichment' },
+        ],
+      },
+    ]);
   });
 
   it('creates a practice before loading subscription state or showing Business checkout', async () => {
@@ -188,5 +221,60 @@ describe('OnboardingFlow subscription ordering', () => {
       expect(getCurrentSubscriptionMock).toHaveBeenCalledTimes(1);
     });
     expect(callOrder).toEqual(['activate:start', 'activate:done', 'subscription']);
+  });
+
+  it('returns from subscription success directly to the payments step', async () => {
+    render(
+      <OnboardingFlow
+        onClose={vi.fn()}
+        onComplete={vi.fn()}
+        initialStep={4}
+        initialHasActiveSubscription
+        subscriptionSuccessPracticeId="practice-returned"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 4 of 6 .* Payments/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Step 1 of 6 .* About you/)).not.toBeInTheDocument();
+    expect(setActiveMock).toHaveBeenCalledWith({ organizationId: 'practice-returned' });
+  });
+
+  it('starts Stripe Connect from the payments step with the active practice', async () => {
+    const redirectToStripe = vi.fn();
+    render(
+      <PaymentsStep
+        draft={{ createdOrganizationId: 'practice-123' }}
+        practiceEmail="owner@example.com"
+        redirectToStripe={redirectToStripe}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Start Stripe setup/i }));
+
+    await waitFor(() => {
+      expect(createConnectedAccountMock).toHaveBeenCalledWith({
+        practiceEmail: 'owner@example.com',
+        practiceUuid: 'practice-123',
+        returnUrl: expect.stringMatching(/\/\?stripe=return$|\/onboarding\?stripe=return$/),
+        refreshUrl: expect.stringMatching(/\/\?stripe=refresh$|\/onboarding\?stripe=refresh$/),
+      });
+    });
+    expect(redirectToStripe).toHaveBeenCalledWith('https://connect.stripe.com/setup/s/acct_123');
+  });
+
+  it('shows standard contact fields and editable-question copy in the intake preview', async () => {
+    render(<IntakeFormStep draft={{ createdOrganizationId: 'practice-123' }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('General consultation')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Collected on every intake')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Phone')).toBeInTheDocument();
+    expect(screen.getByText('Brief summary')).toBeInTheDocument();
+    expect(screen.getByText(/edit these questions/i)).toBeInTheDocument();
   });
 });

--- a/tests/e2e/practice-member-registration.spec.ts
+++ b/tests/e2e/practice-member-registration.spec.ts
@@ -1,13 +1,14 @@
 /**
- * Full end-to-end registration → onboarding → dashboard for a new practice member.
+ * Full end-to-end registration → onboarding for a new practice member.
  *
  * Covers:
  *   1. Email/password signup via the auth form
  *   2. Onboarding step 1 (About you)
  *   3. Onboarding step 2 (Practice profile) — creates the practice via POST /api/practice
  *   4. Onboarding step 3 — drives Stripe-hosted Checkout with test card 4242
- *   5. Onboarding steps 4–6 (Stripe Connect intro, intake form, share intake)
- *   6. Final landing assertion: workspace home at /practice/:slug
+ *   5. Onboarding step 4 — starts Stripe Connect and asserts the payload
+ *   6. Onboarding steps 5–6 — intake form preview and public preview link
+ *   7. Completion save via Better Auth update-user
  *
  * Caveats:
  *   - Hits the staging backend (auth, Better Auth subscription.upgrade, /api/practice).
@@ -36,7 +37,7 @@ interface SubscriptionResponseRecord {
 test.describe('New practice member registration → dashboard', () => {
   test.describe.configure({ mode: 'serial', timeout: ONBOARDING_TIMEOUT_MS });
 
-  test('signs up, completes onboarding (with Stripe Checkout), and lands on workspace home', async ({
+  test('signs up and completes onboarding through payment, payouts, intake, and public preview', async ({
     unauthContext,
     baseURL
   }, testInfo) => {
@@ -187,38 +188,80 @@ test.describe('New practice member registration → dashboard', () => {
 
     await completeStripeCheckoutWithTestCard(page, appOrigin);
 
-    // Stripe success redirects to "/" — AppShell pushes the user back to /onboarding.
-    // The draft is preserved in localStorage; step state resets to 1.
+    // Stripe success redirects to "/" and AppShell pushes the incomplete user
+    // back to onboarding. Subscription success must resume at payments.
     await page.waitForURL(/\/onboarding/, { timeout: 30000 });
     await expect(page.getByTestId('onboarding-flow')).toBeVisible();
+    await expect(page.getByText(/Step 4 of 6 · Payments/i)).toBeVisible();
 
-    // Click through step 1 and step 2 (fields/org preserved), then continue
-    // past the now-subscribed Business step.
-    await page.getByRole('button', { name: /Continue → Your practice/i }).click();
-    await expect(page.getByText(/Step 2 of 6 · Your practice/i)).toBeVisible();
-    await page.getByRole('button', { name: /Continue → Get Business/i }).click();
-    await expect(page.getByText(/Step 3 of 6 · Get Business/i)).toBeVisible();
-    await page.getByRole('button', { name: /Continue → Payments/i }).click();
+    const connectedAccountRequests: Array<{
+      practice_email?: string;
+      practice_uuid?: string;
+      return_url?: string;
+      refresh_url?: string;
+    }> = [];
+    await page.route('**/api/onboarding/connected-accounts', async (route) => {
+      connectedAccountRequests.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          practice_uuid: createdPractice.id,
+          stripe_account_id: 'acct_e2e_onboarding',
+          client_secret: null,
+          url: 'https://connect.stripe.com/setup/s/e2e-onboarding',
+          charges_enabled: false,
+          payouts_enabled: false,
+          details_submitted: false,
+        }),
+      });
+    });
+
+    await page.getByRole('button', { name: /Start Stripe setup/i }).click();
+    await page.waitForURL(
+      (url) => url.hostname === 'connect.stripe.com' || url.hostname === 'dashboard.stripe.com',
+      { timeout: 30000 }
+    );
+    expect(connectedAccountRequests).toEqual([
+      expect.objectContaining({
+        practice_email: user.email,
+        practice_uuid: createdPractice.id,
+        return_url: expect.stringContaining('stripe=return'),
+        refresh_url: expect.stringContaining('stripe=refresh'),
+      }),
+    ]);
+    await page.goBack();
+    await expect(page.getByText(/Step 4 of 6 · Payments/i)).toBeVisible();
 
     // 5. Steps 4 → 5 → 6
-    await expect(page.getByText(/Step 4 of 6 · Payments/i)).toBeVisible();
     await page.getByRole('button', { name: /Continue → Your intake form/i }).click();
 
     await expect(page.getByText(/Step 5 of 6 · Your intake form/i)).toBeVisible();
+    await expect(page.getByText('Collected on every intake')).toBeVisible();
+    await expect(page.getByText('Name', { exact: true })).toBeVisible();
+    await expect(page.getByText('Email', { exact: true })).toBeVisible();
+    await expect(page.getByText('Phone', { exact: true })).toBeVisible();
+    await expect(page.getByText(/edit these questions/i)).toBeVisible();
     await page.getByRole('button', { name: /Continue → Share intake/i }).click();
 
     await expect(page.getByText(/Step 6 of 6 · Share intake/i)).toBeVisible();
-    await page.getByRole('button', { name: /Open your workspace →/i }).click();
+    const previewPagePromise = page.waitForEvent('popup');
+    await page.getByRole('button', { name: /Open preview/i }).click();
+    const previewPage = await previewPagePromise;
+    await previewPage.waitForLoadState('domcontentloaded');
+    await expect(previewPage).toHaveURL(/\/p\//);
+    await expect(previewPage).toHaveURL(/ownerPreview=1/);
+    await expect(previewPage).not.toHaveURL(/\/onboarding/);
+    await expect(previewPage.getByText(/Preview mode: you are logged in as/i)).toBeVisible({ timeout: 30000 });
+    await previewPage.close();
 
-    // 6. Final assertion — workspace home.
-    // Landing on /practice/:slug is the canonical proof: RootRoute only routes
-    // there when the user has a fully-onboarded practice membership (session
-    // has onboarding_complete=true AND an active org). No need for a separate
-    // session-body check.
-    await page.waitForURL(
-      (url) => new URL(url).pathname.startsWith('/practice/'),
+    const updateUserResponsePromise = page.waitForResponse(
+      (response) => response.url().includes('/api/auth/update-user') && response.request().method() === 'POST',
       { timeout: 30000 }
     );
+    await page.getByRole('button', { name: /Open your workspace →/i }).click();
+    const updateUserResponse = await updateUserResponsePromise;
+    expect(updateUserResponse.ok(), 'onboarding completion must persist on the user session').toBe(true);
 
     expect(subscriptionConsoleErrors, 'subscription lookup should not produce browser console errors').toEqual([]);
     expect(


### PR DESCRIPTION
## Summary
- Resume onboarding on the Payments step after Stripe subscription success instead of restarting practice setup.
- Wire the Payments step to create a Stripe Connect account with the expected practice/email/return payload.
- Improve intake preview copy and contact fields, and route public `/p/:slug` preview links without forcing onboarding.

## Root Cause
The subscription return URL was being fed back into onboarding as a normal return target, so completion state restarted earlier steps. The Payments step was still a handoff/TODO surface, and `/p/:slug` conflicted with payment-result routing unless Stripe result params were present.

## Verification
- `npx vitest run -c config/vitest/vitest.config.ts --project component tests/component/onboarding-flow-subscription-order.test.tsx`
- `npx eslint src/features/onboarding/components/OnboardingFlow.tsx src/features/onboarding/steps/PaymentsStep.tsx src/features/onboarding/steps/IntakeFormStep.tsx src/features/onboarding/steps/ShareIntakeStep.tsx src/pages/OnboardingPage.tsx src/index.tsx src/app/PublicWorkspaceRoute.tsx --max-warnings 0`
- `npm run type-check`
- `E2E_BASE_URL=https://dev.blawby.com E2E_WORKER_URL=http://127.0.0.1:8787 npx playwright test -c playwright.public.config.ts --project=chromium tests/e2e/practice-member-registration.spec.ts`
- Chrome smoke: `https://local.blawby.com` returned Cloudflare tunnel 1033 in this environment; the active tunnel advertised `https://dev.blawby.com`, which rendered the app and redirected unauthenticated onboarding to signup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer onboarding flow with direct Stripe setup, updated intake preview messaging, and a visible “Preview mode” banner in workspace views.
  * Improved public link handling so payment-result pages and workspace previews open correctly from shared practice URLs.
  * Previewing an intake form now opens with the proper preview state enabled.

* **Bug Fixes**
  * Onboarding now resumes at the correct step after subscription success and completes with the expected redirect.
  * Public and embedded views now show or hide preview indicators more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->