### PR TITLE
Deploy: make production launch explicit and ordered

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,233 +1,78 @@
-name: Deploy to Cloudflare
+name: Deploy staging
 
 on:
   push:
     branches:
-      - main
       - staging
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
 jobs:
+  validate:
+    name: Validate staging release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run lint
+      - run: npm run validate:production-config
+      - name: Validate staging Worker bundle
+        run: npx wrangler deploy --env staging --config worker/wrangler.toml --dry-run --strict
+
   deploy-worker:
-    name: Deploy Cloudflare Worker
+    name: Deploy staging Worker
+    needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve deploy env
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "DEPLOY_ENV=production" >> "$GITHUB_ENV"
-          else
-            echo "DEPLOY_ENV=staging" >> "$GITHUB_ENV"
-          fi
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Debug - versions
-        run: |
-          node -v
-          npm -v
-          npx --version
-
-      - name: Debug - list worker files
-        run: |
-          pwd
-          ls -la
-          ls -la worker || true
-          ls -la worker/wrangler.toml || true
-
-      - name: Debug - show wrangler config
-        run: |
-          cat worker/wrangler.toml || true
-
-      - name: Validate deployment secrets
-        run: |
-          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
-            echo "❌ CLOUDFLARE_API_TOKEN is not set" >&2
-            exit 1
-          fi
-          if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
-            echo "❌ CLOUDFLARE_ACCOUNT_ID is not set" >&2
-            exit 1
-          fi
-          echo "✅ Deployment secrets are set"
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Deploy Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          npx wrangler deploy --env staging --config worker/wrangler.toml
+          --tag "${GITHUB_SHA}" --message "Git commit ${GITHUB_SHA}" --strict
 
