### PR TITLE
chore(mcp): remove retired Worker scaffolding (#707)

### DIFF
--- a/INTAKE_AI_REFACTOR.md
+++ b/INTAKE_AI_REFACTOR.md
@@ -42,7 +42,7 @@ Branch: `refactor/conversational-intake` → PR to `staging`
 | **completenessWeight** | 0–25 slider for custom fields serialized to `validation_rules.completeness_weight` |
 | **Backend sync** | Fixed API normalizer to handle correct backend response shape `{ template: ... }` / `{ templates: ... }` |
 | **AI prompt accuracy** | Custom fields are resolved by `label` instead of raw backend `key` in the AI `buildIntakeContextSummary` block |
-| **Custom template bootstrap** | Widget bootstrap now honors `?template=<slug>` and, using `MCP_BACKEND_TOKEN`, fetches that published template from the admin templates API so public custom forms can route without backend changes |
+| **Custom template bootstrap** | Widget bootstrap honors `?template=<slug>` and fetches that published template through the backend public intake API, with no Worker MCP dependency |
 | **Public link + embed flow** | Publishing a template opens `EmbedCodeDialog` immediately with the direct public URL (`/public/{slug}?template={templateSlug}`) and widget embed snippet ready to copy |
 | **Types cleaned** | `enrichmentMode` removed from `IntakeConversationState`, `IntakeFieldsPayload`, `PERSISTED_INTAKE_FIELD_KEYS`, `consultationState`, `useChatComposer` |
 | **E2E tests updated** | Removed strengthen-case test; new test: score-threshold CTA + "Strengthen" button must not appear |
@@ -75,7 +75,7 @@ Branch: `refactor/conversational-intake` → PR to `staging`
 
 **Why this matters:**
 - Custom published intake forms can be shared directly via public URL without any authenticated API calls in the widget bootstrap flow
-- No `MCP_BACKEND_TOKEN` required for template selection
+- No Worker-side service token is required for template selection
 
 ### 2. Service-aware field conditions ✅ foundation done
 

--- a/tests/component/McpAccessPage.test.tsx
+++ b/tests/component/McpAccessPage.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@/shared/ui/layout/LoadingSpinner', () => ({
 
 vi.mock('@/shared/lib/mcpOAuth', () => ({
   beginMcpOAuthConnect,
-  getMcpResourceUrl: () => 'https://local.blawby.com/api/mcp',
+  getMcpResourceUrl: () => 'https://staging-api.blawby.com/mcp',
   MCP_OAUTH_STATUS_QUERY_KEY: 'mcp_oauth',
   MCP_OAUTH_MESSAGE_QUERY_KEY: 'message',
 }));
@@ -85,6 +85,7 @@ describe('McpAccessPage', () => {
     await waitFor(() => {
       expect(beginMcpOAuthConnect).toHaveBeenCalledWith('/practice/acme/settings/apps/claude-mcp');
     });
+    expect(screen.getByText('https://staging-api.blawby.com/mcp')).toBeInTheDocument();
   });
 
   it('handles callback success state and refreshes consents', async () => {

--- a/tests/unit/middleware/cors.test.ts
+++ b/tests/unit/middleware/cors.test.ts
@@ -11,7 +11,6 @@ const mockEnv: Env = {
   CHAT_ROOM: {} as Env['CHAT_ROOM'],
   MATTER_PROGRESS: {} as Env['MATTER_PROGRESS'],
   PRESENCE_ROOM: {} as Env['PRESENCE_ROOM'],
-  MCP_SESSION: {} as Env['MCP_SESSION'],
   IDEMPOTENCY_SALT: 'test-salt',
   ONESIGNAL_APP_ID: 'test-app',
   ONESIGNAL_REST_API_KEY: 'test-key',

--- a/tests/unit/middleware/practiceContext.test.ts
+++ b/tests/unit/middleware/practiceContext.test.ts
@@ -20,7 +20,6 @@ const mockEnv: Env = {
   CHAT_ROOM: {} as Env['CHAT_ROOM'],
   MATTER_PROGRESS: {} as Env['MATTER_PROGRESS'],
   PRESENCE_ROOM: {} as Env['PRESENCE_ROOM'],
-  MCP_SESSION: {} as Env['MCP_SESSION'],
   IDEMPOTENCY_SALT: 'test-salt',
   ONESIGNAL_APP_ID: 'test-app',
   ONESIGNAL_REST_API_KEY: 'test-key',

--- a/tests/unit/middleware/rateLimit.test.ts
+++ b/tests/unit/middleware/rateLimit.test.ts
@@ -27,7 +27,6 @@ const createMockEnv = (): {
     CHAT_ROOM: {} as Env['CHAT_ROOM'],
     MATTER_PROGRESS: {} as Env['MATTER_PROGRESS'],
     PRESENCE_ROOM: {} as Env['PRESENCE_ROOM'],
-    MCP_SESSION: {} as Env['MCP_SESSION'],
     IDEMPOTENCY_SALT: 'test-salt',
     ONESIGNAL_APP_ID: 'test-app',
     ONESIGNAL_REST_API_KEY: 'test-key',

--- a/tests/unit/services/mcpOAuth.test.ts
+++ b/tests/unit/services/mcpOAuth.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/config/urls', () => ({
+  getBackendApiUrl: () => 'https://staging-api.blawby.com/',
+  getWorkerApiUrl: () => 'https://dev.blawby.com',
+}));
+
+import { getMcpResourceUrl } from '@/shared/lib/mcpOAuth';
+
+describe('MCP OAuth resource ownership', () => {
+  it('uses the canonical backend MCP endpoint', () => {
+    expect(getMcpResourceUrl()).toBe('https://staging-api.blawby.com/mcp');
+    expect(getMcpResourceUrl()).not.toContain('/api/mcp');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -87,11 +87,6 @@ const workerEndpoints = [
 	'widget',
 	'presence',
 	'search',
-	// U6 of MCP plan: /api/mcp, /api/mcp/ws, /api/mcp/internal/events all
-	// proxy to the worker. Register the prefix so local-dev doesn't fall
-	// through to the backend proxy and 404. Auth and tool surface are wired
-	// in U7-U11.
-	'mcp',
 ];
 
 // Proxy configuration types from http-proxy-middleware

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -129,11 +129,6 @@ export interface Env {
   MATTER_PROGRESS: DurableObjectNamespace;
   CHAT_COUNTER: DurableObjectNamespace;
   PRESENCE_ROOM: DurableObjectNamespace;
-  // U6 of MCP plan: per-session DO holding the live MCP transport
-  // (WebSocket-hibernating), per-session event replay buffer in DO SQLite
-  // storage, and the protocol version negotiation state.
-  // See docs/plans/2026-05-15-002-feat-blawby-mcp-agent-surface-plan.md.
-  MCP_SESSION: DurableObjectNamespace;
   FILES_BUCKET?: R2Bucket;
   ADOBE_CLIENT_ID?: string;
   ADOBE_CLIENT_SECRET?: string;
@@ -154,31 +149,10 @@ export interface Env {
   REQUIRE_EMAIL_VERIFICATION?: string | boolean;
   ENABLE_PUSH_NOTIFICATIONS?: string | boolean;
 
-  /**
-   * Idempotency salt — required for MCP rollout (U12 of the MCP agent
-   * surface plan). Direct-write and high-risk tools refuse to derive
-   * keys without it, so MCP simply doesn't function while the salt is
-   * unset — that's the desired posture.
-   *
-   * Non-MCP callers (ActivityService cursor signing) fall back to a
-   * placeholder when this is unset; historical behavior preserved.
-   *
-   * Set via `wrangler secret put IDEMPOTENCY_SALT` per env. Rotation
-   * requires a coordinated 24h drain since in-flight idempotency keys
-   * are invalidated immediately.
-   */
+  /** ActivityService cursor-signing salt; falls back to a local placeholder when unset. */
   IDEMPOTENCY_SALT?: string;
 
-  // MCP server config.
-  // MCP_BACKEND_AUDIENCE — canonical resource URL for the
-  //   /.well-known/oauth-protected-resource document and JWT `aud` enforcement.
-  //   If unset, derived from the request URL (local dev).
-  // MCP_BACKEND_TOKEN — referenced by MCP tool handlers; pending replacement
-  //   with proper OAuth once the backend wires that auth path.
-  // WORKER_EVENT_SECRET — secret backend sends in `x-worker-secret` header
-  //   on the /api/mcp/internal/events ingest route.
-  MCP_BACKEND_AUDIENCE?: string;
-  MCP_BACKEND_TOKEN?: string;
+  // Authenticates Worker event consumers to the backend.
   WORKER_EVENT_SECRET?: string;
 
   CLOUDFLARE_ACCOUNT_ID?: string;

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -79,15 +79,6 @@ new_classes = ["MatterProgressRoom"]
 tag = "v5"
 new_classes = ["PresenceRoom"]
 
-[[migrations]]
-tag = "v6"
-new_sqlite_classes = ["McpSession"]
-
-[[migrations]]
-tag = "v7"
-deleted_classes = ["McpSession"]
-
-
 [env.dev]
 name = "blawby-ai-chatbot-dev"
 kv_namespaces = [
@@ -155,14 +146,6 @@ new_classes = ["MatterProgressRoom"]
 [[env.dev.migrations]]
 tag = "v5"
 new_classes = ["PresenceRoom"]
-
-[[env.dev.migrations]]
-tag = "v6"
-new_sqlite_classes = ["McpSession"]
-
-[[env.dev.migrations]]
-tag = "v7"
-deleted_classes = ["McpSession"]
 
 [env.dev.vars]
 NODE_ENV = "development"
@@ -270,14 +253,6 @@ deleted_classes = ["MatterDiffStore"]
 tag = "v8"
 new_classes = ["PresenceRoom"]
 
-[[env.staging.migrations]]
-tag = "v9"
-new_sqlite_classes = ["McpSession"]
-
-[[env.staging.migrations]]
-tag = "v10"
-deleted_classes = ["McpSession"]
-
 [env.staging.vars]
 NODE_ENV = "staging"
 LOG_LEVEL = "warn"
@@ -322,12 +297,6 @@ new_classes = ["MatterProgressRoom"]
 [[env.production.migrations]]
 tag = "v6"
 new_classes = ["PresenceRoom"]
-[[env.production.migrations]]
-tag = "v7"
-new_sqlite_classes = ["McpSession"]
-[[env.production.migrations]]
-tag = "v8"
-deleted_classes = ["McpSession"]
 [[env.production.r2_buckets]]
 binding = "FILES_BUCKET"
 bucket_name = "blawby-ai-files"


### PR DESCRIPTION
Closes #707. Advances #714.

## Root cause

PR #708 removed the custom Worker MCP implementation, but residual deployment and type scaffolding still described `McpSession` and routed local `/api/mcp` traffic to the Worker. Tests also continued constructing the dead binding.

## What changed

- removes all remaining `McpSession` migration pairs from base, dev, staging, and production Wrangler config
- removes `MCP_SESSION`, `MCP_BACKEND_AUDIENCE`, and `MCP_BACKEND_TOKEN` from the Worker environment contract
- removes the dead local `/api/mcp` Worker proxy prefix and test fixtures
- keeps `WORKER_EVENT_SECRET` for its live intake event-consumer use and clarifies the surviving idempotency salt use
- updates stale intake documentation
- adds a direct regression proving Claude Desktop resolves `https://staging-api.blawby.com/mcp`, not the removed Worker route

## Verification

- `npm run lint` — passed
- `npm run type-check` — passed
- focused Worker/MCP unit tests — 63 passed
- MCP settings/callback component tests — 8 passed
- `npx wrangler deploy --dry-run --config worker/wrangler.toml` — passed
- Wrangler dry runs for `dev`, `staging`, and `production` — passed; no `McpSession` binding appears
- `npm run build` — passed
- repository scan finds no live Worker MCP binding, token, route, or proxy references; only negative route assertions remain

The internal Practice Assistant remains intact and backend-grounded, per the issue decision and #705.
