### PR TITLE
feat(ops): add native launch monitoring

### DIFF
--- a/.github/workflows/production-health.yml
+++ b/.github/workflows/production-health.yml
@@ -1,0 +1,114 @@
+name: Production health
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: production-health
+  cancel-in-progress: false
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Check production health
+        id: health
+        continue-on-error: true
+        run: npx tsx scripts/production-health-check.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: production-health-${{ github.run_id }}
+          path: production-health.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Notify after two consecutive failures
+        if: steps.health.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          HEALTH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const title = '[production monitor] Production origin health failure';
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'production-health.yml',
+              branch: 'staging',
+              status: 'completed',
+              per_page: 2,
+            });
+            const previous = runs.data.workflow_runs.find((run) => run.id !== context.runId);
+            if (previous?.conclusion !== 'failure') {
+              core.notice('First failing run; waiting for a consecutive failure before notifying.');
+              return;
+            }
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            if (issues.data.some((issue) => issue.title === title)) {
+              core.notice('The bounded production health incident is already open.');
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: [
+                'Two consecutive bounded production health runs failed.',
+                '',
+                `Latest evidence: ${process.env.HEALTH_RUN_URL}`,
+                `Previous failure: ${previous.html_url}`,
+                '',
+                'Use `docs/operations/incident-response.md`; do not retry mutations or expose response bodies.',
+              ].join('\n'),
+            });
+      - name: Close recovered incident
+        if: steps.health.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          HEALTH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const title = '[production monitor] Production origin health failure';
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const incident = issues.data.find((issue) => issue.title === title);
+            if (!incident) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: incident.number,
+              body: `Production health recovered: ${process.env.HEALTH_RUN_URL}`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: incident.number,
+              state: 'closed',
+              state_reason: 'completed',
+            });
+      - name: Fail unhealthy run
+        if: steps.health.outcome == 'failure'
+        run: exit 1

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -1,0 +1,75 @@
+# Launch monitoring and incident response
+
+## Native signal path
+
+No third-party monitoring vendor is required for launch. Cloudflare persists production Worker logs, GitHub Actions checks the public production origin every 15 minutes, GitHub Issues is the bounded engineering notification channel, and Railway remains the source for backend process/deployment evidence.
+
+| Surface | Signal | What it proves |
+| --- | --- | --- |
+| Frontend | `Production health` requests `https://ai.blawby.com/` | The same-origin Pages shell is reachable and returns HTML. |
+| Worker | `/api/health` plus Cloudflare invocation/structured logs | The Worker is reachable and reports its exact Git commit and Worker version ID. |
+| Backend/database | `https://api.blawby.com/api/health` | Railway API routing and the PostgreSQL connection are healthy. |
+| Auth | Anonymous `/api/auth/get-session` bootstrap | The safe session bootstrap path responds without creating a session. |
+| AI | Anonymous `/api/ai/practice-assistant` rejection, release-correlated `/api/ai` errors, and launch smoke | The route/auth boundary is reachable continuously; an authenticated harmless provider query is proven during launch. |
+| Billing | Anonymous `/api/subscriptions` rejection, backend health, and Railway/Stripe evidence | The billing route/auth boundary is reachable; Stripe and webhook processing remain backend-owned signals. |
+| Background jobs | Structured `background_job` Worker events, Cloudflare queue/DLQ state, and Railway Graphile Worker logs | Each queue/cron invocation records started, succeeded, or failed against a release. |
+
+The scheduled check retries each read-only probe at most three times. A single failed workflow is evidence, not an outage notification. Two consecutive failed workflows open one fixed-title GitHub issue. Further failures do not create duplicate issues or comments. The next healthy run comments once and closes that incident.
+
+## Safe event contract
+
+Operational Worker events contain only:
+
+- timestamp, level, and bounded event/outcome names;
+- environment, exact Git release tag, and Worker deployment ID;
+- a generated correlation ID;
+- a non-identifying route family such as `/api/auth` or `queue:notification-events`;
+- bounded failure class, HTTP status, and duration when relevant.
+
+Do not add request/response bodies, names, email addresses, practice/client/matter identifiers, URLs containing identifiers, tokens, raw exception messages, or stack traces. Client 4xx responses are isolated user/request errors unless broader evidence says otherwise. A repeated public check failure, a 5xx cluster across requests, or a failed background invocation is actionable.
+
+## First five minutes
+
+1. Open the monitor run and its `production-health.json` artifact. Do not paste response bodies into the incident.
+2. Record the failing component, first observed time, and the exact release markers from `/api/health`, the last production launch artifact, Cloudflare, and Railway.
+3. Decide whether the failure began with a deployment. If yes, prefer the repository's proven rollback path for the owning surface.
+4. Check whether the failure is isolated (one 4xx/correlation ID) or systemic (two scheduled failures, repeated 5xx, failed queue invocation, or multiple components).
+5. Keep ownership boundaries: this repository may restore Worker/Pages; Railway/backend deployment and database actions require a human backend operator.
+
+## Runbooks
+
+### Auth outage
+
+Confirm `auth_bootstrap` and backend health, then compare `/api/auth` structured failures by release and correlation ID. If the failure began with Pages/Worker, restore the prior exact Cloudflare deployments through the production launch workflow. If Railway session handling is failing, preserve evidence and hand the backend deployment to a human; do not weaken cookies, CSRF, CORS, or session validation.
+
+### Backend outage
+
+Confirm `backend_database`, then inspect Railway API health, deploy identity, and sanitized application logs. Do not add a frontend fallback or route around the backend contract. A human restores or redeploys the backend; rerun `Production health` afterward and verify the same backend deployment identity intended by the operator.
+
+### AI outage
+
+Separate route/auth failure from provider failure. `ai_route` proves only the safe unauthenticated boundary; use `/api/ai` structured server errors and the launch smoke's single harmless query for provider evidence. If failures correlate with a Worker release, restore the prior Worker. If Cloudflare AI is unavailable, keep the feature fast-failing and communicate the outage—do not fabricate responses or silently switch providers.
+
+### Stripe or webhook failure
+
+Use Stripe's event delivery record, the backend webhook-event record, and Railway Graphile Worker logs. Determine whether the event is pending, retrying, processed, or terminally failed before acting. Never submit a valid webhook from monitoring, replay blindly, create a charge, or mutate invoices as a health check. Backend retry/code/deployment actions require human review and execution.
+
+### Queue or scheduled-job failure
+
+For Cloudflare jobs, filter structured events by `background_job`, route, release, and correlation ID; then inspect the matching queue and DLQ. For backend jobs, inspect the Railway event/email worker and Graphile Worker job state. Retry only idempotent jobs and only after the source fault is fixed. A caught error must still fail its invocation so the platform records it.
+
+### Bad frontend release
+
+Compare the canonical Pages deployment ID with the production launch artifact. Run the production workflow from the exact known-good Git commit so it captures current state, deploys, verifies the origin, and automatically restores both Cloudflare surfaces if the smoke fails. Do not use a mutable branch name as release evidence.
+
+### Bad Worker release
+
+Compare `/api/health` commit/version with the production launch artifact and structured errors. Use the exact known-good Git commit through the production workflow. Verify both the restored Worker version and canonical Pages ID because the public application is a same-origin pair.
+
+### Migration failure
+
+Stop further deploys and preserve the failed migration output. Durable Object migration tags are append-only history: never delete, reorder, or reuse a deployed tag when removing a class. Database migrations remain backend/human-owned. Restore the last known-good application deployments, repair the migration source of truth in a focused PR, and rehearse it on staging before another production attempt.
+
+## Backend and Railway gaps
+
+The public backend health endpoint currently proves API uptime and PostgreSQL connectivity, but it does not report Stripe reachability, webhook backlog/age, Graphile Worker heartbeat, failed-job count, or the Railway deployment identifier. Backend task logs also need one consistent sanitized release/correlation/failure contract. [Backend PR #371](https://github.com/Blawby/blawby-backend/pull/371) adds native Railway release identity and a sanitized database-health failure event; it is left for human review and merge. The remaining backend signals stay explicit gaps, and that review does not block the frontend/Worker monitoring and runbooks delivered here.

--- a/docs/operations/production-launch.md
+++ b/docs/operations/production-launch.md
@@ -55,3 +55,5 @@ Successful launches upload `release-evidence.json` for 90 days and append it to 
 - migration-readiness confirmation.
 
 It never includes runtime configuration or secret values.
+
+After launch, the scheduled native checks and component runbooks in [Launch monitoring and incident response](./incident-response.md) own bounded detection, notification, and recovery evidence.

--- a/docs/operations/production-topology.md
+++ b/docs/operations/production-topology.md
@@ -45,3 +45,5 @@ The deploy gate checks that these names exist in Cloudflare without reading or p
 - Push: `ONESIGNAL_APP_ID`, `ONESIGNAL_REST_API_KEY`
 
 GitHub deployment credentials (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) are separately presence-checked by the workflow. Backend, Stripe, OAuth, database, and email secret inventories stay in their owning backend/platform systems and are not copied into this repository.
+
+Production monitoring, thresholds, signal ownership, and incident actions are defined in [Launch monitoring and incident response](./incident-response.md).

--- a/scripts/lib/productionConfig.ts
+++ b/scripts/lib/productionConfig.ts
@@ -142,6 +142,15 @@ export function validateProductionConfig(input: ProductionConfigInput): Validati
   if (asRecord(production.version_metadata).binding !== 'CF_VERSION_METADATA') {
     failures.push({ field: 'worker.env.production.version_metadata.CF_VERSION_METADATA', reason: 'release metadata binding is missing' });
   }
+  const observability = asRecord(production.observability);
+  const observabilityLogs = asRecord(observability.logs);
+  if (observability.enabled !== true || observabilityLogs.enabled !== true ||
+      observabilityLogs.persist !== true || observabilityLogs.invocation_logs !== true) {
+    failures.push({
+      field: 'worker.env.production.observability.logs',
+      reason: 'persisted production invocation logs must be enabled',
+    });
+  }
 
   validateHttpsUrl(failures, 'worker.env.production.vars.CLOUDFLARE_PUBLIC_URL', vars.CLOUDFLARE_PUBLIC_URL, 'ai.blawby.com');
   validateHttpsUrl(failures, 'worker.env.production.vars.BACKEND_API_URL', vars.BACKEND_API_URL, 'api.blawby.com');

--- a/scripts/lib/productionHealth.ts
+++ b/scripts/lib/productionHealth.ts
@@ -1,0 +1,208 @@
+export type ProductionCheckName =
+  | 'frontend'
+  | 'worker'
+  | 'backend_database'
+  | 'auth_bootstrap'
+  | 'ai_route'
+  | 'billing_route';
+
+export type ProductionCheckResult = {
+  name: ProductionCheckName;
+  outcome: 'healthy' | 'failed';
+  attempts: number;
+  status?: number;
+  durationMs: number;
+  failureClass?: 'network' | 'http_status' | 'contract';
+  release?: {
+    commit: string;
+    deploymentId: string;
+  };
+};
+
+type CheckDefinition = {
+  name: ProductionCheckName;
+  url: string;
+  init?: RequestInit;
+  expectedStatus: number;
+  validate?: (response: Response) => Promise<boolean>;
+  releaseMarker?: (response: Response) => Promise<ProductionCheckResult['release']>;
+};
+
+const jsonRecord = async (response: Response): Promise<Record<string, unknown> | null> => {
+  try {
+    const body: unknown = await response.json();
+    return body && typeof body === 'object' && !Array.isArray(body) ? body as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+};
+
+const releaseMarker = (
+  release: Record<string, unknown> | null,
+  deploymentKey: 'workerVersionId' | 'deployment_id',
+): ProductionCheckResult['release'] =>
+  typeof release?.commit === 'string' && typeof release[deploymentKey] === 'string'
+    ? { commit: release.commit, deploymentId: release[deploymentKey] as string }
+    : undefined;
+
+export const productionChecks: CheckDefinition[] = [
+  {
+    name: 'frontend',
+    url: 'https://ai.blawby.com/',
+    expectedStatus: 200,
+    validate: async (response) => response.headers.get('content-type')?.includes('text/html') === true,
+  },
+  {
+    name: 'worker',
+    url: 'https://ai.blawby.com/api/health',
+    expectedStatus: 200,
+    validate: async (response) => {
+      const body = await jsonRecord(response);
+      const data = body?.data && typeof body.data === 'object' && !Array.isArray(body.data)
+        ? body.data as Record<string, unknown>
+        : null;
+      const release = data?.release && typeof data.release === 'object' && !Array.isArray(data.release)
+        ? data.release as Record<string, unknown>
+        : null;
+      return body?.success === true && data?.status === 'ok' && data.environment === 'production' &&
+        typeof release?.commit === 'string' && release.commit !== 'unknown' &&
+        typeof release.workerVersionId === 'string' && release.workerVersionId !== 'unknown';
+    },
+    releaseMarker: async (response) => {
+      const body = await jsonRecord(response);
+      const data = body?.data && typeof body.data === 'object' && !Array.isArray(body.data)
+        ? body.data as Record<string, unknown>
+        : null;
+      const release = data?.release && typeof data.release === 'object' && !Array.isArray(data.release)
+        ? data.release as Record<string, unknown>
+        : null;
+      return releaseMarker(release, 'workerVersionId');
+    },
+  },
+  {
+    name: 'backend_database',
+    url: 'https://api.blawby.com/api/health',
+    expectedStatus: 200,
+    validate: async (response) => {
+      const body = await jsonRecord(response);
+      const database = body?.database && typeof body.database === 'object' && !Array.isArray(body.database)
+        ? body.database as Record<string, unknown>
+        : null;
+      const release = body?.release && typeof body.release === 'object' && !Array.isArray(body.release)
+        ? body.release as Record<string, unknown>
+        : null;
+      return body?.status === 'ok' && database?.status === 'connected' &&
+        typeof release?.commit === 'string' && release.commit !== 'unknown' &&
+        typeof release.deployment_id === 'string' && release.deployment_id !== 'unknown' &&
+        release.environment === 'production';
+    },
+    releaseMarker: async (response) => {
+      const body = await jsonRecord(response);
+      const release = body?.release && typeof body.release === 'object' && !Array.isArray(body.release)
+        ? body.release as Record<string, unknown>
+        : null;
+      return releaseMarker(release, 'deployment_id');
+    },
+  },
+  {
+    name: 'auth_bootstrap',
+    url: 'https://ai.blawby.com/api/auth/get-session',
+    expectedStatus: 200,
+    validate: async (response) => response.headers.get('content-type')?.includes('application/json') === true,
+  },
+  {
+    name: 'ai_route',
+    url: 'https://ai.blawby.com/api/ai/practice-assistant',
+    init: { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' },
+    expectedStatus: 401,
+  },
+  {
+    name: 'billing_route',
+    url: 'https://ai.blawby.com/api/subscriptions',
+    expectedStatus: 401,
+  },
+];
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => globalThis.setTimeout(resolve, milliseconds));
+
+export const runProductionHealthChecks = async ({
+  fetchImpl = fetch,
+  attempts = 3,
+  retryDelayMs = 5_000,
+}: {
+  fetchImpl?: typeof fetch;
+  attempts?: number;
+  retryDelayMs?: number;
+} = {}): Promise<ProductionCheckResult[]> => {
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 5) throw new Error('attempts must be between 1 and 5');
+  const results: ProductionCheckResult[] = [];
+
+  for (const check of productionChecks) {
+    const startedAt = Date.now();
+    let result: ProductionCheckResult | undefined;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const response = await fetchImpl(check.url, {
+          ...check.init,
+          cache: 'no-store',
+          headers: {
+            accept: 'application/json,text/html',
+            'user-agent':
+              'Mozilla/5.0 (compatible; BlawbyProductionMonitor/1.0; +https://github.com/Blawby/blawby-ai-chatbot)',
+            ...check.init?.headers,
+          },
+          redirect: 'follow',
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (response.status !== check.expectedStatus) {
+          result = {
+            name: check.name,
+            outcome: 'failed',
+            attempts: attempt,
+            status: response.status,
+            durationMs: Date.now() - startedAt,
+            failureClass: 'http_status',
+          };
+        } else {
+          const markerResponse = check.releaseMarker ? response.clone() : undefined;
+          if (check.validate && !(await check.validate(response))) {
+            result = {
+              name: check.name,
+              outcome: 'failed',
+              attempts: attempt,
+              status: response.status,
+              durationMs: Date.now() - startedAt,
+              failureClass: 'contract',
+            };
+          } else {
+            const marker = markerResponse && check.releaseMarker
+              ? await check.releaseMarker(markerResponse)
+              : undefined;
+            result = {
+              name: check.name,
+              outcome: 'healthy',
+              attempts: attempt,
+              status: response.status,
+              durationMs: Date.now() - startedAt,
+              ...(marker ? { release: marker } : {}),
+            };
+            break;
+          }
+        }
+      } catch {
+        result = {
+          name: check.name,
+          outcome: 'failed',
+          attempts: attempt,
+          durationMs: Date.now() - startedAt,
+          failureClass: 'network',
+        };
+      }
+      if (attempt < attempts) await delay(retryDelayMs);
+    }
+    if (!result) throw new Error(`No result recorded for ${check.name}`);
+    results.push(result);
+  }
+  return results;
+};

--- a/scripts/production-health-check.ts
+++ b/scripts/production-health-check.ts
@@ -1,0 +1,14 @@
+import { writeFileSync } from 'node:fs';
+import { runProductionHealthChecks } from './lib/productionHealth.js';
+
+const results = await runProductionHealthChecks();
+const evidence = {
+  checkedAt: new Date().toISOString(),
+  environment: 'production',
+  outcome: results.every((result) => result.outcome === 'healthy') ? 'healthy' : 'failed',
+  checks: results,
+};
+
+writeFileSync('production-health.json', `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+process.stdout.write(`${JSON.stringify(evidence)}\n`);
+if (evidence.outcome === 'failed') process.exitCode = 1;

--- a/tests/unit/scripts/productionConfig.test.ts
+++ b/tests/unit/scripts/productionConfig.test.ts
@@ -32,6 +32,10 @@ const validConfig = () => ({
         },
         ai: { binding: 'AI' },
         version_metadata: { binding: 'CF_VERSION_METADATA' },
+        observability: {
+          enabled: true,
+          logs: { enabled: true, persist: true, invocation_logs: true },
+        },
         vars: {
           NODE_ENV: 'production',
           CLOUDFLARE_PUBLIC_URL: 'https://ai.blawby.com',

--- a/tests/unit/scripts/productionHealth.test.ts
+++ b/tests/unit/scripts/productionHealth.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { productionChecks, runProductionHealthChecks } from '../../../scripts/lib/productionHealth.js';
+
+const json = (body: unknown, status = 200): Response => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'content-type': 'application/json' },
+});
+
+describe('production health checks', () => {
+  it('covers the public frontend, Worker, backend database, auth, AI route, and billing route', () => {
+    expect(productionChecks.map((check) => check.name)).toEqual([
+      'frontend',
+      'worker',
+      'backend_database',
+      'auth_bootstrap',
+      'ai_route',
+      'billing_route',
+    ]);
+  });
+
+  it('accepts healthy contracts without reading response bodies into evidence', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const target = String(url);
+      if (target.endsWith('/api/health') && target.startsWith('https://ai.')) {
+        return json({
+          success: true,
+          data: {
+            status: 'ok',
+            environment: 'production',
+            release: { commit: 'sha', workerVersionId: 'worker-id' },
+          },
+          private_field: 'do-not-record',
+        });
+      }
+      if (target.startsWith('https://api.')) {
+        return json({
+          status: 'ok',
+          database: { status: 'connected' },
+          release: { commit: 'backend-sha', deployment_id: 'railway-id', environment: 'production' },
+          private_field: 'do-not-record',
+        });
+      }
+      if (target.endsWith('/api/auth/get-session')) return json(null);
+      if (target.includes('/api/ai/') || target.endsWith('/api/subscriptions')) return json({}, 401);
+      return new Response('<!doctype html>', { status: 200, headers: { 'content-type': 'text/html' } });
+    }) as unknown as typeof fetch;
+
+    const results = await runProductionHealthChecks({ fetchImpl, attempts: 1, retryDelayMs: 0 });
+    expect(results).toHaveLength(6);
+    expect(results.every((result) => result.outcome === 'healthy')).toBe(true);
+    expect(results.find((result) => result.name === 'worker')?.release).toEqual({
+      commit: 'sha',
+      deploymentId: 'worker-id',
+    });
+    expect(results.find((result) => result.name === 'backend_database')?.release).toEqual({
+      commit: 'backend-sha',
+      deploymentId: 'railway-id',
+    });
+    expect(JSON.stringify(results)).not.toContain('do-not-record');
+  });
+
+  it('retries boundedly and reports only a safe failure class', async () => {
+    const fetchImpl = vi.fn(async () => new Response('private upstream detail', { status: 503 })) as unknown as typeof fetch;
+    const results = await runProductionHealthChecks({ fetchImpl, attempts: 2, retryDelayMs: 0 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(productionChecks.length * 2);
+    expect(results.every((result) => result.outcome === 'failed')).toBe(true);
+    expect(results.every((result) => result.failureClass === 'http_status')).toBe(true);
+    expect(JSON.stringify(results)).not.toContain('private upstream detail');
+  });
+});

--- a/tests/unit/scripts/productionMonitoringConfig.test.ts
+++ b/tests/unit/scripts/productionMonitoringConfig.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../../..');
+
+describe('production monitoring configuration', () => {
+  it('uses bounded native checks and a two-failure repository notification threshold', () => {
+    const workflow = readFileSync(resolve(root, '.github/workflows/production-health.yml'), 'utf8');
+
+    expect(workflow).toContain("cron: '*/15 * * * *'");
+    expect(workflow).toContain('timeout-minutes: 10');
+    expect(workflow).toContain('continue-on-error: true');
+    expect(workflow).toContain("previous?.conclusion !== 'failure'");
+    expect(workflow).toContain('[production monitor] Production origin health failure');
+    expect(workflow).toContain("state_reason: 'completed'");
+    expect(workflow).not.toMatch(/datadog|new relic|sentry|pagerduty/i);
+  });
+
+  it('documents every launch incident path and backend ownership boundary', () => {
+    const runbook = readFileSync(resolve(root, 'docs/operations/incident-response.md'), 'utf8');
+
+    for (const heading of [
+      'Auth outage',
+      'Backend outage',
+      'AI outage',
+      'Stripe or webhook failure',
+      'Queue or scheduled-job failure',
+      'Bad frontend release',
+      'Bad Worker release',
+      'Migration failure',
+    ]) {
+      expect(runbook).toContain(`### ${heading}`);
+    }
+    expect(runbook).toContain('require a human backend operator');
+    expect(runbook).toContain('Two consecutive failed workflows');
+  });
+});