-      - name: Validate production configuration
-        run: npm run validate:production-config
-
-      - name: Validate production Worker secret inventory
-        if: env.DEPLOY_ENV == 'production'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -euo pipefail
-          npx wrangler secret list --env production --config worker/wrangler.toml --format json > /tmp/worker-secret-names.json
-          npm run validate:production-config -- --worker-secrets /tmp/worker-secret-names.json
-
-      - name: Validate Worker bundle
-        run: npx wrangler deploy --env "${DEPLOY_ENV}" --config worker/wrangler.toml --dry-run --strict
-
-      - name: Deploy Worker (direct wrangler)
-        env:
-          WRANGLER_LOG: debug
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -euxo pipefail
-          npx wrangler --version
-          npx wrangler deploy --env "${DEPLOY_ENV}" --config worker/wrangler.toml --tag "${GITHUB_SHA}" --message "Git commit ${GITHUB_SHA}" --strict
-
-      - name: Check wrangler logs
-        if: always()
-        run: |
-          echo "📋 Wrangler logs:"
-          ls -la ~/.config/.wrangler/logs 2>/dev/null || true
-          ls -la ~/.wrangler/logs 2>/dev/null || true
-          LATEST_LOG="$(ls -t ~/.config/.wrangler/logs/wrangler-*.log ~/.wrangler/logs/wrangler-*.log 2>/dev/null | head -1)"
-          if [[ -n "$LATEST_LOG" ]]; then
-            echo "Showing latest log: $LATEST_LOG"
-            tail -300 "$LATEST_LOG"
-          else
-            echo "No wrangler logs found"
-          fi
-
-      - name: Deployment summary
-        if: success()
-        run: echo "✅ Worker deployed successfully to production"
-
-      - name: Deployment failed
-        if: failure()
-        run: |
-          echo "❌ Worker deployment failed"
-          exit 1
-
-  deploy-frontend:
-    name: Deploy Cloudflare Pages
+  deploy-pages:
+    name: Deploy staging Pages
+    needs: deploy-worker
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VITE_BACKEND_API_URL: ${{ secrets.VITE_BACKEND_API_URL_STAGING }}
+      VITE_APP_BASE_URL: ${{ secrets.VITE_APP_BASE_URL_STAGING }}
+      VITE_WORKER_API_URL: ${{ secrets.VITE_WORKER_API_URL_STAGING }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve build env
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            echo "DEPLOY_ENV=production" >> "$GITHUB_ENV"
-            echo "PAGES_PROJECT=blawby-ai-chatbot-frontend" >> "$GITHUB_ENV"
-            {
-              echo "VITE_BACKEND_API_URL<<EOF"
-              echo "$VITE_BACKEND_API_URL_PROD"
-              echo "EOF"
-              echo "VITE_APP_BASE_URL<<EOF"
-              echo "$VITE_APP_BASE_URL_PROD"
-              echo "EOF"
-              echo "VITE_WORKER_API_URL<<EOF"
-              echo "$VITE_WORKER_API_URL_PROD"
-              echo "EOF"
-            } >> "$GITHUB_ENV"
-          else
-            echo "DEPLOY_ENV=staging" >> "$GITHUB_ENV"
-            echo "PAGES_PROJECT=blawby-ai-chatbot-frontend-staging" >> "$GITHUB_ENV"
-            {
-              echo "VITE_BACKEND_API_URL<<EOF"
-              echo "$VITE_BACKEND_API_URL_STG"
-              echo "EOF"
-              echo "VITE_APP_BASE_URL<<EOF"
-              echo "$VITE_APP_BASE_URL_STG"
-              echo "EOF"
-              echo "VITE_WORKER_API_URL<<EOF"
-              echo "$VITE_WORKER_API_URL_STG"
-              echo "EOF"
-            } >> "$GITHUB_ENV"
-          fi
-        env:
-          VITE_BACKEND_API_URL_PROD: ${{ secrets.VITE_BACKEND_API_URL }}
-          VITE_APP_BASE_URL_PROD: ${{ secrets.VITE_APP_BASE_URL }}
-          VITE_WORKER_API_URL_PROD: ${{ secrets.VITE_WORKER_API_URL }}
-          VITE_BACKEND_API_URL_STG: ${{ secrets.VITE_BACKEND_API_URL_STAGING }}
-          VITE_APP_BASE_URL_STG: ${{ secrets.VITE_APP_BASE_URL_STAGING }}
-          VITE_WORKER_API_URL_STG: ${{ secrets.VITE_WORKER_API_URL_STAGING }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Validate build env
-        run: |
-          if [[ -z "${VITE_BACKEND_API_URL:-}" ]]; then
-            echo "VITE_BACKEND_API_URL is required for build." >&2
-            exit 1
-          fi
-          if [[ -z "${VITE_APP_BASE_URL:-}" ]]; then
-            echo "VITE_APP_BASE_URL is required for SSR/build contexts." >&2
-            exit 1
-          fi
-          if [[ -z "${VITE_WORKER_API_URL:-}" ]]; then
-            echo "VITE_WORKER_API_URL is required for SSR/build contexts." >&2
-            exit 1
-          fi
-          if [[ "${DEPLOY_ENV}" == "production" ]]; then
-            npm run validate:production-config -- --build-env
-          else
-            npm run validate:production-config
-          fi
-
-      - name: Build
-        run: npm run build
-
-      - name: Bundle size budget check
-        run: npm run build:check-size
-
-      - name: Debug - list build output
-        run: |
-          pwd
-          ls -la
-          ls -la dist || true
-
-      - name: Quick check - Pages project reachable
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run validate:production-config
+      - run: npm run build
+      - run: npm run build:check-size
+      - name: Deploy Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -euo pipefail
-          URL="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${PAGES_PROJECT}"
-          echo "Checking Pages project endpoint for ${PAGES_PROJECT}"
-          HTTP_CODE="$(curl -sS -o /tmp/pages_project.json -w "%{http_code}" \
-            --connect-timeout 8 \
-            --max-time 20 \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json" \
-            "${URL}")"
-          echo "Pages project lookup HTTP status: ${HTTP_CODE}"
-          if [[ "${HTTP_CODE}" -ge 400 ]]; then
-            echo "Pages API preflight failed (HTTP ${HTTP_CODE})"
-            cat /tmp/pages_project.json || true
-            exit 1
-          fi
-
-      - name: Deploy to Cloudflare Pages
-        timeout-minutes: 5
-        uses: cloudflare/wrangler-action@v3
-        env:
-          WRANGLER_LOG: debug
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=${{ env.PAGES_PROJECT }}
+        run: >-
+          npx wrangler pages deploy dist --project-name blawby-ai-chatbot-frontend-staging
+          --branch staging --commit-hash "${GITHUB_SHA}" --commit-message "Git commit ${GITHUB_SHA}"

--- a/.github/workflows/launch-production.yml
+++ b/.github/workflows/launch-production.yml
@@ -1,0 +1,201 @@
+name: Launch production
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type DEPLOY to confirm the production launch
+        required: true
+        type: string
+      backend_git_commit:
+        description: Exact reviewed backend Git commit currently deployed
+        required: true
+        type: string
+      backend_deployment_id:
+        description: Exact backend platform deployment identifier
+        required: true
+        type: string
+      migrations_ready:
+        description: Confirm required backend and Worker migrations are applied
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: launch-production
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Validate launch prerequisites
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VITE_BACKEND_API_URL: ${{ secrets.VITE_BACKEND_API_URL }}
+      VITE_APP_BASE_URL: ${{ secrets.VITE_APP_BASE_URL }}
+      VITE_WORKER_API_URL: ${{ secrets.VITE_WORKER_API_URL }}
+    steps:
+      - name: Require main and explicit confirmations
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          BACKEND_GIT_COMMIT: ${{ inputs.backend_git_commit }}
+          BACKEND_DEPLOYMENT_ID: ${{ inputs.backend_deployment_id }}
+          MIGRATIONS_READY: ${{ inputs.migrations_ready }}
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REF}" == "refs/heads/main" ]] || { echo "Production launches must run from main." >&2; exit 1; }
+          [[ "${CONFIRMATION}" == "DEPLOY" ]] || { echo "Production confirmation must be DEPLOY." >&2; exit 1; }
+          [[ "${MIGRATIONS_READY}" == "true" ]] || { echo "Migration readiness must be confirmed." >&2; exit 1; }
+          [[ "${BACKEND_GIT_COMMIT}" =~ ^[0-9a-fA-F]{7,40}$ ]] || { echo "A valid exact backend Git commit is required." >&2; exit 1; }
+          [[ -n "${BACKEND_DEPLOYMENT_ID// }" ]] || { echo "The backend platform deployment identifier is required." >&2; exit 1; }
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run lint
+      - run: npm run test:unit
+      - run: npm run validate:production-config -- --build-env
+      - name: Validate production Worker bundle
+        run: npx wrangler deploy --env production --config worker/wrangler.toml --dry-run --strict
+      - run: npm run build
+      - run: npm run build:check-size
+      - name: Check backend readiness with bounded retries
+        run: npx tsx scripts/verify-deployment-propagation.ts page https://api.blawby.com/api/health 5 10
+      - uses: actions/upload-artifact@v4
+        with:
+          name: production-pages-dist-${{ github.sha }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 7
+
+  deploy-worker:
+    name: Deploy production Worker
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    outputs:
+      deployment_id: ${{ steps.release.outputs.deployment_id }}
+      deployment_url: ${{ steps.release.outputs.deployment_url }}
+      deployed_at: ${{ steps.release.outputs.deployed_at }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Validate Cloudflare deployment credentials
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || { echo "CLOUDFLARE_API_TOKEN is required." >&2; exit 1; }
+          [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || { echo "CLOUDFLARE_ACCOUNT_ID is required." >&2; exit 1; }
+      - name: Validate production Worker secret inventory
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx wrangler secret list --env production --config worker/wrangler.toml --format json > "${RUNNER_TEMP}/worker-secret-names.json"
+          npm run validate:production-config -- --worker-secrets "${RUNNER_TEMP}/worker-secret-names.json"
+      - name: Deploy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/worker-deploy.ndjson
+        run: >-
+          npx wrangler deploy --env production --config worker/wrangler.toml
+          --tag "${GITHUB_SHA}" --message "Git commit ${GITHUB_SHA}" --strict
+      - name: Read Worker deployment identity
+        id: release
+        run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/worker-deploy.ndjson" deploy
+      - name: Verify Worker propagation
+        env:
+          EXPECTED_COMMIT: ${{ github.sha }}
+          EXPECTED_DEPLOYMENT_ID: ${{ steps.release.outputs.deployment_id }}
+        run: >-
+          npx tsx scripts/verify-deployment-propagation.ts worker
+          https://ai.blawby.com/api/health 10 10
+
+  deploy-pages:
+    name: Deploy production Pages
+    needs: deploy-worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    outputs:
+      deployment_id: ${{ steps.release.outputs.deployment_id }}
+      deployment_url: ${{ steps.release.outputs.deployment_url }}
+      deployed_at: ${{ steps.release.outputs.deployed_at }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: production-pages-dist-${{ github.sha }}
+          path: dist
+      - name: Deploy Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/pages-deploy.ndjson
+        run: >-
+          npx wrangler pages deploy dist --project-name blawby-ai-chatbot-frontend
+          --branch main --commit-hash "${GITHUB_SHA}" --commit-message "Git commit ${GITHUB_SHA}"
+      - name: Read Pages deployment identity
+        id: release
+        run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/pages-deploy.ndjson" pages-deploy
+      - name: Verify Pages deployment and canonical propagation
+        env:
+          DEPLOYMENT_URL: ${{ steps.release.outputs.deployment_url }}
+        run: |
+          set -euo pipefail
+          npx tsx scripts/verify-deployment-propagation.ts page "${DEPLOYMENT_URL}" 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://ai.blawby.com 10 10
+
+  record-release:
+    name: Record production release evidence
+    needs:
+      - deploy-worker
+      - deploy-pages
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Write release evidence
+        env:
+          RELEASE_ENVIRONMENT: production
+          FRONTEND_WORKER_COMMIT: ${{ github.sha }}
+          WORKER_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.deployment_id }}
+          WORKER_DEPLOYMENT_URL: ${{ needs.deploy-worker.outputs.deployment_url }}
+          PAGES_DEPLOYMENT_ID: ${{ needs.deploy-pages.outputs.deployment_id }}
+          PAGES_DEPLOYMENT_URL: ${{ needs.deploy-pages.outputs.deployment_url }}
+          BACKEND_GIT_COMMIT: ${{ inputs.backend_git_commit }}
+          BACKEND_DEPLOYMENT_ID: ${{ inputs.backend_deployment_id }}
+          LAUNCHED_AT: ${{ needs.deploy-pages.outputs.deployed_at }}
+        run: npx tsx scripts/write-release-evidence.ts release-evidence.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: production-release-${{ github.sha }}
+          path: release-evidence.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Publish launch summary
+        run: cat release-evidence.json >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/operations/production-launch.md
+++ b/docs/operations/production-launch.md
@@ -1,0 +1,40 @@
+# Explicit production launch
+
+Production no longer deploys from a push. `.github/workflows/deploy.yml` deploys only `staging`; `.github/workflows/launch-production.yml` is the sole production launch path and must be started manually from `main`.
+
+## Required launch evidence
+
+The operator supplies four explicit confirmations before any production component deploys:
+
+- `confirmation`: exactly `DEPLOY`.
+- `backend_git_commit`: the exact reviewed backend commit already deployed.
+- `backend_deployment_id`: the backend platform deployment identifier.
+- `migrations_ready`: confirmation that required backend and Worker migrations are applied.
+
+The preflight then runs typecheck, lint, the unit suite, production configuration validation, strict Worker dry-run, production build and bundle budget, and a bounded backend health check. The `production` GitHub environment remains the human approval boundary for production credentials and deployment.
+
+## Ordered cutover
+
+Only one `launch-production` run can execute at a time, and queued runs are not allowed to cancel an active cutover.
+
+1. Deploy the Worker with the exact frontend commit as its Cloudflare tag.
+2. Read the native Wrangler Worker version ID and target from structured output.
+3. Poll `/api/health` with bounded attempts/timeouts until the commit and Worker version ID match.
+4. Deploy the already-validated Pages artifact with `main` and the exact commit attached.
+5. Read the native Pages deployment ID and URL from structured output.
+6. Poll both the immutable Pages deployment URL and `https://ai.blawby.com` with bounded attempts/timeouts.
+
+A failed preflight, Worker deploy, propagation check, Pages deploy, or Pages propagation check fails visibly and prevents later jobs from starting.
+
+## Release record
+
+Successful launches upload `release-evidence.json` for 90 days and append it to the workflow summary. It contains only:
+
+- environment and timestamp;
+- exact frontend/Worker Git commit;
+- Cloudflare Worker version ID and target;
+- Cloudflare Pages deployment ID and URL;
+- exact backend Git commit and platform deployment ID;
+- migration-readiness confirmation.
+
+It never includes runtime configuration or secret values.

--- a/docs/operations/production-topology.md
+++ b/docs/operations/production-topology.md
@@ -1,6 +1,6 @@
 # Production topology and configuration ownership
 
-This inventory is the source-of-truth checklist for the production configuration gate. It names systems and configuration fields, never secret values. `npm run validate:production-config` verifies the repository-owned entries against `worker/wrangler.toml`, `public/_headers`, and `public/_redirects`. The production deploy also verifies Cloudflare Worker **secret names** and the three Pages build URLs without printing their values.
+This inventory is the source-of-truth checklist for the production configuration gate. It names systems and configuration fields, never secret values. `npm run validate:production-config` verifies the repository-owned entries against `worker/wrangler.toml`, `public/_headers`, and `public/_redirects`. The manual production launch also verifies Cloudflare Worker **secret names** and the three Pages build URLs without printing their values. Its ordered procedure and release record are documented in `docs/operations/production-launch.md`.
 
 ## Runtime topology
 

--- a/scripts/lib/deploymentEvidence.ts
+++ b/scripts/lib/deploymentEvidence.ts
@@ -1,0 +1,93 @@
+export type WranglerDeploymentKind = 'deploy' | 'pages-deploy';
+
+export interface DeploymentIdentity {
+  deploymentId: string;
+  deploymentUrl: string;
+  deployedAt: string;
+  target: string;
+}
+
+export interface ReleaseEvidenceInput {
+  environment: 'production';
+  frontendWorkerCommit: string;
+  workerDeploymentId: string;
+  workerDeploymentUrl: string;
+  pagesDeploymentId: string;
+  pagesDeploymentUrl: string;
+  backendGitCommit: string;
+  backendDeploymentId: string;
+  launchedAt: string;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+
+const requireString = (record: Record<string, unknown>, field: string): string => {
+  const value = record[field];
+  if (typeof value !== 'string' || !value.trim() || /[\r\n]/.test(value)) {
+    throw new Error(`Wrangler output is missing a valid ${field}`);
+  }
+  return value.trim();
+};
+
+export const parseWranglerDeploymentOutput = (
+  source: string,
+  kind: WranglerDeploymentKind,
+): DeploymentIdentity => {
+  const records = source
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line, index) => {
+      try {
+        return asRecord(JSON.parse(line));
+      } catch {
+        throw new Error(`Wrangler output line ${index + 1} is not valid JSON`);
+      }
+    })
+    .filter((record): record is Record<string, unknown> => record !== null);
+  const failed = records.find((record) => record.type === 'command-failed');
+  if (failed) throw new Error('Wrangler recorded a failed deployment command');
+  const record = records.findLast((candidate) => candidate.type === kind);
+  if (!record) throw new Error(`Wrangler output does not contain ${kind}`);
+
+  if (kind === 'deploy') {
+    const targets = record.targets;
+    if (!Array.isArray(targets) || typeof targets[0] !== 'string') {
+      throw new Error('Wrangler Worker output is missing a deployment target');
+    }
+    return {
+      deploymentId: requireString(record, 'version_id'),
+      deploymentUrl: targets[0],
+      deployedAt: requireString(record, 'timestamp'),
+      target: requireString(record, 'worker_name'),
+    };
+  }
+
+  return {
+    deploymentId: requireString(record, 'deployment_id'),
+    deploymentUrl: requireString(record, 'url'),
+    deployedAt: requireString(record, 'timestamp'),
+    target: requireString(record, 'pages_project'),
+  };
+};
+
+export const buildReleaseEvidence = (input: ReleaseEvidenceInput) => ({
+  environment: input.environment,
+  frontendWorkerCommit: input.frontendWorkerCommit,
+  worker: {
+    deploymentId: input.workerDeploymentId,
+    deploymentUrl: input.workerDeploymentUrl,
+  },
+  pages: {
+    deploymentId: input.pagesDeploymentId,
+    deploymentUrl: input.pagesDeploymentUrl,
+  },
+  backend: {
+    gitCommit: input.backendGitCommit,
+    deploymentId: input.backendDeploymentId,
+    migrationsReady: true,
+  },
+  launchedAt: input.launchedAt,
+});

--- a/scripts/read-wrangler-output.ts
+++ b/scripts/read-wrangler-output.ts
@@ -1,0 +1,23 @@
+import { appendFileSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseWranglerDeploymentOutput, type WranglerDeploymentKind } from './lib/deploymentEvidence.js';
+
+const [sourcePath, rawKind] = process.argv.slice(2);
+if (!sourcePath || (rawKind !== 'deploy' && rawKind !== 'pages-deploy')) {
+  throw new Error('Usage: read-wrangler-output.ts <output.ndjson> <deploy|pages-deploy>');
+}
+
+const identity = parseWranglerDeploymentOutput(
+  readFileSync(resolve(sourcePath), 'utf8'),
+  rawKind as WranglerDeploymentKind,
+);
+const lines = [
+  `deployment_id=${identity.deploymentId}`,
+  `deployment_url=${identity.deploymentUrl}`,
+  `deployed_at=${identity.deployedAt}`,
+  `target=${identity.target}`,
+].join('\n') + '\n';
+
+const githubOutput = process.env.GITHUB_OUTPUT?.trim();
+if (githubOutput) appendFileSync(githubOutput, lines, 'utf8');
+else process.stdout.write(lines);

--- a/scripts/verify-deployment-propagation.ts
+++ b/scripts/verify-deployment-propagation.ts
@@ -1,0 +1,47 @@
+const [mode, rawUrl, rawAttempts = '10', rawTimeoutSeconds = '10'] = process.argv.slice(2);
+if ((mode !== 'worker' && mode !== 'page') || !rawUrl) {
+  throw new Error('Usage: verify-deployment-propagation.ts <worker|page> <https-url> [attempts] [timeout-seconds]');
+}
+const url = new URL(rawUrl);
+if (url.protocol !== 'https:') throw new Error('Propagation checks require HTTPS');
+const attempts = Number.parseInt(rawAttempts, 10);
+const timeoutSeconds = Number.parseInt(rawTimeoutSeconds, 10);
+if (!Number.isInteger(attempts) || attempts < 1 || attempts > 20) throw new Error('Attempts must be between 1 and 20');
+if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 1 || timeoutSeconds > 30) {
+  throw new Error('Timeout must be between 1 and 30 seconds');
+}
+
+const expectedCommit = process.env.EXPECTED_COMMIT?.trim();
+const expectedDeploymentId = process.env.EXPECTED_DEPLOYMENT_ID?.trim();
+if (mode === 'worker' && (!expectedCommit || !expectedDeploymentId)) {
+  throw new Error('Worker propagation requires EXPECTED_COMMIT and EXPECTED_DEPLOYMENT_ID');
+}
+
+let lastFailure = 'No response';
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      redirect: 'follow',
+      signal: AbortSignal.timeout(timeoutSeconds * 1000),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    if (mode === 'worker') {
+      const body = await response.json() as {
+        data?: { environment?: unknown; release?: { commit?: unknown; workerVersionId?: unknown } };
+      };
+      if (body.data?.environment !== 'production') throw new Error('Worker environment is not production');
+      if (body.data.release?.commit !== expectedCommit) throw new Error('Worker commit has not propagated');
+      if (body.data.release?.workerVersionId !== expectedDeploymentId) {
+        throw new Error('Worker deployment identifier has not propagated');
+      }
+    }
+    console.log(`Propagation verified for ${url.hostname} on attempt ${attempt}`);
+    process.exit(0);
+  } catch (error) {
+    lastFailure = error instanceof Error ? error.message : 'Unknown propagation failure';
+    console.log(`Propagation attempt ${attempt}/${attempts} not ready: ${lastFailure}`);
+    if (attempt < attempts) await new Promise((resolveDelay) => setTimeout(resolveDelay, 5000));
+  }
+}
+throw new Error(`Propagation did not complete after ${attempts} attempts: ${lastFailure}`);

