### PR TITLE
Security: harden financial action approvals

### DIFF
--- a/docs/operations/financial-action-launch-verification.md
+++ b/docs/operations/financial-action-launch-verification.md
@@ -1,0 +1,13 @@
+# Financial action launch verification
+
+This document maps #719 to deterministic evidence. Stripe webhook verification and invoice persistence remain backend-owned; backend issue Blawby/blawby-backend#369 and PR Blawby/blawby-backend#370 contain the focused backend fix and proofs for human review and merge.
+
+| Launch guarantee | Enforcement | Automated evidence |
+| --- | --- | --- |
+| Invoice ownership | Practice invoice routes are authorized against the requested Practice. Client invoice identity is derived from the authenticated user, never accepted from request input, and queries include both Practice and client identifiers. | `tests/e2e/security-isolation.spec.ts`, backend `test/invoices/invoice-access-safety.test.ts`, and the billing E2E owner/client detail assertions. |
+| Signature and replay safety | Stripe signatures are verified before event storage. Stripe event IDs are unique and are reused as Graphile job keys; processed event replays do not enqueue or mutate again. Invalid-signature logs contain only the webhook path. | Backend `test/modules/webhooks/financial-webhook-safety.test.ts` and `test/modules/webhooks/webhook-job-idempotency.test.ts`. |
+| Invoice lifecycle integrity | Frontend send, sync, paid, void, and refund views consume backend invoice state. The billing E2E sends the exact draft, follows the returned Stripe hosted URL, syncs from Stripe, and requires owner and client views to converge on paid state. | `tests/e2e/billing-invoicing.spec.ts` and invoice service/component tests. |
+| Mandatory approval | Every assistant create, update, delete, and lifecycle tool produces a stored pending action. Approval executes only the stored payload. The action row is scoped to its Practice, execution is claimed once, and outbound writes carry an action-bound idempotency key. | `tests/unit/practiceAssistant/billingWorkflow.test.ts`, `tests/unit/practiceAssistant/toolRegistry.test.ts`, and `tests/unit/practiceAssistant/actionExecutionSafety.test.ts`. |
+| Sanitized correlation | Failed action rows store only an opaque correlation reference. The same reference is returned in the sanitized 500 response and centralized logs omit unexpected messages and stacks. | `tests/unit/practiceAssistant/actionExecutionSafety.test.ts` and `tests/unit/worker/errorHandler.test.ts`. |
+
+Backend PR #370 is intentionally not a frontend merge dependency. The frontend staging work may finish while that PR awaits human review and merge.

