### PR TITLE
Restore intake prompt and unit contracts

### DIFF
--- a/tests/unit/middleware/corsProduction.test.ts
+++ b/tests/unit/middleware/corsProduction.test.ts
@@ -5,7 +5,7 @@ import type { Env } from '../../../worker/types.js';
 const ctx = {
   waitUntil() {},
   passThroughOnException() {},
-} as ExecutionContext;
+} as unknown as ExecutionContext;
 
 describe('production response security', () => {
   const env = {

--- a/tests/unit/middleware/rateLimit.test.ts
+++ b/tests/unit/middleware/rateLimit.test.ts
@@ -13,7 +13,7 @@ const createMockEnv = (): {
   const mockList = vi.fn();
   const mockDelete = vi.fn();
   const mockGetWithMetadata = vi.fn();
-  const env: Env = {
+  const env = {
     DB: {} as Env['DB'],
     CHAT_SESSIONS: {
       get: mockGet,
@@ -29,7 +29,7 @@ const createMockEnv = (): {
     IDEMPOTENCY_SALT: 'test-salt',
     ONESIGNAL_APP_ID: 'test-app',
     ONESIGNAL_REST_API_KEY: 'test-key',
-  };
+  } as unknown as Env;
   return { env, mockGet, mockPut };
 };
 

--- a/tests/unit/tools/executeIntakeTool.test.ts
+++ b/tests/unit/tools/executeIntakeTool.test.ts
@@ -1,7 +1,20 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { 
-  executeIntakeTool
+  executeIntakeTool,
+  type IntakeSubmissionGate,
 } from '../../../worker/routes/aiChatIntake';
+import { STANDARD_FIELD_DEFINITIONS } from '../../../src/shared/constants/intakeTemplates';
+
+const defaultTemplateGate: IntakeSubmissionGate = {
+  paymentRequiredBeforeSubmit: false,
+  paymentCompleted: false,
+  activeTemplate: {
+    slug: 'default',
+    name: 'Default',
+    isDefault: true,
+    fields: STANDARD_FIELD_DEFINITIONS,
+  },
+};
 
 describe('executeIntakeTool', () => {
   beforeEach(() => {
@@ -90,9 +103,7 @@ describe('executeIntakeTool', () => {
       opposingParty: 'John Doe'
     });
     const storedIntakeState = null;
-    const submissionGate = { paymentRequiredBeforeSubmit: false, paymentCompleted: false };
-
-    const result = executeIntakeTool(toolName, rawArgs, storedIntakeState, submissionGate);
+    const result = executeIntakeTool(toolName, rawArgs, storedIntakeState, defaultTemplateGate);
     
     expect(result.success).toBe(true);
     expect(result.actions).toEqual(expect.arrayContaining([

--- a/tests/unit/tools/save_case_details.test.ts
+++ b/tests/unit/tools/save_case_details.test.ts
@@ -1,5 +1,17 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { handleSaveCaseDetails, type IntakeSubmissionGate } from '../../../worker/routes/aiChatIntake';
+import { STANDARD_FIELD_DEFINITIONS } from '../../../src/shared/constants/intakeTemplates';
+
+const defaultTemplateGate: IntakeSubmissionGate = {
+  paymentRequiredBeforeSubmit: false,
+  paymentCompleted: false,
+  activeTemplate: {
+    slug: 'default',
+    name: 'Default',
+    isDefault: true,
+    fields: STANDARD_FIELD_DEFINITIONS,
+  },
+};
 
 describe('save_case_details tool', () => {
   beforeEach(() => {
@@ -46,8 +58,7 @@ describe('save_case_details tool', () => {
       state: 'CA'
     };
 
-    const submissionGate = { paymentRequiredBeforeSubmit: false, paymentCompleted: false };
-    const result = handleSaveCaseDetails(args, null, submissionGate);
+    const result = handleSaveCaseDetails(args, null, defaultTemplateGate);
     
     expect(result.success).toBe(true);
     expect(result.actions).toEqual(expect.arrayContaining([
@@ -160,8 +171,7 @@ describe('save_case_details tool', () => {
       opposingParty: 'John Doe'
     };
 
-    const submissionGate = { paymentRequiredBeforeSubmit: false, paymentCompleted: false };
-    const result = handleSaveCaseDetails(args, null, submissionGate);
+    const result = handleSaveCaseDetails(args, null, defaultTemplateGate);
     
     expect(result.success).toBe(true);
     expect(result.message).toBe('Case details saved. All required fields collected.');
@@ -177,8 +187,7 @@ describe('save_case_details tool', () => {
       state: 'CA'
     };
 
-    const submissionGate = { paymentRequiredBeforeSubmit: false, paymentCompleted: false };
-    const result = handleSaveCaseDetails(args, null, submissionGate);
+    const result = handleSaveCaseDetails(args, null, defaultTemplateGate);
     
     expect(result.success).toBe(true);
     expect(result.message).toBe('Case details saved. All required fields collected.');

--- a/worker/routes/aiChatIntake.ts
+++ b/worker/routes/aiChatIntake.ts
@@ -22,6 +22,7 @@ import {
 
 const MAX_SERVICES_IN_PROMPT = 20;
 type IntakePromptService = { name: string; uuid: string };
+const CONTACT_INFO_RULE = 'Contact information is already collected by the secure contact form. Never ask for contact info (name, email, or phone) again.';
 
 const US_STATE_NAME_TO_CODE: Record<string, string> = {
   alabama: 'AL', alaska: 'AK', arizona: 'AZ', arkansas: 'AR', california: 'CA',
@@ -606,6 +607,8 @@ export const buildIntakeSystemPrompt = (
 
 ${clientName}'s required information is complete.${contextBlock ? `\n\nCollected:\n${contextBlock}` : ''}
 
+${CONTACT_INFO_RULE}
+
 Write a warm 2-3 sentence summary of what ${clientName} shared. End with: "Ready to submit, or would you like to add anything first?"
 
 If they say yes/ready → call submit_intake.
@@ -621,7 +624,8 @@ No legal advice. No new questions.`.trim();
 
     const questionLines = queue.map((f, i) => {
       const q = f.previewQuestion?.trim() ?? f.promptHint?.trim() ?? `What is your ${f.label.toLowerCase()}?`;
-      return `${i + 1}. ${q}`;
+      const typeRule = getFieldValueTypeInstruction(f);
+      return `${i + 1}. ${q}${typeRule ? `\n   Answer rule: ${typeRule}` : ''}`;
     }).join('\n');
 
     const contextBlock = buildIntakeContextSummary(storedIntakeState, services, templateFields);
@@ -629,6 +633,7 @@ No legal advice. No new questions.`.trim();
 
     return `You are collecting intake information for ${practiceName}.
 ${collectedBlock}
+${CONTACT_INFO_RULE}
 Every response must have two parts — always, no exceptions:
 Part 1 (text): One warm sentence using "you/your" — something like "That sounds really stressful" or "I'm sorry you're going through this". No legal language (never say "illegal", "rights", "violation", "claim", "liable"). No "thank you", no "perfect". Then ask the first question from the list below that their message hasn't already answered. If all questions are already answered, write: "I'm sorry you're dealing with this — ready to submit, or would you like to add anything first?"
 Part 2 (tool): Call save_case_details with everything ${clientName} shared.
@@ -639,7 +644,7 @@ ${questionLines}
 No analysis, no legal opinions, no other questions beyond this list.`.trim();
   }
 
-  return `You are collecting intake information for ${practiceName}. Tell ${clientName} their information looks complete — one sentence. Call submit_intake if they confirm.`;
+  return `You are collecting intake information for ${practiceName}. ${CONTACT_INFO_RULE} Tell ${clientName} their information looks complete — one sentence. Call submit_intake if they confirm.`;
 };
 
 


### PR DESCRIPTION
## Summary
- restore the secure-contact-form rule across every intake prompt branch
- include the existing select/date/boolean/number safety rules in the active question queue
- update submit-action tests to use the active template that production always supplies, preserving fail-closed CTA behavior
- repair Cloudflare test fixture typing without changing the exercised KV rate-limit path

## Source-of-truth decision
The active intake template is the canonical submit gate. A missing template must not produce a submit CTA. The slim contact form remains authoritative for name/email/phone, and structured custom fields retain strict extraction rules.

## Verification
- affected tests: 38/38 pass
- full unit suite: 677/677 pass
- typecheck: pass
- lint: pass
- production build: pass
- bundle budget: pass

Closes #728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI intake conversations no longer ask for contact information again after it has been securely submitted.
  * Intake questions now provide clearer guidance about the expected answer format, helping people submit complete and usable information.
  * Submission flows now handle configured intake templates more consistently across different completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->