--- a/tests/unit/worker/entrypoint.test.ts
+++ b/tests/unit/worker/entrypoint.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import worker, { scheduled } from '../../../worker/index.js';
+
+describe('Worker entrypoint', () => {
+  it('exports the scheduled handler to the Cloudflare runtime', () => {
+    expect(worker.scheduled).toBe(scheduled);
+  });
+});

--- a/tests/unit/worker/operationalLogging.test.ts
+++ b/tests/unit/worker/operationalLogging.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { failureClass, logOperationalEvent, routeFamily } from '../../../worker/utils/operationalLogging.js';
+
+describe('operational logging', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reduces request paths to non-identifying route families', () => {
+    expect(routeFamily('/api/matters/matter-123/private')).toBe('/api/matters');
+    expect(routeFamily('/api/ai/chat/conversation-123')).toBe('/api/ai');
+    expect(routeFamily('/private/client-name')).toBe('/other');
+  });
+
+  it('uses bounded failure classes instead of error messages', () => {
+    expect(failureClass(new Error('client@example.com'))).toBe('unexpected_error');
+    expect(failureClass(new TypeError('secret payload'))).toBe('type_error');
+    expect(failureClass(undefined, 503)).toBe('server_error');
+    expect(failureClass(undefined, 401)).toBe('client_error');
+  });
+
+  it('emits release-correlated fields without arbitrary error data', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    logOperationalEvent({
+      level: 'error',
+      event: 'request.failed',
+      env: {
+        NODE_ENV: 'production',
+        CF_VERSION_METADATA: { tag: 'commit-sha', id: 'worker-version', timestamp: '2026-07-12T00:00:00Z' },
+      },
+      correlationId: 'correlation-id',
+      route: '/api/auth',
+      outcome: 'failed',
+      failureClass: 'server_error',
+      status: 503,
+    });
+
+    const entry = JSON.parse(String(error.mock.calls[0]?.[0]));
+    expect(entry).toMatchObject({
+      environment: 'production',
+      release: 'commit-sha',
+      deployment_id: 'worker-version',
+      correlation_id: 'correlation-id',
+      route: '/api/auth',
+      failure_class: 'server_error',
+      status: 503,
+    });
+    expect(entry).not.toHaveProperty('error');
+    expect(entry).not.toHaveProperty('stack');
+  });
+});

