### PR TITLE
fix(deploy): preserve staging migration v10

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -286,6 +286,10 @@ new_classes = ["PresenceRoom"]
 tag = "v9"
 new_classes = ["ChatCounterObject"]
 
+# Staging already records v10; retain it so Wrangler does not replay earlier migrations.
+[[env.staging.migrations]]
+tag = "v10"
+
 [env.staging.vars]
 NODE_ENV = "staging"
 LOG_LEVEL = "warn"


### PR DESCRIPTION
## Summary
- record the no-op staging Durable Object migration tag already deployed in Cloudflare
- prevent Wrangler from replaying older migrations and attempting to recreate PresenceRoom

## Evidence
- failed staging deployment: https://github.com/Blawby/blawby-ai-chatbot/actions/runs/29188631895
- Cloudflare reported the deployed script is at v10 while the repository ended at v9
- 
px wrangler deploy --env staging --config worker/wrangler.toml --dry-run --strict passes

Unblocks the staging rollback rehearsal for #721.