--- a/tests/e2e/security-isolation.spec.ts
+++ b/tests/e2e/security-isolation.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from './fixtures.auth';
 const OTHER_PRACTICE_ID = '00000000-0000-4000-8000-000000000718';
 
 const expectDenied = async (response: { status(): number; text(): Promise<string> }) => {
-  expect([401, 403, 404], await response.text()).toContain(response.status());
+  expect([400, 401, 403, 404], await response.text()).toContain(response.status());
 };
 
 test.describe('launch security isolation', () => {

--- a/tests/unit/practiceAssistant/actionExecutionSafety.test.ts
+++ b/tests/unit/practiceAssistant/actionExecutionSafety.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PracticeAssistantActionService } from '../../../worker/services/practiceAssistant/actionService.js';
+import type { Env } from '../../../worker/types.js';
+
+type ActionRow = {
+  id: string;
+  practice_id: string;
+  conversation_id: string;
+  created_by_user_id: string;
+  tool_use_id: string;
+  tool_name: string;
+  status: 'approved' | 'executed' | 'failed';
+  approval_summary_json: string;
+  payload_json: string;
+  result_json: string | null;
+  error_message: string | null;
+  executed_at: string | null;
+};
+
+const makeHarness = () => {
+  const row: ActionRow = {
+    id: 'action-719',
+    practice_id: 'practice-a',
+    conversation_id: 'conversation-1',
+    created_by_user_id: 'owner-1',
+    tool_use_id: 'tool-1',
+    tool_name: 'run_entity_action',
+    status: 'approved',
+    approval_summary_json: JSON.stringify({ title: 'Send invoice', description: 'Send invoice invoice-1.' }),
+    payload_json: JSON.stringify({
+      actionType: 'run_entity_action',
+      entityType: 'invoice',
+      id: 'invoice-1',
+      action: 'send',
+      input: { delivery: 'email' },
+    }),
+    result_json: null,
+    error_message: null,
+    executed_at: null,
+  };
+
+  const prepare = vi.fn((sql: string) => ({
+    bind: (...args: unknown[]) => ({
+      first: async () => {
+        if (!sql.includes('SELECT *')) return null;
+        return args[0] === row.id && args[1] === row.practice_id ? { ...row } : null;
+      },
+      run: async () => {
+        if (sql.includes('SET executed_at = ?')) {
+          if (row.status !== 'approved' || row.executed_at !== null) return { meta: { changes: 0 } };
+          row.executed_at = String(args[0]);
+          return { meta: { changes: 1 } };
+        }
+        if (sql.includes("SET status = 'executed'")) {
+          row.status = 'executed';
+          row.result_json = String(args[0]);
+          return { meta: { changes: 1 } };
+        }
+        if (sql.includes("SET status = 'failed'")) {
+          row.status = 'failed';
+          row.error_message = String(args[0]);
+          return { meta: { changes: 1 } };
+        }
+        throw new Error(`Unexpected SQL: ${sql}`);
+      },
+    }),
+  }));
+
+  const env = {
+    DB: { prepare },
+    BACKEND_API_URL: 'https://staging-api.blawby.com',
+  } as unknown as Env;
+  return { env, row };
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('practice assistant action execution safety', () => {
+  it('executes the stored payload once with an action-bound idempotency key', async () => {
+    const { env, row } = makeHarness();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ status: 'sent' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const service = new PracticeAssistantActionService(env);
+
+    const result = await service.executeApproved(
+      row.id,
+      row.practice_id,
+      new Request('https://ai.blawby.com/api/ai/practice-assistant/actions/action-719/approve'),
+    );
+
+    expect(result.status).toBe('executed');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://staging-api.blawby.com/api/invoices/practice-a/invoice-1/send');
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('Idempotency-Key')).toBe('practice-assistant-action:action-719');
+    expect(JSON.parse(String(init.body))).toEqual({ delivery: 'email' });
+
+    await expect(service.executeApproved(
+      row.id,
+      row.practice_id,
+      new Request('https://ai.blawby.com/api/ai/practice-assistant/actions/action-719/approve'),
+    )).rejects.toThrow('Action must be approved before execution');
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not allow an approved action to cross Practice boundaries', async () => {
+    const { env, row } = makeHarness();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(new PracticeAssistantActionService(env).executeApproved(
+      row.id,
+      'practice-b',
+      new Request('https://ai.blawby.com/api/ai/practice-assistant/actions/action-719/approve'),
+    )).rejects.toThrow('Action not found');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('persists a correlation reference without persisting backend error details', async () => {
+    const { env, row } = makeHarness();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: 'database password and internal stack details',
+    }), { status: 500, headers: { 'Content-Type': 'application/json' } })));
+
+    await expect(new PracticeAssistantActionService(env).executeApproved(
+      row.id,
+      row.practice_id,
+      new Request('https://ai.blawby.com/api/ai/practice-assistant/actions/action-719/approve', {
+        headers: { 'x-correlation-id': 'corr-719' },
+      }),
+    )).rejects.toMatchObject({
+      status: 500,
+      details: { correlationId: 'corr-719' },
+    });
+
+    expect(row.status).toBe('failed');
+    expect(row.error_message).toBe('Execution failed. Correlation ID: corr-719');
+    expect(row.error_message).not.toContain('password');
+    expect(row.error_message).not.toContain('stack');
+  });
+});

--- a/tests/unit/worker/errorHandler.test.ts
+++ b/tests/unit/worker/errorHandler.test.ts
@@ -26,6 +26,22 @@ describe('public error sanitization', () => {
       correlationId: 'correlation-123',
     });
     expect(JSON.stringify(body)).not.toMatch(/secret-value|stack detail|password/i);