--- a/worker/errorHandler.ts
+++ b/worker/errorHandler.ts
@@ -3,11 +3,16 @@ import { ZodError } from 'zod';
 
 // Structured logging for better observability
 export function logError(error: unknown, context: Record<string, unknown> = {}) {
-  const isSafeClientError = error instanceof HttpError && error.status < 500;
+  const status = error instanceof HttpError
+    ? error.status
+    : error instanceof ZodError || error instanceof SyntaxError
+      ? 400
+      : 500;
   const errorData = {
-    error: isSafeClientError ? error.message : 'Internal server error',
-    errorType: error instanceof Error ? error.name : typeof error,
-    context,
+    event: 'error.response',
+    status,
+    failure_class: status >= 500 ? 'server_error' : 'client_error',
+    correlation_id: typeof context.correlationId === 'string' ? context.correlationId : 'unknown',
     timestamp: new Date().toISOString(),
     worker: 'blawby-ai-chatbot'
   };

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -50,6 +50,7 @@ import type { IntakeConversationQueueMessage } from './types/intakeConversationQ
 import { handleNotificationQueue } from './queues/notificationProcessor.js';
 import { handleSearchIndexQueue } from './queues/searchIndexConsumer.js';
 import type { SearchIndexEvent } from './types/search.js';
+import { failureClass, logOperationalEvent, routeFamily } from './utils/operationalLogging.js';
 
 export function validateRequest(request: Request): boolean {
   const contentLength = request.headers.get('content-length');
@@ -353,8 +354,21 @@ const affectsSidebarCounts = (pathname: string): boolean =>
 async function handleRequestInternal(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   const path = url.pathname;
+  const requestId = crypto.randomUUID();
+  const startedAt = Date.now();
 
   if (!validateRequest(request)) {
+    logOperationalEvent({
+      level: 'warn',
+      event: 'request.failed',
+      env,
+      correlationId: requestId,
+      route: routeFamily(path),
+      outcome: 'failed',
+      failureClass: 'invalid_request',
+      status: 400,
+      durationMs: Date.now() - startedAt,
+    });
     return new Response(JSON.stringify({
       success: false,
       error: 'Invalid request',
@@ -382,52 +396,130 @@ async function handleRequestInternal(request: Request, env: Env, ctx: ExecutionC
     ) {
       edgeCache.invalidate('sidebar:counts:', /* prefix */ true);
     }
+    if (response.status >= 400) {
+      logOperationalEvent({
+        level: response.status >= 500 ? 'error' : 'warn',
+        event: 'request.failed',
+        env,
+        correlationId: requestId,
+        route: routeFamily(path),
+        outcome: 'failed',
+        failureClass: failureClass(undefined, response.status),
+        status: response.status,
+        durationMs: Date.now() - startedAt,
+      });
+    }
     return response;
   } catch (error) {
-    return handleError(error);
+    logOperationalEvent({
+      level: 'error',
+      event: 'request.failed',
+      env,
+      correlationId: requestId,
+      route: routeFamily(path),
+      outcome: 'failed',
+      failureClass: failureClass(error),
+      status: 500,
+      durationMs: Date.now() - startedAt,
+    });
+    return handleError(error, requestId);
   }
 }
 
 export const handleRequest = withCORS(handleRequestInternal, getCorsConfig);
 
 async function handleQueue(batch: MessageBatch<unknown>, env: Env): Promise<void> {
-  if (batch.queue.startsWith('search-index-events')) {
-    return handleSearchIndexQueue(batch as MessageBatch<SearchIndexEvent>, env);
+  const correlationId = crypto.randomUUID();
+  const startedAt = Date.now();
+  const route = batch.queue.startsWith('search-index-events')
+    ? 'queue:search-index-events'
+    : batch.queue.startsWith('intake-conversation-events')
+      ? 'queue:intake-conversation-events'
+      : 'queue:notification-events';
+  logOperationalEvent({ level: 'info', event: 'background_job', env, correlationId, route, outcome: 'started' });
+  try {
+    if (batch.queue.startsWith('search-index-events')) {
+      await handleSearchIndexQueue(batch as MessageBatch<SearchIndexEvent>, env);
+    } else if (batch.queue.startsWith('intake-conversation-events')) {
+      await handleIntakeConversationQueue(batch as MessageBatch<IntakeConversationQueueMessage>, env);
+    } else {
+      await handleNotificationQueue(batch as MessageBatch<NotificationQueueMessage>, env);
+    }
+    logOperationalEvent({
+      level: 'info',
+      event: 'background_job',
+      env,
+      correlationId,
+      route,
+      outcome: 'succeeded',
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (error) {
+    logOperationalEvent({
+      level: 'error',
+      event: 'background_job',
+      env,
+      correlationId,
+      route,
+      outcome: 'failed',
+      failureClass: failureClass(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
   }
-  if (batch.queue.startsWith('intake-conversation-events')) {
-    return handleIntakeConversationQueue(batch as MessageBatch<IntakeConversationQueueMessage>, env);
-  }
-  return handleNotificationQueue(batch as MessageBatch<NotificationQueueMessage>, env);
 }
 
 export default {
   fetch: handleRequest,
-  queue: handleQueue
+  queue: handleQueue,
+  scheduled,
 };
 
 export async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
   const { StatusService } = await import('./services/StatusService');
+  const correlationId = crypto.randomUUID();
 
-  const cleanupPromise = StatusService.cleanupExpiredStatuses(env)
-    .then(count => {
-      console.log(`Scheduled cleanup: removed ${count} expired status entries`);
-    })
-    .catch(error => {
-      console.error('Scheduled cleanup failed:', error);
-    });
+  const runTask = async (route: string, task: Promise<unknown>): Promise<void> => {
+    const startedAt = Date.now();
+    logOperationalEvent({ level: 'info', event: 'background_job', env, correlationId, route, outcome: 'started' });
+    try {
+      await task;
+      logOperationalEvent({
+        level: 'info',
+        event: 'background_job',
+        env,
+        correlationId,
+        route,
+        outcome: 'succeeded',
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (error) {
+      logOperationalEvent({
+        level: 'error',
+        event: 'background_job',
+        env,
+        correlationId,
+        route,
+        outcome: 'failed',
+        failureClass: failureClass(error),
+        durationMs: Date.now() - startedAt,
+      });
+      throw error;
+    }
+  };
+
+  const cleanupPromise = runTask(
+    'scheduled:status-cleanup',
+    StatusService.cleanupExpiredStatuses(env),
+  );
 
   const searchPurgeCutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
-  const searchPurgePromise = env.DB.prepare(
-    `DELETE FROM search_query_log WHERE created_at < ?`,
-  )
-    .bind(searchPurgeCutoff)
-    .run()
-    .then((res) => {
-      console.log(`search_query_log purge: removed ${res.meta?.changes ?? 0} rows older than ${searchPurgeCutoff}`);
-    })
-    .catch((error) => {
-      console.error('search_query_log purge failed:', error);
-    });
+  const searchPurgePromise = runTask(
+    'scheduled:search-log-purge',
+    env.DB.prepare(`DELETE FROM search_query_log WHERE created_at < ?`)
+      .bind(searchPurgeCutoff)
+      .run(),
+  );
 
   ctx.waitUntil(Promise.all([cleanupPromise, searchPurgePromise]));
 }

--- a/worker/routes/analyze.ts
+++ b/worker/routes/analyze.ts
@@ -323,7 +323,7 @@ export async function handleAnalyze(request: Request, env: Env): Promise<Respons
   // Rate limiting for analysis endpoint
   const clientId = getClientId(request);
   if (!(await rateLimit(env, clientId, 30, 60))) { // 30 requests per minute
-    logWarning('analyze', 'rate_limit.exceeded', 'Rate limit exceeded', { clientId });
+    logWarning('analyze', 'rate_limit.exceeded', 'Rate limit exceeded');
     return createRateLimitResponse(60, {
       errorMessage: 'Rate limit exceeded. Please try again later.'
     });
@@ -354,10 +354,8 @@ export async function handleAnalyze(request: Request, env: Env): Promise<Respons
     }
 
     log('info', 'file_analysis_start', {
-      fileName: file.name,
       fileType: file.type,
       fileSize: file.size,
-      question: question,
       ENABLE_ADOBE_EXTRACT: env.ENABLE_ADOBE_EXTRACT,
       ADOBE_CLIENT_ID: env.ADOBE_CLIENT_ID ? 'SET' : 'NOT SET',
       requestId
@@ -394,7 +392,6 @@ export async function handleAnalyze(request: Request, env: Env): Promise<Respons
     };
 
     log('info', 'analysis_completed', {
-      fileName: file.name,
       confidence: analysis.confidence,
       summaryLength: analysis.summary?.length || 0,
       keyFactsCount: analysis.key_facts?.length || 0,

--- a/worker/utils/logging.ts
+++ b/worker/utils/logging.ts
@@ -91,8 +91,11 @@ export function logJSONParsing(requestId: string, step: string, data: LogData = 
 export function logError(requestId: string, stage: string, error: Error, data: LogData = {}): void {
   log('error', stage, {
     request_id: requestId,
-    error: error.message,
-    stack: error.stack,
+    failure_class: error instanceof SyntaxError
+      ? 'invalid_json'
+      : error instanceof TypeError
+        ? 'type_error'
+        : 'unexpected_error',
     ...data
   });
 }

--- a/worker/utils/operationalLogging.ts
+++ b/worker/utils/operationalLogging.ts
@@ -1,0 +1,68 @@
+import type { Env } from '../types';
+
+type OperationalLevel = 'info' | 'warn' | 'error';
+
+type OperationalEvent = {
+  level: OperationalLevel;
+  event: string;
+  env: Pick<Env, 'NODE_ENV' | 'CF_VERSION_METADATA'>;
+  correlationId: string;
+  route: string;
+  outcome: 'started' | 'succeeded' | 'failed';
+  failureClass?: string;
+  status?: number;
+  durationMs?: number;
+};
+
+const emit = (level: OperationalLevel, entry: Record<string, unknown>): void => {
+  const serialized = JSON.stringify(entry);
+  if (level === 'error') console.error(serialized);
+  else if (level === 'warn') console.warn(serialized);
+  else console.log(serialized);
+};
+
+export const routeFamily = (pathname: string): string => {
+  if (pathname === '/') return '/';
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] !== 'api') return '/other';
+  if (!segments[1]) return '/api';
+  if (segments[1] === 'ai') return '/api/ai';
+  return `/api/${segments[1]}`;
+};
+
+export const failureClass = (error: unknown, status?: number): string => {
+  if (status !== undefined) {
+    if (status >= 500) return 'server_error';
+    if (status >= 400) return 'client_error';
+  }
+  if (error instanceof SyntaxError) return 'invalid_json';
+  if (error instanceof TypeError) return 'type_error';
+  return 'unexpected_error';
+};
+
+export const logOperationalEvent = ({
+  level,
+  event,
+  env,
+  correlationId,
+  route,
+  outcome,
+  failureClass: classifiedFailure,
+  status,
+  durationMs,
+}: OperationalEvent): void => {
+  emit(level, {
+    ts: new Date().toISOString(),
+    level,
+    event,
+    environment: env.NODE_ENV ?? 'unknown',
+    release: env.CF_VERSION_METADATA?.tag ?? 'unknown',
+    deployment_id: env.CF_VERSION_METADATA?.id ?? 'unknown',
+    correlation_id: correlationId,
+    route,
+    outcome,
+    ...(classifiedFailure ? { failure_class: classifiedFailure } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(durationMs !== undefined ? { duration_ms: durationMs } : {}),
+  });
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -410,6 +410,15 @@ binding = "AI"
 [env.production.version_metadata]
 binding = "CF_VERSION_METADATA"
 
+[env.production.observability]
+enabled = true
+
+[env.production.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = true
+persist = true
+
 [env.production.triggers]
 crons = ["30 3 * * *"]
 


### PR DESCRIPTION
Closes #722

## What changed
- enables persisted Cloudflare production invocation logs and sanitized release-correlated operational events
- adds bounded native production checks for frontend, Worker, backend/database, auth, AI, billing, queues, and scheduled jobs
- opens one GitHub incident only after two consecutive failures and closes it on recovery
- adds launch incident runbooks for every requested failure surface

## Backend boundary
Backend PR Blawby/blawby-backend#371 adds exact Railway release identity and sanitized database-health failure logging. It is ready for human review and is intentionally not merged here. Its pending review does not block the frontend/Worker delivery.

## Verification
- 105 unit test files / 817 tests passed
- npm run type-check
- npm run lint
- npm run validate:production-config
- npm run build
- bundle budget: 284.3 KB / 300 KB
- strict production Worker dry-run
- git diff --check

The live production monitor is expected to report a contract failure until the production Worker cutover and backend PR land; it does not hide that drift or add a fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated production health monitoring across frontend, backend, authentication, AI, and billing services.
  - Health checks retry failures, record evidence, and track deployment details.
  - Monitoring automatically reports sustained incidents and closes them after recovery.
  - Added structured operational logging for requests, background jobs, and scheduled tasks.

- **Bug Fixes**
  - Scheduled task failures are now surfaced instead of being silently ignored.
  - Sensitive request details, error messages, and stack traces are excluded from operational logs.

- **Documentation**
  - Added incident-response runbooks and updated production launch and topology guidance.

- **Validation**
  - Production configuration now requires persistent observability logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->