--- a/scripts/write-release-evidence.ts
+++ b/scripts/write-release-evidence.ts
@@ -1,0 +1,27 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildReleaseEvidence, type ReleaseEvidenceInput } from './lib/deploymentEvidence.js';
+
+const required = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value || /[\r\n]/.test(value)) throw new Error(`${name} is required`);
+  return value;
+};
+
+const outputPath = process.argv[2];
+if (!outputPath) throw new Error('Usage: write-release-evidence.ts <output.json>');
+const environment = required('RELEASE_ENVIRONMENT');
+if (environment !== 'production') throw new Error('Release evidence environment must be production');
+
+const input: ReleaseEvidenceInput = {
+  environment,
+  frontendWorkerCommit: required('FRONTEND_WORKER_COMMIT'),
+  workerDeploymentId: required('WORKER_DEPLOYMENT_ID'),
+  workerDeploymentUrl: required('WORKER_DEPLOYMENT_URL'),
+  pagesDeploymentId: required('PAGES_DEPLOYMENT_ID'),
+  pagesDeploymentUrl: required('PAGES_DEPLOYMENT_URL'),
+  backendGitCommit: required('BACKEND_GIT_COMMIT'),
+  backendDeploymentId: required('BACKEND_DEPLOYMENT_ID'),
+  launchedAt: required('LAUNCHED_AT'),
+};
+writeFileSync(resolve(outputPath), `${JSON.stringify(buildReleaseEvidence(input), null, 2)}\n`, 'utf8');

