### PR TITLE
fix(deploy): identify health verification requests

### DIFF
--- a/scripts/capture-cloudflare-release.ts
+++ b/scripts/capture-cloudflare-release.ts
@@ -27,6 +27,11 @@ if (!token || !accountId)
 
 const workerResponse = await fetch(healthUrl, {
   cache: "no-store",
+  headers: {
+    accept: "application/json",
+    "user-agent":
+      "Mozilla/5.0 (compatible; BlawbyDeploymentVerifier/1.0; +https://github.com/Blawby/blawby-ai-chatbot)",
+  },
   signal: AbortSignal.timeout(10_000),
 });
 if (!workerResponse.ok)

--- a/scripts/verify-deployment-propagation.ts
+++ b/scripts/verify-deployment-propagation.ts
@@ -26,6 +26,11 @@ for (let attempt = 1; attempt <= attempts; attempt += 1) {
   try {
     const response = await fetch(url, {
       cache: 'no-store',
+      headers: {
+        accept: mode === 'worker' ? 'application/json' : 'text/html,application/xhtml+xml',
+        'user-agent':
+          'Mozilla/5.0 (compatible; BlawbyDeploymentVerifier/1.0; +https://github.com/Blawby/blawby-ai-chatbot)',
+      },
       redirect: 'follow',
       signal: AbortSignal.timeout(timeoutSeconds * 1000),
     });


### PR DESCRIPTION
## Summary
- send an explicit standards-shaped deployment-verifier User-Agent from propagation checks
- request the expected response content type
- apply the same identity when capturing the current Worker release before rollback

## Why
Staging deployed successfully at exact commit dccd68f, and the public health endpoint returned its exact Worker version. GitHub-hosted Node requests were challenged with HTTP 403 because they had no browser-compatible request identity, so the workflow could not verify the healthy release.

## Verification
- exact staging Worker health identity passes locally
- type-check passes
- lint passes
- diff check passes

Unblocks the staging Pages deploy and rollback rehearsal for #721.