### PR TITLE
[codex] Improve onboarding practice setup

### DIFF
--- a/src/design-system/primitives/Chip.tsx
+++ b/src/design-system/primitives/Chip.tsx
@@ -1,15 +1,15 @@
-import type { ComponentChildren } from 'preact';
+import type { ComponentChildren, JSX } from 'preact';
 import { X } from 'lucide-preact';
 import { cn } from '@/shared/utils/cn';
 import { Icon } from '@/shared/ui/Icon';
 
 export type ChipVariant = 'default' | 'primary' | 'accent' | 'warn';
 
-export interface ChipProps {
+export interface ChipProps extends Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'children' | 'className' | 'onClick' | 'title' | 'type'> {
   variant?: ChipVariant;
   onRemove?: () => void;
   href?: string;
-  onClick?: () => void;
+  onClick?: JSX.MouseEventHandler<HTMLButtonElement>;
   children: ComponentChildren;
   className?: string;
   removeAriaLabel?: string;
@@ -27,6 +27,7 @@ export function Chip({
   removeAriaLabel = 'Remove',
   title,
   type = 'button',
+  ...buttonProps
 }: ChipProps) {
   const classes = cn('chip', variant !== 'default' && variant, className);
 
@@ -61,7 +62,7 @@ export function Chip({
 
   if (onClick) {
     return (
-      <button type={type} className={classes} onClick={onClick} title={title}>
+      <button {...buttonProps} type={type} className={classes} onClick={onClick} title={title}>
         {content}
       </button>
     );

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useTranslation } from '@/shared/i18n/hooks';
 import { useSessionContext } from '@/shared/contexts/SessionContext';
 import { useToastContext } from '@/shared/contexts/ToastContext';
-import { createPractice, getCurrentSubscription } from '@/shared/lib/apiClient';
+import { createPractice, getCurrentSubscription, updatePracticeDetails } from '@/shared/lib/apiClient';
 import { getPreferencesCategory, updatePreferencesCategory } from '@/shared/lib/preferencesApi';
 import type { SubscriptionPlan } from '@/shared/utils/fetchPlans';
 import {
@@ -363,6 +363,15 @@ const OnboardingFlowImpl = ({
     }
   }, [draft, requiresNameCollection, step]);
 
+  const handleIntakeTemplateReady = useCallback((template: { slug?: string }) => {
+    const nextSlug = template.slug?.trim() || null;
+    setDraft((prev) => (
+      nextSlug && nextSlug !== prev.defaultIntakeTemplateSlug
+        ? { ...prev, defaultIntakeTemplateSlug: nextSlug }
+        : prev
+    ));
+  }, []);
+
   const resolvedTestId = testId ?? 'onboarding-flow';
 
   return (
@@ -446,7 +455,6 @@ const OnboardingFlowImpl = ({
                 variant="onboarding"
               />
               <StageFooter
-                onSkip={handleSkip}
                 onBack={handleBack}
                 onContinue={handleContinue}
                 continueLabel={CONTINUE_LABEL[3]}
@@ -495,17 +503,20 @@ const OnboardingFlowImpl = ({
                 title={<>Get <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>paid</em> — properly.</>}
                 lede={
                   <>
-                    You&apos;ll connect Stripe from your workspace so you can accept
-                    payments and receive payouts. Stripe will verify your business
-                    and representative details before enabling payouts.
+                    Connect the Stripe account where payouts from invoices,
+                    consultation fees, and other client payments should land.
+                    Stripe verifies your business and authorized representative
+                    before it can send funds to that account.
                   </>
                 }
               />
-              <AssistantTurn trail="why now matters">
+              <AssistantTurn trail="payout routing">
                 <p style={{ margin: 0 }}>
-                  Once your practice is live, the &ldquo;Connect Stripe&rdquo; banner in your
-                  workspace is the fastest way to finish setup. If you&apos;re not ready
-                  this second, you can come back and complete verification there.
+                  Blawby uses this connected account for money movement: client
+                  payments are processed by Stripe, then paid out to the bank account
+                  your practice designates. Use the appropriate operating or
+                  trust/IOLTA account for the type of funds you collect, consistent
+                  with your jurisdiction&apos;s rules.
                 </p>
               </AssistantTurn>
               <PaymentsStep
@@ -543,7 +554,10 @@ const OnboardingFlowImpl = ({
                   create forms for different matter types.
                 </p>
               </AssistantTurn>
-              <IntakeFormStep draft={draft} />
+              <IntakeFormStep
+                draft={draft}
+                onTemplateReady={handleIntakeTemplateReady}
+              />
               <StageFooter
                 onSkip={handleSkip}
                 onBack={handleBack}
@@ -681,6 +695,7 @@ export const OnboardingFlow = ({
 
         // Activate the new org in the Better Auth session.
         await authClient.organization.setActive({ organizationId: practice.id });
+        await updatePracticeDetails(practice.id, { isPublic: true });
 
         return { id: practice.id, slug: practice.slug ?? slugify(name) };
       }}

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -363,10 +363,10 @@ const OnboardingFlowImpl = ({
     }
   }, [draft, requiresNameCollection, step]);
 
-  const handleIntakeTemplateReady = useCallback((template: { slug?: string }) => {
-    const nextSlug = template.slug?.trim() || null;
+  const handleIntakeTemplateReady = useCallback((template: { slug?: string } | null) => {
+    const nextSlug = template?.slug?.trim() || null;
     setDraft((prev) => (
-      nextSlug && nextSlug !== prev.defaultIntakeTemplateSlug
+      nextSlug !== (prev.defaultIntakeTemplateSlug ?? null)
         ? { ...prev, defaultIntakeTemplateSlug: nextSlug }
         : prev
     ));
@@ -695,7 +695,9 @@ export const OnboardingFlow = ({
 
         // Activate the new org in the Better Auth session.
         await authClient.organization.setActive({ organizationId: practice.id });
-        await updatePracticeDetails(practice.id, { isPublic: true });
+        void updatePracticeDetails(practice.id, { isPublic: true }).catch((error) => {
+          console.error('[ONBOARDING][PRACTICE_VISIBILITY] failed to publish practice', error);
+        });
 
         return { id: practice.id, slug: practice.slug ?? slugify(name) };
       }}

--- a/src/features/onboarding/steps/IntakeFormStep.tsx
+++ b/src/features/onboarding/steps/IntakeFormStep.tsx
@@ -8,7 +8,7 @@ import type { OnboardingDraft } from '../types';
 
 interface IntakeFormStepProps {
   draft: OnboardingDraft;
-  onTemplateReady?: (template: IntakeTemplate) => void;
+  onTemplateReady?: (template: IntakeTemplate | null) => void;
 }
 
 const fieldPhase = (field: IntakeFieldDefinition) => field.phase ?? (field.required ? 'required' : 'enrichment');
@@ -70,17 +70,20 @@ export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) 
     if (!orgId) {
       setIsLoading(false);
       setError('Practice not created yet. Go back to step 3.');
+      onTemplateReady?.(null);
       return;
     }
 
     let mounted = true;
     setIsLoading(true);
+    setError(null);
     listIntakeTemplates(orgId)
       .then((templates) => {
         if (!mounted) return;
         const defaultTemplate = templates.find((t) => t.is_default) ?? templates[0] ?? null;
         setTemplate(defaultTemplate);
-        if (defaultTemplate) onTemplateReady?.(defaultTemplate);
+        setError(null);
+        onTemplateReady?.(defaultTemplate);
         setIsLoading(false);
       })
       .catch((err: unknown) => {
@@ -92,6 +95,8 @@ export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) 
             ? 'Intake form not available yet. The backend endpoint may still be deploying.'
             : msg || 'Unable to load intake form.'
         );
+        setTemplate(null);
+        onTemplateReady?.(null);
         setIsLoading(false);
       });
 

--- a/src/features/onboarding/steps/IntakeFormStep.tsx
+++ b/src/features/onboarding/steps/IntakeFormStep.tsx
@@ -1,23 +1,65 @@
 import { useEffect, useState } from 'preact/hooks';
-import { CheckCircle2, Sparkles } from 'lucide-preact';
+import { Sparkles } from 'lucide-preact';
 import { Icon } from '@/shared/ui/Icon';
 import { LoadingBlock } from '@/shared/ui/layout/LoadingBlock';
 import { listIntakeTemplates } from '@/features/intake/api/intakeTemplatesApi';
-import type { IntakeTemplate } from '@/shared/types/intake';
+import type { IntakeFieldDefinition, IntakeTemplate } from '@/shared/types/intake';
 import type { OnboardingDraft } from '../types';
 
 interface IntakeFormStepProps {
   draft: OnboardingDraft;
+  onTemplateReady?: (template: IntakeTemplate) => void;
 }
 
+const fieldPhase = (field: IntakeFieldDefinition) => field.phase ?? (field.required ? 'required' : 'enrichment');
+
+const PreviewInput = ({ field }: { field: IntakeFieldDefinition }) => {
+  const inputClass = 'mt-1.5 w-full rounded-sm border border-[var(--rule)] bg-[var(--paper)] px-3 py-2 text-sm text-dim';
+
+  if (field.type === 'select') {
+    return (
+      <select className={inputClass} disabled aria-label={field.label}>
+        <option>{field.options?.[0] ?? 'Select an option'}</option>
+      </select>
+    );
+  }
+
+  if (field.type === 'boolean') {
+    return (
+      <div className="mt-2 flex gap-2" aria-label={field.label}>
+        <span className="rounded-sm border border-[var(--rule)] bg-[var(--paper)] px-3 py-1.5 text-xs text-dim">Yes</span>
+        <span className="rounded-sm border border-[var(--rule)] bg-[var(--paper)] px-3 py-1.5 text-xs text-dim">No</span>
+      </div>
+    );
+  }
+
+  if (field.backendFieldType === 'textarea' || field.key === 'description') {
+    return (
+      <textarea
+        className={`${inputClass} min-h-[88px] resize-none`}
+        placeholder={field.validationHint ?? 'Client describes what happened here.'}
+        disabled
+        aria-label={field.label}
+      />
+    );
+  }
+
+  return (
+    <input
+      className={inputClass}
+      type={field.type === 'number' ? 'number' : 'text'}
+      placeholder={field.validationHint ?? (field.type === 'date' ? 'MM/DD/YYYY' : 'Client answer')}
+      disabled
+      aria-label={field.label}
+    />
+  );
+};
+
 /**
- * Step 5 — shows the seeded intake template so the user knows what their
- * intake form looks like before sharing the link in step 6.
- *
- * The template is seeded by the backend on PracticeCreated (PR #318).
- * This step is read-only: editing happens in Settings → Intake forms.
+ * Step 5 shows the seeded intake template as a read-only client-form preview.
+ * Editing happens after onboarding in Settings -> Intake forms.
  */
-export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
+export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) => {
   const [template, setTemplate] = useState<IntakeTemplate | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -27,7 +69,7 @@ export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
   useEffect(() => {
     if (!orgId) {
       setIsLoading(false);
-      setError('Practice not created yet — go back to step 3.');
+      setError('Practice not created yet. Go back to step 3.');
       return;
     }
 
@@ -38,23 +80,25 @@ export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
         if (!mounted) return;
         const defaultTemplate = templates.find((t) => t.is_default) ?? templates[0] ?? null;
         setTemplate(defaultTemplate);
+        if (defaultTemplate) onTemplateReady?.(defaultTemplate);
         setIsLoading(false);
       })
       .catch((err: unknown) => {
         if (!mounted) return;
         const msg = err instanceof Error ? err.message : String(err);
-        // Surface a clear message — likely the backend endpoint isn't live yet.
         const isParseError = msg.includes('JSON') || msg.includes('Unexpected');
         setError(
           isParseError
-            ? 'Intake form not available yet — the backend endpoint may still be deploying.'
+            ? 'Intake form not available yet. The backend endpoint may still be deploying.'
             : msg || 'Unable to load intake form.'
         );
         setIsLoading(false);
       });
 
-    return () => { mounted = false; };
-  }, [orgId]);
+    return () => {
+      mounted = false;
+    };
+  }, [onTemplateReady, orgId]);
 
   if (isLoading) {
     return <LoadingBlock />;
@@ -64,90 +108,93 @@ export const IntakeFormStep = ({ draft }: IntakeFormStepProps) => {
     return (
       <div className="card" style={{ padding: '22px' }}>
         <p className="text-sm" style={{ color: 'var(--neg)' }}>
-          {error ?? 'No intake form found. You can create one from Settings → Intake forms.'}
+          {error ?? 'No intake form found. You can create one from Settings -> Intake forms.'}
         </p>
       </div>
     );
   }
 
-  const requiredFields = template.fields.filter((f) => (f.phase ?? (f.required ? 'required' : 'enrichment')) === 'required');
-  const enrichmentFields = template.fields.filter((f) => (f.phase ?? (f.required ? 'required' : 'enrichment')) === 'enrichment');
-  const standardContactFields = ['Name', 'Email', 'Phone'];
+  const requiredFields = template.fields.filter((field) => fieldPhase(field) === 'required');
+  const enrichmentFields = template.fields.filter((field) => fieldPhase(field) === 'enrichment');
+  const contactFields: Array<{ label: string; placeholder: string; type?: string }> = [
+    { label: 'Name', placeholder: 'Jane Client' },
+    { label: 'Email', placeholder: 'jane@example.com', type: 'email' },
+    { label: 'Phone', placeholder: '(555) 014-2190', type: 'tel' },
+  ];
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Template name */}
-      <div className="card" style={{ padding: '22px' }}>
-        <div style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--dim)', marginBottom: 6 }}>
-          Intake form
-        </div>
-        <div style={{ fontFamily: 'var(--serif)', fontSize: 22, lineHeight: 1.2, letterSpacing: '-0.01em', color: 'var(--ink)' }}>
-          {template.name}
-        </div>
-        {template.introMessage && (
-          <p className="mt-2 text-sm" style={{ color: 'var(--ink-2)', lineHeight: 1.5 }}>
-            {template.introMessage}
+      <div className="card overflow-hidden" style={{ padding: 0 }}>
+        <div className="border-b border-[var(--rule)] px-5 py-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
+            Client preview
+          </div>
+          <div className="mt-1 font-serif text-[24px] leading-tight tracking-[-0.01em] text-ink">
+            {template.name}
+          </div>
+          <p className="mt-2 max-w-[58ch] text-sm leading-6 text-ink-2">
+            {template.introMessage || 'Clients start by sharing contact details and the facts needed for your practice to review the request.'}
           </p>
-        )}
-      </div>
-
-      <div className="card" style={{ padding: '22px' }}>
-        <div style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--dim)', marginBottom: 14 }}>
-          Collected on every intake
         </div>
-        <ul style={{ display: 'flex', flexDirection: 'column', gap: 10, margin: 0, padding: 0, listStyle: 'none' }}>
-          {standardContactFields.map((label) => (
-            <li key={label} style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-              <Icon icon={CheckCircle2} className="h-4 w-4 shrink-0 mt-0.5" style={{ color: 'var(--pos)' }} />
-              <span style={{ fontSize: 14, color: 'var(--ink)' }}>{label}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
 
-      {/* Required fields */}
-      {requiredFields.length > 0 && (
-        <div className="card" style={{ padding: '22px' }}>
-          <div style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--dim)', marginBottom: 14 }}>
-            Required — clients must answer these
+        <div className="bg-[var(--paper)]/45 px-5 py-5">
+          <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
+            Collected on every intake
           </div>
-          <ul style={{ display: 'flex', flexDirection: 'column', gap: 10, margin: 0, padding: 0, listStyle: 'none' }}>
-            {requiredFields.map((field) => (
-              <li key={field.key} style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-                <Icon icon={CheckCircle2} className="h-4 w-4 shrink-0 mt-0.5" style={{ color: 'var(--pos)' }} />
-                <span style={{ fontSize: 14, color: 'var(--ink)' }}>{field.label}</span>
-              </li>
+          <div className="mt-3 grid gap-4 md:grid-cols-3">
+            {contactFields.map((field) => (
+              <label key={field.label} className="block text-sm font-medium text-ink">
+                {field.label}
+                <input
+                  className="mt-1.5 w-full rounded-sm border border-[var(--rule)] bg-[var(--paper)] px-3 py-2 text-sm text-dim"
+                  type={field.type ?? 'text'}
+                  placeholder={field.placeholder}
+                  disabled
+                />
+              </label>
             ))}
-          </ul>
-        </div>
-      )}
-
-      {/* Enrichment fields */}
-      {enrichmentFields.length > 0 && (
-        <div className="card" style={{ padding: '22px' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 14 }}>
-            <Icon icon={Sparkles} className="h-3.5 w-3.5" style={{ color: 'var(--accent-deep)' }} />
-            <span style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--dim)' }}>
-              AI follow-up — collected to strengthen the case
-            </span>
           </div>
-          <ul style={{ display: 'flex', flexDirection: 'column', gap: 8, margin: 0, padding: 0, listStyle: 'none' }}>
-            {enrichmentFields.map((field) => (
-              <li key={field.key} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                <span style={{
-                  width: 6, height: 6, borderRadius: '50%', flexShrink: 0,
-                  background: 'var(--rule)', display: 'inline-block'
-                }} />
-                <span style={{ fontSize: 13.5, color: 'var(--ink-2)' }}>{field.label}</span>
-              </li>
-            ))}
-          </ul>
+
+          {requiredFields.length > 0 && (
+            <div className="mt-6">
+              <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
+                Required before submission
+              </div>
+              <div className="mt-3 grid gap-4">
+                {requiredFields.map((field) => (
+                  <label key={field.key} className="block text-sm font-medium text-ink">
+                    {field.label}
+                    <PreviewInput field={field} />
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {enrichmentFields.length > 0 && (
+            <div className="mt-6 rounded-sm border border-[var(--rule)] bg-[var(--card)] p-4">
+              <div className="flex items-center gap-2">
+                <Icon icon={Sparkles} className="h-3.5 w-3.5" style={{ color: 'var(--accent-deep)' }} />
+                <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
+                  AI follow-up questions
+                </span>
+              </div>
+              <div className="mt-3 grid gap-4 md:grid-cols-2">
+                {enrichmentFields.map((field) => (
+                  <label key={field.key} className="block text-sm font-medium text-ink">
+                    {field.label}
+                    <PreviewInput field={field} />
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
-      )}
+      </div>
 
       <p style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--dim)', letterSpacing: '0.02em' }}>
         You can rename this form, edit these questions, and add custom questions from{' '}
-        <strong style={{ color: 'var(--ink-2)' }}>Settings → Intake forms</strong>{' '}
+        <strong style={{ color: 'var(--ink-2)' }}>Settings {'->'} Intake forms</strong>{' '}
         any time after setup.
       </p>
     </div>

--- a/src/features/onboarding/steps/PracticeStep.tsx
+++ b/src/features/onboarding/steps/PracticeStep.tsx
@@ -214,6 +214,7 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
                           key={area}
                           variant={isSelected ? 'accent' : 'default'}
                           onClick={() => togglePracticeArea(area)}
+                          aria-pressed={isSelected}
                         >
                           {area}
                         </Chip>

--- a/src/features/onboarding/steps/PracticeStep.tsx
+++ b/src/features/onboarding/steps/PracticeStep.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'preact/hooks';
-import { Building2, Plus } from 'lucide-preact';
+import { Building2 } from 'lucide-preact';
 import { Chip } from '@/design-system/primitives';
-import { Button } from '@/shared/ui/Button';
 import { Input, Textarea } from '@/shared/ui/input';
 import { slugify } from '@/shared/lib/orgCreation';
 import { getPublicFormOrigin } from '@/config/urls';
@@ -61,8 +60,14 @@ const PRACTICE_SERVICE_GROUPS: ReadonlyArray<{
   }
 ];
 
-const PRACTICE_TYPES = PRACTICE_SERVICE_GROUPS.map((group) => group.type);
 const CATALOG_PRACTICE_AREAS = PRACTICE_SERVICE_GROUPS.flatMap((group) => group.services);
+
+const getPracticeTypesForAreas = (areas: readonly string[]) => {
+  const areaSet = new Set(areas);
+  return PRACTICE_SERVICE_GROUPS
+    .filter((group) => group.services.some((service) => areaSet.has(service)))
+    .map((group) => group.type);
+};
 
 /**
  * Step 2 body — practice identity plus grounding fields. All fields are sent
@@ -72,48 +77,32 @@ const CATALOG_PRACTICE_AREAS = PRACTICE_SERVICE_GROUPS.flatMap((group) => group.
  */
 export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
   const [otherPracticeArea, setOtherPracticeArea] = useState('');
-  const [otherPracticeType, setOtherPracticeType] = useState(PRACTICE_TYPES[0] ?? '');
   const computedSlug = slugify(draft.practiceName ?? '');
   const selectedAreas = new Set(draft.practiceAreas ?? []);
-  const selectedTypes = new Set(draft.practiceTypes ?? []);
+  const customPracticeAreas = (draft.practiceAreas ?? [])
+    .filter((area) => !CATALOG_PRACTICE_AREAS.includes(area));
   const publicOrigin = (() => { try { return getPublicFormOrigin(); } catch { return ''; } })();
 
   const setPracticeAreas = (areas: string[]) => {
     const uniqueAreas = Array.from(new Set(areas.map((area) => area.trim()).filter(Boolean)));
-    onChange({ practiceAreas: uniqueAreas });
+    onChange({
+      practiceAreas: uniqueAreas,
+      practiceTypes: getPracticeTypesForAreas(uniqueAreas)
+    });
   };
 
-  const setPracticeTypes = (types: string[]) => {
-    const uniqueTypes = Array.from(new Set(types.map((type) => type.trim()).filter(Boolean)));
-    onChange({ practiceTypes: uniqueTypes });
-  };
-
-  const togglePracticeType = (type: string) => {
-    const next = new Set(selectedTypes);
-    if (next.has(type)) {
-      next.delete(type);
-    } else {
-      next.add(type);
-    }
-    setPracticeTypes(Array.from(next));
-  };
-
-  const togglePracticeArea = (area: string, practiceType?: string) => {
+  const togglePracticeArea = (area: string) => {
     const next = new Set(selectedAreas);
-    const isAdding = !next.has(area);
     if (next.has(area)) {
       next.delete(area);
     } else {
       next.add(area);
     }
     const nextAreas = Array.from(next);
-    const nextTypes = practiceType && isAdding
-      ? Array.from(new Set([...(draft.practiceTypes ?? []), practiceType]))
-      : (draft.practiceTypes ?? []);
 
     onChange({
       practiceAreas: nextAreas,
-      practiceTypes: nextTypes
+      practiceTypes: getPracticeTypesForAreas(nextAreas)
     });
   };
 
@@ -121,7 +110,6 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
     const nextArea = otherPracticeArea.trim();
     if (!nextArea) return;
     setPracticeAreas([...(draft.practiceAreas ?? []), nextArea]);
-    setPracticeTypes([...(draft.practiceTypes ?? []), otherPracticeType]);
     setOtherPracticeArea('');
   };
 
@@ -203,17 +191,20 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
           </p>
           <div className="flex flex-col gap-5">
             {PRACTICE_SERVICE_GROUPS.map((group) => {
-              const hasSelectedService = group.services.some((service) => selectedAreas.has(service));
-              const isTypeSelected = selectedTypes.has(group.type) || hasSelectedService;
+              const selectedCount = group.services.filter((service) => selectedAreas.has(service)).length;
               return (
                 <div key={group.type}>
-                  <div className="mb-2 flex items-center gap-2">
-                    <Chip
-                      variant={isTypeSelected ? 'accent' : 'default'}
-                      onClick={() => togglePracticeType(group.type)}
-                    >
-                      {group.type}
-                    </Chip>
+                  <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-dim-2">
+                    <span>{group.type}</span>
+                    {selectedCount > 0 && (
+                      <span
+                        className="rounded-sm border border-line px-1.5 py-0.5 text-[10px] tracking-normal"
+                        style={{ color: 'var(--dim)' }}
+                        aria-label={`${selectedCount} selected`}
+                      >
+                        {selectedCount}
+                      </span>
+                    )}
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {group.services.map((area) => {
@@ -222,7 +213,7 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
                         <Chip
                           key={area}
                           variant={isSelected ? 'accent' : 'default'}
-                          onClick={() => togglePracticeArea(area, group.type)}
+                          onClick={() => togglePracticeArea(area)}
                         >
                           {area}
                         </Chip>
@@ -232,56 +223,37 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
                 </div>
               );
             })}
-            {(draft.practiceAreas ?? [])
-              .filter((area) => !CATALOG_PRACTICE_AREAS.includes(area))
-              .map((area) => (
-                <Chip
-                  key={area}
-                  variant="accent"
-                  onClick={() => togglePracticeArea(area)}
-                  onRemove={() => togglePracticeArea(area)}
-                  removeAriaLabel={`Remove ${area}`}
-                >
-                  {area}
-                </Chip>
-              ))}
           </div>
-          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-            <select
-              id="onboarding-practice-area-other-type"
-              value={otherPracticeType}
-              onInput={(event) => setOtherPracticeType((event.target as HTMLSelectElement).value)}
-              className="select sm:max-w-[180px]"
-              aria-label="Practice type for custom area"
-            >
-              {PRACTICE_TYPES.map((type) => (
-                <option key={type} value={type}>
-                  {type}
-                </option>
-              ))}
-            </select>
+          <div className="mt-4">
             <Input
               id="onboarding-practice-area-other"
               type="text"
               value={otherPracticeArea}
               onChange={setOtherPracticeArea}
+              onBlur={addOtherPracticeArea}
               onKeyDown={(event) => {
                 if (event.key === 'Enter') {
                   event.preventDefault();
                   addOtherPracticeArea();
                 }
               }}
-              placeholder="Other practice area"
+              label="Add custom practice area"
+              placeholder="e.g. Aviation law"
             />
-            <Button
-              type="button"
-              variant="secondary"
-              icon={Plus}
-              onClick={addOtherPracticeArea}
-              disabled={otherPracticeArea.trim().length === 0}
-            >
-              Add
-            </Button>
+            {customPracticeAreas.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {customPracticeAreas.map((area) => (
+                  <Chip
+                    key={area}
+                    variant="accent"
+                    onRemove={() => togglePracticeArea(area)}
+                    removeAriaLabel={`Remove ${area}`}
+                  >
+                    {area}
+                  </Chip>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/features/onboarding/steps/ShareIntakeStep.tsx
+++ b/src/features/onboarding/steps/ShareIntakeStep.tsx
@@ -24,8 +24,13 @@ export const ShareIntakeStep = ({ draft }: ShareIntakeStepProps) => {
 
   const intakeUrl = useMemo(() => {
     const slug = draft.createdOrganizationSlug ?? 'your-practice';
-    return `${getPublicFormOrigin()}/p/${slug}`;
-  }, [draft.createdOrganizationSlug]);
+    const url = new URL(`/p/${encodeURIComponent(slug)}`, getPublicFormOrigin());
+    const templateSlug = draft.defaultIntakeTemplateSlug?.trim();
+    if (templateSlug) {
+      url.searchParams.set('template', templateSlug);
+    }
+    return url.toString();
+  }, [draft.createdOrganizationSlug, draft.defaultIntakeTemplateSlug]);
 
   const handleCopy = async () => {
     try {

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -24,6 +24,7 @@ export interface OnboardingDraft {
   practiceAreas?: string[];
   practiceTypes?: string[];
   description?: string;
+  defaultIntakeTemplateSlug?: string | null;
   /** Set once createPractice() has succeeded so we don't re-create on back/forward. */
   createdOrganizationId?: string | null;
   createdOrganizationSlug?: string | null;

--- a/src/features/pricing/components/PricingView.tsx
+++ b/src/features/pricing/components/PricingView.tsx
@@ -99,7 +99,8 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
 
   const handleUpgrade = async (plan: SubscriptionPlan) => {
     const hasYearly = Boolean(plan.stripeYearlyPriceId && plan.yearlyPrice);
-    const isYearly = billingPeriod === 'yearly';
+    const hasMonthlyPrice = Boolean(plan.monthlyPrice);
+    const isYearly = (billingPeriod === 'yearly' && hasYearly) || (!hasMonthlyPrice && hasYearly);
     const selectedPlanName = plan.name;
     try {
       if (!selectedPlanName) {
@@ -123,7 +124,6 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
     }
   };
 
-  const isYearly = billingPeriod === 'yearly';
   const hasYearly = Boolean(plan.stripeYearlyPriceId && plan.yearlyPrice);
   const features = Array.isArray(plan.features)
     ? plan.features.filter((feature): feature is string => typeof feature === 'string' && feature.trim().length > 0)
@@ -131,19 +131,24 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
   const hasMonthlyPrice = Boolean(plan.monthlyPrice);
   const monthlyPriceValue = plan.monthlyPrice ? Number.parseFloat(plan.monthlyPrice) : NaN;
   const yearlyPriceValue = plan.yearlyPrice ? Number.parseFloat(plan.yearlyPrice) : NaN;
-  const selectedPriceValue = isYearly && hasYearly
+  const effectiveBillingPeriod: BillingPeriod = !hasMonthlyPrice && hasYearly ? 'yearly' : billingPeriod;
+  const isEffectiveYearly = effectiveBillingPeriod === 'yearly' && hasYearly;
+  const selectedPriceValue = isEffectiveYearly
     ? yearlyPriceValue
     : monthlyPriceValue;
   const hasDisplayPrice = Number.isFinite(selectedPriceValue);
-  const periodLabel = isYearly && hasYearly
+  const periodLabel = isEffectiveYearly
     ? t('pricing:billing.yearly')
     : t('pricing:billing.monthly');
-  const billingDescription = isYearly && hasYearly
+  const billingDescription = isEffectiveYearly
     ? t('pricing:billing.billedAnnually')
     : t('pricing:billing.billedMonthly');
   const monthlyLabel = t('pricing:billing.monthly');
   const annuallyLabel = t('pricing:billing.annually', {
     defaultValue: t('pricing:billing.yearly')
+  });
+  const paymentFrequencyLabel = t('pricing:billing.paymentFrequency', {
+    defaultValue: 'Payment frequency'
   });
   const yearlyDiscountPercent = (() => {
     if (!hasYearly || !Number.isFinite(monthlyPriceValue) || !Number.isFinite(yearlyPriceValue)) {
@@ -157,6 +162,12 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
     const roundedDiscount = Math.round(discount);
     return roundedDiscount > 0 ? roundedDiscount : null;
   })();
+  const yearlyDiscountLabel = yearlyDiscountPercent
+    ? t('pricing:billing.savePercent', {
+        percent: yearlyDiscountPercent,
+        defaultValue: 'Save {{percent}}%'
+      })
+    : null;
   const showBillingSelector = hasMonthlyPrice && hasYearly;
   const isOnboarding = variant === 'onboarding';
   const billingToggleButtonClass = (active: boolean) => [
@@ -173,7 +184,7 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
           <div className={`flex justify-center ${isOnboarding ? 'pb-0' : 'pb-1'}`}>
             <div
               role="group"
-              aria-label="Payment frequency"
+              aria-label={paymentFrequencyLabel}
               className="inline-flex rounded-full border border-[var(--rule)] bg-[var(--card)]/40 p-1"
             >
               <button
@@ -193,13 +204,13 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
                 onClick={() => setBillingPeriod('yearly')}
               >
                 <span>{annuallyLabel}</span>
-                {yearlyDiscountPercent ? (
+                {yearlyDiscountLabel ? (
                   <span
                     className={billingPeriod === 'yearly'
                       ? 'text-[11px] font-semibold text-[var(--paper)]/75'
                       : 'text-[11px] font-semibold text-[var(--accent-deep)]'}
                   >
-                    Save {yearlyDiscountPercent}%
+                    {yearlyDiscountLabel}
                   </span>
                 ) : null}
               </button>

--- a/src/features/pricing/components/PricingView.tsx
+++ b/src/features/pricing/components/PricingView.tsx
@@ -2,7 +2,6 @@ import { FunctionComponent } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { useTranslation } from '@/shared/i18n/hooks';
 import { Button } from '@/shared/ui/Button';
-import { Seg } from '@/design-system/patterns';
 import { Check } from 'lucide-preact';
 
 import { Icon } from '@/shared/ui/Icon';
@@ -158,29 +157,53 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
     const roundedDiscount = Math.round(discount);
     return roundedDiscount > 0 ? roundedDiscount : null;
   })();
-  const annuallyLabelWithDiscount = yearlyDiscountPercent
-    ? `${annuallyLabel} -${yearlyDiscountPercent}%`
-    : annuallyLabel;
-  const showBillingSelector = hasMonthlyPrice || hasYearly;
-  const billingOptions: Array<{ value: BillingPeriod; label: string; disabled?: boolean }> = [
-    { value: 'monthly', label: monthlyLabel, disabled: !hasMonthlyPrice },
-    { value: 'yearly', label: annuallyLabelWithDiscount, disabled: !hasYearly }
-  ];
+  const showBillingSelector = hasMonthlyPrice && hasYearly;
   const isOnboarding = variant === 'onboarding';
+  const billingToggleButtonClass = (active: boolean) => [
+    'inline-flex h-9 items-center justify-center gap-1.5 rounded-full px-4 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)] disabled:cursor-not-allowed disabled:opacity-50',
+    active
+      ? 'bg-[var(--ink)] text-[var(--paper)]'
+      : 'text-dim-2 hover:bg-[var(--paper)] hover:text-ink'
+  ].join(' ');
 
   return (
     <div className={`w-full text-ink ${className ?? ''}`}>
       <div className={`mx-auto w-full max-w-xl ${isOnboarding ? '' : 'px-2 pt-2 pb-2 md:px-3 md:pt-3 md:pb-3'}`}>
         {showBillingSelector ? (
           <div className={`flex justify-center ${isOnboarding ? 'pb-0' : 'pb-1'}`}>
-            <Seg<BillingPeriod>
-              className={isOnboarding ? 'w-full max-w-[420px] rounded-[14px] border border-[var(--rule)] bg-[var(--card)] p-1 shadow-[var(--shadow-1)]' : 'w-full max-w-[420px]'}
-              value={billingPeriod}
-              options={billingOptions}
-              onChange={setBillingPeriod}
-              ariaLabel="Payment frequency"
-              disabled={submitting}
-            />
+            <div
+              role="group"
+              aria-label="Payment frequency"
+              className="inline-flex rounded-full border border-[var(--rule)] bg-[var(--card)]/40 p-1"
+            >
+              <button
+                type="button"
+                aria-pressed={billingPeriod === 'monthly'}
+                disabled={submitting}
+                className={billingToggleButtonClass(billingPeriod === 'monthly')}
+                onClick={() => setBillingPeriod('monthly')}
+              >
+                {monthlyLabel}
+              </button>
+              <button
+                type="button"
+                aria-pressed={billingPeriod === 'yearly'}
+                disabled={submitting}
+                className={billingToggleButtonClass(billingPeriod === 'yearly')}
+                onClick={() => setBillingPeriod('yearly')}
+              >
+                <span>{annuallyLabel}</span>
+                {yearlyDiscountPercent ? (
+                  <span
+                    className={billingPeriod === 'yearly'
+                      ? 'text-[11px] font-semibold text-[var(--paper)]/75'
+                      : 'text-[11px] font-semibold text-[var(--accent-deep)]'}
+                  >
+                    Save {yearlyDiscountPercent}%
+                  </span>
+                ) : null}
+              </button>
+            </div>
           </div>
         ) : null}
 

--- a/src/locales/en/pricing.json
+++ b/src/locales/en/pricing.json
@@ -280,6 +280,8 @@
     "monthly": "Monthly",
     "annually": "Annually",
     "yearly": "year",
+    "paymentFrequency": "Payment frequency",
+    "savePercent": "Save {{percent}}%",
     "billedMonthly": "Billed monthly. Cancel anytime.",
     "billedAnnually": "Billed annually. Cancel anytime.",
     "noPracticeSelected": "No practice selected",

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -57,11 +57,11 @@ const OnboardingPage = () => {
   const subscriptionSuccessPracticeId = getSubscriptionSuccessPracticeId(fallbackPath);
   const completionPath = subscriptionSuccessPracticeId ? '/' : fallbackPath;
   const stripeReturnStatus = getStripeReturnStatus(location.query?.stripe);
-  const initialOnboardingStep = subscriptionSuccessPracticeId
-    ? 4
-    : stripeReturnStatus === 'return'
-      ? 5
-      : stripeReturnStatus === 'refresh'
+  const initialOnboardingStep = stripeReturnStatus === 'return'
+    ? 5
+    : stripeReturnStatus === 'refresh'
+      ? 4
+      : subscriptionSuccessPracticeId
         ? 4
         : undefined;
   const handleComplete = () => {

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -31,6 +31,10 @@ const getSubscriptionSuccessPracticeId = (path: string | null): string | null =>
   }
 };
 
+const getStripeReturnStatus = (value: unknown): 'return' | 'refresh' | null => {
+  return value === 'return' || value === 'refresh' ? value : null;
+};
+
 const OnboardingPage = () => {
   const { session, isPending } = useSessionContext();
   const { navigate } = useNavigation();
@@ -52,6 +56,14 @@ const OnboardingPage = () => {
   const fallbackPath: string = isSafeRedirectPath(rawReturnTo) ? rawReturnTo : '/';
   const subscriptionSuccessPracticeId = getSubscriptionSuccessPracticeId(fallbackPath);
   const completionPath = subscriptionSuccessPracticeId ? '/' : fallbackPath;
+  const stripeReturnStatus = getStripeReturnStatus(location.query?.stripe);
+  const initialOnboardingStep = subscriptionSuccessPracticeId
+    ? 4
+    : stripeReturnStatus === 'return'
+      ? 5
+      : stripeReturnStatus === 'refresh'
+        ? 4
+        : undefined;
   const handleComplete = () => {
     if (typeof window !== 'undefined') {
       window.location.assign(completionPath);
@@ -104,7 +116,7 @@ const OnboardingPage = () => {
     <OnboardingFlow
       onClose={() => navigate(completionPath, true)}
       onComplete={handleComplete}
-      initialStep={subscriptionSuccessPracticeId ? 4 : undefined}
+      initialStep={initialOnboardingStep}
       initialHasActiveSubscription={Boolean(subscriptionSuccessPracticeId)}
       subscriptionSuccessPracticeId={subscriptionSuccessPracticeId}
       active

--- a/tests/component/onboarding-flow-subscription-order.test.tsx
+++ b/tests/component/onboarding-flow-subscription-order.test.tsx
@@ -211,6 +211,36 @@ describe('OnboardingFlow subscription ordering', () => {
     });
   });
 
+  it('continues onboarding when publishing the public practice flag fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    updatePracticeDetailsMock.mockRejectedValue(new Error('visibility update failed'));
+
+    render(<OnboardingFlow onClose={vi.fn()} onComplete={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 1 of 6 .* About you/)).toBeInTheDocument();
+    });
+    fireEvent.input(document.querySelector('#onboarding-birthday') as HTMLInputElement, {
+      target: { value: '1990-01-15' },
+    });
+    fireEvent.click(document.querySelector('#onboarding-terms') as HTMLInputElement);
+    fireEvent.click(screen.getByRole('button', { name: /^Continue .* Your practice/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2 of 6 .* Your practice/)).toBeInTheDocument();
+    });
+    fireEvent.input(document.querySelector('#onboarding-firmName') as HTMLInputElement, {
+      target: { value: 'E2E Practice' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Continue .* Get Business/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 3 of 6 .* Get Business/)).toBeInTheDocument();
+    });
+    expect(updatePracticeDetailsMock).toHaveBeenCalledWith('practice-123', { isPublic: true });
+    consoleError.mockRestore();
+  });
+
   it('activates an existing membership before loading subscription state', async () => {
     organizationsMock = [{ id: 'existing-practice-123', slug: 'existing-practice', name: 'Existing Practice' }];
     const callOrder: string[] = [];
@@ -274,6 +304,21 @@ describe('OnboardingFlow subscription ordering', () => {
     expect(screen.queryByText(/Step 1 of 6 .* About you/)).not.toBeInTheDocument();
   });
 
+  it('prioritizes explicit Stripe return over subscription success returnTo', async () => {
+    locationMock.url = '/onboarding?stripe=return&returnTo=%2F%3Fsubscription%3Dsuccess%26practiceId%3Dpractice-returned';
+    locationMock.query = {
+      stripe: 'return',
+      returnTo: '%2F%3Fsubscription%3Dsuccess%26practiceId%3Dpractice-returned',
+    };
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 5 of 6 .* Your intake form/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Step 4 of 6 .* Payments/)).not.toBeInTheDocument();
+  });
+
   it('starts Stripe Connect from the payments step with the active practice', async () => {
     const redirectToStripe = vi.fn();
     render(
@@ -309,5 +354,17 @@ describe('OnboardingFlow subscription ordering', () => {
     expect(screen.getByText('Phone')).toBeInTheDocument();
     expect(screen.getByText('Brief summary')).toBeInTheDocument();
     expect(screen.getByText(/edit these questions/i)).toBeInTheDocument();
+  });
+
+  it('clears the stored intake template slug when template loading fails', async () => {
+    const onTemplateReady = vi.fn();
+    listIntakeTemplatesMock.mockRejectedValue(new Error('template unavailable'));
+
+    render(<IntakeFormStep draft={{ createdOrganizationId: 'practice-123' }} onTemplateReady={onTemplateReady} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('template unavailable')).toBeInTheDocument();
+    });
+    expect(onTemplateReady).toHaveBeenCalledWith(null);
   });
 });

--- a/tests/component/onboarding-flow-subscription-order.test.tsx
+++ b/tests/component/onboarding-flow-subscription-order.test.tsx
@@ -1,12 +1,23 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/preact';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const locationMock = vi.hoisted(() => ({
+  path: '/onboarding',
+  url: '/onboarding',
+  query: {} as Record<string, string>,
+  route: vi.fn(),
+}));
 const createPracticeMock = vi.fn();
+const updatePracticeDetailsMock = vi.fn();
 const createConnectedAccountMock = vi.fn();
 const getCurrentSubscriptionMock = vi.fn();
 const setActiveMock = vi.fn();
 const listIntakeTemplatesMock = vi.fn();
 let organizationsMock: unknown[] = [];
+
+vi.mock('preact-iso', () => ({
+  useLocation: () => locationMock,
+}));
 
 vi.mock('@/shared/i18n/hooks', () => ({
   useTranslation: () => ({
@@ -43,6 +54,7 @@ vi.mock('@/shared/contexts/ToastContext', () => ({
 
 vi.mock('@/shared/lib/apiClient', () => ({
   createPractice: (...args: unknown[]) => createPracticeMock(...args),
+  updatePracticeDetails: (...args: unknown[]) => updatePracticeDetailsMock(...args),
   createConnectedAccount: (...args: unknown[]) => createConnectedAccountMock(...args),
   getCurrentSubscription: (...args: unknown[]) => getCurrentSubscriptionMock(...args),
 }));
@@ -84,17 +96,24 @@ vi.mock('@/features/pricing/components/PricingView', () => ({
 import { OnboardingFlow } from '@/features/onboarding/components/OnboardingFlow';
 import PaymentsStep from '@/features/onboarding/steps/PaymentsStep';
 import IntakeFormStep from '@/features/onboarding/steps/IntakeFormStep';
+import OnboardingPage from '@/pages/OnboardingPage';
 
 describe('OnboardingFlow subscription ordering', () => {
   beforeEach(() => {
     localStorage.clear();
     createPracticeMock.mockReset();
+    updatePracticeDetailsMock.mockReset();
     createConnectedAccountMock.mockReset();
     getCurrentSubscriptionMock.mockReset();
     setActiveMock.mockReset();
     listIntakeTemplatesMock.mockReset();
+    locationMock.path = '/onboarding';
+    locationMock.url = '/onboarding';
+    locationMock.query = {};
+    locationMock.route.mockReset();
     organizationsMock = [];
     createPracticeMock.mockResolvedValue({ id: 'practice-123', slug: 'e2e-practice' });
+    updatePracticeDetailsMock.mockResolvedValue(null);
     createConnectedAccountMock.mockResolvedValue({
       practiceUuid: 'practice-123',
       stripeAccountId: 'acct_123',
@@ -150,18 +169,18 @@ describe('OnboardingFlow subscription ordering', () => {
     expect(screen.getByText('Business formation')).toBeInTheDocument();
     expect(screen.getByText('Compliance counseling')).toBeInTheDocument();
     expect(screen.getByText('Business disputes')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Transactional' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Regulatory' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Litigation' })).not.toBeInTheDocument();
 
     jurisdictionSelect.value = 'VT';
     fireEvent.input(jurisdictionSelect);
     fireEvent.change(jurisdictionSelect);
-    const otherTypeSelect = document.getElementById('onboarding-practice-area-other-type') as unknown as HTMLSelectElement;
-    otherTypeSelect.value = 'Litigation';
-    fireEvent.input(otherTypeSelect);
-    fireEvent.change(otherTypeSelect);
-    fireEvent.input(document.querySelector('#onboarding-practice-area-other') as HTMLInputElement, {
+    const customPracticeArea = document.querySelector('#onboarding-practice-area-other') as HTMLInputElement;
+    fireEvent.input(customPracticeArea, {
       target: { value: 'Aviation law' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+    fireEvent.keyDown(customPracticeArea, { key: 'Enter' });
     fireEvent.click(screen.getByRole('button', { name: 'Business disputes' }));
     fireEvent.click(screen.getByRole('button', { name: /Continue → Get Business/i }));
 
@@ -179,11 +198,13 @@ describe('OnboardingFlow subscription ordering', () => {
         })
       );
     });
+    expect(updatePracticeDetailsMock).toHaveBeenCalledWith('practice-123', { isPublic: true });
     expect(setActiveMock).toHaveBeenCalledWith({ organizationId: 'practice-123' });
 
     await waitFor(() => {
       expect(screen.getByText(/Step 3 of 6 .* Get Business/)).toBeInTheDocument();
     });
+    expect(screen.queryByRole('button', { name: /skip/i })).not.toBeInTheDocument();
     expect(screen.getByTestId('pricing-practice-id')).toHaveTextContent('practice-123');
     await waitFor(() => {
       expect(getCurrentSubscriptionMock).toHaveBeenCalledTimes(1);
@@ -239,6 +260,18 @@ describe('OnboardingFlow subscription ordering', () => {
     });
     expect(screen.queryByText(/Step 1 of 6 .* About you/)).not.toBeInTheDocument();
     expect(setActiveMock).toHaveBeenCalledWith({ organizationId: 'practice-returned' });
+  });
+
+  it('returns from Stripe Connect directly to the intake form step', async () => {
+    locationMock.url = '/onboarding?stripe=return';
+    locationMock.query = { stripe: 'return' };
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Step 5 of 6 .* Your intake form/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Step 1 of 6 .* About you/)).not.toBeInTheDocument();
   });
 
   it('starts Stripe Connect from the payments step with the active practice', async () => {

--- a/tests/component/pricing-view.test.tsx
+++ b/tests/component/pricing-view.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SubscriptionPlan } from '@/shared/utils/fetchPlans';
+
+const submitUpgradeMock = vi.fn();
+const showErrorMock = vi.fn();
+
+vi.mock('@/shared/i18n/hooks', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; percent?: number }) => {
+      const messages: Record<string, string> = {
+        'pricing:billing.monthly': 'Monthly',
+        'pricing:billing.annually': 'Annually',
+        'pricing:billing.yearly': 'year',
+        'pricing:billing.billedMonthly': 'Billed monthly. Cancel anytime.',
+        'pricing:billing.billedAnnually': 'Billed annually. Cancel anytime.',
+        'pricing:billing.paymentFrequency': 'Billing cadence',
+        'pricing:billing.savePercent': `Localized save ${options?.percent}%`,
+        'pricing:modal.openingBilling': 'Opening billing',
+        'pricing:upgradeButton': `Upgrade for ${(options as { price?: string } | undefined)?.price}`,
+        'pricing:noFeatures': 'This plan has no features.',
+        'pricing:upgradeFailed': 'Upgrade failed',
+        'common:errors.tryAgainLater': 'Try again later',
+      };
+      return messages[key] ?? options?.defaultValue ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/shared/i18n', () => ({
+  i18n: { language: 'en' },
+}));
+
+vi.mock('@/shared/contexts/ToastContext', () => ({
+  useToastContext: () => ({
+    showError: showErrorMock,
+  }),
+}));
+
+vi.mock('@/shared/hooks/usePaymentUpgrade', () => ({
+  usePaymentUpgrade: () => ({
+    submitUpgrade: submitUpgradeMock,
+    submitting: false,
+  }),
+}));
+
+const basePlan: SubscriptionPlan = {
+  id: 'plan-practice',
+  name: 'blawby_practice',
+  displayName: 'Blawby Practice',
+  description: 'Practice plan',
+  stripeProductId: 'prod_practice',
+  stripeMonthlyPriceId: 'price_monthly',
+  stripeYearlyPriceId: 'price_yearly',
+  monthlyPrice: '40.00',
+  yearlyPrice: '420.00',
+  currency: 'USD',
+  features: [],
+  limits: {},
+  isActive: true,
+  isPublic: true,
+};
+
+describe('PricingView', () => {
+  beforeEach(() => {
+    submitUpgradeMock.mockReset();
+    showErrorMock.mockReset();
+  });
+
+  it('submits yearly-only plans as annual and shows the yearly price', async () => {
+    const PricingView = (await import('@/features/pricing/components/PricingView')).default;
+    render(
+      <PricingView
+        practiceId="practice-123"
+        planOverride={{
+          ...basePlan,
+          stripeMonthlyPriceId: null,
+          monthlyPrice: null,
+        }}
+      />
+    );
+
+    expect(screen.queryByRole('group', { name: 'Billing cadence' })).not.toBeInTheDocument();
+    expect(screen.getByText('/year')).toBeInTheDocument();
+    expect(screen.getByText('Billed annually. Cancel anytime.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Upgrade for/i }));
+
+    await waitFor(() => {
+      expect(submitUpgradeMock).toHaveBeenCalledWith({
+        practiceId: 'practice-123',
+        plan: 'blawby_practice',
+        annual: true,
+      });
+    });
+  });
+
+  it('uses localized labels for the billing selector and yearly discount', async () => {
+    const PricingView = (await import('@/features/pricing/components/PricingView')).default;
+    render(<PricingView planOverride={basePlan} />);
+
+    expect(screen.getByRole('group', { name: 'Billing cadence' })).toBeInTheDocument();
+    expect(screen.getByText('Localized save 13%')).toBeInTheDocument();
+  });
+});

--- a/tests/e2e/practice-member-registration.spec.ts
+++ b/tests/e2e/practice-member-registration.spec.ts
@@ -135,6 +135,14 @@ test.describe('New practice member registration → dashboard', () => {
     await page.locator('#onboarding-jurisdiction').selectOption(practice.jurisdiction);
     await expect(page.locator('#onboarding-jurisdiction')).toContainText('WY · Wyoming');
     await expect(page.getByText('Civil litigation')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /^Transactional$/ })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /^Regulatory$/ })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /^Litigation$/ })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Contract drafting' })).toBeVisible();
+    await page.getByLabel('Add custom practice area').fill('Aviation law');
+    await page.locator('#onboarding-practice-area-other').press('Enter');
+    await expect(page.getByText('Aviation law', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Remove Aviation law' })).toBeVisible();
 
     const createPracticeRequest = page.waitForRequest(
       (request) => request.url().includes('/api/practice') && request.method() === 'POST',
@@ -163,6 +171,10 @@ test.describe('New practice member registration → dashboard', () => {
 
     // 4. Step 3 — Get Business → Stripe Checkout
     await expect(page.getByText(/Step 3 of 6 · Get Business/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /skip/i })).toHaveCount(0);
+    await expect(page.getByRole('group', { name: /Payment frequency/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Monthly$/i })).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByRole('button', { name: /Annually/i })).toHaveAttribute('aria-pressed', 'false');
     await page.waitForTimeout(2000);
     expect(
       subscriptionResponses.filter((response) => response.beforePracticeCreated),
@@ -237,10 +249,12 @@ test.describe('New practice member registration → dashboard', () => {
     await page.getByRole('button', { name: /Continue → Your intake form/i }).click();
 
     await expect(page.getByText(/Step 5 of 6 · Your intake form/i)).toBeVisible();
+    await expect(page.getByText('Client preview')).toBeVisible();
     await expect(page.getByText('Collected on every intake')).toBeVisible();
-    await expect(page.getByText('Name', { exact: true })).toBeVisible();
-    await expect(page.getByText('Email', { exact: true })).toBeVisible();
-    await expect(page.getByText('Phone', { exact: true })).toBeVisible();
+    await expect(page.getByText('Required before submission')).toBeVisible();
+    await expect(page.getByRole('textbox', { name: 'Name' })).toBeDisabled();
+    await expect(page.getByRole('textbox', { name: 'Email' })).toBeDisabled();
+    await expect(page.getByRole('textbox', { name: 'Phone' })).toBeDisabled();
     await expect(page.getByText(/edit these questions/i)).toBeVisible();
     await page.getByRole('button', { name: /Continue → Share intake/i }).click();
 


### PR DESCRIPTION
## Summary
- simplify onboarding practice services hierarchy and custom practice area entry
- make Get Business required, polish the billing period toggle, and improve Stripe payout copy
- show a read-only intake form preview, carry the default template into share links, publish new practices for public preview, and resume Stripe returns at Step 5
- expand component and onboarding e2e coverage for the new UX

## Validation
- npm run test:component -- tests/component/onboarding-flow-subscription-order.test.tsx
- npm run lint:src -- --quiet
- npm run type-check
- E2E_BASE_URL=https://dev.blawby.com npm run test:e2e -- practice-member-registration.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated onboarding practice setup and intake template preview (including clearer “not found” guidance).
  * Intake share links now include the selected template when available.
  * Refreshed pricing billing UI with a monthly/yearly toggle and inline “Save X%” messaging.
* **Bug Fixes**
  * Stripe return/refresh routing now starts the onboarding flow on the correct step.
  * Newly created practices are published as public, and intake template handling is more reliable.
  * Disabled footer-driven skipping for the affected onboarding step.
* **Tests**
  * Expanded onboarding and pricing test coverage for the updated flows and UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->