### PR TITLE
test(ai): cover owner-approved billing workflow (#705)

### DIFF
--- a/docs/engineering/practice-assistant-billing-contract.md
+++ b/docs/engineering/practice-assistant-billing-contract.md
@@ -1,0 +1,36 @@
+# Practice Assistant billing contract
+
+Tracks [#705](https://github.com/Blawby/blawby-ai-chatbot/issues/705) and launch readiness [#714](https://github.com/Blawby/blawby-ai-chatbot/issues/714).
+
+## Ownership
+
+- The Worker owns model orchestration, tool permission checks, pending-action persistence, approval/rejection, and audit events.
+- The backend owns matters, clients, time entries, expenses, invoices, invoice lifecycle actions, and persisted billing state.
+- The model never writes billing data directly. It selects capability-oriented tools and receives their results.
+
+## Supported flow
+
+1. Read a known matter and its `time_entry` / `matter_expense` children, or query related practice records.
+2. Propose `create_entity` with `entityType: "invoice"` and the backend draft fields.
+3. Persist the proposal in `practice_assistant_actions` with status `pending`; no backend write occurs yet.
+4. The owner approves or rejects the action through `/api/ai/practice-assistant/actions/:actionId/:decision`.
+5. Approval executes `POST /api/invoices/:practiceId` and records `executed` or `failed` from the backend result.
+6. Sending is a separate `run_entity_action` proposal with action `send`; it also requires explicit approval before `POST /api/invoices/:practiceId/:invoiceId/send`.
+
+## Draft contract
+
+Required fields match the backend create schema:
+
+- `client_id`
+- `connected_account_id`
+- at least one `line_items` entry containing `type`, `description`, and `unit_price`
+
+Optional supported fields are `matter_id`, `invoice_number`, `invoice_type`, `due_date`, `notes`, `memo`, `time_entry_ids`, `expense_ids`, and `milestone_id`.
+
+The assistant rejects unknown fields, missing required fields, empty line items, malformed line items, and unsupported invoice lifecycle actions before presenting an approval card.
+
+## Stable verification boundary
+
+Automated coverage supplies deterministic model-style tool calls at the tool executor boundary. It asserts backend-sourced reads, valid pending draft creation, invalid proposal rejection before approval, and a separately pending send action. Assertions intentionally avoid generated prose and live-model selection so billing safety and CI reliability do not depend on wording or model nondeterminism.
+
+The deterministic owner/client/Stripe payment path remains in `tests/e2e/billing-invoicing.spec.ts`; assistant tests do not duplicate or couple themselves to hosted payment reliability.

--- a/tests/unit/practiceAssistant/billingWorkflow.test.ts
+++ b/tests/unit/practiceAssistant/billingWorkflow.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PracticeAssistantActionService } from '../../../worker/services/practiceAssistant/actionService.js';
+import { PracticeAssistantAuditService } from '../../../worker/services/practiceAssistant/auditService.js';
+import { PracticeAssistantDataService } from '../../../worker/services/practiceAssistant/dataService.js';
+import { ENTITY_REGISTRY } from '../../../worker/services/practiceAssistant/EntityRegistry.js';
+import { executePracticeAssistantTools } from '../../../worker/services/practiceAssistant/toolExecutor.js';
+import type { PracticeAssistantContext, PracticeAssistantToolCall } from '../../../worker/services/practiceAssistant/types.js';
+
+const context = (): PracticeAssistantContext => ({
+  env: {} as never,
+  request: new Request('https://example.com'),
+  auth: { userId: 'owner-1', memberRole: 'owner' } as never,
+  practiceId: 'practice-1',
+  practiceSlug: 'billing-practice',
+  conversationId: 'conversation-1',
+  userId: 'owner-1',
+  emitProgress: vi.fn(),
+});
+
+const call = (name: string, args: Record<string, unknown>, index = 0): PracticeAssistantToolCall => ({
+  id: `tool-${index + 1}`,
+  name,
+  arguments: JSON.stringify(args),
+  index,
+});
+
+const validDraft = {
+  client_id: 'client-1',
+  matter_id: 'matter-1',
+  connected_account_id: 'account-1',
+  invoice_type: 'flat_fee',
+  line_items: [
+    {
+      type: 'time_entry',
+      description: 'Draft demand letter',
+      quantity: 1,
+      unit_price: 25_000,
+      time_entry_id: 'time-1',
+    },
+  ],
+  time_entry_ids: ['time-1'],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('practice assistant billing workflow', () => {
+  it('maps invoice draft fields to the backend create contract', () => {
+    const invoice = ENTITY_REGISTRY.invoice;
+    expect(invoice.requiredCreateFields).toEqual(['client_id', 'connected_account_id', 'line_items']);
+    expect(invoice.creatableFields?.map((field) => field.field)).toEqual([
+      'client_id',
+      'matter_id',
+      'connected_account_id',
+      'invoice_number',
+      'invoice_type',
+      'due_date',
+      'notes',
+      'memo',
+      'line_items',
+      'time_entry_ids',
+      'expense_ids',
+      'milestone_id',
+    ]);
+  });
+
+  it('reads unbilled time without creating an action', async () => {
+    vi.spyOn(PracticeAssistantAuditService.prototype, 'record').mockResolvedValue(undefined);
+    vi.spyOn(PracticeAssistantDataService.prototype, 'listEntities').mockResolvedValue({
+      records: [{ id: 'time-1', description: 'Draft demand letter', duration_minutes: 60, billable: true }],
+      sources: [{ type: 'matter', id: 'matter-1', label: 'Matter matter-1' }],
+    });
+    const createPending = vi.spyOn(PracticeAssistantActionService.prototype, 'createPending');
+
+    const [result] = await executePracticeAssistantTools([
+      call('list_entities', {
+        entityType: 'time_entry',
+        parent: { entityType: 'matter', id: 'matter-1' },
+        includeSources: true,
+      }),
+    ], context());
+
+    expect(result.ok).toBe(true);
+    expect(result.action).toBeUndefined();
+    expect(createPending).not.toHaveBeenCalled();
+  });
+
+  it('stages a valid invoice draft without writing to the backend', async () => {
+    vi.spyOn(PracticeAssistantAuditService.prototype, 'record').mockResolvedValue(undefined);
+    const createPending = vi.spyOn(PracticeAssistantActionService.prototype, 'createPending').mockResolvedValue({
+      actionId: 'action-draft',
+      toolUseId: 'tool-1',
+      toolName: 'create_entity',
+      title: 'Create invoice',
+      description: 'Create a new invoice record.',
+      status: 'pending',
+      payload: { actionType: 'create_entity', entityType: 'invoice', data: validDraft },
+      sources: [{ type: 'matter', id: 'matter-1', label: 'Matter matter-1' }],
+    });
+
+    const [result] = await executePracticeAssistantTools([
+      call('create_entity', {
+        actionType: 'create_entity',
+        entityType: 'invoice',
+        data: validDraft,
+        rationale: 'Prepare a draft from approved unbilled work.',
+        sources: [{ type: 'matter', id: 'matter-1', label: 'Matter matter-1' }],
+      }),
+    ], context());
+
+    expect(result.ok).toBe(true);
+    expect(result.action).toMatchObject({ actionId: 'action-draft', status: 'pending' });
+    expect(createPending).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an invalid invoice proposal before asking for approval', async () => {
+    vi.spyOn(PracticeAssistantAuditService.prototype, 'record').mockResolvedValue(undefined);
+    const createPending = vi.spyOn(PracticeAssistantActionService.prototype, 'createPending');
+
+    const [result] = await executePracticeAssistantTools([
+      call('create_entity', {
+        actionType: 'create_entity',
+        entityType: 'invoice',
+        data: { client_id: 'client-1', line_items: [] },
+      }),
+    ], context());
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('connected_account_id');
+    expect(createPending).not.toHaveBeenCalled();
+  });
+
+  it('stages send as a second owner-approved action', async () => {
+    vi.spyOn(PracticeAssistantAuditService.prototype, 'record').mockResolvedValue(undefined);
+    vi.spyOn(PracticeAssistantActionService.prototype, 'createPending').mockResolvedValue({
+      actionId: 'action-send',
+      toolUseId: 'tool-1',
+      toolName: 'run_entity_action',
+      title: 'send invoice',
+      description: 'Run "send" on invoice invoice-1.',
+      status: 'pending',
+      payload: { actionType: 'run_entity_action', entityType: 'invoice', id: 'invoice-1', action: 'send' },
+      sources: [{ type: 'invoice', id: 'invoice-1', label: 'Invoice invoice-1' }],
+    });
+
+    const [result] = await executePracticeAssistantTools([
+      call('run_entity_action', {
+        actionType: 'run_entity_action',
+        entityType: 'invoice',
+        id: 'invoice-1',
+        action: 'send',
+        rationale: 'The owner asked to send the reviewed draft.',
+        sources: [{ type: 'invoice', id: 'invoice-1', label: 'Invoice invoice-1' }],
+      }),
+    ], context());
+
+    expect(result.ok).toBe(true);
+    expect(result.action).toMatchObject({ actionId: 'action-send', status: 'pending' });
+  });
+});

--- a/worker/services/practiceAssistant/EntityRegistry.ts
+++ b/worker/services/practiceAssistant/EntityRegistry.ts
@@ -31,8 +31,8 @@ export type FieldValidator =
   | { kind: "money"; min?: number; max?: number }
   | { kind: "number"; min?: number; max?: number; integer?: boolean }
   | { kind: "boolean" }
-  | { kind: "array"; items?: FieldValidator }
-  | { kind: "object"; schema?: Record<string, FieldValidator> };
+  | { kind: "array"; items?: FieldValidator; minItems?: number }
+  | { kind: "object"; schema?: Record<string, FieldValidator>; requiredFields?: string[] };
 
 export interface WritableField {
   field: string;
@@ -101,6 +101,23 @@ export interface EntityConfig {
 // ─── Registry ─────────────────────────────────────────────────────────────────
 
 const enc = encodeURIComponent;
+const invoiceLineItemsValidator: FieldValidator = {
+  kind: "array",
+  items: {
+    kind: "object",
+    requiredFields: ["type", "description", "unit_price"],
+    schema: {
+      type: { kind: "enum", values: ["service", "time_entry", "expense", "flat_fee", "retainer", "other"] as const },
+      description: { kind: "string", minLength: 1 },
+      quantity: { kind: "number", integer: true, min: 1 },
+      unit_price: { kind: "money", min: 0 },
+      time_entry_id: { kind: "string", minLength: 1 },
+      expense_id: { kind: "string", minLength: 1 },
+      sort_order: { kind: "number", integer: true, min: 0 },
+    },
+  },
+  minItems: 1,
+};
 
 export const ENTITY_REGISTRY: Record<string, EntityConfig> = {
   // ── Practice ────────────────────────────────────────────────────────────────
@@ -401,11 +418,37 @@ export const ENTITY_REGISTRY: Record<string, EntityConfig> = {
     deleteRoute: ({ practiceId, id }) => `/api/invoices/${enc(practiceId)}/${enc(id!)}`,
     deleteSemantics: "delete",
     writableFields: [
-      { field: "status", validator: { kind: "string" }, allowedOps: ["set"] },
+      { field: "status", validator: { kind: "enum", values: ["draft", "pending", "sent", "overdue", "cancelled"] as const }, allowedOps: ["set"] },
       { field: "due_date", aliases: ["dueDate"], validator: { kind: "date" }, allowedOps: ["set"] },
-      { field: "description", validator: { kind: "string" }, allowedOps: ["set", "replace"] },
-      { field: "matter_id", aliases: ["matterId"], validator: { kind: "string" }, allowedOps: ["set"] },
+      { field: "notes", validator: { kind: "string" }, allowedOps: ["set", "replace", "append"] },
+      { field: "memo", validator: { kind: "string" }, allowedOps: ["set", "replace", "append"] },
+      {
+        field: "line_items",
+        aliases: ["lineItems"],
+        validator: invoiceLineItemsValidator,
+        allowedOps: ["set", "replace"],
+      },
     ],
+    creatableFields: [
+      { field: "client_id", aliases: ["clientId"], validator: { kind: "string", minLength: 1 }, allowedOps: ["set"] },
+      { field: "matter_id", aliases: ["matterId"], validator: { kind: "string", minLength: 1 }, allowedOps: ["set"] },
+      { field: "connected_account_id", aliases: ["connectedAccountId"], validator: { kind: "string", minLength: 1 }, allowedOps: ["set"] },
+      { field: "invoice_number", aliases: ["invoiceNumber"], validator: { kind: "string", minLength: 1, maxLength: 50 }, allowedOps: ["set"] },
+      { field: "invoice_type", aliases: ["invoiceType"], validator: { kind: "enum", values: ["flat_fee", "phase_fee", "retainer_deposit"] as const }, allowedOps: ["set"] },
+      { field: "due_date", aliases: ["dueDate"], validator: { kind: "date" }, allowedOps: ["set"] },
+      { field: "notes", validator: { kind: "string" }, allowedOps: ["set"] },
+      { field: "memo", validator: { kind: "string" }, allowedOps: ["set"] },
+      {
+        field: "line_items",
+        aliases: ["lineItems"],
+        validator: invoiceLineItemsValidator,
+        allowedOps: ["set"],
+      },
+      { field: "time_entry_ids", aliases: ["timeEntryIds"], validator: { kind: "array", items: { kind: "string", minLength: 1 } }, allowedOps: ["set"] },
+      { field: "expense_ids", aliases: ["expenseIds"], validator: { kind: "array", items: { kind: "string", minLength: 1 } }, allowedOps: ["set"] },
+      { field: "milestone_id", aliases: ["milestoneId"], validator: { kind: "string", minLength: 1 }, allowedOps: ["set"] },
+    ],
+    requiredCreateFields: ["client_id", "connected_account_id", "line_items"],
     lifecycleActions: [
       {
         action: "send",
@@ -665,6 +708,46 @@ export const validateActionPayload = (
   return result.data;
 };
 
+/** Fail before staging approval when a model proposes an unsupported create or lifecycle payload. */
+export const validateProposedActionContract = (action: ActionPayload): void => {
+  const config = getEntityConfig(action.entityType);
+
+  if (action.actionType === "create_entity") {
+    if (!config.createRoute) {
+      throw HttpErrors.badRequest(`Entity type ${action.entityType} does not support create`);
+    }
+    const createFields = config.creatableFields ?? config.writableFields ?? [];
+    const allowedNames = new Set(createFields.flatMap((field) => [field.field, ...(field.aliases ?? [])]));
+    for (const key of Object.keys(action.data)) {
+      if (!allowedNames.has(key)) {
+        throw HttpErrors.badRequest(`Field "${key}" is not creatable on ${action.entityType}`);
+      }
+    }
+    for (const required of config.requiredCreateFields ?? []) {
+      const field = createFields.find((candidate) => candidate.field === required);
+      if (![required, ...(field?.aliases ?? [])].some((name) => action.data[name] !== undefined)) {
+        throw HttpErrors.badRequest(`Field "${required}" is required when creating ${action.entityType}`);
+      }
+    }
+    for (const field of createFields) {
+      const value = action.data[field.field]
+        ?? field.aliases?.map((alias) => action.data[alias]).find((candidate) => candidate !== undefined);
+      if (value !== undefined) validateFieldValue(field.validator, value, field.field);
+    }
+  }
+
+  if (action.actionType === "run_entity_action") {
+    const lifecycle = config.lifecycleActions?.find((candidate) => candidate.action === action.action);
+    if (!lifecycle) {
+      throw HttpErrors.badRequest(`Action "${action.action}" is not supported for ${action.entityType}`);
+    }
+    const parsed = lifecycle.inputSchema?.safeParse(action.input ?? {});
+    if (parsed && !parsed.success) {
+      throw HttpErrors.badRequest(`Invalid input for ${action.entityType}.${action.action}: ${parsed.error.message}`);
+    }
+  }
+};
+
 // ─── Copy derivation ──────────────────────────────────────────────────────────
 
 const opVerbMap: Record<OpName, string> = {
@@ -784,6 +867,8 @@ export const validateFieldValue = (
     case 'array': {
       if (!Array.isArray(value))
         throw HttpErrors.badRequest(`${label} must be an array`);
+      if (validator.minItems !== undefined && value.length < validator.minItems)
+        throw HttpErrors.badRequest(`${label} must contain at least ${validator.minItems} item(s)`);
       if (validator.items) {
         for (let i = 0; i < value.length; i++) {
           validateFieldValue(validator.items, value[i], `${label}[${i}]`);
@@ -795,6 +880,11 @@ export const validateFieldValue = (
       if (value === null || typeof value !== 'object' || Array.isArray(value))
         throw HttpErrors.badRequest(`${label} must be an object`);
       if (validator.schema) {
+        for (const required of validator.requiredFields ?? []) {
+          if ((value as Record<string, unknown>)[required] === undefined) {
+            throw HttpErrors.badRequest(`${label}.${required} is required`);
+          }
+        }
         for (const [k, subValidator] of Object.entries(validator.schema)) {
           const subValue = (value as Record<string, unknown>)[k];
           if (subValue !== undefined) {

--- a/worker/services/practiceAssistant/toolRegistry.ts
+++ b/worker/services/practiceAssistant/toolRegistry.ts
@@ -8,6 +8,7 @@ import {
   deleteEntitySchema,
   runEntityActionSchema,
   validateActionPayload,
+  validateProposedActionContract,
   deriveActionCopy,
 } from './EntityRegistry.js';
 import type { PracticeAssistantSource } from './types.js';
@@ -101,6 +102,7 @@ const renderEntityApproval = async (
 ): Promise<{ title: string; description: string; payload: Record<string, unknown>; sources: PracticeAssistantSource[] }> => {
   const parsed = asRecord(input);
   const payload = validateActionPayload(parsed);
+  validateProposedActionContract(payload);
   const derived = deriveActionCopy(payload);
   return {
     title: derived.title,


### PR DESCRIPTION
Closes #705. Advances #714.

## Root cause

The Practice Assistant exposed invoice creation through generic entity tools, but its registry reused four update-style fields and did not match the backend draft schema. A model could therefore prepare an approval action that was guaranteed to fail only after the owner approved it.

## What changed

- maps invoice create/update fields to the backend-owned billing contract
- requires client, connected account, and at least one valid line item for drafts
- rejects unknown fields, missing required fields, empty/malformed line items, and unsupported lifecycle actions before an approval card is persisted
- keeps draft creation and invoice sending as two separately pending owner approvals
- adds deterministic model-style tool execution coverage for unbilled reads, valid draft staging, invalid draft rejection, and send staging
- documents the Worker/backend ownership and approval sequence

## Verification

- `npm run lint` — passed
- `npm run type-check` — passed
- focused Practice Assistant suite — 86/86 passed
- full unit suite — 636 passed; 8 unrelated pre-existing intake assertions failed and are tracked in #728

The stable tests assert tool selection results, persisted pending actions, backend contract fields, and approval boundaries rather than generated prose or live-model wording. Stripe/payment reliability remains isolated in #712.
