### PR TITLE
fix(deploy): verify the actual staging origin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           set -euo pipefail
           npx tsx scripts/verify-deployment-propagation.ts page "${DEPLOYMENT_URL}" 10 10
-          npx tsx scripts/verify-deployment-propagation.ts page https://staging.blawby.com 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://ai-staging.blawby.com 10 10
           npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend-staging "${DEPLOYMENT_ID}" 10 10
       - uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.rehearse_rollback }}
@@ -194,7 +194,7 @@ jobs:
         run: |
           set -euo pipefail
           npx tsx scripts/verify-deployment-propagation.ts page "${PREVIOUS_PAGES_DEPLOYMENT_URL}" 10 10
-          npx tsx scripts/verify-deployment-propagation.ts page https://staging.blawby.com 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://ai-staging.blawby.com 10 10
           npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend-staging "${PREVIOUS_PAGES_DEPLOYMENT_ID}" 10 10
       - name: Record measured rollback duration
         if: always()
@@ -252,7 +252,7 @@ jobs:
           set -euo pipefail
           npx tsx scripts/verify-deployment-propagation.ts worker https://ai-staging.blawby.com/api/health 10 10
           npx tsx scripts/verify-deployment-propagation.ts page "${RESTORED_PAGES_URL}" 10 10
-          npx tsx scripts/verify-deployment-propagation.ts page https://staging.blawby.com 10 10
+          npx tsx scripts/verify-deployment-propagation.ts page https://ai-staging.blawby.com 10 10
           npx tsx scripts/verify-pages-canonical.ts blawby-ai-chatbot-frontend-staging "${{ steps.restored-pages.outputs.deployment_id }}" 10 10
       - uses: actions/upload-artifact@v4
         if: always()

--- a/tests/unit/scripts/deploymentEvidence.test.ts
+++ b/tests/unit/scripts/deploymentEvidence.test.ts
@@ -186,6 +186,8 @@ describe('deployment evidence', () => {
     expect(staging).toContain('rollbackDurationSeconds');
     expect(staging).toContain('Redeploy current staging Worker');
     expect(staging).toContain('Redeploy current staging Pages');
+    expect(staging).toContain('page https://ai-staging.blawby.com');
+    expect(staging).not.toContain('https://staging.blawby.com');
 
     expect(smoke).toContain('production-launch-test');
     expect(smoke).toContain('production_launch_smoke');


### PR DESCRIPTION
## Summary
- verify Pages on the configured i-staging.blawby.com same-origin hostname
- use that origin for deploy, rollback, and post-rehearsal restoration checks
- test that the nonexistent staging.blawby.com hostname cannot return

## Evidence
- Pages deployment itself succeeded: https://github.com/Blawby/blawby-ai-chatbot/actions/runs/29189115503
- immutable Pages URL propagated on attempt 1
- staging.blawby.com has no DNS record
- Worker config routes i-staging.blawby.com/api/*, leaving the same hostname's remaining paths to Pages
- focused deployment evidence suite passes (7/7)

Unblocks #721.