+    expect(console.error).toHaveBeenCalledOnce();
+    expect(vi.mocked(console.error).mock.calls[0]?.[0]).not.toMatch(/secret-value|stack detail|password/i);
+  });
+
+  it('uses a server error correlation reference without exposing it as details', async () => {
+    const response = handleError(
+      HttpErrors.internalServerError('Action execution failed', { correlationId: 'action-correlation' }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: 'Internal server error',
+      errorCode: 'HTTP_500',
+      correlationId: 'action-correlation',
+    });
+    expect(response.headers.get('X-Request-ID')).toBe('action-correlation');
   });
 
   it('sanitizes explicit server errors while preserving safe client errors', async () => {

--- a/worker/errorHandler.ts
+++ b/worker/errorHandler.ts
@@ -3,9 +3,10 @@ import { ZodError } from 'zod';
 
 // Structured logging for better observability
 export function logError(error: unknown, context: Record<string, unknown> = {}) {
+  const isSafeClientError = error instanceof HttpError && error.status < 500;
   const errorData = {
-    error: error instanceof Error ? error.message : String(error),
-    stack: error instanceof Error ? error.stack : undefined,
+    error: isSafeClientError ? error.message : 'Internal server error',
+    errorType: error instanceof Error ? error.name : typeof error,
     context,
     timestamp: new Date().toISOString(),
     worker: 'blawby-ai-chatbot'
@@ -15,8 +16,14 @@ export function logError(error: unknown, context: Record<string, unknown> = {}) 
 }
 
 // Centralized error handler with enhanced features
-export function handleError(error: unknown, correlationId = crypto.randomUUID()): Response {
-  logError(error, { endpoint: 'unknown', correlationId });
+export function handleError(error: unknown, correlationId?: string): Response {
+  const errorCorrelationId = error instanceof HttpError &&
+    error.details && typeof error.details === 'object' && !Array.isArray(error.details) &&
+    typeof (error.details as Record<string, unknown>).correlationId === 'string'
+    ? (error.details as Record<string, unknown>).correlationId as string
+    : undefined;
+  const resolvedCorrelationId = correlationId || errorCorrelationId || crypto.randomUUID();
+  logError(error, { endpoint: 'unknown', correlationId: resolvedCorrelationId });
 
   let status = 500;
   let message = 'Internal server error';
@@ -52,14 +59,14 @@ export function handleError(error: unknown, correlationId = crypto.randomUUID())
     error: message,
     errorCode,
     ...(details && { details }),
-    correlationId,
+    correlationId: resolvedCorrelationId,
   };
 
   return new Response(JSON.stringify(response), {
     status,
     headers: {
       'Content-Type': 'application/json',
-      'X-Request-ID': correlationId,
+      'X-Request-ID': resolvedCorrelationId,
     }
   });
 }

--- a/worker/services/practiceAssistant/actionService.ts
+++ b/worker/services/practiceAssistant/actionService.ts
@@ -32,6 +32,7 @@ interface ActionRow {
   payload_json: string;
   result_json: string | null;
   error_message: string | null;
+  executed_at: string | null;
 }
 
 export class PracticeAssistantActionService {
@@ -127,23 +128,31 @@ export class PracticeAssistantActionService {
     if (row.status !== 'approved') {
       throw HttpErrors.conflict(`Action must be approved before execution. Current status: ${row.status}`);
     }
+    const correlationId = request.headers.get('x-correlation-id')?.trim() || crypto.randomUUID();
+    const claim = await this.env.DB.prepare(`
+      UPDATE practice_assistant_actions
+      SET executed_at = ?
+      WHERE id = ? AND practice_id = ? AND status = 'approved' AND executed_at IS NULL
+    `).bind(new Date().toISOString(), actionId, practiceId).run();
+    if (!claim.meta.changes) {
+      throw HttpErrors.conflict('Action execution has already been claimed');
+    }
     const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
     try {
-      const result = await this.executePayload(practiceId, payload, request);
+      const result = await this.executePayload(actionId, practiceId, payload, request);
       await this.env.DB.prepare(`
         UPDATE practice_assistant_actions
-        SET status = 'executed', result_json = ?, executed_at = ?
-        WHERE id = ? AND practice_id = ?
-      `).bind(JSON.stringify(result ?? {}), new Date().toISOString(), actionId, practiceId).run();
+        SET status = 'executed', result_json = ?
+        WHERE id = ? AND practice_id = ? AND status = 'approved' AND executed_at IS NOT NULL
+      `).bind(JSON.stringify(result ?? {}), actionId, practiceId).run();
       return this.toSummary({ ...row, status: 'executed', result_json: JSON.stringify(result ?? {}) });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+    } catch {
       await this.env.DB.prepare(`
         UPDATE practice_assistant_actions
         SET status = 'failed', error_message = ?
-        WHERE id = ? AND practice_id = ?
-      `).bind(message, actionId, practiceId).run();
-      throw error;
+        WHERE id = ? AND practice_id = ? AND status = 'approved' AND executed_at IS NOT NULL
+      `).bind(`Execution failed. Correlation ID: ${correlationId}`, actionId, practiceId).run();
+      throw HttpErrors.internalServerError('Action execution failed', { correlationId });
     }
   }
 
@@ -179,16 +188,17 @@ export class PracticeAssistantActionService {
   // ─── Execution ──────────────────────────────────────────────────────────────
 
   private async executePayload(
+    actionId: string,
     practiceId: string,
     payload: Record<string, unknown>,
     request: Request,
   ): Promise<unknown> {
     const action = validateActionPayload(payload);
     switch (action.actionType) {
-      case 'update_entity': return this.executeUpdateEntity(practiceId, action, request);
-      case 'create_entity': return this.executeCreateEntity(practiceId, action, request);
-      case 'delete_entity': return this.executeDeleteEntity(practiceId, action, request);
-      case 'run_entity_action': return this.executeRunEntityAction(practiceId, action, request);
+      case 'update_entity': return this.executeUpdateEntity(actionId, practiceId, action, request);
+      case 'create_entity': return this.executeCreateEntity(actionId, practiceId, action, request);
+      case 'delete_entity': return this.executeDeleteEntity(actionId, practiceId, action, request);
+      case 'run_entity_action': return this.executeRunEntityAction(actionId, practiceId, action, request);
     }
   }
 
@@ -214,6 +224,7 @@ export class PracticeAssistantActionService {
   }
 
   private async executeUpdateEntity(
+    actionId: string,
     practiceId: string,
     action: UpdateEntityPayload,
     request: Request,
@@ -266,7 +277,7 @@ export class PracticeAssistantActionService {
     );
     let currentEntity: Record<string, unknown> = {};
     if (needsReadFirst && config.readRoute) {
-      const fetched = await this.entityFetch(config, config.readRoute(scope), request, { method: 'GET' });
+      const fetched = await this.entityFetch(actionId, config, config.readRoute(scope), request, { method: 'GET' });
       if (fetched && typeof fetched === 'object' && !Array.isArray(fetched)) {
         currentEntity = fetched as Record<string, unknown>;
       }
@@ -338,13 +349,13 @@ export class PracticeAssistantActionService {
       }
     }
 
-    const updated = await this.entityFetch(config, config.updateRoute(scope), request, {
+    const updated = await this.entityFetch(actionId, config, config.updateRoute(scope), request, {
       method: config.updateMethod,
       body: patch,
     });
 
     if (config.readRoute) {
-      const verified = await this.entityFetch(config, config.readRoute(scope), request, { method: 'GET' });
+      const verified = await this.entityFetch(actionId, config, config.readRoute(scope), request, { method: 'GET' });
       const verifiedRecord =
         verified && typeof verified === 'object' && !Array.isArray(verified)
           ? (verified as Record<string, unknown>)
@@ -359,6 +370,7 @@ export class PracticeAssistantActionService {
   }
 
   private async executeCreateEntity(
+    actionId: string,
     practiceId: string,
     action: CreateEntityPayload,
     request: Request,
@@ -413,7 +425,7 @@ export class PracticeAssistantActionService {
       }
     }
 
-    const created = await this.entityFetch(config, config.createRoute(scope), request, {
+    const created = await this.entityFetch(actionId, config, config.createRoute(scope), request, {
       method: 'POST',
       body: action.data,
     });
@@ -421,6 +433,7 @@ export class PracticeAssistantActionService {
   }
 
   private async executeDeleteEntity(
+    actionId: string,
     practiceId: string,
     action: DeleteEntityPayload,
     request: Request,
@@ -433,12 +446,12 @@ export class PracticeAssistantActionService {
     const scope = this.buildScope(practiceId, action);
     this.requireParent(config, scope);
 
-    await this.entityFetch(config, config.deleteRoute(scope), request, { method: 'DELETE' });
+    await this.entityFetch(actionId, config, config.deleteRoute(scope), request, { method: 'DELETE' });
 
     // Verify hard deletes: if the entity is still readable, the delete failed.
     if ((config.deleteSemantics ?? 'delete') === 'delete' && config.readRoute) {
       try {
-        await this.entityFetch(config, config.readRoute(scope), request, { method: 'GET' });
+        await this.entityFetch(actionId, config, config.readRoute(scope), request, { method: 'GET' });
         // If we reach here the entity still exists — delete did not take effect.
         throw new Error(`Delete verification failed: ${action.entityType} ${action.id} is still readable after delete`);
       } catch (error) {
@@ -457,6 +470,7 @@ export class PracticeAssistantActionService {
   }
 
   private async executeRunEntityAction(
+    actionId: string,
     practiceId: string,
     action: RunEntityActionPayload,
     request: Request,
@@ -483,13 +497,13 @@ export class PracticeAssistantActionService {
       }
     }
 
-    const result = await this.entityFetch(config, lifecycleAction.route(scope), request, {
+    const result = await this.entityFetch(actionId, config, lifecycleAction.route(scope), request, {
       method: lifecycleAction.method,
       body: action.input ?? {},
     });
 
     if (lifecycleAction.verifyReadRoute) {
-      const verified = await this.entityFetch(config, lifecycleAction.verifyReadRoute(scope), request, { method: 'GET' });
+      const verified = await this.entityFetch(actionId, config, lifecycleAction.verifyReadRoute(scope), request, { method: 'GET' });
       return { result, verified };
     }
     return { result };
@@ -503,41 +517,46 @@ export class PracticeAssistantActionService {
    * forwarding the original auth headers so the route's auth checks pass.
    */
   private entityFetch(
+    actionId: string,
     config: EntityConfig,
     path: string,
     request: Request,
     init: { method: string; body?: unknown },
   ): Promise<unknown> {
     return config.owner === 'worker'
-      ? this.workerFetch(path, request, init)
-      : this.backendFetch(path, request, init);
+      ? this.workerFetch(actionId, path, request, init)
+      : this.backendFetch(actionId, path, request, init);
   }
 
   private async workerFetch(
+    actionId: string,
     path: string,
     request: Request,
     init: { method: string; body?: unknown },
   ): Promise<unknown> {
     const origin = new URL(request.url).origin;
-    return this.doFetch(`${origin}${path}`, request, init);
+    return this.doFetch(actionId, `${origin}${path}`, request, init);
   }
 
   private async backendFetch(
+    actionId: string,
     path: string,
     request: Request,
     init: { method: string; body?: unknown },
   ): Promise<unknown> {
     const base = this.env.BACKEND_API_URL?.trim();
     if (!base) throw HttpErrors.internalServerError('BACKEND_API_URL is required');
-    return this.doFetch(`${base.replace(/\/+$/, '')}${path}`, request, init);
+    return this.doFetch(actionId, `${base.replace(/\/+$/, '')}${path}`, request, init);
   }
 
   private async doFetch(
+    actionId: string,
     url: string,
     request: Request,
     init: { method: string; body?: unknown },
   ): Promise<unknown> {
     const headers = new Headers({ 'Content-Type': 'application/json' });
+    headers.set('Idempotency-Key', `practice-assistant-action:${actionId}`);
     const cookie = request.headers.get('Cookie');
     const authorization = request.headers.get('Authorization');
     if (cookie) headers.set('Cookie', cookie);


### PR DESCRIPTION
Closes #719
Advances #716

## Outcome
- claims approved assistant actions exactly once before any external write
- executes only the stored, Practice-bound payload
- sends a stable action-bound Idempotency-Key to Worker/backend mutations
- rejects replay and cross-Practice execution before any fetch
- persists only an opaque failure correlation reference and reuses it in sanitized 500 responses
- removes unexpected error messages and stacks from centralized logs
- documents financial launch evidence and accepts the backend explicit 400 as a valid isolation denial

## Backend handoff
- Blawby/blawby-backend#370 fixes raw invalid-signature logging and adds invoice/webhook/idempotency proofs; human review/merge required
- Blawby/blawby-backend#365 supplies the staging client-link endpoint required by the live billing suite; human review/merge required
- neither pending backend merge blocks this frontend staging PR

## Verification
- focused approval/error tests: 11/11 green
- tunnel security isolation at https://dev.blawby.com: 4/4 green
- full unit suite: 662 pass; exactly 8 pre-existing failures tracked by #728
- lint and typecheck: green
- production build: green
- first-load bundle: 284.3 KB / 300 KB
- live billing suite currently reaches the known staging 404 for POST /api/clients/:practiceId supplied by backend PR #365; no frontend fallback added

## Backend verification
Backend PR #370 focused Vitest: 6/6 green; typecheck and touched-file quality checks green.