### PR TITLE
Automate bounded production smoke and Cloudflare rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - staging
   workflow_dispatch:
+    inputs:
+      rehearse_rollback:
+        description: Deploy staging, restore the previous release, verify it, then redeploy the current commit
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -35,6 +41,12 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      deployment_id: ${{ steps.release.outputs.deployment_id }}
+      previous_worker_commit: ${{ steps.current.outputs.previous_worker_commit }}
+      previous_worker_deployment_id: ${{ steps.current.outputs.previous_worker_deployment_id }}
+      previous_pages_deployment_id: ${{ steps.current.outputs.previous_pages_deployment_id }}
+      previous_pages_deployment_url: ${{ steps.current.outputs.previous_pages_deployment_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,19 +54,43 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
-      - name: Deploy Worker
+      - name: Capture current staging release for rollback rehearsal
+        id: current
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.rehearse_rollback }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: >-
+          npx tsx scripts/capture-cloudflare-release.ts
+          https://ai-staging.blawby.com/api/health blawby-ai-chatbot-frontend-staging staging
+      - name: Deploy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/worker-deploy.ndjson
+        run: >-
           npx wrangler deploy --env staging --config worker/wrangler.toml
           --tag "${GITHUB_SHA}" --message "Git commit ${GITHUB_SHA}" --strict
+      - name: Read Worker deployment identity
+        id: release
+        run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/worker-deploy.ndjson" deploy
+      - name: Verify staging Worker propagation
+        env:
+          EXPECTED_ENVIRONMENT: staging
+          EXPECTED_COMMIT: ${{ github.sha }}
+          EXPECTED_DEPLOYMENT_ID: ${{ steps.release.outputs.deployment_id }}
+        run: >-
+          npx tsx scripts/verify-deployment-propagation.ts worker
+          https://ai-staging.blawby.com/api/health 10 10
 
   deploy-pages:
     name: Deploy staging Pages
     needs: deploy-worker
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      deployment_id: ${{ steps.release.outputs.deployment_id }}
+      deployment_url: ${{ steps.release.outputs.deployment_url }}
     env:
       VITE_BACKEND_API_URL: ${{ secrets.VITE_BACKEND_API_URL_STAGING }}
       VITE_APP_BASE_URL: ${{ secrets.VITE_APP_BASE_URL_STAGING }}
@@ -73,6 +109,155 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/pages-deploy.ndjson
         run: >-
           npx wrangler pages deploy dist --project-name blawby-ai-chatbot-frontend-staging
           --branch staging --commit-hash "${GITHUB_SHA}" --commit-message "Git commit ${GITHUB_SHA}"
+      - name: Read Pages deployment identity
+        id: release
+        run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/pages-deploy.ndjson" pages-deploy
+      - name: Verify staging Pages propagation
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOYMENT_ID: ${{ steps.release.outputs.deployment_id }}
+          DEPLOYMENT_URL: ${{ steps.release.outputs.deployment_url }}
+        run: |
+          set -euo pipefail
+          npx tsx scripts/verify-deployment-propagation.ts page "${DEPLOYMENT_URL}" 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://staging.blawby.com 10 10
+          npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend-staging "${DEPLOYMENT_ID}" 10 10
+      - uses: actions/upload-artifact@v4
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.rehearse_rollback }}
+        with:
+          name: staging-pages-dist-${{ github.sha }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
+
+  rollback-rehearsal:
+    name: Rehearse staging rollback and restore
+    needs:
+      - deploy-worker
+      - deploy-pages
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.rehearse_rollback }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: staging-pages-dist-${{ github.sha }}
+          path: dist
+      - name: Start rollback timer
+        id: timer
+        run: echo "started_at=$(date +%s)" >> "${GITHUB_OUTPUT}"
+      - name: Restore previous staging Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_WORKER_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.previous_worker_deployment_id }}
+        run: >-
+          npx wrangler rollback "${PREVIOUS_WORKER_DEPLOYMENT_ID}"
+          --env staging --config worker/wrangler.toml
+          --message "Staging rollback rehearsal for ${GITHUB_SHA}" --yes
+      - name: Restore previous staging Pages
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_PAGES_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.previous_pages_deployment_id }}
+        run: >-
+          npx tsx scripts/rollback-pages-deployment.ts
+          blawby-ai-chatbot-frontend-staging "${PREVIOUS_PAGES_DEPLOYMENT_ID}"
+      - name: Verify previous staging Worker
+        if: always()
+        env:
+          EXPECTED_ENVIRONMENT: staging
+          EXPECTED_COMMIT: ${{ needs.deploy-worker.outputs.previous_worker_commit }}
+          EXPECTED_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.previous_worker_deployment_id }}
+        run: >-
+          npx tsx scripts/verify-deployment-propagation.ts worker
+          https://ai-staging.blawby.com/api/health 10 10
+      - name: Verify previous staging Pages
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_PAGES_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.previous_pages_deployment_id }}
+          PREVIOUS_PAGES_DEPLOYMENT_URL: ${{ needs.deploy-worker.outputs.previous_pages_deployment_url }}
+        run: |
+          set -euo pipefail
+          npx tsx scripts/verify-deployment-propagation.ts page "${PREVIOUS_PAGES_DEPLOYMENT_URL}" 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://staging.blawby.com 10 10
+          npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend-staging "${PREVIOUS_PAGES_DEPLOYMENT_ID}" 10 10
+      - name: Record measured rollback duration
+        if: always()
+        env:
+          STARTED_AT: ${{ steps.timer.outputs.started_at }}
+          PREVIOUS_WORKER_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.previous_worker_deployment_id }}
+          PREVIOUS_PAGES_DEPLOYMENT_ID: ${{ needs.deploy-worker.outputs.previous_pages_deployment_id }}
+        run: |
+          set -euo pipefail
+          finished_at=$(date +%s)
+          jq -n \
+            --arg environment staging \
+            --arg gitCommit "${GITHUB_SHA}" \
+            --arg workerDeploymentId "${PREVIOUS_WORKER_DEPLOYMENT_ID}" \
+            --arg pagesDeploymentId "${PREVIOUS_PAGES_DEPLOYMENT_ID}" \
+            --argjson rollbackDurationSeconds "$((finished_at - STARTED_AT))" \
+            '{environment: $environment, gitCommit: $gitCommit, workerDeploymentId: $workerDeploymentId, pagesDeploymentId: $pagesDeploymentId, rollbackDurationSeconds: $rollbackDurationSeconds}' \
+            > staging-rollback-rehearsal.json
+      - name: Redeploy current staging Worker
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/worker-restore.ndjson
+        run: >-
+          npx wrangler deploy --env staging --config worker/wrangler.toml
+          --tag "${GITHUB_SHA}" --message "Restore Git commit ${GITHUB_SHA} after rollback rehearsal" --strict
+      - name: Read restored Worker identity
+        id: restored-worker
+        if: always()
+        run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/worker-restore.ndjson" deploy
+      - name: Redeploy current staging Pages
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/pages-restore.ndjson
+        run: >-
+          npx wrangler pages deploy dist --project-name blawby-ai-chatbot-frontend-staging
+          --branch staging --commit-hash "${GITHUB_SHA}" --commit-message "Restore after rollback rehearsal"
+      - name: Read restored Pages identity
+        id: restored-pages
+        if: always()
+        run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/pages-restore.ndjson" pages-deploy
+      - name: Verify current staging release restored
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_ENVIRONMENT: staging
+          EXPECTED_COMMIT: ${{ github.sha }}
+          EXPECTED_DEPLOYMENT_ID: ${{ steps.restored-worker.outputs.deployment_id }}
+          RESTORED_PAGES_URL: ${{ steps.restored-pages.outputs.deployment_url }}
+        run: |
+          set -euo pipefail
+          npx tsx scripts/verify-deployment-propagation.ts worker https://ai-staging.blawby.com/api/health 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page "${RESTORED_PAGES_URL}" 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://staging.blawby.com 10 10
+          npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend-staging "${{ steps.restored-pages.outputs.deployment_id }}" 10 10
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: staging-rollback-rehearsal-${{ github.sha }}
+          path: staging-rollback-rehearsal.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/launch-production.yml
+++ b/.github/workflows/launch-production.yml
@@ -73,9 +73,36 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  capture-current:
+    name: Capture current production release
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production
+    outputs:
+      previous_worker_commit: ${{ steps.current.outputs.previous_worker_commit }}
+      previous_worker_deployment_id: ${{ steps.current.outputs.previous_worker_deployment_id }}
+      previous_pages_deployment_id: ${{ steps.current.outputs.previous_pages_deployment_id }}
+      previous_pages_deployment_url: ${{ steps.current.outputs.previous_pages_deployment_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Read current Worker and Pages identities
+        id: current
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          npx tsx scripts/capture-cloudflare-release.ts
+          https://ai.blawby.com/api/health blawby-ai-chatbot-frontend production
+
   deploy-worker:
     name: Deploy production Worker
-    needs: preflight
+    needs: capture-current
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: production
@@ -159,17 +186,122 @@ jobs:
         run: npx tsx scripts/read-wrangler-output.ts "${RUNNER_TEMP}/pages-deploy.ndjson" pages-deploy
       - name: Verify Pages deployment and canonical propagation
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOYMENT_URL: ${{ steps.release.outputs.deployment_url }}
+          DEPLOYMENT_ID: ${{ steps.release.outputs.deployment_id }}
         run: |
           set -euo pipefail
           npx tsx scripts/verify-deployment-propagation.ts page "${DEPLOYMENT_URL}" 10 10
           npx tsx scripts/verify-deployment-propagation.ts page https://ai.blawby.com 10 10
+          npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend "${DEPLOYMENT_ID}" 10 10
+
+  production-smoke:
+    name: Run bounded production smoke
+    needs: deploy-pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    env:
+      E2E_BASE_URL: https://ai.blawby.com
+      E2E_REQUIRE_ENV_ONLY: "true"
+      E2E_FORCE_AUTH_REFRESH: "true"
+      E2E_REQUIRE_EXISTING_USERS: "true"
+      E2E_SKIP_ANONYMOUS_AUTH: "true"
+      E2E_SKIP_ONBOARDING_PREFERENCE: "true"
+      E2E_LAUNCH_TEST_MARKER: production-launch-test
+      E2E_PRACTICE_ID: ${{ secrets.PRODUCTION_SMOKE_PRACTICE_ID }}
+      E2E_PRACTICE_SLUG: ${{ secrets.PRODUCTION_SMOKE_PRACTICE_SLUG }}
+      E2E_OWNER_EMAIL: ${{ secrets.PRODUCTION_SMOKE_OWNER_EMAIL }}
+      E2E_OWNER_PASSWORD: ${{ secrets.PRODUCTION_SMOKE_OWNER_PASSWORD }}
+      E2E_CLIENT_EMAIL: ${{ secrets.PRODUCTION_SMOKE_CLIENT_EMAIL }}
+      E2E_CLIENT_PASSWORD: ${{ secrets.PRODUCTION_SMOKE_CLIENT_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run production-origin smoke
+        run: npx playwright test -c playwright.production-smoke.config.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: production-smoke-${{ github.sha }}
+          path: .tmp/playwright/production-smoke
+          if-no-files-found: ignore
+          retention-days: 30
+
+  rollback-production:
+    name: Restore previous production release
+    needs:
+      - capture-current
+      - deploy-worker
+      - deploy-pages
+      - production-smoke
+    if: >-
+      ${{ always() && needs.capture-current.result == 'success' &&
+          (needs.deploy-worker.result == 'failure' || needs.deploy-pages.result == 'failure' ||
+           needs.production-smoke.result == 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Restore previous Worker version
+        id: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_WORKER_DEPLOYMENT_ID: ${{ needs.capture-current.outputs.previous_worker_deployment_id }}
+        run: >-
+          npx wrangler rollback "${PREVIOUS_WORKER_DEPLOYMENT_ID}"
+          --env production --config worker/wrangler.toml
+          --message "Automatic rollback after failed launch ${GITHUB_SHA}" --yes
+      - name: Restore previous Pages deployment
+        id: pages
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_PAGES_DEPLOYMENT_ID: ${{ needs.capture-current.outputs.previous_pages_deployment_id }}
+        run: >-
+          npx tsx scripts/rollback-pages-deployment.ts
+          blawby-ai-chatbot-frontend "${PREVIOUS_PAGES_DEPLOYMENT_ID}"
+      - name: Verify restored Worker
+        if: always()
+        env:
+          EXPECTED_COMMIT: ${{ needs.capture-current.outputs.previous_worker_commit }}
+          EXPECTED_DEPLOYMENT_ID: ${{ needs.capture-current.outputs.previous_worker_deployment_id }}
+        run: >-
+          npx tsx scripts/verify-deployment-propagation.ts worker
+          https://ai.blawby.com/api/health 10 10
+      - name: Verify restored Pages deployment
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIOUS_PAGES_DEPLOYMENT_ID: ${{ needs.capture-current.outputs.previous_pages_deployment_id }}
+          PREVIOUS_PAGES_DEPLOYMENT_URL: ${{ needs.capture-current.outputs.previous_pages_deployment_url }}
+        run: |
+          set -euo pipefail
+          npx tsx scripts/verify-deployment-propagation.ts page "${PREVIOUS_PAGES_DEPLOYMENT_URL}" 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://ai.blawby.com 10 10
+          npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend "${PREVIOUS_PAGES_DEPLOYMENT_ID}" 10 10
 
   record-release:
     name: Record production release evidence
     needs:
       - deploy-worker
       - deploy-pages
+      - production-smoke
     runs-on: ubuntu-latest
     if: success()
     steps:

--- a/docs/operations/production-launch.md
+++ b/docs/operations/production-launch.md
@@ -23,8 +23,25 @@ Only one `launch-production` run can execute at a time, and queued runs are not 
 4. Deploy the already-validated Pages artifact with `main` and the exact commit attached.
 5. Read the native Pages deployment ID and URL from structured output.
 6. Poll both the immutable Pages deployment URL and `https://ai.blawby.com` with bounded attempts/timeouts.
+7. Run the production-origin smoke with dedicated launch-test owner/client secrets.
 
-A failed preflight, Worker deploy, propagation check, Pages deploy, or Pages propagation check fails visibly and prevents later jobs from starting.
+Before either Cloudflare deployment changes, the workflow records the current healthy Worker's exact Git commit and Worker version ID plus the canonical Pages deployment ID and URL. A failed Worker deploy, Pages deploy, propagation check, or production smoke restores both recorded deployments and verifies the restored Worker and Pages origins with bounded retries.
+
+## Bounded production smoke
+
+The smoke configuration accepts credentials only from the `production` GitHub environment. It does not load developer env files or the ignored E2E credential fixture. Required secrets are:
+
+- `PRODUCTION_SMOKE_PRACTICE_ID` and `PRODUCTION_SMOKE_PRACTICE_SLUG`;
+- `PRODUCTION_SMOKE_OWNER_EMAIL` and `PRODUCTION_SMOKE_OWNER_PASSWORD`;
+- `PRODUCTION_SMOKE_CLIENT_EMAIL` and `PRODUCTION_SMOKE_CLIENT_PASSWORD`.
+
+Those identities belong only to the clearly marked launch-test Practice. Setup reuses the configured client linkage or creates the single marked client record when missing. The smoke checks root assets, safe health metadata, sign-in/session/sign-out and cross-origin auth rejection, active-Practice isolation, critical owner/client/widget proxy reads, desktop/mobile shell basics, browser errors, mixed-content and non-production calls. Billing checks are GET-only. The run creates or reuses at most one active `[LAUNCH SMOKE]` conversation, sends one harmless Practice Assistant query, and archives that conversation even when an assertion fails.
+
+The smoke contains no matter/invoice mutation, communication send, webhook acceptance, or charge path.
+
+## Staging rollback rehearsal
+
+Run `Deploy staging` manually with `rehearse_rollback` enabled. The workflow captures the current staging Worker and canonical Pages identities, deploys the selected staging commit, restores and verifies both previous deployments, records the measured rollback duration in `staging-rollback-rehearsal.json`, and then redeploys and verifies the selected commit so staging is not left on the old release. The artifact is retained for 90 days.
 
 ## Release record
 

--- a/playwright.production-smoke.config.ts
+++ b/playwright.production-smoke.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+import { loadE2EEnvFiles } from "./tests/e2e/helpers/e2eConfig";
+
+loadE2EEnvFiles();
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: /production-smoke\.spec\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 180_000,
+  outputDir: "./.tmp/playwright/production-smoke/results",
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "https://ai.blawby.com",
+    trace: "off",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    ...devices["Desktop Chrome"],
+  },
+  globalSetup: "./tests/e2e/global-setup.auth.ts",
+  reporter: [
+    [
+      "html",
+      {
+        outputFolder: "./.tmp/playwright/production-smoke/report",
+        open: "never",
+      },
+    ],
+    ["list"],
+  ],
+});

--- a/scripts/capture-cloudflare-release.ts
+++ b/scripts/capture-cloudflare-release.ts
@@ -1,0 +1,63 @@
+import { appendFileSync } from "node:fs";
+import {
+  parsePagesCanonicalDeployment,
+  parseWorkerHealthRelease,
+} from "./lib/deploymentEvidence.js";
+
+const [rawHealthUrl, pagesProject, rawEnvironment] = process.argv.slice(2);
+if (
+  !rawHealthUrl ||
+  !pagesProject ||
+  (rawEnvironment !== "production" && rawEnvironment !== "staging")
+) {
+  throw new Error(
+    "Usage: capture-cloudflare-release.ts <health-url> <pages-project> <production|staging>",
+  );
+}
+const healthUrl = new URL(rawHealthUrl);
+if (healthUrl.protocol !== "https:")
+  throw new Error("Worker health URL must use HTTPS");
+if (!/^[a-z0-9-]+$/i.test(pagesProject))
+  throw new Error("Pages project name is invalid");
+
+const token = process.env.CLOUDFLARE_API_TOKEN?.trim();
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
+if (!token || !accountId)
+  throw new Error("Cloudflare deployment credentials are required");
+
+const workerResponse = await fetch(healthUrl, {
+  cache: "no-store",
+  signal: AbortSignal.timeout(10_000),
+});
+if (!workerResponse.ok)
+  throw new Error(
+    `Worker health request failed with HTTP ${workerResponse.status}`,
+  );
+const worker = parseWorkerHealthRelease(
+  await workerResponse.json(),
+  rawEnvironment,
+);
+
+const pagesResponse = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/pages/projects/${encodeURIComponent(pagesProject)}`,
+  {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(10_000),
+  },
+);
+if (!pagesResponse.ok)
+  throw new Error(
+    `Cloudflare Pages project request failed with HTTP ${pagesResponse.status}`,
+  );
+const pages = parsePagesCanonicalDeployment(await pagesResponse.json());
+
+const output =
+  [
+    `previous_worker_commit=${worker.commit}`,
+    `previous_worker_deployment_id=${worker.deploymentId}`,
+    `previous_pages_deployment_id=${pages.deploymentId}`,
+    `previous_pages_deployment_url=${pages.deploymentUrl}`,
+  ].join("\n") + "\n";
+const githubOutput = process.env.GITHUB_OUTPUT?.trim();
+if (githubOutput) appendFileSync(githubOutput, output, "utf8");
+else process.stdout.write(output);

--- a/scripts/lib/deploymentEvidence.ts
+++ b/scripts/lib/deploymentEvidence.ts
@@ -7,6 +7,16 @@ export interface DeploymentIdentity {
   target: string;
 }
 
+export interface WorkerReleaseIdentity {
+  commit: string;
+  deploymentId: string;
+}
+
+export interface PagesCanonicalDeployment {
+  deploymentId: string;
+  deploymentUrl: string;
+}
+
 export interface ReleaseEvidenceInput {
   environment: 'production';
   frontendWorkerCommit: string;
@@ -20,22 +30,54 @@ export interface ReleaseEvidenceInput {
 }
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
-  value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null;
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
 
 const requireString = (record: Record<string, unknown>, field: string): string => {
   const value = record[field];
   if (typeof value !== 'string' || !value.trim() || /[\r\n]/.test(value)) {
-    throw new Error(`Wrangler output is missing a valid ${field}`);
+    throw new Error(`Deployment evidence is missing a valid ${field}`);
   }
   return value.trim();
 };
 
-export const parseWranglerDeploymentOutput = (
-  source: string,
-  kind: WranglerDeploymentKind,
-): DeploymentIdentity => {
+const requireHttpsUrl = (value: string, field: string): string => {
+  const url = new URL(value);
+  if (url.protocol !== 'https:') throw new Error(`${field} must use HTTPS`);
+  return url.toString().replace(/\/$/, '');
+};
+
+export const parseWorkerHealthRelease = (
+  payload: unknown,
+  expectedEnvironment: 'production' | 'staging'
+): WorkerReleaseIdentity => {
+  const root = asRecord(payload);
+  const data = asRecord(root?.data);
+  const release = asRecord(data?.release);
+  if (data?.environment !== expectedEnvironment) {
+    throw new Error(`Worker health environment is not ${expectedEnvironment}`);
+  }
+  if (!release) throw new Error('Worker health is missing release identity');
+  const commit = requireString(release, 'commit');
+  const deploymentId = requireString(release, 'workerVersionId');
+  if (commit === 'unknown' || deploymentId === 'unknown') {
+    throw new Error('Worker health release identity is unknown');
+  }
+  return { commit, deploymentId };
+};
+
+export const parsePagesCanonicalDeployment = (payload: unknown): PagesCanonicalDeployment => {
+  const root = asRecord(payload);
+  if (root?.success !== true) throw new Error('Cloudflare Pages project request was not successful');
+  const result = asRecord(root.result);
+  const deployment = asRecord(result?.canonical_deployment);
+  if (!deployment) throw new Error('Cloudflare Pages project is missing a canonical deployment');
+  return {
+    deploymentId: requireString(deployment, 'id'),
+    deploymentUrl: requireHttpsUrl(requireString(deployment, 'url'), 'Pages deployment URL')
+  };
+};
+
+export const parseWranglerDeploymentOutput = (source: string, kind: WranglerDeploymentKind): DeploymentIdentity => {
   const records = source
     .split(/\r?\n/)
     .filter((line) => line.trim())
@@ -61,7 +103,7 @@ export const parseWranglerDeploymentOutput = (
       deploymentId: requireString(record, 'version_id'),
       deploymentUrl: targets[0],
       deployedAt: requireString(record, 'timestamp'),
-      target: requireString(record, 'worker_name'),
+      target: requireString(record, 'worker_name')
     };
   }
 
@@ -69,7 +111,7 @@ export const parseWranglerDeploymentOutput = (
     deploymentId: requireString(record, 'deployment_id'),
     deploymentUrl: requireString(record, 'url'),
     deployedAt: requireString(record, 'timestamp'),
-    target: requireString(record, 'pages_project'),
+    target: requireString(record, 'pages_project')
   };
 };
 
@@ -78,16 +120,16 @@ export const buildReleaseEvidence = (input: ReleaseEvidenceInput) => ({
   frontendWorkerCommit: input.frontendWorkerCommit,
   worker: {
     deploymentId: input.workerDeploymentId,
-    deploymentUrl: input.workerDeploymentUrl,
+    deploymentUrl: input.workerDeploymentUrl
   },
   pages: {
     deploymentId: input.pagesDeploymentId,
-    deploymentUrl: input.pagesDeploymentUrl,
+    deploymentUrl: input.pagesDeploymentUrl
   },
   backend: {
     gitCommit: input.backendGitCommit,
     deploymentId: input.backendDeploymentId,
-    migrationsReady: true,
+    migrationsReady: true
   },
-  launchedAt: input.launchedAt,
+  launchedAt: input.launchedAt
 });

--- a/scripts/rollback-pages-deployment.ts
+++ b/scripts/rollback-pages-deployment.ts
@@ -1,0 +1,32 @@
+const [pagesProject, deploymentId] = process.argv.slice(2);
+if (!pagesProject || !deploymentId) {
+  throw new Error(
+    "Usage: rollback-pages-deployment.ts <pages-project> <deployment-id>",
+  );
+}
+if (!/^[a-z0-9-]+$/i.test(pagesProject))
+  throw new Error("Pages project name is invalid");
+if (/\s/.test(deploymentId))
+  throw new Error("Pages deployment identifier is invalid");
+
+const token = process.env.CLOUDFLARE_API_TOKEN?.trim();
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
+if (!token || !accountId)
+  throw new Error("Cloudflare deployment credentials are required");
+
+const response = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/pages/projects/${encodeURIComponent(pagesProject)}/deployments/${encodeURIComponent(deploymentId)}/rollback`,
+  {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(30_000),
+  },
+);
+if (!response.ok)
+  throw new Error(
+    `Cloudflare Pages rollback failed with HTTP ${response.status}`,
+  );
+const payload = (await response.json()) as { success?: unknown };
+if (payload.success !== true)
+  throw new Error("Cloudflare Pages rollback was not successful");
+console.log(`Pages rollback accepted for ${pagesProject}`);

--- a/scripts/verify-deployment-propagation.ts
+++ b/scripts/verify-deployment-propagation.ts
@@ -13,6 +13,10 @@ if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 1 || timeoutSeconds > 
 
 const expectedCommit = process.env.EXPECTED_COMMIT?.trim();
 const expectedDeploymentId = process.env.EXPECTED_DEPLOYMENT_ID?.trim();
+const expectedEnvironment = process.env.EXPECTED_ENVIRONMENT?.trim() || 'production';
+if (expectedEnvironment !== 'production' && expectedEnvironment !== 'staging') {
+  throw new Error('EXPECTED_ENVIRONMENT must be production or staging');
+}
 if (mode === 'worker' && (!expectedCommit || !expectedDeploymentId)) {
   throw new Error('Worker propagation requires EXPECTED_COMMIT and EXPECTED_DEPLOYMENT_ID');
 }
@@ -27,10 +31,15 @@ for (let attempt = 1; attempt <= attempts; attempt += 1) {
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     if (mode === 'worker') {
-      const body = await response.json() as {
-        data?: { environment?: unknown; release?: { commit?: unknown; workerVersionId?: unknown } };
+      const body = (await response.json()) as {
+        data?: {
+          environment?: unknown;
+          release?: { commit?: unknown; workerVersionId?: unknown };
+        };
       };
-      if (body.data?.environment !== 'production') throw new Error('Worker environment is not production');
+      if (body.data?.environment !== expectedEnvironment) {
+        throw new Error(`Worker environment is not ${expectedEnvironment}`);
+      }
       if (body.data.release?.commit !== expectedCommit) throw new Error('Worker commit has not propagated');
       if (body.data.release?.workerVersionId !== expectedDeploymentId) {
         throw new Error('Worker deployment identifier has not propagated');
@@ -41,7 +50,7 @@ for (let attempt = 1; attempt <= attempts; attempt += 1) {
   } catch (error) {
     lastFailure = error instanceof Error ? error.message : 'Unknown propagation failure';
     console.log(`Propagation attempt ${attempt}/${attempts} not ready: ${lastFailure}`);
-    if (attempt < attempts) await new Promise((resolveDelay) => setTimeout(resolveDelay, 5000));
+    if (attempt < attempts) await new Promise((resolveDelay) => globalThis.setTimeout(resolveDelay, 5000));
   }
 }
 throw new Error(`Propagation did not complete after ${attempts} attempts: ${lastFailure}`);

--- a/scripts/verify-pages-canonical.ts
+++ b/scripts/verify-pages-canonical.ts
@@ -1,0 +1,70 @@
+import { parsePagesCanonicalDeployment } from "./lib/deploymentEvidence.js";
+
+const [
+  pagesProject,
+  expectedDeploymentId,
+  rawAttempts = "10",
+  rawTimeoutSeconds = "10",
+] = process.argv.slice(2);
+if (!pagesProject || !expectedDeploymentId) {
+  throw new Error(
+    "Usage: verify-pages-canonical.ts <pages-project> <deployment-id> [attempts] [timeout-seconds]",
+  );
+}
+if (!/^[a-z0-9-]+$/i.test(pagesProject))
+  throw new Error("Pages project name is invalid");
+if (/\s/.test(expectedDeploymentId))
+  throw new Error("Pages deployment identifier is invalid");
+const attempts = Number.parseInt(rawAttempts, 10);
+const timeoutSeconds = Number.parseInt(rawTimeoutSeconds, 10);
+if (!Number.isInteger(attempts) || attempts < 1 || attempts > 20) {
+  throw new Error("Attempts must be between 1 and 20");
+}
+if (
+  !Number.isInteger(timeoutSeconds) ||
+  timeoutSeconds < 1 ||
+  timeoutSeconds > 30
+) {
+  throw new Error("Timeout must be between 1 and 30 seconds");
+}
+
+const token = process.env.CLOUDFLARE_API_TOKEN?.trim();
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
+if (!token || !accountId)
+  throw new Error("Cloudflare deployment credentials are required");
+
+let lastFailure = "No response";
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  try {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/pages/projects/${encodeURIComponent(pagesProject)}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(timeoutSeconds * 1000),
+      },
+    );
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const canonical = parsePagesCanonicalDeployment(await response.json());
+    if (canonical.deploymentId !== expectedDeploymentId) {
+      throw new Error("Pages canonical deployment has not propagated");
+    }
+    console.log(`Canonical Pages deployment verified on attempt ${attempt}`);
+    process.exit(0);
+  } catch (error) {
+    lastFailure =
+      error instanceof Error
+        ? error.message
+        : "Unknown Pages verification failure";
+    console.log(
+      `Pages verification attempt ${attempt}/${attempts} not ready: ${lastFailure}`,
+    );
+    if (attempt < attempts) {
+      await new Promise((resolveDelay) =>
+        globalThis.setTimeout(resolveDelay, 5000),
+      );
+    }
+  }
+}
+throw new Error(
+  `Pages canonical deployment did not propagate after ${attempts} attempts: ${lastFailure}`,
+);

--- a/tests/e2e/globalSetupSupport.ts
+++ b/tests/e2e/globalSetupSupport.ts
@@ -26,6 +26,15 @@ const FORCE_AUTH_REFRESH = ['true', '1', 'yes'].includes(
 const SKIP_CLIENT_AUTH = ['true', '1', 'yes'].includes(
   (process.env.E2E_SKIP_CLIENT_AUTH || '').toLowerCase()
 );
+const SKIP_ANONYMOUS_AUTH = ['true', '1', 'yes'].includes(
+  (process.env.E2E_SKIP_ANONYMOUS_AUTH || '').toLowerCase()
+);
+const REQUIRE_EXISTING_USERS = ['true', '1', 'yes'].includes(
+  (process.env.E2E_REQUIRE_EXISTING_USERS || '').toLowerCase()
+);
+const SKIP_ONBOARDING_PREFERENCE = ['true', '1', 'yes'].includes(
+  (process.env.E2E_SKIP_ONBOARDING_PREFERENCE || '').toLowerCase()
+);
 
 const shouldVerifyLocalWorker = (baseURL: string): boolean => {
   const hostname = new URL(baseURL).hostname.toLowerCase();
@@ -370,6 +379,10 @@ const createSignedInState = async (options: {
     }
 
     if (signInResponse?.status() === 401) {
+      if (REQUIRE_EXISTING_USERS) {
+        writeAuthDebugFiles(label, authNetworkLogs, consoleLogs, pageErrors);
+        throw new Error(`Configured ${label} launch-test user must already exist and sign in successfully.`);
+      }
       console.log(`🧾 ${label} sign-in returned 401; attempting to register configured E2E user...`);
       try {
         await createTestUser(page, {
@@ -406,26 +419,28 @@ const createSignedInState = async (options: {
       );
     }
 
-    try {
-      await page.evaluate(async () => {
-        try {
-          await fetch('/api/preferences/onboarding', {
-            method: 'PUT',
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              completed: true,
-              welcome_modal_shown: true,
-              practice_welcome_shown: true
-            })
-          });
-        } catch {
-          // Ignore preference update failures in e2e bootstrap
+    if (!SKIP_ONBOARDING_PREFERENCE) {
+      try {
+        await page.evaluate(async () => {
+          try {
+            await fetch('/api/preferences/onboarding', {
+              method: 'PUT',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                completed: true,
+                welcome_modal_shown: true,
+                practice_welcome_shown: true
+              })
+            });
+          } catch {
+            // Ignore preference update failures in e2e bootstrap
+          }
+        });
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message.includes('Execution context was destroyed')) {
+          console.warn('E2E setup onboarding preference update failed', error);
         }
-      });
-    } catch (error) {
-      if (!(error instanceof Error) || !error.message.includes('Execution context was destroyed')) {
-        console.warn('E2E setup onboarding preference update failed', error);
       }
     }
 
@@ -571,7 +586,9 @@ export const runAuthGlobalSetup = async (config: FullConfig): Promise<void> => {
     });
   }
 
-  if (!FORCE_AUTH_REFRESH && await hasValidSessionFromStorage(baseURL, anonymousPath)) {
+  if (SKIP_ANONYMOUS_AUTH) {
+    console.log('⏭️  anonymous storageState skipped because E2E_SKIP_ANONYMOUS_AUTH is enabled');
+  } else if (!FORCE_AUTH_REFRESH && await hasValidSessionFromStorage(baseURL, anonymousPath)) {
     console.log(`✅ anonymous storageState already valid at ${anonymousPath}`);
   } else {
     await createAnonymousState({

--- a/tests/e2e/helpers/e2eConfig.ts
+++ b/tests/e2e/helpers/e2eConfig.ts
@@ -39,6 +39,7 @@ const parseEnvValue = (value: string): string => {
 export const loadE2EEnvFiles = (): void => {
   if (envFilesLoaded) return;
   envFilesLoaded = true;
+  if (process.env.E2E_REQUIRE_ENV_ONLY === 'true') return;
   const protectedEnvKeys = new Set(Object.keys(process.env));
 
   for (const fileName of ['.env', '.env.local']) {
@@ -81,6 +82,7 @@ export const normalizeE2EPracticeSlug = (value: string | null | undefined, fallb
 };
 
 const readConfigFile = (): Partial<E2EConfig> | null => {
+  if (process.env.E2E_REQUIRE_ENV_ONLY === 'true') return null;
   const filePath = resolve(process.cwd(), 'tests/e2e/fixtures/e2e-credentials.json');
   if (!existsSync(filePath)) {
     return null;

--- a/tests/e2e/production-smoke.spec.ts
+++ b/tests/e2e/production-smoke.spec.ts
@@ -1,0 +1,527 @@
+import { AUTH_STATE_PATHS } from "./helpers/authState";
+import { loadE2EConfig } from "./helpers/e2eConfig";
+import { expect, test, type Page } from "@playwright/test";
+
+type JsonRecord = Record<string, unknown>;
+
+const config = loadE2EConfig();
+const requireRecord = (value: unknown, label: string): JsonRecord => {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${label} is not an object`);
+  return value as JsonRecord;
+};
+const unwrap = (value: unknown): unknown => {
+  const record =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as JsonRecord)
+      : null;
+  return record && "data" in record ? unwrap(record.data) : value;
+};
+const records = (value: unknown): JsonRecord[] => {
+  const unwrapped = unwrap(value);
+  if (Array.isArray(unwrapped))
+    return unwrapped.filter((item): item is JsonRecord =>
+      Boolean(item && typeof item === "object" && !Array.isArray(item)),
+    );
+  const record =
+    unwrapped && typeof unwrapped === "object" && !Array.isArray(unwrapped)
+      ? (unwrapped as JsonRecord)
+      : null;
+  if (!record) return [];
+  for (const key of ["data", "items", "clients", "conversations", "invoices"]) {
+    if (Array.isArray(record[key])) return records(record[key]);
+  }
+  return [];
+};
+const text = (record: JsonRecord, ...keys: string[]): string | null => {
+  for (const key of keys)
+    if (typeof record[key] === "string" && record[key])
+      return record[key] as string;
+  return null;
+};
+
+const installBrowserGuards = (
+  page: Page,
+  errors: string[],
+  forbiddenRequests: string[],
+  failedRequiredRequests: string[],
+) => {
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("request", (request) => {
+    const url = request.url();
+    if (
+      /localhost|127\.0\.0\.1|staging/i.test(url) ||
+      (page.url().startsWith("https:") && url.startsWith("http:"))
+    ) {
+      forbiddenRequests.push(url);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    const url = new URL(request.url());
+    const requiredResource =
+      ["document", "script", "stylesheet"].includes(request.resourceType()) ||
+      url.pathname.startsWith("/api/");
+    if (requiredResource && url.origin === new URL(page.url()).origin) {
+      failedRequiredRequests.push(`${request.method()} ${url.pathname}`);
+    }
+  });
+  page.on("response", (response) => {
+    const request = response.request();
+    const url = new URL(response.url());
+    const requiredAsset = ["document", "script", "stylesheet"].includes(
+      request.resourceType(),
+    );
+    const failedApi =
+      url.pathname.startsWith("/api/") && response.status() >= 500;
+    if (
+      (failedApi || (requiredAsset && response.status() >= 400)) &&
+      url.origin === new URL(page.url()).origin &&
+      response.status() >= 400
+    ) {
+      failedRequiredRequests.push(
+        `${response.status()} ${request.method()} ${url.pathname}`,
+      );
+    }
+  });
+};
+
+const expectShellBasics = async (page: Page) => {
+  await expect(page.locator("body")).toBeVisible();
+  const main = page.locator('main, [role="main"]');
+  expect(await main.count()).toBeGreaterThan(0);
+  await expect(main.first()).toBeVisible();
+  expect(
+    await page.evaluate(() => ({
+      fitsViewport:
+        document.documentElement.scrollWidth <= window.innerWidth + 2,
+      language: document.documentElement.lang,
+      duplicateIds: Array.from(document.querySelectorAll("[id]"))
+        .map((element) => element.id)
+        .filter((id, index, ids) => id && ids.indexOf(id) !== index),
+      unnamedControls: Array.from(
+        document.querySelectorAll("button, a[href], input, select, textarea"),
+      ).filter((element) => {
+        const text = element.textContent?.trim();
+        return (
+          !text &&
+          !element.getAttribute("aria-label") &&
+          !element.getAttribute("aria-labelledby") &&
+          !(element instanceof HTMLInputElement && element.type === "hidden") &&
+          !(element instanceof HTMLInputElement && element.labels?.length)
+        );
+      }).length,
+    })),
+  ).toEqual({
+    fitsViewport: true,
+    language: expect.stringMatching(/^[a-z]{2}/i),
+    duplicateIds: [],
+    unnamedControls: 0,
+  });
+};
+
+test.describe("bounded production launch smoke", () => {
+  test("verifies production safely and archives its single harmless AI conversation", async ({
+    browser,
+    baseURL,
+  }) => {
+    expect(process.env.E2E_REQUIRE_ENV_ONLY).toBe("true");
+    const launchMarker = process.env.E2E_LAUNCH_TEST_MARKER;
+    expect(launchMarker).toBe("production-launch-test");
+    expect(baseURL).toBe("https://ai.blawby.com");
+    if (!config)
+      throw new Error(
+        "Dedicated production launch-test credentials are required",
+      );
+    expect(config.practice.slug.toLowerCase()).toContain(launchMarker);
+
+    const errors: string[] = [];
+    const forbiddenRequests: string[] = [];
+    const failedRequiredRequests: string[] = [];
+    const owner = await browser.newContext({
+      baseURL,
+      storageState: AUTH_STATE_PATHS.owner,
+    });
+    const client = await browser.newContext({
+      baseURL,
+      storageState: AUTH_STATE_PATHS.client,
+    });
+    const publicVisitor = await browser.newContext({ baseURL });
+    let smokeConversationId: string | null = null;
+
+    try {
+      const health = await owner.request.get("/api/health");
+      expect(health.status()).toBe(200);
+      const healthPayload = requireRecord(
+        await health.json(),
+        "health payload",
+      );
+      expect(healthPayload).toMatchObject({
+        success: true,
+        data: {
+          status: "ok",
+          environment: "production",
+          release: {
+            commit: expect.any(String),
+            workerVersionId: expect.any(String),
+          },
+        },
+      });
+      const healthData = requireRecord(healthPayload.data, "health data");
+      const healthRelease = requireRecord(healthData.release, "health release");
+      expect(text(healthRelease, "commit")).not.toBe("unknown");
+      expect(text(healthRelease, "workerVersionId")).not.toBe("unknown");
+
+      const root = await owner.request.get("/");
+      expect(root.ok()).toBe(true);
+      const rootHtml = await root.text();
+      const assetPaths = [
+        ...rootHtml.matchAll(/(?:src|href)="(\/assets\/[^"]+)"/g),
+      ].map((match) => match[1]);
+      expect(assetPaths.length).toBeGreaterThan(0);
+      for (const assetPath of assetPaths) {
+        expect(
+          (await owner.request.get(assetPath)).ok(),
+          `asset ${assetPath}`,
+        ).toBe(true);
+      }
+
+      const authContext = await browser.newContext({ baseURL });
+      const signIn = await authContext.request.post("/api/auth/sign-in/email", {
+        data: { email: config.owner.email, password: config.owner.password },
+      });
+      expect(signIn.ok()).toBe(true);
+      const authCookies = await authContext.cookies();
+      expect(
+        authCookies.some(
+          (cookie) =>
+            /better-auth.*session/i.test(cookie.name) &&
+            cookie.secure &&
+            cookie.sameSite !== "None",
+        ),
+      ).toBe(true);
+      expect(
+        (await authContext.request.get("/api/auth/get-session")).status(),
+      ).toBe(200);
+      expect((await authContext.request.post("/api/auth/sign-out")).ok()).toBe(
+        true,
+      );
+      const signedOut = unwrap(
+        await (await authContext.request.get("/api/auth/get-session")).json(),
+      );
+      const signedOutRecord =
+        signedOut && typeof signedOut === "object" && !Array.isArray(signedOut)
+          ? (signedOut as JsonRecord)
+          : null;
+      expect(signedOutRecord?.user ?? null).toBeNull();
+      await authContext.close();
+
+      const crossOrigin = await browser.newContext({
+        baseURL,
+        extraHTTPHeaders: { Origin: "https://not-blawby.example" },
+      });
+      const csrfAttempt = await crossOrigin.request.post(
+        "/api/auth/sign-in/email",
+        {
+          data: { email: config.owner.email, password: config.owner.password },
+        },
+      );
+      expect([400, 403]).toContain(csrfAttempt.status());
+      await crossOrigin.close();
+
+      const ownerSession = requireRecord(
+        unwrap(await (await owner.request.get("/api/auth/get-session")).json()),
+        "owner session",
+      );
+      const ownerUser = requireRecord(ownerSession.user, "owner user");
+      const ownerUserId = text(ownerUser, "id");
+      if (!ownerUserId) throw new Error("Owner launch-test user id is missing");
+      const ownerSessionRecord = requireRecord(
+        ownerSession.session,
+        "owner session record",
+      );
+      expect(
+        text(
+          ownerSessionRecord,
+          "activeOrganizationId",
+          "active_organization_id",
+        ),
+      ).toBe(config.practice.id);
+
+      const practiceList = await owner.request.get("/api/practice/list");
+      expect(practiceList.ok()).toBe(true);
+      const configuredPractice = records(await practiceList.json()).find(
+        (practice) => text(practice, "id") === config.practice.id,
+      );
+      expect(configuredPractice).toBeDefined();
+      expect(
+        text(configuredPractice as JsonRecord, "slug")?.toLowerCase(),
+      ).toContain(launchMarker);
+      const setActive = await owner.request.post(
+        "/api/auth/organization/set-active",
+        { data: { organizationId: config.practice.id } },
+      );
+      expect(setActive.ok()).toBe(true);
+      const isolated = await owner.request.get(
+        "/api/practice/00000000-0000-4000-8000-000000000721/sidebar/counts",
+      );
+      expect(isolated.status()).toBe(403);
+
+      const conversationList = await owner.request.get(
+        `/api/conversations?practiceId=${encodeURIComponent(config.practice.id)}&limit=100`,
+      );
+      expect(conversationList.ok()).toBe(true);
+      const existing = records(await conversationList.json()).filter(
+        (conversation) => {
+          const metadata =
+            conversation.user_info && typeof conversation.user_info === "object"
+              ? (conversation.user_info as JsonRecord)
+              : {};
+          return (
+            metadata.source === "production_launch_smoke" &&
+            conversation.status !== "archived"
+          );
+        },
+      );
+      for (const duplicate of existing.slice(1)) {
+        const duplicateId = text(duplicate, "id");
+        if (!duplicateId)
+          throw new Error(
+            "Duplicate launch-smoke conversation is missing an id",
+          );
+        const archived = await owner.request.patch(
+          `/api/conversations/${encodeURIComponent(duplicateId)}?practiceId=${encodeURIComponent(config.practice.id)}`,
+          { data: { status: "archived" } },
+        );
+        expect(archived.ok()).toBe(true);
+      }
+      if (existing[0]) smokeConversationId = text(existing[0], "id");
+      if (!smokeConversationId) {
+        const created = await owner.request.post(
+          `/api/conversations?practiceId=${encodeURIComponent(config.practice.id)}`,
+          {
+            data: {
+              participantUserIds: [ownerUserId],
+              metadata: {
+                source: "production_launch_smoke",
+                mode: "PRACTICE_ASSISTANT",
+                title: "[LAUNCH SMOKE] Harmless assistant query",
+              },
+            },
+          },
+        );
+        expect(created.ok()).toBe(true);
+        smokeConversationId = text(
+          requireRecord(unwrap(await created.json()), "smoke conversation"),
+          "id",
+        );
+      }
+      if (!smokeConversationId)
+        throw new Error("Smoke conversation id is missing");
+
+      const clientsResponse = await owner.request.get(
+        `/api/clients/${encodeURIComponent(config.practice.id)}?limit=100`,
+      );
+      expect(clientsResponse.ok()).toBe(true);
+      let linkedClient = records(await clientsResponse.json()).find((entry) => {
+        const user =
+          entry.user && typeof entry.user === "object"
+            ? (entry.user as JsonRecord)
+            : {};
+        return (
+          text(user, "email")?.toLowerCase() ===
+          config.client.email.toLowerCase()
+        );
+      });
+      if (!linkedClient) {
+        const created = await owner.request.post(
+          `/api/clients/${encodeURIComponent(config.practice.id)}`,
+          {
+            data: {
+              name: "[LAUNCH SMOKE] Client",
+              email: config.client.email,
+              status: "active",
+            },
+          },
+        );
+        expect(created.ok()).toBe(true);
+        const refreshedClients = await owner.request.get(
+          `/api/clients/${encodeURIComponent(config.practice.id)}?limit=100`,
+        );
+        expect(refreshedClients.ok()).toBe(true);
+        linkedClient = records(await refreshedClients.json()).find((entry) => {
+          const user =
+            entry.user && typeof entry.user === "object"
+              ? (entry.user as JsonRecord)
+              : {};
+          return (
+            text(user, "email")?.toLowerCase() ===
+            config.client.email.toLowerCase()
+          );
+        });
+      }
+      expect(linkedClient).toBeDefined();
+      const linkedClientUser = requireRecord(
+        linkedClient?.user,
+        "linked launch-smoke client user",
+      );
+      expect(text(linkedClientUser, "email")?.toLowerCase()).toBe(
+        config.client.email.toLowerCase(),
+      );
+      expect(
+        (
+          text(linkedClient as JsonRecord, "name") ??
+          text(linkedClientUser, "name")
+        )?.toLowerCase(),
+      ).toContain("launch smoke");
+      const clientSetActive = await client.request.post(
+        "/api/auth/organization/set-active",
+        {
+          data: { organizationId: config.practice.id },
+        },
+      );
+      expect(clientSetActive.ok()).toBe(true);
+      const clientSession = requireRecord(
+        unwrap(
+          await (await client.request.get("/api/auth/get-session")).json(),
+        ),
+        "client session",
+      );
+      const clientSessionRecord = requireRecord(
+        clientSession.session,
+        "client session record",
+      );
+      expect(
+        text(
+          clientSessionRecord,
+          "activeOrganizationId",
+          "active_organization_id",
+        ),
+      ).toBe(config.practice.id);
+
+      const ownerInvoices = await owner.request.get(
+        `/api/invoices/${encodeURIComponent(config.practice.id)}?limit=5`,
+      );
+      const clientInvoices = await client.request.get(
+        `/api/invoices/${encodeURIComponent(config.practice.id)}/client?limit=5`,
+      );
+      expect(ownerInvoices.ok()).toBe(true);
+      expect(clientInvoices.ok()).toBe(true);
+      expect(
+        (
+          await owner.request.get(
+            `/api/practice/${encodeURIComponent(config.practice.id)}/sidebar/counts`,
+          )
+        ).ok(),
+      ).toBe(true);
+      expect(
+        (
+          await publicVisitor.request.get(
+            `/api/widget/bootstrap?slug=${encodeURIComponent(config.practice.slug)}`,
+          )
+        ).ok(),
+      ).toBe(true);
+
+      const ownerPage = await owner.newPage();
+      const clientPage = await client.newPage();
+      installBrowserGuards(
+        ownerPage,
+        errors,
+        forbiddenRequests,
+        failedRequiredRequests,
+      );
+      installBrowserGuards(
+        clientPage,
+        errors,
+        forbiddenRequests,
+        failedRequiredRequests,
+      );
+      await ownerPage.goto(
+        `/practice/${encodeURIComponent(config.practice.slug)}`,
+        { waitUntil: "domcontentloaded" },
+      );
+      await expectShellBasics(ownerPage);
+      await clientPage.goto(
+        `/client/${encodeURIComponent(config.practice.slug)}`,
+        { waitUntil: "domcontentloaded" },
+      );
+      await expectShellBasics(clientPage);
+      const widgetPage = await owner.newPage();
+      installBrowserGuards(
+        widgetPage,
+        errors,
+        forbiddenRequests,
+        failedRequiredRequests,
+      );
+      await widgetPage.goto(
+        `/public/${encodeURIComponent(config.practice.slug)}?v=widget`,
+        { waitUntil: "domcontentloaded" },
+      );
+      await expect(widgetPage.locator("body")).toBeVisible();
+
+      const mobile = await browser.newContext({
+        baseURL,
+        storageState: AUTH_STATE_PATHS.client,
+        viewport: { width: 375, height: 667 },
+      });
+      const mobilePage = await mobile.newPage();
+      installBrowserGuards(
+        mobilePage,
+        errors,
+        forbiddenRequests,
+        failedRequiredRequests,
+      );
+      await mobilePage.goto(
+        `/client/${encodeURIComponent(config.practice.slug)}`,
+        { waitUntil: "domcontentloaded" },
+      );
+      await expectShellBasics(mobilePage);
+      await mobile.close();
+
+      const query =
+        "In one short sentence, say that the launch smoke is healthy. Do not create, update, send, or delete anything.";
+      expect(
+        (
+          await owner.request.post(
+            `/api/conversations/${encodeURIComponent(smokeConversationId)}/messages?practiceId=${encodeURIComponent(config.practice.id)}`,
+            {
+              data: { content: query },
+            },
+          )
+        ).ok(),
+      ).toBe(true);
+      const aiResponse = await owner.request.post("/api/ai/chat", {
+        data: {
+          conversationId: smokeConversationId,
+          practiceSlug: config.practice.slug,
+          mode: "PRACTICE_ASSISTANT",
+          messages: [{ role: "user", content: query }],
+        },
+        timeout: 60_000,
+      });
+      expect(aiResponse.ok()).toBe(true);
+      const stream = await aiResponse.text();
+      expect(stream).toContain('"done":true');
+      expect(stream).not.toContain('"error":true');
+
+      expect(errors).toEqual([]);
+      expect(forbiddenRequests).toEqual([]);
+      expect(failedRequiredRequests).toEqual([]);
+    } finally {
+      if (smokeConversationId) {
+        const archived = await owner.request.patch(
+          `/api/conversations/${encodeURIComponent(smokeConversationId)}?practiceId=${encodeURIComponent(config.practice.id)}`,
+          {
+            data: { status: "archived" },
+          },
+        );
+        expect(archived.ok()).toBe(true);
+      }
+      await owner.close();
+      await client.close();
+      await publicVisitor.close();
+    }
+  });
+});

--- a/tests/unit/scripts/deploymentEvidence.test.ts
+++ b/tests/unit/scripts/deploymentEvidence.test.ts
@@ -1,49 +1,62 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { buildReleaseEvidence, parseWranglerDeploymentOutput } from '../../../scripts/lib/deploymentEvidence.js';
+import {
+  buildReleaseEvidence,
+  parsePagesCanonicalDeployment,
+  parseWorkerHealthRelease,
+  parseWranglerDeploymentOutput
+} from '../../../scripts/lib/deploymentEvidence.js';
 
 describe('deployment evidence', () => {
   it('reads native Worker and Pages deployment identifiers', () => {
-    const session = JSON.stringify({ type: 'wrangler-session', timestamp: '2026-07-12T00:00:00Z' });
+    const session = JSON.stringify({
+      type: 'wrangler-session',
+      timestamp: '2026-07-12T00:00:00Z'
+    });
     const worker = JSON.stringify({
       type: 'deploy',
       worker_name: 'blawby-ai-chatbot',
       version_id: 'worker-version-720',
       targets: ['https://ai.blawby.com/api/*'],
-      timestamp: '2026-07-12T00:00:01Z',
+      timestamp: '2026-07-12T00:00:01Z'
     });
     const pages = JSON.stringify({
       type: 'pages-deploy',
       pages_project: 'blawby-ai-chatbot-frontend',
       deployment_id: 'pages-deployment-720',
       url: 'https://720.blawby-ai-chatbot-frontend.pages.dev',
-      timestamp: '2026-07-12T00:00:02Z',
+      timestamp: '2026-07-12T00:00:02Z'
     });
 
     expect(parseWranglerDeploymentOutput(`${session}\n${worker}\n`, 'deploy')).toEqual({
       deploymentId: 'worker-version-720',
       deploymentUrl: 'https://ai.blawby.com/api/*',
       deployedAt: '2026-07-12T00:00:01Z',
-      target: 'blawby-ai-chatbot',
+      target: 'blawby-ai-chatbot'
     });
     expect(parseWranglerDeploymentOutput(`${session}\n${pages}\n`, 'pages-deploy')).toEqual({
       deploymentId: 'pages-deployment-720',
       deploymentUrl: 'https://720.blawby-ai-chatbot-frontend.pages.dev',
       deployedAt: '2026-07-12T00:00:02Z',
-      target: 'blawby-ai-chatbot-frontend',
+      target: 'blawby-ai-chatbot-frontend'
     });
   });
 
   it('fails closed on a failed or incomplete Wrangler command', () => {
-    expect(() => parseWranglerDeploymentOutput(
-      JSON.stringify({ type: 'command-failed', message: 'token detail' }),
-      'deploy',
-    )).toThrow('failed deployment command');
-    expect(() => parseWranglerDeploymentOutput(
-      JSON.stringify({ type: 'deploy', worker_name: 'worker', timestamp: 'now' }),
-      'deploy',
-    )).toThrow('deployment target');
+    expect(() =>
+      parseWranglerDeploymentOutput(JSON.stringify({ type: 'command-failed', message: 'token detail' }), 'deploy')
+    ).toThrow('failed deployment command');
+    expect(() =>
+      parseWranglerDeploymentOutput(
+        JSON.stringify({
+          type: 'deploy',
+          worker_name: 'worker',
+          timestamp: 'now'
+        }),
+        'deploy'
+      )
+    ).toThrow('deployment target');
   });
 
   it('records only release identity and readiness evidence', () => {
@@ -56,7 +69,7 @@ describe('deployment evidence', () => {
       pagesDeploymentUrl: 'https://pages-id.pages.dev',
       backendGitCommit: 'backend-commit',
       backendDeploymentId: 'railway-id',
-      launchedAt: '2026-07-12T00:00:00Z',
+      launchedAt: '2026-07-12T00:00:00Z'
     });
 
     expect(evidence).toMatchObject({
@@ -64,9 +77,68 @@ describe('deployment evidence', () => {
       frontendWorkerCommit: 'frontend-commit',
       worker: { deploymentId: 'worker-id' },
       pages: { deploymentId: 'pages-id' },
-      backend: { gitCommit: 'backend-commit', deploymentId: 'railway-id', migrationsReady: true },
+      backend: {
+        gitCommit: 'backend-commit',
+        deploymentId: 'railway-id',
+        migrationsReady: true
+      }
     });
     expect(JSON.stringify(evidence)).not.toMatch(/token|secret|runtimeConfig/i);
+  });
+
+  it('reads the current Worker and canonical Pages release identities', () => {
+    expect(
+      parseWorkerHealthRelease(
+        {
+          success: true,
+          data: {
+            environment: 'production',
+            release: {
+              commit: 'abcdef0123456789',
+              workerVersionId: 'worker-version-721'
+            }
+          }
+        },
+        'production'
+      )
+    ).toEqual({
+      commit: 'abcdef0123456789',
+      deploymentId: 'worker-version-721'
+    });
+    expect(
+      parsePagesCanonicalDeployment({
+        success: true,
+        result: {
+          canonical_deployment: {
+            id: 'pages-deployment-721',
+            url: 'https://721.blawby-ai-chatbot-frontend.pages.dev/'
+          }
+        }
+      })
+    ).toEqual({
+      deploymentId: 'pages-deployment-721',
+      deploymentUrl: 'https://721.blawby-ai-chatbot-frontend.pages.dev'
+    });
+  });
+
+  it('fails closed when the current Cloudflare identity is unsafe to restore', () => {
+    expect(() =>
+      parseWorkerHealthRelease(
+        {
+          data: {
+            environment: 'staging',
+            release: { commit: 'unknown', workerVersionId: 'worker-version' }
+          }
+        },
+        'staging'
+      )
+    ).toThrow('unknown');
+    expect(() =>
+      parsePagesCanonicalDeployment({
+        success: true,
+        result: { canonical_deployment: null }
+      })
+    ).toThrow('canonical deployment');
   });
 
   it('keeps staging automatic and production manual, serialized, and ordered', () => {
@@ -80,10 +152,48 @@ describe('deployment evidence', () => {
     expect(production).not.toMatch(/\n\s*push:/);
     expect(production).toContain('group: launch-production');
     expect(production).toContain('cancel-in-progress: false');
-    expect(production).toMatch(/deploy-worker:[\s\S]*needs: preflight/);
+    expect(production).toMatch(/capture-current:[\s\S]*needs: preflight/);
+    expect(production).toMatch(/deploy-worker:[\s\S]*needs: capture-current/);
     expect(production).toMatch(/deploy-pages:[\s\S]*needs: deploy-worker/);
     expect(production).toContain('environment: production');
     expect(production).toContain('WRANGLER_OUTPUT_FILE_PATH');
     expect(production).toContain('verify-deployment-propagation.ts');
+  });
+
+  it('smokes production with dedicated secrets and restores both Cloudflare surfaces on failure', () => {
+    const root = resolve(import.meta.dirname, '../../..');
+    const production = readFileSync(resolve(root, '.github/workflows/launch-production.yml'), 'utf8');
+    const staging = readFileSync(resolve(root, '.github/workflows/deploy.yml'), 'utf8');
+    const smoke = readFileSync(resolve(root, 'tests/e2e/production-smoke.spec.ts'), 'utf8');
+    const smokeConfig = readFileSync(resolve(root, 'playwright.production-smoke.config.ts'), 'utf8');
+    const e2eConfig = readFileSync(resolve(root, 'tests/e2e/helpers/e2eConfig.ts'), 'utf8');
+
+    expect(production).toContain('capture-cloudflare-release.ts');
+    expect(production).toContain('E2E_REQUIRE_ENV_ONLY');
+    expect(production).toContain('E2E_REQUIRE_EXISTING_USERS');
+    expect(production).toContain('E2E_SKIP_ANONYMOUS_AUTH');
+    expect(production).toContain('PRODUCTION_SMOKE_OWNER_EMAIL');
+    expect(production).toContain('PRODUCTION_SMOKE_CLIENT_EMAIL');
+    expect(production).toContain('playwright.production-smoke.config.ts');
+    expect(production).toContain('wrangler rollback');
+    expect(production).toContain('rollback-pages-deployment.ts');
+    expect(production).toContain('verify-pages-canonical.ts');
+    expect(production).toMatch(/rollback-production:[\s\S]*if:[\s\S]*production-smoke\.result == 'failure'/);
+    expect(production).toMatch(/record-release:[\s\S]*- production-smoke/);
+
+    expect(staging).toContain('rehearse_rollback');
+    expect(staging).toContain('rollback-rehearsal:');
+    expect(staging).toContain('rollbackDurationSeconds');
+    expect(staging).toContain('Redeploy current staging Worker');
+    expect(staging).toContain('Redeploy current staging Pages');
+
+    expect(smoke).toContain('production-launch-test');
+    expect(smoke).toContain('production_launch_smoke');
+    expect(smoke).toContain('/api/ai/chat');
+    expect(smoke).toMatch(/data:\s*\{\s*status:\s*["']archived["']\s*\}/);
+    expect(smoke).not.toMatch(/request\.(?:post|patch|put|delete)\(`?\/api\/(?:invoices|matters)/);
+    expect(smoke).not.toMatch(/webhook|charge|send-email|send-sms/i);
+    expect(smokeConfig).toMatch(/trace:\s*["']off["']/);
+    expect(e2eConfig).toContain("if (process.env.E2E_REQUIRE_ENV_ONLY === 'true') return;");
   });
 });


### PR DESCRIPTION
## Summary
- run an environment-only production-origin smoke with dedicated, visibly marked launch-test identities
- capture exact current Worker and canonical Pages deployment IDs before launch, then restore and verify both on failure
- add a measured staging rollback rehearsal that restores the selected staging commit afterward
- document the secure smoke inputs and rollback operations

## Verification
- focused deployment evidence tests: 7/7 pass
- Playwright production smoke collection: 1 test discovered
- lint: pass
- production build and bundle budget: pass (284.3 KB / 300 KB)
- strict production Worker dry-run: pass
- full unit suite: 669 pass; the same 8 pre-existing failures tracked by #728 remain
- test TypeScript config: only the same 2 pre-existing #728 fixture errors remain

Part of #721. The issue should close only after the staging rollback rehearsal has run and passed.