--- a/tests/unit/scripts/deploymentEvidence.test.ts
+++ b/tests/unit/scripts/deploymentEvidence.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildReleaseEvidence, parseWranglerDeploymentOutput } from '../../../scripts/lib/deploymentEvidence.js';
+
+describe('deployment evidence', () => {
+  it('reads native Worker and Pages deployment identifiers', () => {
+    const session = JSON.stringify({ type: 'wrangler-session', timestamp: '2026-07-12T00:00:00Z' });
+    const worker = JSON.stringify({
+      type: 'deploy',
+      worker_name: 'blawby-ai-chatbot',
+      version_id: 'worker-version-720',
+      targets: ['https://ai.blawby.com/api/*'],
+      timestamp: '2026-07-12T00:00:01Z',
+    });
+    const pages = JSON.stringify({
+      type: 'pages-deploy',
+      pages_project: 'blawby-ai-chatbot-frontend',
+      deployment_id: 'pages-deployment-720',
+      url: 'https://720.blawby-ai-chatbot-frontend.pages.dev',
+      timestamp: '2026-07-12T00:00:02Z',
+    });
+
+    expect(parseWranglerDeploymentOutput(`${session}\n${worker}\n`, 'deploy')).toEqual({
+      deploymentId: 'worker-version-720',
+      deploymentUrl: 'https://ai.blawby.com/api/*',
+      deployedAt: '2026-07-12T00:00:01Z',
+      target: 'blawby-ai-chatbot',
+    });
+    expect(parseWranglerDeploymentOutput(`${session}\n${pages}\n`, 'pages-deploy')).toEqual({
+      deploymentId: 'pages-deployment-720',
+      deploymentUrl: 'https://720.blawby-ai-chatbot-frontend.pages.dev',
+      deployedAt: '2026-07-12T00:00:02Z',
+      target: 'blawby-ai-chatbot-frontend',
+    });
+  });
+
+  it('fails closed on a failed or incomplete Wrangler command', () => {
+    expect(() => parseWranglerDeploymentOutput(
+      JSON.stringify({ type: 'command-failed', message: 'token detail' }),
+      'deploy',
+    )).toThrow('failed deployment command');
+    expect(() => parseWranglerDeploymentOutput(
+      JSON.stringify({ type: 'deploy', worker_name: 'worker', timestamp: 'now' }),
+      'deploy',
+    )).toThrow('deployment target');
+  });
+
+  it('records only release identity and readiness evidence', () => {
+    const evidence = buildReleaseEvidence({
+      environment: 'production',
+      frontendWorkerCommit: 'frontend-commit',
+      workerDeploymentId: 'worker-id',
+      workerDeploymentUrl: 'https://ai.blawby.com/api/*',
+      pagesDeploymentId: 'pages-id',
+      pagesDeploymentUrl: 'https://pages-id.pages.dev',
+      backendGitCommit: 'backend-commit',
+      backendDeploymentId: 'railway-id',
+      launchedAt: '2026-07-12T00:00:00Z',
+    });
+
+    expect(evidence).toMatchObject({
+      environment: 'production',
+      frontendWorkerCommit: 'frontend-commit',
+      worker: { deploymentId: 'worker-id' },
+      pages: { deploymentId: 'pages-id' },
+      backend: { gitCommit: 'backend-commit', deploymentId: 'railway-id', migrationsReady: true },
+    });
+    expect(JSON.stringify(evidence)).not.toMatch(/token|secret|runtimeConfig/i);
+  });
+
+  it('keeps staging automatic and production manual, serialized, and ordered', () => {
+    const root = resolve(import.meta.dirname, '../../..');
+    const staging = readFileSync(resolve(root, '.github/workflows/deploy.yml'), 'utf8');
+    const production = readFileSync(resolve(root, '.github/workflows/launch-production.yml'), 'utf8');
+
+    expect(staging).toMatch(/push:\s*\n\s*branches:\s*\n\s*- staging/);
+    expect(staging).not.toMatch(/- main/);
+    expect(production).toMatch(/on:\s*\n\s*workflow_dispatch:/);
+    expect(production).not.toMatch(/\n\s*push:/);
+    expect(production).toContain('group: launch-production');
+    expect(production).toContain('cancel-in-progress: false');
+    expect(production).toMatch(/deploy-worker:[\s\S]*needs: preflight/);
+    expect(production).toMatch(/deploy-pages:[\s\S]*needs: deploy-worker/);
+    expect(production).toContain('environment: production');
+    expect(production).toContain('WRANGLER_OUTPUT_FILE_PATH');
+    expect(production).toContain('verify-deployment-propagation.ts');
+  });
+});


### PR DESCRIPTION
Closes #720
Advances #716

## Outcome
- keeps automatic deployment only for staging pushes
- removes every production deploy path from ordinary main pushes
- adds a manual main-only production launch with non-cancelling concurrency
- requires exact backend Git commit, backend platform deployment ID, and migration readiness confirmation
- runs quality/config/build/backend-health preflight before deployment
- deploys Worker, verifies exact commit and native Worker version ID propagation, then deploys Pages
- verifies immutable Pages URL and canonical origin with bounded retries/timeouts
- records native Worker/Pages platform IDs, URLs, environment, backend identity, exact frontend commit, and timestamp in a 90-day artifact and workflow summary
- never records runtime configuration or secret values

There is no custom SHA model: the record uses the exact Git commit plus Cloudflare native deployment identifiers.

## Verification
- deployment/config unit tests: 9/9 green
- typecheck and direct script lint: green
- workflow YAML parse/format: green
- production config validation: green
- strict Wrangler staging dry-run: green, staging resources resolved
- strict Wrangler production dry-run: green, production resources resolved
- repository workflow search confirms production deploy commands exist only in the manual launch workflow

The production preflight intentionally runs the full unit suite. Its 8 current failures are already scoped to #728, which is in this launch-gate workstream and must be green before an actual production launch.