### PR TITLE
Finish residual product-shell typography and transition cleanup

### DIFF
--- a/docs/engineering/product-shell-style-exceptions.md
+++ b/docs/engineering/product-shell-style-exceptions.md
@@ -1,0 +1,31 @@
+# Product-shell style exceptions
+
+Issue #725 applies one strict boundary: product work uses the sans type voice and static styling uses design-system classes. The exact allowlists live in `scripts/lib/productShellStyleAudit.ts` and are enforced by unit tests.
+
+## Inline styles
+
+Remaining inline styles belong to one of five categories:
+
+| Category | Allowed use |
+| --- | --- |
+| Theme preview | Miniature theme swatches and the debug dialog matrix need literal preview values without changing the active app theme. |
+| Document rendering | Engagement letters and exported invoice previews need print geometry and document-specific layout values. |
+| Runtime geometry and virtualization | Progress width, SVG stroke offsets, measured mobile insets, virtual-list sizing, and caller-supplied dimensions are values known only at runtime. |
+| Platform positioning and layers | Popovers, dialogs, drawers, menus, and overlays receive measured coordinates or centralized z-index values. |
+| Primitive escape hatch | The shared `Button` passes through a caller's typed `style` prop; call sites still have to satisfy this allowlist. |
+
+Static padding, colors, typography, grids, borders, shadows, and decoration were moved to tokenized classes. Adding an inline style in any other file fails the regression test and requires either a class migration or an explicit category decision here.
+
+## Serif typography
+
+Serif remains only on:
+
+- public intake editorial components, where a client is reading a guided public surface;
+- client engagement and signature components, where the UI renders the legal document being reviewed;
+- `.letter-paper` rules in `src/index.css`, which are the exported-document stylesheet.
+
+Settings, calendar, trust, contacts, invoices, matters, reports, onboarding, and all other product-shell working surfaces use sans. Marketing pricing also uses sans until the repository ships the documented Outfit brand token; it does not substitute legal-document serif as a display font.
+
+## Visual review matrix
+
+The affected product surfaces are reviewed through the developer tunnel at mobile, tablet, and desktop widths in light, dark, midnight, and parchment themes. Public intake and engagement-document exceptions are reviewed separately to confirm that their editorial/legal type voice remains intentional.

--- a/scripts/lib/productShellStyleAudit.ts
+++ b/scripts/lib/productShellStyleAudit.ts
@@ -1,0 +1,78 @@
+/**
+ * Explicit exceptions for issue #725. A file may retain inline styles only
+ * when its values are computed at runtime or belong to a renderer that cannot
+ * express them as a static design-system class.
+ */
+export const INLINE_STYLE_EXCEPTION_FILES = {
+  themePreview: [
+    'src/features/settings/pages/GeneralPage.tsx',
+    'src/pages/DebugDialogsPage.tsx',
+  ],
+  documentRendering: [
+    'src/features/engagements/pages/ClientEngagementReviewPage.tsx',
+    'src/features/invoices/components/InvoicePreview.tsx',
+  ],
+  runtimeGeometryAndVirtualization: [
+    'src/design-system/patterns/JourneyProgress.tsx',
+    'src/design-system/primitives/Bar.tsx',
+    'src/features/chat/components/ChatContainer.tsx',
+    'src/features/chat/components/VirtualMessageList.tsx',
+    'src/features/chat/views/ConversationListView.tsx',
+    'src/features/matters/components/MatterSummaryCards.tsx',
+    'src/features/matters/components/time-entries/TimeEntriesPanel.tsx',
+    'src/features/settings/pages/PracticeTeamPage.tsx',
+    'src/shared/ui/feedback/Alert.tsx',
+    'src/shared/ui/input/LogoUploadInput.tsx',
+    'src/shared/ui/input/PhoneInput.tsx',
+    'src/shared/ui/input/Slider.tsx',
+    'src/shared/ui/layout/AppShell.tsx',
+    'src/shared/ui/list/EntityList.tsx',
+    'src/shared/ui/media/Image.tsx',
+    'src/shared/ui/ProgressRing.tsx',
+    'src/shared/ui/upload/molecules/FileCard.tsx',
+    'src/shared/ui/upload/molecules/UploadQueueRow.tsx',
+  ],
+  platformPositioningAndLayers: [
+    'src/design-system/layout/FocusDrawer.tsx',
+    'src/features/media/components/FileMenu.tsx',
+    'src/shared/components/ToastContainer.tsx',
+    'src/shared/ui/dialog/Dialog.tsx',
+    'src/shared/ui/dialog/Fullscreen.tsx',
+    'src/shared/ui/DragDropOverlay.tsx',
+    'src/shared/ui/dropdown/DropdownMenuContent.tsx',
+    'src/shared/ui/nav/OrgSwitcherMenu.tsx',
+    'src/shared/ui/nav/Sidebar.tsx',
+    'src/shared/ui/nav/SidebarProfileMenu.tsx',
+    'src/shared/ui/overlays/ContextMenu.tsx',
+  ],
+  primitiveEscapeHatch: [
+    'src/shared/ui/Button.tsx',
+  ],
+} as const;
+
+/** Serif is reserved for public editorial intake and legal-document surfaces. */
+export const SERIF_EXCEPTION_FILES = {
+  publicIntake: [
+    'src/features/intake/components/IntakeAcceptancePreview.tsx',
+    'src/features/intake/components/IntakeFirmBar.tsx',
+    'src/features/intake/components/IntakePaymentCard.tsx',
+    'src/features/intake/components/IntakePaymentSummary.tsx',
+    'src/features/intake/components/IntakePreflightChecks.tsx',
+    'src/features/intake/components/IntakeScorecard.tsx',
+    'src/features/intake/components/IntakeStickyHeader.tsx',
+  ],
+  legalEngagement: [
+    'src/features/engagements/components/ClientEngagementAcknowledgmentsCard.tsx',
+    'src/features/engagements/components/ClientEngagementDecideRow.tsx',
+    'src/features/engagements/components/ClientEngagementGreetingBand.tsx',
+    'src/features/engagements/components/ClientEngagementSignatureCard.tsx',
+    'src/features/engagements/pages/ClientEngagementReviewPage.tsx',
+  ],
+  exportedDocumentStylesheet: [
+    'src/index.css',
+  ],
+} as const;
+
+export const flattenExceptionFiles = (
+  groups: Readonly<Record<string, readonly string[]>>,
+): string[] => Object.values(groups).flat().sort();

--- a/src/app/WidgetApp.tsx
+++ b/src/app/WidgetApp.tsx
@@ -623,7 +623,7 @@ export const WidgetApp: FunctionComponent<WidgetAppProps> = ({
             <circle cx="12" cy="12" r={radius} strokeWidth="2" fill="none" className="text-line-glass/30" stroke="currentColor" />
             <circle
               cx="12" cy="12" r={radius} strokeWidth="2" fill="none" strokeLinecap="round"
-              className={`transition-all duration-300 ${ringClass}`} stroke="currentColor"
+              className={`transition-[stroke-dashoffset] duration-300 ${ringClass}`} stroke="currentColor"
               strokeDasharray={circumference} strokeDashoffset={dashOffset}
             />
           </svg>

--- a/src/design-system/patterns/StatStrip.tsx
+++ b/src/design-system/patterns/StatStrip.tsx
@@ -28,7 +28,7 @@ export interface StatStripProps {
  * Stat strip (DESIGN_SYSTEM §3.13).
  *
  * 5-cell horizontal strip used in the Matter detail header. Each cell:
- * mono label + serif large number with tabular-nums + optional extra line.
+ * mono label + sans large number with tabular-nums + optional extra line.
  */
 export function StatStrip({ cells, className }: StatStripProps) {
   return (

--- a/src/features/calendar/components/CalendarAgendaView.tsx
+++ b/src/features/calendar/components/CalendarAgendaView.tsx
@@ -46,7 +46,7 @@ export function CalendarAgendaView({
         )}
         emptyState={
           <div className="p-8 text-center">
-            <p className="font-serif text-xl text-ink">No upcoming events</p>
+            <p className="font-sans text-xl text-ink">No upcoming events</p>
             <p className="mt-2 text-sm text-dim-2">
               The calendar aggregates task due dates, time entries, engagement
               lifecycle, invoice due dates, court dates and matter milestones.

--- a/src/features/calendar/components/CalendarEventRow.tsx
+++ b/src/features/calendar/components/CalendarEventRow.tsx
@@ -115,7 +115,7 @@ export function CalendarEventRow({
         <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">{dayName}</span>
         <span
           className={cn(
-            'font-serif text-2xl leading-none tracking-tight',
+            'font-sans text-2xl leading-none tracking-tight',
             urgent ? 'text-neg' : 'text-ink'
           )}
         >
@@ -129,7 +129,7 @@ export function CalendarEventRow({
       <div
         aria-hidden="true"
         className={cn(
-          'flex h-8 w-8 items-center justify-center rounded-full border font-serif text-sm italic',
+          'flex h-8 w-8 items-center justify-center rounded-full border font-sans text-sm italic',
           KIND_GLYPH_TONE[event.kind]
         )}
       >
@@ -153,7 +153,7 @@ export function CalendarEventRow({
             <Pill tone="dim">{event.court}</Pill>
           )}
         </div>
-        <div className="truncate font-serif text-base leading-tight tracking-tight text-ink">
+        <div className="truncate font-sans text-base leading-tight tracking-tight text-ink">
           {event.title}
         </div>
         {event.matterId && event.matterTitle && (

--- a/src/features/calendar/components/CalendarFocusDrawer.tsx
+++ b/src/features/calendar/components/CalendarFocusDrawer.tsx
@@ -204,9 +204,9 @@ export function CalendarFocusDrawer({
     >
       <div className="flex flex-col gap-4">
 
-        {/* Header — kind pill + serif H1 + when meta. Inline here (not in
+        {/* Header — kind pill + sans H1 + when meta. Inline here (not in
             FocusDrawer's title/subtitle slots) so we get full styling control
-            over the serif H1 and don't fight the title slot's CSS cascade. */}
+            over the sans H1 and don't fight the title slot's CSS cascade. */}
         <header className="flex flex-col gap-2 pb-1">
           <span className="inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
             {showPulse && (
@@ -217,7 +217,7 @@ export function CalendarFocusDrawer({
             )}
             {KIND_LABELS[event.kind]}
           </span>
-          <h2 className="m-0 font-serif text-[26px] font-normal leading-tight tracking-tight text-ink">
+          <h2 className="m-0 font-sans text-[26px] font-normal leading-tight tracking-tight text-ink">
             {event.title}
           </h2>
           <p className="m-0 text-[13px] text-ink-2">
@@ -259,7 +259,7 @@ export function CalendarFocusDrawer({
           <StatStrip
             cells={whenCells.map((cell) => ({
               label: cell.label,
-              value: <span className="font-serif text-lg leading-none tracking-tight">{cell.value}</span>
+              value: <span className="font-sans text-lg leading-none tracking-tight">{cell.value}</span>
             }))}
           />
         )}
@@ -342,7 +342,7 @@ export function CalendarFocusDrawer({
               <span className="font-mono text-[9.5px] uppercase tracking-[0.12em] text-dim">
                 Active matter
               </span>
-              <h4 className="font-serif text-[19px] font-normal leading-tight tracking-tight text-ink">
+              <h4 className="font-sans text-[19px] font-normal leading-tight tracking-tight text-ink">
                 {event.matterTitle}
               </h4>
               {event.clientName && (

--- a/src/features/calendar/components/CalendarMonthView.tsx
+++ b/src/features/calendar/components/CalendarMonthView.tsx
@@ -137,7 +137,7 @@ export function CalendarMonthView({
               <div className="flex items-baseline justify-between">
                 <span
                   className={cn(
-                    'font-serif text-base leading-none tracking-tight',
+                    'font-sans text-base leading-none tracking-tight',
                     isToday ? 'text-accent-deep' : 'text-ink',
                     past && !isToday && 'text-dim-2'
                   )}
@@ -179,7 +179,7 @@ export function CalendarMonthView({
                           {time}
                         </span>
                       )}
-                      <span className="font-serif text-xs leading-tight text-ink line-clamp-1">
+                      <span className="font-sans text-xs leading-tight text-ink line-clamp-1">
                         {event.title}
                       </span>
                     </button>

--- a/src/features/calendar/components/CalendarWeekView.tsx
+++ b/src/features/calendar/components/CalendarWeekView.tsx
@@ -121,7 +121,7 @@ export function CalendarWeekView({
               </span>
               <span
                 className={cn(
-                  'font-serif text-lg leading-none tracking-tight',
+                  'font-sans text-lg leading-none tracking-tight',
                   isToday ? 'text-accent-deep' : 'text-ink'
                 )}
               >
@@ -166,7 +166,7 @@ export function CalendarWeekView({
                           {time}
                         </span>
                       )}
-                      <span className="font-serif text-xs leading-tight text-ink line-clamp-2">
+                      <span className="font-sans text-xs leading-tight text-ink line-clamp-2">
                         {event.title}
                       </span>
                     </button>

--- a/src/features/calendar/pages/PracticeCalendarPage.tsx
+++ b/src/features/calendar/pages/PracticeCalendarPage.tsx
@@ -219,14 +219,14 @@ export function PracticeCalendarPage({
         {/* Main column ----------------------------------------------------- */}
         <div className="flex min-w-0 flex-1 flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
 
-          {/* Chat-first page header: serif H1 with em accent on "deadlines"
+          {/* Chat-first page header: sans H1 with em accent on "deadlines"
               + right-aligned StatStrip with three deterministic cells. */}
           <header className="flex flex-wrap items-end justify-between gap-4 border-b border-rule pb-5">
             <div className="min-w-0">
               <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-dim">
                 Calendar
               </div>
-              <h1 className="mt-1.5 font-serif text-[32px] font-normal leading-none tracking-tight text-ink lg:text-[44px]">
+              <h1 className="mt-1.5 font-sans text-[32px] font-normal leading-none tracking-tight text-ink lg:text-[44px]">
                 Calendar &amp; <em className="not-italic text-accent-deep">deadlines.</em>
               </h1>
             </div>

--- a/src/features/chat/components/MessageActions.tsx
+++ b/src/features/chat/components/MessageActions.tsx
@@ -254,7 +254,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 											href={url}
 											target="_blank"
 											rel="noopener noreferrer"
-											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
+											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-[opacity,transform] hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
 										>
 											{action.label}
 										</a>
@@ -285,7 +285,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 										<button
 											key={getChatActionKey(action, idx)}
 											type="button"
-											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
+											className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-[opacity,transform] hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
 											onClick={() => navigate(`${parsed.pathname}${parsed.search}${parsed.hash}`)}
 										>
 											{action.label}
@@ -298,7 +298,7 @@ export const MessageActions: FunctionComponent<MessageActionsProps> = ({
 										href={action.url}
 										target="_blank"
 										rel="noopener noreferrer"
-										className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-all hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
+										className={`btn ${action.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} btn-sm shrink-0 no-underline inline-flex items-center justify-center px-4 rounded-r-md font-semibold transition-[opacity,transform] hover:opacity-90 active:scale-[0.98] h-8 text-xs`}
 									>
 										{action.label}
 									</a>

--- a/src/features/chat/components/PracticeAssistantBriefing.tsx
+++ b/src/features/chat/components/PracticeAssistantBriefing.tsx
@@ -537,7 +537,7 @@ export function PracticeAssistantBriefing({
             <span className="font-sans text-3xl font-semibold leading-none tabular-nums text-ink">{formatCurrency(revenueStat?.value ?? unbilledStat?.value ?? 0)}</span>
             <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">{revenueStat ? 'collected · 7d' : 'unbilled · 7d'}</span>
           </div>
-          <svg aria-hidden="true" width="100%" height="40" viewBox="0 0 280 40" preserveAspectRatio="none" style={{ display: 'block', marginTop: '10px' }}>
+          <svg aria-hidden="true" width="100%" height="40" viewBox="0 0 280 40" preserveAspectRatio="none" className="mt-2.5 block">
             <defs>
               <linearGradient id="pa-spark-data" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="oklch(0.72 0.13 82)" stopOpacity="0.55" />
@@ -558,7 +558,7 @@ export function PracticeAssistantBriefing({
         </>
       ) : (
         <>
-          <svg aria-hidden="true" width="100%" height="40" viewBox="0 0 280 40" preserveAspectRatio="none" style={{ display: 'block', marginTop: '12px' }}>
+          <svg aria-hidden="true" width="100%" height="40" viewBox="0 0 280 40" preserveAspectRatio="none" className="mt-3 block">
             <line x1="0" y1="20" x2="280" y2="20" stroke="var(--rule)" strokeWidth="1" strokeDasharray="5 4" />
             {[0, 56, 112, 168, 224, 280].map((x) => (<circle key={x} cx={x} cy="20" r="2.5" fill="var(--paper-2)" stroke="var(--rule)" strokeWidth="1" />))}
           </svg>
@@ -884,7 +884,7 @@ export function PracticeAssistantBriefing({
           <section>
             <div className="mb-2 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
               <span>Quick actions</span>
-              <button type="button" className="font-sans text-[11px] normal-case tracking-normal text-ink-2" style={{ textDecoration: 'underline dotted', textUnderlineOffset: '2px' }} onClick={() => goToMatter(matter.id)}>everything else, just ask</button>
+              <button type="button" className="font-sans text-[11px] normal-case tracking-normal text-ink-2 underline decoration-dotted underline-offset-2" onClick={() => goToMatter(matter.id)}>everything else, just ask</button>
             </div>
             <div className="flex flex-wrap gap-1.5">
               <button type="button" className="chip" onClick={() => goToMatter(matter.id)}>Log time</button>
@@ -928,7 +928,7 @@ export function PracticeAssistantBriefing({
                   )}
                   <span>{new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}</span>
                 </div>
-                <p className="mb-4 max-w-[52ch] font-sans text-lg font-medium leading-snug tracking-tight text-ink" style={{ textWrap: 'balance' } as React.CSSProperties}>
+                <p className="mb-4 max-w-[52ch] text-balance font-sans text-lg font-medium leading-snug tracking-tight text-ink">
                   Here&apos;s your day.{' '}
                   {priorityIntake
                     ? <>One intake needs a decision before it goes cold.</>

--- a/src/features/chat/views/WorkspaceHomeView.tsx
+++ b/src/features/chat/views/WorkspaceHomeView.tsx
@@ -90,7 +90,7 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
             type="button"
             onClick={onOpenRecentMessage}
             disabled={!canOpenRecentMessage}
-            className="card px-5 py-5 text-left transition-all duration-300 hover:scale-[1.01] hover:bg-paper-2/40 dark:hover:bg-paper-2/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+            className="card px-5 py-5 text-left transition-[transform,background-color,box-shadow,opacity] duration-300 hover:scale-[1.01] hover:bg-paper-2/40 dark:hover:bg-paper-2/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
             aria-label={t("workspace.home.recentMessage")}
           >
             <div className="text-xs font-semibold uppercase tracking-wide text-dim-2">
@@ -126,14 +126,14 @@ const WorkspaceHomeView: FunctionComponent<WorkspaceHomeViewProps> = ({
           type="button"
           onClick={onSendMessage}
           disabled={!canSendMessage}
-          className="card flex w-full items-center justify-between px-6 py-5 text-left text-ink transition-all duration-300 hover:scale-[1.01] hover:bg-paper-2/40 dark:hover:bg-paper-2/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+          className="card flex w-full items-center justify-between px-6 py-5 text-left text-ink transition-[transform,background-color,box-shadow,opacity] duration-300 hover:scale-[1.01] hover:bg-paper-2/40 dark:hover:bg-paper-2/10 hover:shadow-glass active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
           aria-label={t("workspace.home.sendMessage")}
         >
           <span className="text-lg font-bold tracking-tight">
             {t("workspace.home.sendMessage")}
           </span>
           <span
-            className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-accent text-accent-ink pointer-events-none transition-all duration-300"
+            className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-accent text-accent-ink pointer-events-none"
             aria-hidden="true"
           >
             <Icon icon={Send} className="h-5 w-5" aria-hidden="true" />

--- a/src/features/clients/components/ClientDirectoryRow.tsx
+++ b/src/features/clients/components/ClientDirectoryRow.tsx
@@ -107,7 +107,7 @@ export function ClientDirectoryRow({
 
       {/* Col 2: name + primary matter sub-line */}
       <div className="min-w-0">
-        <div className="truncate font-[family-name:var(--serif)] text-[17px] leading-[1.1] tracking-[-0.005em] text-ink">
+        <div className="truncate font-sans text-[17px] leading-[1.1] tracking-[-0.005em] text-ink">
           {name}
         </div>
         <div className="mt-1 truncate font-mono text-[11px] uppercase tracking-wider text-dim">

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -162,13 +162,7 @@ const PendingInvitationDetailPanel = ({
   return (
     <div className="h-full overflow-y-auto @container">
       <div className="space-y-6">
-        <section
-          className="relative overflow-hidden rounded-r-md border"
-          style={{
-            background: 'linear-gradient(180deg, color-mix(in oklab, var(--accent) 12%, var(--card)), var(--card))',
-            borderColor: 'color-mix(in oklab, var(--accent) 30%, var(--rule))',
-          }}
-        >
+        <section className="relative overflow-hidden rounded-r-md border border-rule bg-card">
           <div className="px-6 pb-12 pt-10">
             <div className="flex flex-col items-center text-center">
               <Avatar name={invitation.email} size="xl" />
@@ -355,7 +349,7 @@ const ClientDetailPanel = ({
           <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
             {isClientRecord ? 'Selected client' : 'Team member'}
           </div>
-          <h2 className="font-[family-name:var(--serif)] text-3xl font-normal leading-[1.05] tracking-[-0.012em] text-ink">
+          <h2 className="font-sans text-3xl font-normal leading-[1.05] tracking-[-0.012em] text-ink">
             {(() => {
               const parts = splitName(client.name);
               if (parts.first && parts.last) {
@@ -1210,7 +1204,7 @@ export const PracticeContactsPage = ({
           <div className="flex min-w-0 items-center gap-3">
             <Avatar name={client.name} size="md" className={cn('shrink-0 text-ink', signal === 'frustrated' && 'ring-1 ring-neg')} />
             <div className="min-w-0">
-              <div className="truncate font-[family-name:var(--serif)] text-[17px] leading-tight text-ink">
+              <div className="truncate font-sans text-[17px] leading-tight text-ink">
                 {client.name}
               </div>
               <div className="mt-1 truncate text-xs text-dim-2">
@@ -1568,7 +1562,7 @@ export const PracticeContactsPage = ({
               <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-dim">
                 Clients · {totalForCrumb} active
               </div>
-              <h1 className="mt-1.5 font-[family-name:var(--serif)] text-[32px] font-normal leading-[1.05] tracking-[-0.022em] text-ink sm:text-[44px] sm:leading-none lg:text-[56px]">
+              <h1 className="mt-1.5 font-sans text-[32px] font-normal leading-[1.05] tracking-[-0.022em] text-ink sm:text-[44px] sm:leading-none lg:text-[56px]">
                 Clients you{' '}
                 <em className="not-italic text-accent">haven&apos;t heard from.</em>
               </h1>
@@ -1731,7 +1725,7 @@ export const PracticeContactsPage = ({
             <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-dim">
               Contacts · {sortedPendingInvitations.length} pending
             </div>
-            <h1 className="mt-1.5 font-[family-name:var(--serif)] text-[32px] font-normal leading-[1.05] tracking-[-0.022em] text-ink sm:text-[44px] sm:leading-none lg:text-[56px]">
+            <h1 className="mt-1.5 font-sans text-[32px] font-normal leading-[1.05] tracking-[-0.022em] text-ink sm:text-[44px] sm:leading-none lg:text-[56px]">
               Pending invitations
             </h1>
           </div>

--- a/src/features/engagements/components/ClientEngagementAcknowledgmentsCard.tsx
+++ b/src/features/engagements/components/ClientEngagementAcknowledgmentsCard.tsx
@@ -75,7 +75,7 @@ export const ClientEngagementAcknowledgmentsCard: FunctionComponent<ClientEngage
         className="mb-1.5 mt-0.5 font-serif text-[26px] font-normal leading-[1.15] tracking-[-0.012em] text-ink"
       >
         Before you{' '}
-        <em className="text-accent" style={{ fontStyle: 'italic' }}>sign,</em>
+        <em className="italic text-accent">sign,</em>
         {' '}please confirm.
       </h3>
       <p className="mb-5 max-w-[60ch] text-[14px] leading-[1.55] text-ink-2">
@@ -108,7 +108,7 @@ export const ClientEngagementAcknowledgmentsCard: FunctionComponent<ClientEngage
               <span
                 aria-hidden="true"
                 className={cn(
-                  'mt-0.5 grid h-[18px] w-[18px] place-items-center rounded-[4px] border-[1.5px] transition-all',
+                  'mt-0.5 grid h-[18px] w-[18px] place-items-center rounded-[4px] border-[1.5px] transition-[background-color,border-color,color]',
                   checked
                     ? 'border-ink bg-ink'
                     : 'border-ink-3 bg-card',

--- a/src/features/engagements/components/ClientEngagementDecideRow.tsx
+++ b/src/features/engagements/components/ClientEngagementDecideRow.tsx
@@ -58,7 +58,7 @@ export const ClientEngagementDecideRow: FunctionComponent<ClientEngagementDecide
       <div>
         <h3 className="m-0 mb-1 font-serif text-[24px] font-normal leading-[1.15] tracking-[-0.012em] text-ink">
           Ready to{' '}
-          <em className="text-accent" style={{ fontStyle: 'italic' }}>accept?</em>
+          <em className="italic text-accent">accept?</em>
         </h3>
         <p className="m-0 text-[13.5px] leading-[1.55] text-ink-2">{subCopy}</p>
       </div>

--- a/src/features/engagements/components/ClientEngagementGreetingBand.tsx
+++ b/src/features/engagements/components/ClientEngagementGreetingBand.tsx
@@ -62,7 +62,7 @@ export const ClientEngagementGreetingBand: FunctionComponent<ClientEngagementGre
           </div>
         ) : null}
         <h1 className="m-0 font-serif text-[28px] font-normal leading-[1.05] tracking-[-0.018em] text-ink text-balance sm:text-[42px]">
-          Hi {displayName} — <em className="text-accent" style={{ fontStyle: 'italic' }}>here&apos;s the agreement</em> {attorney} wants to sign with you.
+          Hi {displayName} — <em className="italic text-accent">here&apos;s the agreement</em> {attorney} wants to sign with you.
         </h1>
         <p className="m-0 mt-2.5 max-w-[62ch] text-[15px] leading-[1.55] text-ink-2">
           {introCopy}

--- a/src/features/engagements/components/ClientEngagementSignatureCard.tsx
+++ b/src/features/engagements/components/ClientEngagementSignatureCard.tsx
@@ -136,11 +136,11 @@ export const ClientEngagementSignatureCard: FunctionComponent<ClientEngagementSi
         className="m-0 mb-1.5 font-serif text-[26px] font-normal leading-[1.15] tracking-[-0.012em] text-ink"
       >
         Sign{' '}
-        <em className="text-accent" style={{ fontStyle: 'italic' }}>here.</em>
+        <em className="italic text-accent">here.</em>
       </h3>
       <p className="mb-[18px] text-[14px] leading-[1.55] text-ink-2">
         Draw your signature using your finger, trackpad, or mouse. By signing you agree to the terms above on{' '}
-        <em className="text-accent-deep" style={{ fontStyle: 'italic' }}>{todayLong}</em>.
+        <em className="italic text-accent-deep">{todayLong}</em>.
       </p>
 
       <div

--- a/src/features/engagements/components/EngagementWorkbench.tsx
+++ b/src/features/engagements/components/EngagementWorkbench.tsx
@@ -12,7 +12,7 @@
  *
  * Layout (per design_handoff_blawby_chat_first/screens/Engagement.html):
  *
- *   [topbar — breadcrumb + serif H1 "Engagement for {Client}" + saved indicator]
+ *   [topbar — breadcrumb + sans H1 "Engagement for {Client}" + saved indicator]
  *   [AIRibbon authoring — "I generated this draft from X, prefilled with Y.
  *                         {N} of {Total} placeholders unresolved"]
  *   ┌──────────────────────┬─────────────────────────────────────┐
@@ -809,7 +809,7 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
       <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
         Engagement · {engagementNumber} · {status}
       </div>
-      <h1 className="m-0 font-serif text-[22px] font-normal leading-tight tracking-[-0.012em] text-ink">
+      <h1 className="m-0 font-sans text-[22px] font-normal leading-tight tracking-[-0.012em] text-ink">
         Engagement for <em className="not-italic text-accent-deep italic">{clientNameDisplay}</em>
       </h1>
     </div>
@@ -1081,7 +1081,7 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
                       ai suggested
                     </span>
                   )}
-                  <span className="font-serif text-[15px] tracking-[-0.005em] text-ink">{opt.title}</span>
+                  <span className="font-sans text-[15px] tracking-[-0.005em] text-ink">{opt.title}</span>
                   <span className="text-[11.5px] leading-snug text-dim">{opt.description}</span>
                 </button>
               );
@@ -1442,7 +1442,7 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
 
   const clientReviewView = (
     <div className="rounded-md border border-card-border bg-card p-5 text-sm text-ink-2">
-      <p className="font-serif text-base text-ink">Client review page preview</p>
+      <p className="font-sans text-base text-ink">Client review page preview</p>
       <p className="mt-2">
         Clients see this letter inside the standard review page with a signature
         pad and consent checkbox.
@@ -1472,7 +1472,7 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
 
   const placeholdersCard = (
     <div className="rounded-md border border-card-border bg-card px-4 py-3">
-      <h4 className="m-0 font-serif text-[15px] font-normal">
+      <h4 className="m-0 font-sans text-[15px] font-normal">
         {placeholderStats.total} placeholders — {placeholderStats.resolved} resolved, {placeholderStats.unresolved} open
       </h4>
       <div className="mt-2 flex flex-col">

--- a/src/features/intake/components/DocumentChecklist.tsx
+++ b/src/features/intake/components/DocumentChecklist.tsx
@@ -115,7 +115,7 @@ const DocumentChecklist: FunctionComponent<DocumentChecklistProps> = ({
         {documents.map((doc) => (
           <div
             key={doc.id}
-            className={`border rounded-r-md p-4 transition-all duration-300 ${
+            className={`border rounded-r-md p-4 transition-[transform,background-color,border-color] duration-300 ${
               dragOverId === doc.id 
                 ? 'border-accent bg-accent/10 scale-[1.02]' 
                 : 'border-line-subtle bg-paper-2/5'

--- a/src/features/intake/components/IntakePaymentCard.tsx
+++ b/src/features/intake/components/IntakePaymentCard.tsx
@@ -76,7 +76,7 @@ export const IntakePaymentCard: FunctionComponent<IntakePaymentCardProps> = ({
           // mobile so the Pay link clears the iOS HIG tap-target threshold
           // (the desktop py-3.5 is already ~14px both sides; mobile uses
           // padding-block: 12px + min-height: 44px to keep proportions).
-          className="intake-payment-card-cta btn btn-primary inline-flex w-full items-center justify-center rounded-r-md px-4 py-3.5 text-center font-semibold no-underline transition-all hover:opacity-90 active:scale-[0.98]"
+          className="intake-payment-card-cta btn btn-primary inline-flex w-full items-center justify-center rounded-r-md px-4 py-3.5 text-center font-semibold no-underline transition-[opacity,transform] hover:opacity-90 active:scale-[0.98]"
         >
           {buttonLabel}
         </a>

--- a/src/features/invoices/components/ClientInvoiceRow.tsx
+++ b/src/features/invoices/components/ClientInvoiceRow.tsx
@@ -13,7 +13,7 @@ export interface ClientInvoiceRowProps {
  *
  * Built separately from PracticeInvoiceRow per the client/practice
  * separation rule — the client surface shows:
- *   top: serif invoice number + mono amount
+ *   top: sans invoice number + mono amount
  *   mid: matter title (the work being billed)
  *   bot: status pill + due date / paid date
  *
@@ -34,9 +34,9 @@ export function ClientInvoiceRow({ invoice, isSelected = false }: ClientInvoiceR
           : 'border-l-transparent hover:bg-rule-soft'
       )}
     >
-      {/* Top row: serif invoice # + mono amount */}
+      {/* Top row: sans invoice # + mono amount */}
       <div className="flex items-baseline justify-between gap-3">
-        <div className="min-w-0 flex-1 truncate font-[family-name:var(--serif)] text-[17px] leading-tight tracking-[-0.005em] text-ink">
+        <div className="min-w-0 flex-1 truncate font-sans text-[17px] leading-tight tracking-[-0.005em] text-ink">
           {invoice.invoiceNumber || 'Invoice'}
         </div>
         <div className="shrink-0 font-mono text-[14px] tabular-nums tracking-[-0.01em] text-ink">

--- a/src/features/invoices/components/PracticeInvoiceRow.tsx
+++ b/src/features/invoices/components/PracticeInvoiceRow.tsx
@@ -13,7 +13,7 @@ export interface PracticeInvoiceRowProps {
  * Chat-first practice invoice row (Invoices.html `.inv-row`).
  *
  * Three-line composition:
- *   top: serif client name + mono amount
+ *   top: sans client name + mono amount
  *   mid: mono "INV-#### · matter · sub-line"
  *   bot: status pill + mono due qualifier ("due in 3d" / "overdue 18d" / "Nov 25")
  *
@@ -35,9 +35,9 @@ export function PracticeInvoiceRow({ invoice, isSelected = false }: PracticeInvo
           : 'border-l-transparent hover:bg-rule-soft'
       )}
     >
-      {/* Top row: serif client + mono amount */}
+      {/* Top row: sans client + mono amount */}
       <div className="flex items-baseline justify-between gap-3">
-        <div className="min-w-0 flex-1 truncate font-[family-name:var(--serif)] text-[17px] leading-tight tracking-[-0.005em] text-ink">
+        <div className="min-w-0 flex-1 truncate font-sans text-[17px] leading-tight tracking-[-0.005em] text-ink">
           {invoice.clientName ?? 'Unknown client'}
         </div>
         <div className="shrink-0 font-mono text-[14px] tabular-nums tracking-[-0.01em] text-ink">

--- a/src/features/invoices/pages/ClientInvoicesPage.tsx
+++ b/src/features/invoices/pages/ClientInvoicesPage.tsx
@@ -136,7 +136,7 @@ export function ClientInvoicesPage({
       <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
         {`Your account · ${invoices.length} ${invoices.length === 1 ? 'invoice' : 'invoices'}`}
       </div>
-      <h1 className="mt-1 font-[family-name:var(--serif)] text-[28px] font-normal leading-none tracking-[-0.02em] text-ink sm:text-[34px]">
+      <h1 className="mt-1 font-sans text-[28px] font-normal leading-none tracking-[-0.02em] text-ink sm:text-[34px]">
         Invoices
       </h1>
       {totalDue > 0 ? (

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -314,7 +314,7 @@ export function PracticeInvoicesPage({
           <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
             Workspace · {aggregates.loading ? '—' : `${totalCount} invoices`}
           </div>
-          <h1 className="mt-1 font-[family-name:var(--serif)] text-[28px] font-normal leading-none tracking-[-0.02em] text-ink sm:text-[34px]">
+          <h1 className="mt-1 font-sans text-[28px] font-normal leading-none tracking-[-0.02em] text-ink sm:text-[34px]">
             Invoices
           </h1>
         </div>

--- a/src/features/matters/components/MatterAskCard.tsx
+++ b/src/features/matters/components/MatterAskCard.tsx
@@ -79,7 +79,7 @@ export const MatterAskCard = ({
       <div className="flex items-center gap-2.5">
         <div
           aria-hidden="true"
-          className="flex h-7 w-7 items-center justify-center rounded-full bg-[color:var(--accent)] font-[family-name:var(--serif)] text-base italic text-[color:var(--accent-ink)]"
+          className="flex h-7 w-7 items-center justify-center rounded-full bg-[color:var(--accent)] font-sans text-base italic text-[color:var(--accent-ink)]"
         >
           B
         </div>
@@ -87,7 +87,7 @@ export const MatterAskCard = ({
           <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-dim-2">
             {contextLabel}
           </div>
-          <h4 className="font-[family-name:var(--serif)] text-base font-normal text-ink">
+          <h4 className="font-sans text-base font-normal text-ink">
             Ask about this matter
           </h4>
         </div>
@@ -125,7 +125,7 @@ export const MatterAskCard = ({
                   onClick={() => submit(suggestion)}
                   className="flex w-full items-center gap-2 py-1 text-left font-[family-name:var(--sans)] text-[12.5px] text-accent-deep transition-colors hover:text-accent dark:text-accent dark:hover:text-accent-deep"
                 >
-                  <span aria-hidden="true" className="font-[family-name:var(--serif)] italic opacity-70">
+                  <span aria-hidden="true" className="font-sans italic opacity-70">
                     ›
                   </span>
                   <span>{suggestion}</span>

--- a/src/features/matters/components/MatterDetailHeader.tsx
+++ b/src/features/matters/components/MatterDetailHeader.tsx
@@ -22,10 +22,10 @@ const URGENCY_BREADCRUMB_LABEL: Record<NonNullable<MatterDetail['urgency']>, str
   emergency: 'priority high'
 };
 
-const URGENCY_COLOR_VAR: Record<NonNullable<MatterDetail['urgency']>, string> = {
-  routine: 'var(--dim)',
-  time_sensitive: 'var(--warn)',
-  emergency: 'var(--neg)'
+const URGENCY_COLOR_CLASS: Record<NonNullable<MatterDetail['urgency']>, string> = {
+  routine: 'text-dim',
+  time_sensitive: 'text-warn',
+  emergency: 'text-neg'
 };
 
 // Derive a stable "BLB-####" matter number from the matter UUID when the
@@ -116,7 +116,7 @@ const MoreMenu = ({ items }: { items: MatterMoreMenuItem[] }) => (
  *
  * Layout (top to bottom):
  *   1. Breadcrumb row     — mono uppercase: "Matters / BLB-#### · priority high"
- *   2. Title row          — serif h1 44px with client name in --accent · top-right action cluster
+ *   2. Title row          — sans h1 44px with client name in --accent · top-right action cluster
  *   3. Sub strip          — bold practice-area · bold jurisdiction · opened date · billing pill
  *   4. 5-cell StatStrip   — retainer balance · unbilled time · events 30d · SoL/next deadline · est. value
  *
@@ -135,7 +135,7 @@ export const MatterDetailHeader = ({
   const title = detail.title?.trim() || 'Untitled matter';
   const matterNumber = deriveMatterNumber(detail);
   const urgencyLabel = detail.urgency ? URGENCY_BREADCRUMB_LABEL[detail.urgency] : null;
-  const urgencyColor = detail.urgency ? URGENCY_COLOR_VAR[detail.urgency] : undefined;
+  const urgencyColorClass = detail.urgency ? URGENCY_COLOR_CLASS[detail.urgency] : undefined;
 
   const openedLabel = formatOpenedDate(detail.openDate);
   const openedDays = daysBetween(detail.openDate);
@@ -199,7 +199,7 @@ export const MatterDetailHeader = ({
         {urgencyLabel ? (
           <>
             <span className="text-dim-2" aria-hidden="true">·</span>
-            <span style={{ color: urgencyColor }}>{urgencyLabel}</span>
+            <span className={urgencyColorClass}>{urgencyLabel}</span>
           </>
         ) : null}
       </div>
@@ -207,7 +207,7 @@ export const MatterDetailHeader = ({
       {/* title row */}
       <div className="mt-1.5 grid grid-cols-1 items-end gap-4 lg:grid-cols-[1fr_auto] lg:gap-8">
         <div className="min-w-0">
-          <h1 className="font-[family-name:var(--serif)] text-[34px] font-normal leading-[1.05] tracking-tight text-ink sm:text-[44px]">
+          <h1 className="font-sans text-[34px] font-normal leading-[1.05] tracking-tight text-ink sm:text-[44px]">
             {title}
             {clientLabel ? (
               <>
@@ -253,21 +253,15 @@ export const MatterDetailHeader = ({
         </div>
       </div>
 
-      {/* Stat strip — 5-cell on lg+, 3-cell on <lg (per canonical Matter.html
-          1180px breakpoint). The DS .stat-strip CSS is hard-coded to 5 cols
-          via repeat(5, 1fr); on mobile we slice to 3 cells and override the
-          grid-template-columns inline so the strip doesn't show 2 empty
-          phantom cells. Authoring a responsive rule in index.css is out of
-          scope for this feature. */}
+      {/* Stat strip: 5 cells on lg+, 3 cells below lg. */}
       {statCells && statCells.length > 0 ? (
         <div className="mt-6">
           <div className="hidden lg:block">
             <StatStrip cells={statCells} />
           </div>
-          <div className="lg:hidden" style={{ ['--stat-cols' as string]: '3' }}>
+          <div className="lg:hidden">
             <div
-              className="stat-strip"
-              style={{ gridTemplateColumns: 'repeat(3, 1fr)' }}
+              className="stat-strip grid-cols-3"
               role="group"
             >
               {statCells.slice(0, 3).map((cell, idx) => (

--- a/src/features/matters/components/MatterDetailsPanel.tsx
+++ b/src/features/matters/components/MatterDetailsPanel.tsx
@@ -167,7 +167,7 @@ const SectionHeader = ({
   onCancel: () => void;
 }) => (
   <div className="mb-4 flex items-center justify-between">
-    <h4 className="font-serif text-sm font-semibold tracking-tight text-ink">
+    <h4 className="font-sans text-sm font-semibold tracking-tight text-ink">
       {title}
     </h4>
     {isEditing ? (
@@ -198,7 +198,7 @@ const SectionHeader = ({
         onClick={onEdit}
         icon={Pencil} iconClassName="h-4 w-4"
         className={cn(
-          'text-dim-2 transition-all',
+          'text-dim-2 transition-colors',
           'hover:bg-paper-2 hover:text-ink focus-visible:text-ink'
         )}
         aria-label={`Edit ${title.toLowerCase()}`}
@@ -382,7 +382,7 @@ export const MatterDetailsPanel = ({
   return (
     <div className="panel divide-y divide-white/[0.06]">
       <div className="flex items-center justify-between px-5 py-4">
-        <h3 className="font-serif text-sm font-semibold tracking-tight text-ink">Matter details</h3>
+        <h3 className="font-sans text-sm font-semibold tracking-tight text-ink">Matter details</h3>
         <span aria-hidden="true" className="h-px w-8 bg-gradient-to-r from-accent/0 via-accent/60 to-accent/0" />
       </div>
 

--- a/src/features/matters/components/MatterListItem.tsx
+++ b/src/features/matters/components/MatterListItem.tsx
@@ -18,7 +18,7 @@ export const MatterListItem = ({ matter, onSelect, isSelected = false }: MatterL
   const statusLabel = MATTER_STATUS_LABELS[matter.status];
 
   const rowClassName = cn(
-    'relative w-full text-left flex items-center gap-3 px-4 py-3 transition-all duration-150',
+    'relative w-full text-left flex items-center gap-3 px-4 py-3 transition-colors duration-150',
     isSelected ? SELECTED_ACCENT_SURFACE_CLASS : '',
     isInteractive ? 'hover:bg-paper-2 cursor-pointer' : 'cursor-default'
   );

--- a/src/features/matters/components/MatterStatusPopover.tsx
+++ b/src/features/matters/components/MatterStatusPopover.tsx
@@ -123,7 +123,7 @@ export const MatterStatusPopover = ({ currentStatus, onSelect, disabled }: Matte
         className={cn(
           'inline-flex items-center gap-2 rounded-full px-3 py-1.5',
           'text-sm font-medium ring-1 ring-inset',
-          'transition-all duration-150',
+          'transition-[filter,box-shadow] duration-150',
           'hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
           'disabled:opacity-50 disabled:cursor-not-allowed',
           colorClasses

--- a/src/features/matters/components/MatterSummaryCards.tsx
+++ b/src/features/matters/components/MatterSummaryCards.tsx
@@ -39,8 +39,8 @@ const summaryItemBase = 'min-w-0 flex flex-col gap-1';
 const gridBase = 'grid grid-cols-1 gap-x-4 gap-y-5 @lg:grid-cols-2 @3xl:grid-cols-4 @3xl:gap-x-6';
 const wrapperBase = 'card relative overflow-hidden rounded-[20px] @container p-5 sm:p-7';
 const labelClass = 'text-[10px] font-semibold uppercase tracking-[0.14em] text-dim-2';
-const kpiValueClass = 'font-serif text-[28px] font-bold leading-none tracking-tight tabular-nums text-ink';
-const denseValueClass = 'font-serif text-[24px] font-bold leading-none tracking-tight tabular-nums text-ink';
+const kpiValueClass = 'font-sans text-[28px] font-bold leading-none tracking-tight tabular-nums text-ink';
+const denseValueClass = 'font-sans text-[24px] font-bold leading-none tracking-tight tabular-nums text-ink';
 const iconSquareClass = 'inline-flex h-7 w-7 items-center justify-center rounded-lg border border-card-border bg-card text-accent';
 const revealClass = 'motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-300';
 
@@ -182,7 +182,7 @@ export const MatterSummaryCards = ({
                 size="xs"
                 onClick={() => onCreateInvoice?.()}
                 disabled={!onCreateInvoice}
-                className="w-full justify-center font-serif font-semibold tracking-wide"
+                className="w-full justify-center font-sans font-semibold tracking-wide"
               >
                 Invoice
               </Button>
@@ -248,13 +248,13 @@ export const MatterSummaryCards = ({
               <p className={cn(labelClass, 'leading-tight')}>{billingTypeLabel}</p>
             </div>
             {Array.isArray(billingRateLines) ? (
-              <div className="mt-3 space-y-1 font-serif text-base font-semibold leading-snug tabular-nums text-ink">
+              <div className="mt-3 space-y-1 font-sans text-base font-semibold leading-snug tabular-nums text-ink">
                 {billingRateLines.map((line) => (
                   <p key={line}>{line}</p>
                 ))}
               </div>
             ) : (
-              <p className="mt-3 font-serif text-lg font-semibold leading-snug tabular-nums text-ink">{billingRateLines}</p>
+              <p className="mt-3 font-sans text-lg font-semibold leading-snug tabular-nums text-ink">{billingRateLines}</p>
             )}
           </div>
           <div
@@ -275,7 +275,7 @@ export const MatterSummaryCards = ({
               size="md"
               onClick={() => onCreateInvoice?.()}
               disabled={!onCreateInvoice}
-              className="justify-center rounded-full px-8 font-serif font-semibold tracking-wide shadow-sm"
+              className="justify-center rounded-full px-8 font-sans font-semibold tracking-wide shadow-sm"
             >
               Invoice
             </Button>

--- a/src/features/matters/components/MatterTab.tsx
+++ b/src/features/matters/components/MatterTab.tsx
@@ -152,7 +152,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
     <div>
       {/* Matter Header */}
       <div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <div className="flex items-center gap-2">
           <h3>{matter.matterNumber || 'Matter'}</h3>
           <MatterStatusBadge status={badgeStatus} />
         </div>
@@ -169,7 +169,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
             }
           })();
           return (
-            <p style={{ fontSize: '0.85rem', color: 'var(--gray-500)' }}>
+            <p className="text-[0.85rem] text-dim">
               {msg}
             </p>
           );
@@ -279,7 +279,7 @@ const MatterTab: FunctionComponent<MatterTabProps> = ({
         multiple
         accept=".pdf,.doc,.docx,.txt,.jpg,.jpeg,.png,.gif,.webp"
         onChange={handleDocumentIconUpload}
-        style={{ display: 'none' }}
+        className="hidden"
       />
     </div>
   );

--- a/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
+++ b/src/features/matters/components/time-entries/WorkDiaryCalendar.tsx
@@ -77,8 +77,7 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
       <div className="text-sm font-semibold text-ink text-center">{monthLabel}</div>
 
       <div
-        className="mt-4 grid gap-2 text-center text-[11px] font-medium text-dim-2 justify-items-center"
-        style={{ gridTemplateColumns: 'repeat(7, minmax(0, 1fr))' }}
+        className="mt-4 grid grid-cols-7 justify-items-center gap-2 text-center text-[11px] font-medium text-dim-2"
       >
         {WEEKDAYS.map((day) => (
           <div key={day}>{day}</div>
@@ -86,8 +85,7 @@ export const WorkDiaryCalendar = ({ selectedWeekStart, onSelectWeek }: WorkDiary
       </div>
 
       <div
-        className="mt-2 grid gap-2 justify-items-center"
-        style={{ gridTemplateColumns: 'repeat(7, minmax(0, 1fr))' }}
+        className="mt-2 grid grid-cols-7 justify-items-center gap-2"
       >
         {calendarDays.map((day) => {
           const isCurrentMonth = day.getUTCMonth() === monthStart.getUTCMonth();

--- a/src/features/matters/pages/ClientMattersPage.tsx
+++ b/src/features/matters/pages/ClientMattersPage.tsx
@@ -436,7 +436,7 @@ export const ClientMattersPage = ({
                   className={[
                     'relative px-3 py-3 text-sm font-medium whitespace-nowrap',
                     'transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-t-sm',
-                    'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-all after:duration-150',
+                    'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-colors after:duration-150',
                     isActive
                       ? 'text-ink after:bg-accent'
                       : 'text-dim-2 hover:text-ink after:bg-transparent hover:after:bg-line-subtle'

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -2519,7 +2519,6 @@ export const PracticeMattersPage = ({
                   onClick={() => toggleFilter(chip.id)}
                   aria-pressed={isOn}
                   className={isOn ? filterChipActiveClass : filterChipInactiveClass}
-                  style={isOn ? { color: 'var(--ink)' } : undefined}
                 >
                   {chip.label}
                   {isOn ? <span className="text-dim-2">×</span> : null}
@@ -2605,7 +2604,7 @@ export const PracticeMattersPage = ({
             </div>
           ) : viewMode === 'timeline' ? (
             <div className="panel px-6 py-16 text-center">
-              <p className="font-[family-name:var(--serif)] text-lg text-ink">Timeline view</p>
+              <p className="font-sans text-lg text-ink">Timeline view</p>
               <p className="mt-2 text-sm text-dim-2">
                 Coming soon — a chronological lane of matter activity grouped by week.
               </p>
@@ -2658,7 +2657,6 @@ export const PracticeMattersPage = ({
                   onClick={() => toggleFilter(chip.id)}
                   aria-pressed={isOn}
                   className={isOn ? mobileFilterChipActiveClass : mobileFilterChipInactiveClass}
-                  style={isOn ? { color: 'var(--ink)' } : undefined}
                 >
                   <span>{chip.label}</span>
                   {isOn ? <span className="font-mono text-xs text-dim-2">×</span> : null}
@@ -2796,7 +2794,7 @@ function MattersTable({
               >
                 {/* Matter (title + sub) */}
                 <div className="min-w-0">
-                  <div className="truncate font-[family-name:var(--serif)] text-[17px] leading-tight text-ink">
+                  <div className="truncate font-sans text-[17px] leading-tight text-ink">
                     {summary.title}
                   </div>
                   <div className="mt-1 truncate font-mono text-xs text-dim">
@@ -2925,7 +2923,7 @@ function MattersBoard({
                       {row.caseNumber ?? 'BLB-—'}
                       {row.summary.practiceArea ? <> · {row.summary.practiceArea}</> : null}
                     </div>
-                    <div className="font-[family-name:var(--serif)] text-[15px] leading-tight text-ink">
+                    <div className="font-sans text-[15px] leading-tight text-ink">
                       {row.summary.title}
                     </div>
                     <div className="mt-1.5 flex items-center justify-between">

--- a/src/features/media/components/AudioRecordingUI.tsx
+++ b/src/features/media/components/AudioRecordingUI.tsx
@@ -331,7 +331,7 @@ const AudioRecordingUI: FunctionComponent<AudioRecordingUIProps> = ({
                 onClick={onCancel}
                 aria-label="Cancel recording"
                 title="Cancel recording"
-                className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-all duration-200 text-dim-2 hover:text-red-400 bg-paper-2/5 hover:bg-red-500/10 animate-zoom-in"
+                className="flex items-center justify-center w-8 h-8 p-1.5 border-none rounded-full cursor-pointer transition-colors duration-200 text-dim-2 hover:text-red-400 bg-paper-2/5 hover:bg-red-500/10 animate-zoom-in"
             >
                 <Icon icon={X} className="w-5 h-5" aria-hidden="true"  />
             </Button>
@@ -351,7 +351,7 @@ const AudioRecordingUI: FunctionComponent<AudioRecordingUIProps> = ({
                 aria-label="Confirm and send recording"
                 title="Confirm and send recording"
                 ref={confirmBtnRef}
-                className="flex items-center justify-center w-8 h-8 p-1.5 rounded-full shadow-lg shadow-accent/20 cursor-pointer transition-all duration-200 animate-zoom-in hover:scale-110 active:scale-95"
+                className="flex items-center justify-center w-8 h-8 p-1.5 rounded-full shadow-lg shadow-accent/20 cursor-pointer transition-transform duration-200 animate-zoom-in hover:scale-110 active:scale-95"
             >
                 <Icon icon={Check} className="w-5 h-5" aria-hidden="true"  />
             </Button>

--- a/src/features/media/components/FileMenu.tsx
+++ b/src/features/media/components/FileMenu.tsx
@@ -159,7 +159,7 @@ const FileMenu: FunctionComponent<FileMenuProps> = ({
           aria-labelledby="attachment-menu-button"
           className={`
             absolute bottom-full left-0 mb-2 min-w-[220px]
-            p-1 rounded-r-md border border-line-subtle bg-card/95 backdrop-blur-2xl shadow-glass transition-all duration-200
+            p-1 rounded-r-md border border-line-subtle bg-card/95 backdrop-blur-2xl shadow-glass transition-[opacity,transform] duration-200
             ${isClosing ? 'opacity-0 scale-95 pointer-events-none' : 'opacity-100 scale-100'}
           `}
           style={{ zIndex: THEME.zIndex.fileMenu }}

--- a/src/features/media/components/MediaSidebar.tsx
+++ b/src/features/media/components/MediaSidebar.tsx
@@ -107,7 +107,7 @@ const MediaRow: FunctionComponent<MediaRowProps> = ({ media, onPreview, onError 
       role="button"
       tabIndex={0}
       aria-busy={busy}
-      className="cursor-pointer transition-all duration-200 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-accent/50 rounded-r-md"
+      className="cursor-pointer transition-[transform,box-shadow] duration-200 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-accent/50 rounded-r-md"
       onClick={() => { void handleActivate(); }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {

--- a/src/features/modals/components/CameraCaptureButton.tsx
+++ b/src/features/modals/components/CameraCaptureButton.tsx
@@ -16,7 +16,7 @@ const CameraCaptureButton: FunctionComponent<CameraCaptureButtonProps> = ({ onCl
       onClick={onClick}
       disabled={disabled}
       title="Take photo"
-      className={`cursor-pointer flex items-center justify-center transition-all duration-200 w-20 h-20 rounded-full panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-paper-2/10 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
+      className={`cursor-pointer flex items-center justify-center transition-[background-color,box-shadow,opacity] duration-200 w-20 h-20 rounded-full panel p-0 relative disabled:opacity-50 disabled:cursor-not-allowed hover:bg-paper-2/10 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-surface-base ${className || ''}`}
       aria-label="Take photo"
     >
       <Icon icon={Camera} className="w-16 h-16 text-ink"  />

--- a/src/features/modals/components/CameraDialog.tsx
+++ b/src/features/modals/components/CameraDialog.tsx
@@ -128,7 +128,7 @@ const CameraDialog: FunctionComponent<CameraDialogProps> = ({
         )}
         <div className="relative w-full h-full overflow-hidden bg-paper flex-grow border-t border-line-subtle">
           <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-cover" />
-          <canvas ref={canvasRef} style={{ display: 'none' }} />
+          <canvas ref={canvasRef} className="hidden" />
         </div>
         <div className="absolute bottom-10 left-0 right-0 flex justify-center items-center py-4 z-10">
           <CameraCaptureButton onClick={takePhoto} disabled={!isCameraReady} />

--- a/src/features/onboarding/components/AssistantTurn.tsx
+++ b/src/features/onboarding/components/AssistantTurn.tsx
@@ -26,54 +26,22 @@ export const AssistantTurn = ({
   return (
     <div className="grid grid-cols-[40px_1fr] items-start gap-4">
       <div
-        className="grid h-10 w-10 place-items-center rounded-full text-base font-medium"
-        style={{
-          background: 'var(--paper)',
-          boxShadow: '0 0 0 6px var(--paper)',
-        }}
+        className="grid h-10 w-10 place-items-center rounded-full bg-paper text-base font-medium shadow-[0_0_0_6px_var(--paper)]"
         aria-hidden="true"
       >
         <Logo size="md" showText={false} />
       </div>
-      <div
-        className="card"
-        style={{
-          padding: '18px 20px',
-          maxWidth: '64ch',
-          boxShadow: 'var(--shadow-2)'
-        }}
-      >
-        <div
-          className="mb-2.5 flex items-center gap-2"
-          style={{
-            fontFamily: 'var(--mono)',
-            fontSize: '10px',
-            letterSpacing: '0.1em',
-            textTransform: 'uppercase',
-            color: 'var(--dim)'
-          }}
-        >
+      <div className="card max-w-[64ch] px-5 py-[18px] shadow-[var(--shadow-2)]">
+        <div className="mb-2.5 flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
           <span>{label}</span>
           {trail && (
-            <span
-              className="inline-flex items-center gap-1"
-              style={{ color: 'var(--pos)' }}
-            >
-              <span
-                className="h-[5px] w-[5px] rounded-full"
-                style={{ background: 'var(--pos)' }}
-              />
+            <span className="inline-flex items-center gap-1 text-pos">
+              <span className="h-[5px] w-[5px] rounded-full bg-pos" />
               {trail}
             </span>
           )}
         </div>
-        <div
-          style={{
-            color: 'var(--ink)',
-            fontSize: '15px',
-            lineHeight: 1.55
-          }}
-        >
+        <div className="text-[15px] leading-[1.55] text-ink">
           {children}
         </div>
       </div>

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -375,14 +375,7 @@ const OnboardingFlowImpl = ({
   const resolvedTestId = testId ?? 'onboarding-flow';
 
   return (
-    <div
-      className={`min-h-screen w-full ${className}`}
-      data-testid={resolvedTestId}
-      style={{
-        background:
-          'radial-gradient(ellipse 1200px 800px at 80% -10%, color-mix(in oklab, var(--accent) 18%, transparent), transparent 60%), var(--paper)'
-      }}
-    >
+    <div className={`min-h-screen w-full bg-paper ${className}`} data-testid={resolvedTestId}>
       <div className="mx-auto grid min-h-screen w-full max-w-[1440px] grid-cols-1 lg:grid-cols-[340px_1fr]">
         <ProgressSidebar
           currentStep={step}
@@ -390,17 +383,14 @@ const OnboardingFlowImpl = ({
           onStepSelect={enableSidebarStepSelect ? setStep : undefined}
         />
 
-        <main
-          className="flex min-h-screen flex-col gap-9 px-6 py-10 lg:px-20 lg:py-16"
-          style={{ maxWidth: '940px' }}
-        >
+        <main className="flex min-h-screen max-w-[940px] flex-col gap-9 px-6 py-10 lg:px-20 lg:py-16">
           <ProgressPips currentStep={step} />
 
           {step === 1 && (
             <>
               <StageHeader
                 crumb={CRUMB[1]}
-                title={<>So, let&apos;s <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>start</em> with you.</>}
+                title={<>So, let&apos;s <em className="italic text-accent">start</em> with you.</>}
                 lede={
                   <>
                     We&apos;ll use your name on engagement letters and your birthday for
@@ -410,9 +400,9 @@ const OnboardingFlowImpl = ({
                 }
               />
               <AssistantTurn trail="private to you">
-                <p style={{ margin: 0 }}>
+                <p className="m-0">
                   I see you just signed up. Let&apos;s get the basics, then we&apos;ll set up
-                  your practice — should take about <em style={{ color: 'var(--accent-deep)', fontStyle: 'italic' }}>two minutes</em>.
+                  your practice — should take about <em className="italic text-accent-deep">two minutes</em>.
                 </p>
               </AssistantTurn>
               <AboutYouStep
@@ -433,7 +423,7 @@ const OnboardingFlowImpl = ({
             <>
               <StageHeader
                 crumb={CRUMB[3]}
-                title={<>Set up <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>Business</em>.</>}
+                title={<>Set up <em className="italic text-accent">Business</em>.</>}
                 lede={
                   <>
                     This is the same Business plan surface you&apos;ll use before heading
@@ -442,7 +432,7 @@ const OnboardingFlowImpl = ({
                 }
               />
               <AssistantTurn trail="shared workspace">
-                <p style={{ margin: 0 }}>
+                <p className="m-0">
                   Business gives you the shared practice workspace, pricing, and
                   billing setup this flow expects. If you&apos;re reviewing styling,
                   this step should now mirror the existing pricing screen instead
@@ -468,7 +458,7 @@ const OnboardingFlowImpl = ({
             <>
               <StageHeader
                 crumb={CRUMB[2]}
-                title={<>Now — what&apos;s your <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>practice</em> called?</>}
+                title={<>Now — what&apos;s your <em className="italic text-accent">practice</em> called?</>}
                 lede={
                   <>
                     Your practice is the workspace your team and clients see. Pick a
@@ -478,7 +468,7 @@ const OnboardingFlowImpl = ({
                 }
               />
               <AssistantTurn trail="grounding context">
-                <p style={{ margin: 0 }}>
+                <p className="m-0">
                   {firstName ? <>Got it, <strong>{firstName}</strong>. </> : 'Got it. '}
                   Add the practice name clients should see. We&apos;ll use the
                   jurisdiction, service areas, and practice type to qualify leads
@@ -500,7 +490,7 @@ const OnboardingFlowImpl = ({
             <>
               <StageHeader
                 crumb={CRUMB[4]}
-                title={<>Get <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>paid</em> — properly.</>}
+                title={<>Get <em className="italic text-accent">paid</em> — properly.</>}
                 lede={
                   <>
                     Connect the Stripe account where payouts from invoices,
@@ -511,7 +501,7 @@ const OnboardingFlowImpl = ({
                 }
               />
               <AssistantTurn trail="payout routing">
-                <p style={{ margin: 0 }}>
+                <p className="m-0">
                   Blawby uses this connected account for money movement: client
                   payments are processed by Stripe, then paid out to the bank account
                   your practice designates. Use the appropriate operating or
@@ -538,7 +528,7 @@ const OnboardingFlowImpl = ({
             <>
               <StageHeader
                 crumb={CRUMB[5]}
-                title={<>Your intake form is <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>ready.</em></>}
+                title={<>Your intake form is <em className="italic text-accent">ready.</em></>}
                 lede={
                   <>
                     This is what clients see when they reach out. The required fields
@@ -548,7 +538,7 @@ const OnboardingFlowImpl = ({
                 }
               />
               <AssistantTurn trail="seeded for your practice">
-                <p style={{ margin: 0 }}>
+                <p className="m-0">
                   I&apos;ve set up a general consultation intake tuned to your practice areas.
                   Once you&apos;re in your workspace you can rename it, add custom fields, or
                   create forms for different matter types.
@@ -573,7 +563,7 @@ const OnboardingFlowImpl = ({
             <>
               <StageHeader
                 crumb={CRUMB[6]}
-                title={<>You&apos;re <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>live</em>.</>}
+                title={<>You&apos;re <em className="italic text-accent">live</em>.</>}
                 lede={
                   <>
                     Your intake link is ready. Share it directly, embed it on your
@@ -583,10 +573,10 @@ const OnboardingFlowImpl = ({
                 }
               />
               <AssistantTurn trail="ready for clients">
-                <p style={{ margin: 0 }}>
+                <p className="m-0">
                   Everything is set up. The next thing you&apos;ll see is your
                   workspace — your intake link is already accepting traffic, and
-                  I&apos;ll prompt you to <em style={{ color: 'var(--accent-deep)', fontStyle: 'italic' }}>connect Stripe</em> as
+                  I&apos;ll prompt you to <em className="italic text-accent-deep">connect Stripe</em> as
                   your first action there.
                 </p>
               </AssistantTurn>

--- a/src/features/onboarding/components/ProgressSidebar.tsx
+++ b/src/features/onboarding/components/ProgressSidebar.tsx
@@ -71,27 +71,14 @@ const getStepState = (
   return 'next';
 };
 
-const indicatorStyles = (state: 'done' | 'now' | 'next') => {
+const indicatorClasses = (state: 'done' | 'now' | 'next') => {
   if (state === 'done') {
-    return {
-      background: 'var(--ink)',
-      border: '1px solid var(--ink)',
-      color: 'var(--accent)'
-    };
+    return 'border-ink bg-ink text-accent';
   }
   if (state === 'now') {
-    return {
-      background: 'var(--accent)',
-      border: '1px solid var(--accent)',
-      color: 'var(--accent-ink)',
-      boxShadow: '0 0 0 4px var(--accent-soft)'
-    };
+    return 'border-accent bg-accent text-accent-ink shadow-[0_0_0_4px_var(--accent-soft)]';
   }
-  return {
-    background: 'var(--card)',
-    border: '1px solid var(--rule)',
-    color: 'var(--dim)'
-  };
+  return 'border-rule bg-card text-dim';
 };
 
 const getMobileState = (
@@ -109,23 +96,11 @@ export const ProgressSidebar = ({
   onStepSelect
 }: ProgressSidebarProps) => {
   return (
-    <aside
-      className="hidden lg:flex lg:flex-col lg:w-[340px] lg:shrink-0 lg:border-r lg:border-rule lg:px-8 lg:pt-9 lg:pb-8"
-      style={{ background: 'color-mix(in oklab, var(--paper) 96%, var(--card))' }}
-    >
+    <aside className="hidden bg-[color-mix(in_oklab,var(--paper)_96%,var(--card))] lg:flex lg:w-[340px] lg:shrink-0 lg:flex-col lg:border-r lg:border-rule lg:px-8 lg:pb-8 lg:pt-9">
       <div>
         <Logo size="md" />
-        <p
-          className="mt-7 max-w-[22ch] text-balance"
-          style={{
-            fontFamily: 'var(--serif)',
-            fontSize: '26px',
-            lineHeight: 1.15,
-            letterSpacing: '-0.012em',
-            color: 'var(--ink)'
-          }}
-        >
-          Let&apos;s get your practice <em style={{ color: 'var(--accent)', fontStyle: 'italic' }}>running itself</em>.
+        <p className="mt-7 max-w-[22ch] text-balance font-sans text-[26px] leading-[1.15] tracking-[-0.012em] text-ink">
+          Let&apos;s get your practice <em className="italic text-accent">running itself</em>.
         </p>
       </div>
 
@@ -144,65 +119,27 @@ export const ProgressSidebar = ({
                 !canClick ? undefined : () => onStepSelect?.(step.clickStep as OnboardingStep)
               }
               disabled={!canClick}
-              className="relative grid grid-cols-[24px_1fr] gap-3.5 rounded-r-md px-3 py-3.5 text-left"
-              style={{
-                cursor: canClick ? 'pointer' : 'default',
-                opacity: 1,
-                background: 'transparent',
-                border: 0
-              }}
+              className={`relative grid grid-cols-[24px_1fr] gap-3.5 rounded-r-md border-0 bg-transparent px-3 py-3.5 text-left opacity-100 ${canClick ? 'cursor-pointer' : 'cursor-default'}`}
             >
               {index < SIDEBAR_STEPS.length - 1 && (
                 <span
                   aria-hidden="true"
-                  className="absolute"
-                  style={{
-                    left: '23px',
-                    top: '38px',
-                    bottom: '-2px',
-                    width: '1px',
-                    background: state === 'done' ? 'var(--ink)' : 'var(--rule)'
-                  }}
+                  className={`absolute bottom-[-2px] left-[23px] top-[38px] w-px ${state === 'done' ? 'bg-ink' : 'bg-rule'}`}
                 />
               )}
 
               <span
                 aria-hidden="true"
-                className="relative z-[1] grid h-6 w-6 place-items-center rounded-full"
-                style={{
-                  fontFamily: 'var(--mono)',
-                  fontSize: '11px',
-                  ...indicatorStyles(state)
-                }}
+                className={`relative z-[1] grid h-6 w-6 place-items-center rounded-full border font-mono text-[11px] ${indicatorClasses(state)}`}
               >
                 {indicatorLabel}
               </span>
 
               <span className="flex min-w-0 flex-col gap-0.5">
-                <span
-                  style={{
-                    fontSize: '14px',
-                    fontWeight: 500,
-                    color:
-                      step.row === 3 && state === 'now'
-                        ? 'var(--accent-deep)'
-                        : state === 'done'
-                          ? 'var(--ink-2)'
-                          : 'var(--ink)',
-                    textDecoration:
-                      state === 'done' && step.row !== 3 ? 'line-through' : 'none',
-                    textDecorationColor: 'var(--dim-2)'
-                  }}
-                >
+                <span className={`text-sm font-medium decoration-dim-2 ${step.row === 3 && state === 'now' ? 'text-accent-deep' : state === 'done' ? 'text-ink-2' : 'text-ink'} ${state === 'done' && step.row !== 3 ? 'line-through' : ''}`}>
                   {step.title}
                 </span>
-                <span
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--dim)',
-                    lineHeight: 1.35
-                  }}
-                >
+                <span className="text-xs leading-[1.35] text-dim">
                   {step.description}
                 </span>
               </span>
@@ -211,14 +148,7 @@ export const ProgressSidebar = ({
         })}
       </nav>
 
-      <div
-        className="mt-auto"
-        style={{
-          fontFamily: 'var(--mono)',
-          fontSize: '11px',
-          color: 'var(--dim)'
-        }}
-      >
+      <div className="mt-auto font-mono text-[11px] text-dim">
         Step {getSidebarPosition(currentStep)} of 6
       </div>
     </aside>
@@ -241,14 +171,7 @@ export const ProgressPips = ({ currentStep }: ProgressSidebarProps) => {
           <li
             key={step}
             aria-current={isActive ? 'step' : undefined}
-            className="h-1.5 flex-1 rounded-full"
-            style={{
-              background: isActive
-                ? 'var(--accent)'
-                : isDone
-                  ? 'var(--ink)'
-                  : 'var(--rule)'
-            }}
+            className={`h-1.5 flex-1 rounded-full ${isActive ? 'bg-accent' : isDone ? 'bg-ink' : 'bg-rule'}`}
             title={`Step ${step}`}
           />
         );

--- a/src/features/onboarding/components/StageFooter.tsx
+++ b/src/features/onboarding/components/StageFooter.tsx
@@ -33,25 +33,13 @@ export const StageFooter = ({
   skipLabel = "Skip — I'll set this up later"
 }: StageFooterProps) => {
   return (
-    <div
-      className="mt-auto flex items-center justify-between gap-4 pt-6"
-      style={{ borderTop: '1px solid var(--rule)' }}
-    >
+    <div className="mt-auto flex items-center justify-between gap-4 border-t border-rule pt-6">
       {onSkip ? (
         <button
           type="button"
           onClick={onSkip}
           disabled={isSubmitting}
-          className="bg-transparent border-0 cursor-pointer py-1"
-          style={{
-            fontFamily: 'var(--mono)',
-            fontSize: '11px',
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-            color: 'var(--dim)',
-            borderBottom: '1px dotted var(--dim-2)',
-            padding: '4px 0'
-          }}
+          className="cursor-pointer border-0 border-b border-dotted border-dim-2 bg-transparent py-1 font-mono text-[11px] uppercase tracking-[0.08em] text-dim"
         >
           {skipLabel}
         </button>

--- a/src/features/onboarding/components/StageHeader.tsx
+++ b/src/features/onboarding/components/StageHeader.tsx
@@ -3,7 +3,7 @@ import type { ComponentChildren } from 'preact';
 interface StageHeaderProps {
   /** Mono crumb above the title — e.g. "Step 3 of 6 · About your practice". */
   crumb: string;
-  /** Serif H1; pass an accent <em> inside for the gold word. */
+  /** Sans H1; pass an accent <em> inside for the gold word. */
   title: ComponentChildren;
   /** Lede paragraph (≤ 56ch). */
   lede: ComponentChildren;
@@ -15,42 +15,13 @@ interface StageHeaderProps {
 export const StageHeader = ({ crumb, title, lede }: StageHeaderProps) => {
   return (
     <div className="flex flex-col gap-4">
-      <p
-        style={{
-          fontFamily: 'var(--mono)',
-          fontSize: '10px',
-          letterSpacing: '0.14em',
-          textTransform: 'uppercase',
-          color: 'var(--dim)',
-          margin: 0
-        }}
-      >
+      <p className="m-0 font-mono text-[10px] uppercase tracking-[0.14em] text-dim">
         {crumb}
       </p>
-      <h1
-        className="text-balance"
-        style={{
-          fontFamily: 'var(--serif)',
-          fontWeight: 400,
-          fontSize: 'clamp(40px, 6vw, 64px)',
-          lineHeight: 1,
-          letterSpacing: '-0.025em',
-          margin: 0,
-          maxWidth: '18ch',
-          color: 'var(--ink)'
-        }}
-      >
+      <h1 className="m-0 max-w-[18ch] text-balance font-sans text-[clamp(40px,6vw,64px)] font-normal leading-none tracking-[-0.025em] text-ink">
         {title}
       </h1>
-      <p
-        style={{
-          fontSize: '18px',
-          lineHeight: 1.55,
-          color: 'var(--ink-2)',
-          maxWidth: '56ch',
-          margin: 0
-        }}
-      >
+      <p className="m-0 max-w-[56ch] text-lg leading-[1.55] text-ink-2">
         {lede}
       </p>
     </div>

--- a/src/features/onboarding/steps/AboutYouStep.tsx
+++ b/src/features/onboarding/steps/AboutYouStep.tsx
@@ -18,21 +18,8 @@ export const AboutYouStep = ({ draft, requireName, onChange }: AboutYouStepProps
   const today = new Date().toISOString().split('T')[0];
 
   return (
-    <section
-      className="card"
-      style={{ padding: '28px' }}
-    >
-      <h2
-        style={{
-          fontFamily: 'var(--serif)',
-          fontWeight: 400,
-          fontSize: '28px',
-          lineHeight: 1.15,
-          letterSpacing: '-0.01em',
-          margin: '0 0 18px',
-          color: 'var(--ink)'
-        }}
-      >
+    <section className="card p-7">
+      <h2 className="mb-[18px] font-sans text-[28px] font-normal leading-[1.15] tracking-[-0.01em] text-ink">
         About you
       </h2>
 

--- a/src/features/onboarding/steps/IntakeFormStep.tsx
+++ b/src/features/onboarding/steps/IntakeFormStep.tsx
@@ -111,8 +111,8 @@ export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) 
 
   if (error || !template) {
     return (
-      <div className="card" style={{ padding: '22px' }}>
-        <p className="text-sm" style={{ color: 'var(--neg)' }}>
+      <div className="card p-[22px]">
+        <p className="text-sm text-neg">
           {error ?? 'No intake form found. You can create one from Settings -> Intake forms.'}
         </p>
       </div>
@@ -129,12 +129,12 @@ export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) 
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="card overflow-hidden" style={{ padding: 0 }}>
+      <div className="card overflow-hidden p-0">
         <div className="border-b border-[var(--rule)] px-5 py-4">
           <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
             Client preview
           </div>
-          <div className="mt-1 font-serif text-[24px] leading-tight tracking-[-0.01em] text-ink">
+          <div className="mt-1 font-sans text-[24px] leading-tight tracking-[-0.01em] text-ink">
             {template.name}
           </div>
           <p className="mt-2 max-w-[58ch] text-sm leading-6 text-ink-2">
@@ -179,7 +179,7 @@ export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) 
           {enrichmentFields.length > 0 && (
             <div className="mt-6 rounded-sm border border-[var(--rule)] bg-[var(--card)] p-4">
               <div className="flex items-center gap-2">
-                <Icon icon={Sparkles} className="h-3.5 w-3.5" style={{ color: 'var(--accent-deep)' }} />
+                <Icon icon={Sparkles} className="h-3.5 w-3.5 text-accent-deep" />
                 <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
                   AI follow-up questions
                 </span>
@@ -197,9 +197,9 @@ export const IntakeFormStep = ({ draft, onTemplateReady }: IntakeFormStepProps) 
         </div>
       </div>
 
-      <p style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--dim)', letterSpacing: '0.02em' }}>
+      <p className="font-mono text-[11px] tracking-[0.02em] text-dim">
         You can rename this form, edit these questions, and add custom questions from{' '}
-        <strong style={{ color: 'var(--ink-2)' }}>Settings {'->'} Intake forms</strong>{' '}
+        <strong className="text-ink-2">Settings {'->'} Intake forms</strong>{' '}
         any time after setup.
       </p>
     </div>

--- a/src/features/onboarding/steps/PaymentsStep.tsx
+++ b/src/features/onboarding/steps/PaymentsStep.tsx
@@ -69,56 +69,23 @@ export const PaymentsStep = ({
   };
 
   return (
-    <section className="card" style={{ padding: '28px' }}>
-      <h2
-        style={{
-          fontFamily: 'var(--serif)',
-          fontWeight: 400,
-          fontSize: '28px',
-          lineHeight: 1.15,
-          letterSpacing: '-0.01em',
-          margin: '0 0 18px',
-          color: 'var(--ink)'
-        }}
-      >
+    <section className="card p-7">
+      <h2 className="mb-[18px] font-sans text-[28px] font-normal leading-[1.15] tracking-[-0.01em] text-ink">
         Payments &amp; payouts
       </h2>
 
-      <div
-        className="flex flex-col gap-4 rounded-md border p-4 sm:flex-row sm:items-center"
-        style={{
-          background: 'var(--card)',
-          borderColor: 'var(--rule)',
-          borderRadius: 'var(--r-md)'
-        }}
-      >
+      <div className="flex flex-col gap-4 rounded-[var(--r-md)] border border-rule bg-card p-4 sm:flex-row sm:items-center">
         <div
-          className="grid h-10 w-10 shrink-0 place-items-center rounded"
-          style={{
-            background: 'var(--ink)',
-            color: 'var(--paper)',
-            fontWeight: 700,
-            fontFamily: 'var(--sans)',
-            fontSize: '18px'
-          }}
+          className="grid h-10 w-10 shrink-0 place-items-center rounded bg-ink font-sans text-lg font-bold text-paper"
           aria-hidden="true"
         >
           S
         </div>
         <div className="min-w-0 flex-1">
-          <h4
-            style={{
-              fontFamily: 'var(--serif)',
-              fontWeight: 400,
-              fontSize: '18px',
-              margin: 0,
-              lineHeight: 1.2,
-              color: 'var(--ink)'
-            }}
-          >
+          <h4 className="m-0 font-sans text-lg font-normal leading-[1.2] text-ink">
             Set up payouts to get paid
           </h4>
-          <p className="mt-1 text-sm" style={{ color: 'var(--dim)', maxWidth: '50ch' }}>
+          <p className="mt-1 max-w-[50ch] text-sm text-dim">
             Connect your bank account with Stripe so you can accept payments and
             receive payouts.
           </p>
@@ -133,30 +100,22 @@ export const PaymentsStep = ({
         </Button>
       </div>
 
-      <div
-        className="mt-6 rounded-md border p-4 text-sm"
-        style={{
-          background: 'var(--accent-soft)',
-          borderColor: 'color-mix(in oklab, var(--accent) 30%, var(--rule))',
-          borderRadius: 'var(--r-md)',
-          color: 'var(--ink-2)'
-        }}
-      >
+      <div className="mt-6 rounded-[var(--r-md)] border border-[color-mix(in_oklab,var(--accent)_30%,var(--rule))] bg-[var(--accent-soft)] p-4 text-sm text-ink-2">
         Stripe opens a secure hosted flow for business and representative
         verification. You can return here after Stripe sends you back.
       </div>
 
-      <ul className="mt-6 flex flex-col gap-3 text-sm" style={{ color: 'var(--ink-2)' }}>
+      <ul className="mt-6 flex flex-col gap-3 text-sm text-ink-2">
         <li className="flex items-start gap-2">
-          <Icon icon={CheckCircle2} className="h-4 w-4 mt-0.5" style={{ color: 'var(--pos)' }} />
+          <Icon icon={CheckCircle2} className="mt-0.5 h-4 w-4 text-pos" />
           <span>Connect Stripe to receive payouts for your practice</span>
         </li>
         <li className="flex items-start gap-2">
-          <Icon icon={CheckCircle2} className="h-4 w-4 mt-0.5" style={{ color: 'var(--pos)' }} />
+          <Icon icon={CheckCircle2} className="mt-0.5 h-4 w-4 text-pos" />
           <span>Stripe will verify your business and representative details before enabling payouts</span>
         </li>
         <li className="flex items-start gap-2">
-          <Icon icon={CheckCircle2} className="h-4 w-4 mt-0.5" style={{ color: 'var(--pos)' }} />
+          <Icon icon={CheckCircle2} className="mt-0.5 h-4 w-4 text-pos" />
           <span>You can also finish setup later from Payouts &amp; billing settings</span>
         </li>
       </ul>

--- a/src/features/onboarding/steps/PracticeStep.tsx
+++ b/src/features/onboarding/steps/PracticeStep.tsx
@@ -115,18 +115,8 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
 
   return (
     <section className="flex flex-col gap-5">
-      <div className="card" style={{ padding: '28px' }}>
-        <h2
-          style={{
-            fontFamily: 'var(--serif)',
-            fontWeight: 400,
-            fontSize: '28px',
-            lineHeight: 1.15,
-            letterSpacing: '-0.01em',
-            margin: '0 0 18px',
-            color: 'var(--ink)'
-          }}
-        >
+      <div className="card p-7">
+        <h2 className="mb-[18px] font-sans text-[28px] font-normal leading-[1.15] tracking-[-0.01em] text-ink">
           Practice profile
         </h2>
 
@@ -145,7 +135,7 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
               icon={Building2}
               iconClassName="h-5 w-5 text-dim-2"
             />
-            <p className="mt-1 text-xs" style={{ color: 'var(--dim)' }}>
+            <p className="mt-1 text-xs text-dim">
               {publicOrigin}/p/{computedSlug || 'your-practice'}
             </p>
           </div>
@@ -198,8 +188,7 @@ export const PracticeStep = ({ draft, onChange }: PracticeStepProps) => {
                     <span>{group.type}</span>
                     {selectedCount > 0 && (
                       <span
-                        className="rounded-sm border border-line px-1.5 py-0.5 text-[10px] tracking-normal"
-                        style={{ color: 'var(--dim)' }}
+                        className="rounded-sm border border-line px-1.5 py-0.5 text-[10px] tracking-normal text-dim"
                         aria-label={`${selectedCount} selected`}
                       >
                         {selectedCount}

--- a/src/features/onboarding/steps/ShareIntakeStep.tsx
+++ b/src/features/onboarding/steps/ShareIntakeStep.tsx
@@ -57,32 +57,13 @@ export const ShareIntakeStep = ({ draft }: ShareIntakeStepProps) => {
 
   return (
     <section className="flex flex-col gap-6">
-      <div
-        className="card flex flex-col gap-4"
-        style={{ padding: '28px' }}
-      >
+      <div className="card flex flex-col gap-4 p-7">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
-            <p
-              style={{
-                fontFamily: 'var(--mono)',
-                fontSize: '10px',
-                letterSpacing: '0.1em',
-                textTransform: 'uppercase',
-                color: 'var(--dim)',
-                margin: 0
-              }}
-            >
+            <p className="m-0 font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
               Your intake link
             </p>
-            <p
-              className="mt-1.5 truncate"
-              style={{
-                fontFamily: 'var(--mono)',
-                fontSize: '15px',
-                color: 'var(--ink)'
-              }}
-            >
+            <p className="mt-1.5 truncate font-mono text-[15px] text-ink">
               {intakeUrl}
             </p>
           </div>
@@ -123,16 +104,9 @@ export const ShareIntakeStep = ({ draft }: ShareIntakeStepProps) => {
         ]}
       />
 
-      <div
-        className="flex items-start gap-3 rounded-md border p-4"
-        style={{
-          background: 'var(--accent-soft)',
-          borderColor: 'color-mix(in oklab, var(--accent) 30%, var(--rule))',
-          borderRadius: 'var(--r-md)'
-        }}
-      >
-        <Icon icon={Sparkles} className="h-5 w-5 mt-0.5" style={{ color: 'var(--accent-deep)' }} />
-        <div className="flex-1 text-sm" style={{ color: 'var(--ink)', lineHeight: 1.55 }}>
+      <div className="flex items-start gap-3 rounded-[var(--r-md)] border border-[color-mix(in_oklab,var(--accent)_30%,var(--rule))] bg-[var(--accent-soft)] p-4">
+        <Icon icon={Sparkles} className="mt-0.5 h-5 w-5 text-accent-deep" />
+        <div className="flex-1 text-sm leading-[1.55] text-ink">
           <strong>You&apos;re ready.</strong> Your intake link works the moment you finish.
           Share it with clients, embed it on your site, or paste it into any reply.
           We&apos;ll connect Stripe and finish payouts from the workspace banner.

--- a/src/features/pricing/components/PricingView.tsx
+++ b/src/features/pricing/components/PricingView.tsx
@@ -218,15 +218,11 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
           </div>
         ) : null}
 
-        <div
-          className={isOnboarding ? 'mt-5 rounded-[20px] border bg-[var(--card)] px-6 py-7 shadow-[var(--shadow-2)] md:px-8 md:py-8' : 'mt-6 card px-5 py-6 md:px-7 md:py-8'}
-          style={isOnboarding ? { borderColor: 'var(--rule)' } : undefined}
-        >
+        <div className={isOnboarding ? 'mt-5 rounded-[20px] border border-rule bg-[var(--card)] px-6 py-7 shadow-[var(--shadow-2)] md:px-8 md:py-8' : 'mt-6 card px-5 py-6 md:px-7 md:py-8'}>
           <div className="flex flex-col items-start text-left">
             <h1
               data-testid="pricing-page-title"
-              className={isOnboarding ? 'text-[40px] tracking-[-0.03em] text-ink md:text-[52px]' : 'text-3xl font-semibold tracking-tight text-ink md:text-4xl'}
-              style={isOnboarding ? { fontFamily: 'var(--serif)', fontWeight: 400, lineHeight: 0.95 } : undefined}
+              className={isOnboarding ? 'font-sans text-[40px] font-normal leading-[0.95] tracking-[-0.03em] text-ink md:text-[52px]' : 'text-3xl font-semibold tracking-tight text-ink md:text-4xl'}
             >
               {plan.displayName || plan.name}
             </h1>
@@ -240,14 +236,12 @@ const PricingView: FunctionComponent<PricingViewProps> = ({
             {hasDisplayPrice && plan.currency ? (
               <div className={`flex items-end gap-1.5 ${isOnboarding ? 'mt-8' : 'mt-7'}`}>
                 <span
-                  className={isOnboarding ? 'text-[54px] tracking-[-0.04em] text-ink md:text-[68px]' : 'text-5xl font-semibold tracking-tight text-ink md:text-6xl'}
-                  style={isOnboarding ? { fontFamily: 'var(--serif)', fontWeight: 400, lineHeight: 0.95 } : undefined}
+                  className={isOnboarding ? 'font-sans text-[54px] font-normal leading-[0.95] tracking-[-0.04em] text-ink md:text-[68px]' : 'text-5xl font-semibold tracking-tight text-ink md:text-6xl'}
                 >
                   {formatCurrency(selectedPriceValue, plan.currency, i18n.language)}
                 </span>
                 <span
-                  className={isOnboarding ? 'pb-1 text-lg text-dim md:pb-2 md:text-xl' : 'pb-1 text-xl font-semibold text-dim-2 md:pb-2 md:text-2xl'}
-                  style={isOnboarding ? { fontFamily: 'var(--mono)', letterSpacing: '0.08em', textTransform: 'uppercase' } : undefined}
+                  className={isOnboarding ? 'pb-1 font-mono text-lg uppercase tracking-[0.08em] text-dim md:pb-2 md:text-xl' : 'pb-1 text-xl font-semibold text-dim-2 md:pb-2 md:text-2xl'}
                 >
                   /{periodLabel}
                 </span>

--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -514,7 +514,7 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
 
         <section className="flex flex-col gap-3">
           <div className="flex items-end justify-between border-b border-rule pb-3">
-            <h2 className="font-serif text-2xl font-normal tracking-tight text-ink">
+            <h2 className="font-sans text-2xl font-normal tracking-tight text-ink">
               All reports
             </h2>
             <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
@@ -552,7 +552,7 @@ const KpiBlock: FunctionComponent<KpiBlockProps> = ({ label, value, extra, tone 
       <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
         {label}
       </div>
-      <div className="font-serif text-3xl leading-none tracking-tight text-ink tabular-nums">
+      <div className="font-sans text-3xl leading-none tracking-tight text-ink tabular-nums">
         {value}
       </div>
       {extra && (
@@ -591,7 +591,7 @@ const RevenueCompositionSection: FunctionComponent<RevenueCompositionSectionProp
   return (
     <section className="flex flex-col gap-4">
       <div className="flex items-end justify-between border-b border-rule pb-3">
-        <h2 className="font-serif text-2xl font-normal tracking-tight text-ink">
+        <h2 className="font-sans text-2xl font-normal tracking-tight text-ink">
           Revenue &amp; composition
         </h2>
         <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
@@ -610,7 +610,7 @@ const RevenueCompositionSection: FunctionComponent<RevenueCompositionSectionProp
               <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
                 Monthly revenue · 6mo trailing
               </div>
-              <div className="font-serif text-2xl leading-none tracking-tight text-ink tabular-nums">
+              <div className="font-sans text-2xl leading-none tracking-tight text-ink tabular-nums">
                 {formatCurrency(periodPaidCents / 100)}
               </div>
             </div>
@@ -639,7 +639,7 @@ const RevenueCompositionSection: FunctionComponent<RevenueCompositionSectionProp
               <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
                 Revenue by practice area
               </div>
-              <div className="font-serif text-2xl leading-none tracking-tight text-ink">
+              <div className="font-sans text-2xl leading-none tracking-tight text-ink">
                 {byArea.length > 0 ? `${byArea.length} area${byArea.length === 1 ? '' : 's'} · ${periodLabel}` : '—'}
               </div>
             </div>
@@ -653,7 +653,7 @@ const RevenueCompositionSection: FunctionComponent<RevenueCompositionSectionProp
               {byArea.map((row) => (
                 <div key={row.label} className="flex flex-col gap-1.5">
                   <div className="flex items-baseline justify-between text-sm">
-                    <span className="font-serif text-ink">{row.label}</span>
+                    <span className="font-sans text-ink">{row.label}</span>
                     <span className="font-mono tabular-nums text-ink-2">
                       {formatCurrency(row.amountCents / 100)} · {row.share}%
                     </span>
@@ -691,7 +691,7 @@ const IntakeQualitySection: FunctionComponent<IntakeQualitySectionProps> = ({
   return (
     <section className="flex flex-col gap-4">
       <div className="flex items-end justify-between border-b border-rule pb-3">
-        <h2 className="font-serif text-2xl font-normal tracking-tight text-ink">
+        <h2 className="font-sans text-2xl font-normal tracking-tight text-ink">
           Intake quality &amp; conversion
         </h2>
         <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
@@ -721,7 +721,7 @@ const IntakeQualitySection: FunctionComponent<IntakeQualitySectionProps> = ({
               key={row.label}
               className="grid grid-cols-[1.4fr_80px_80px_90px_1fr] items-center gap-4 border-b border-rule px-5 py-3 text-sm last:border-b-0"
             >
-              <div className="truncate font-serif text-base text-ink" title={row.label}>{row.label}</div>
+              <div className="truncate font-sans text-base text-ink" title={row.label}>{row.label}</div>
               <div className="text-right font-mono tabular-nums text-ink-2">{row.total}</div>
               <div className="text-right font-mono tabular-nums text-ink-2">{row.accepted}</div>
               <div className="text-right font-mono tabular-nums text-ink-2">
@@ -766,7 +766,7 @@ const AssistantActivitySection: FunctionComponent = () => {
   return (
     <section className="flex flex-col gap-4">
       <div className="flex items-end justify-between border-b border-rule pb-3">
-        <h2 className="font-serif text-2xl font-normal tracking-tight text-ink">
+        <h2 className="font-sans text-2xl font-normal tracking-tight text-ink">
           Assistant activity log
         </h2>
         <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
@@ -792,7 +792,7 @@ const AssistantActivitySection: FunctionComponent = () => {
             className="grid grid-cols-[90px_1fr_90px_90px] items-center gap-4 border-b border-rule px-5 py-3 text-sm last:border-b-0"
           >
             <div className="font-mono text-[11px] uppercase tracking-[0.04em] text-dim">{row.when}</div>
-            <div className="font-serif text-sm text-ink">{row.what}</div>
+            <div className="font-sans text-sm text-ink">{row.what}</div>
             <div className="text-right font-mono tabular-nums text-ink-2">{row.saved}</div>
             <div className="flex justify-center">
               <Pill tone="dim">{row.status}</Pill>
@@ -816,7 +816,7 @@ const ReportListRow: FunctionComponent<ReportListRowProps> = ({ definition }) =>
         <Icon className="h-4 w-4 text-dim-2" aria-hidden="true" />
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate font-serif text-base font-normal text-ink">
+        <span className="truncate font-sans text-base font-normal text-ink">
           {definition.title}
         </span>
         <span className="truncate text-sm text-dim-2">

--- a/src/features/settings/pages/AccountPage.tsx
+++ b/src/features/settings/pages/AccountPage.tsx
@@ -850,7 +850,7 @@ export const AccountPage = ({
                 progress={avatarUploading ? avatarUploadProgress : null}
               />
               <div className="min-w-0">
-                <div className="font-serif text-[28px] font-normal tracking-[-0.01em] text-ink">{displayName}</div>
+                <div className="font-sans text-[28px] font-normal tracking-[-0.01em] text-ink">{displayName}</div>
                 <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.08em] text-dim">User profile</div>
               </div>
             </div>
@@ -886,7 +886,7 @@ export const AccountPage = ({
           <SettingsCard className="max-w-[760px]">
             <div className="flex items-start justify-between gap-4 border-b border-rule pb-5 max-sm:flex-col">
               <div>
-                <div className="font-serif text-[26px] font-normal tracking-[-0.01em] text-ink">{currentPlanLabel}</div>
+                <div className="font-sans text-[26px] font-normal tracking-[-0.01em] text-ink">{currentPlanLabel}</div>
                 <p className="mt-1 text-[13.5px] leading-relaxed text-dim">
                   {subscriptionDescription ?? 'You can manage renewals, cancellation, and payment details from here.'}
                 </p>
@@ -1081,7 +1081,7 @@ export const AccountPage = ({
         <section className="rounded-[20px] border border-[color:color-mix(in_oklab,var(--neg)_30%,var(--rule))] bg-[color:color-mix(in_oklab,var(--neg)_6%,var(--card))] px-5 py-5 sm:px-6">
           <div className="flex items-start justify-between gap-4 max-sm:flex-col">
             <div>
-              <h3 className="font-serif text-2xl font-normal tracking-tight text-[var(--neg)]">Delete account</h3>
+              <h3 className="font-sans text-2xl font-normal tracking-tight text-[var(--neg)]">Delete account</h3>
               <p className="mt-1 max-w-[60ch] text-[13.5px] leading-relaxed text-ink-2">
                 Permanently remove your Blawby account and personal data. If you are the billing owner, cancel the active subscription before continuing.
               </p>

--- a/src/features/settings/pages/AppsPage.tsx
+++ b/src/features/settings/pages/AppsPage.tsx
@@ -59,7 +59,7 @@ const AppCard = ({ app, onSelect }: AppCardProps) => (
     onClick={onSelect}
     className={cn(
       'bg-card border border-rule rounded-lg p-5 text-left flex flex-col gap-3 w-full',
-      'cursor-pointer shadow-sm transition-all',
+      'cursor-pointer shadow-sm transition-[transform,border-color,box-shadow]',
       'hover:border-ink hover:-translate-y-px hover:shadow-md',
     )}
   >
@@ -93,7 +93,7 @@ const AppCard = ({ app, onSelect }: AppCardProps) => (
 
 const SectionHeader = ({ title, count, first = false }: { title: string; count: number; first?: boolean }) => (
   <div className={cn('flex items-baseline gap-2 mb-4', !first && 'pt-8 border-t border-rule')}>
-    <h3 className="font-serif text-[22px] font-normal tracking-tight">{title}</h3>
+    <h3 className="font-sans text-[22px] font-normal tracking-tight">{title}</h3>
     <span className="font-mono text-[10px] tracking-widest text-dim">{count}</span>
   </div>
 );
@@ -117,7 +117,7 @@ export const AppsPage = ({ apps, onSelect, className = '' }: AppsPageProps) => {
       <SettingsCard className="mb-8 max-w-[860px]">
         <div className="flex items-start justify-between gap-4 max-sm:flex-col">
           <div>
-            <div className="font-serif text-[24px] font-normal tracking-[-0.01em] text-ink">Connected tools</div>
+            <div className="font-sans text-[24px] font-normal tracking-[-0.01em] text-ink">Connected tools</div>
             <p className="mt-1 max-w-[58ch] text-[13.5px] leading-relaxed text-dim">
               Connect external services the assistant can read from or act on with your approval.
             </p>

--- a/src/features/settings/pages/AuditLogPage.tsx
+++ b/src/features/settings/pages/AuditLogPage.tsx
@@ -15,17 +15,17 @@ import { SettingsCard } from '@/features/settings/components/SettingsCard';
 
 type EventType = 'ai' | 'update' | 'create' | 'delete' | 'auth';
 
-const DEMO_EVENTS: Array<{ id: string; ts: string; actor: string; actorInitial: string; actorStyle: string; type: EventType; action: string; target: string }> = [
-  { id: 'e1', ts: 'Jun 1, 10:42 AM', actor: 'Assistant', actorInitial: 'B', actorStyle: 'background:var(--ink);color:var(--accent);font-style:italic', type: 'ai', action: 'Drafted invoice for Chen v. Williams — awaiting approval', target: 'invoice_0047' },
-  { id: 'e2', ts: 'Jun 1, 10:38 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorStyle: 'background:linear-gradient(135deg,#374151,#111827);color:#f9fafb', type: 'update', action: 'Approved staged invoice for matter_0012', target: 'invoice_0047' },
-  { id: 'e3', ts: 'Jun 1, 10:22 AM', actor: 'Assistant', actorInitial: 'B', actorStyle: 'background:var(--ink);color:var(--accent);font-style:italic', type: 'ai', action: 'Sent morning briefing email', target: 'sarah@sarahchenlaw.com' },
-  { id: 'e4', ts: 'Jun 1, 09:14 AM', actor: 'Stripe', actorInitial: 'S', actorStyle: 'background:#635BFF;color:#fff', type: 'create', action: 'Payment received $2,500.00 from Janet Williams', target: 'pay_3Q8xN2' },
-  { id: 'e5', ts: 'Jun 1, 08:50 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorStyle: 'background:linear-gradient(135deg,#374151,#111827);color:#f9fafb', type: 'auth', action: 'Signed in from 74.125.xx.xx (Charlotte, NC)', target: 'session_a8f2' },
-  { id: 'e6', ts: 'May 31, 4:55 PM', actor: 'Assistant', actorInitial: 'B', actorStyle: 'background:var(--ink);color:var(--accent);font-style:italic', type: 'ai', action: 'Created calendar event "Thompson custody hearing" for Jul 14', target: 'event_0089' },
-  { id: 'e7', ts: 'May 31, 3:20 PM', actor: 'Sarah Chen', actorInitial: 'SC', actorStyle: 'background:linear-gradient(135deg,#374151,#111827);color:#f9fafb', type: 'create', action: 'Created new matter Thompson v. Thompson', target: 'matter_0015' },
-  { id: 'e8', ts: 'May 31, 2:44 PM', actor: 'System', actorInitial: 'SY', actorStyle: 'background:var(--rule-soft,#f3f4f6);color:var(--dim)', type: 'update', action: 'Intake form submitted by new lead (family law, DV flagged)', target: 'intake_0041' },
-  { id: 'e9', ts: 'May 31, 11:30 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorStyle: 'background:linear-gradient(135deg,#374151,#111827);color:#f9fafb', type: 'update', action: 'Updated retainer threshold to 30% for Services & pricing', target: 'settings' },
-  { id: 'e10', ts: 'May 31, 10:15 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorStyle: 'background:linear-gradient(135deg,#374151,#111827);color:#f9fafb', type: 'delete', action: 'Removed draft engagement letter for intake_0038', target: 'doc_0072' },
+const DEMO_EVENTS: Array<{ id: string; ts: string; actor: string; actorInitial: string; actorClass: string; type: EventType; action: string; target: string }> = [
+  { id: 'e1', ts: 'Jun 1, 10:42 AM', actor: 'Assistant', actorInitial: 'B', actorClass: 'bg-ink text-accent italic', type: 'ai', action: 'Drafted invoice for Chen v. Williams — awaiting approval', target: 'invoice_0047' },
+  { id: 'e2', ts: 'Jun 1, 10:38 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'update', action: 'Approved staged invoice for matter_0012', target: 'invoice_0047' },
+  { id: 'e3', ts: 'Jun 1, 10:22 AM', actor: 'Assistant', actorInitial: 'B', actorClass: 'bg-ink text-accent italic', type: 'ai', action: 'Sent morning briefing email', target: 'sarah@sarahchenlaw.com' },
+  { id: 'e4', ts: 'Jun 1, 09:14 AM', actor: 'Stripe', actorInitial: 'S', actorClass: 'bg-accent text-accent-ink', type: 'create', action: 'Payment received $2,500.00 from Janet Williams', target: 'pay_3Q8xN2' },
+  { id: 'e5', ts: 'Jun 1, 08:50 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'auth', action: 'Signed in from 74.125.xx.xx (Charlotte, NC)', target: 'session_a8f2' },
+  { id: 'e6', ts: 'May 31, 4:55 PM', actor: 'Assistant', actorInitial: 'B', actorClass: 'bg-ink text-accent italic', type: 'ai', action: 'Created calendar event "Thompson custody hearing" for Jul 14', target: 'event_0089' },
+  { id: 'e7', ts: 'May 31, 3:20 PM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'create', action: 'Created new matter Thompson v. Thompson', target: 'matter_0015' },
+  { id: 'e8', ts: 'May 31, 2:44 PM', actor: 'System', actorInitial: 'SY', actorClass: 'bg-paper-2 text-dim', type: 'update', action: 'Intake form submitted by new lead (family law, DV flagged)', target: 'intake_0041' },
+  { id: 'e9', ts: 'May 31, 11:30 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'update', action: 'Updated retainer threshold to 30% for Services & pricing', target: 'settings' },
+  { id: 'e10', ts: 'May 31, 10:15 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'delete', action: 'Removed draft engagement letter for intake_0038', target: 'doc_0072' },
 ];
 
 const TYPE_STYLES: Record<EventType, string> = {
@@ -80,8 +80,7 @@ export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => {
         <SettingsCard className="mb-5 max-w-[860px]">
         <div className="flex flex-wrap items-center gap-[10px]">
           <input
-            className="input flex-1"
-            style={{ minWidth: 260 }}
+            className="input min-w-[260px] flex-1"
             placeholder="Search events…"
             value={search}
             onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
@@ -100,7 +99,7 @@ export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => {
             <option value="Assistant">Assistant</option>
             <option value="System">System</option>
           </select>
-          <select className="select" value={rangeFilter} onChange={(e) => setRangeFilter((e.target as HTMLSelectElement).value)} style={{ width: 140 }}>
+          <select className="select w-[140px]" value={rangeFilter} onChange={(e) => setRangeFilter((e.target as HTMLSelectElement).value)}>
             <option value="7d">Last 7 days</option>
             <option value="30d">Last 30 days</option>
             <option value="90d">Last 90 days</option>
@@ -128,8 +127,7 @@ export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => {
                       <td className="py-3 pr-3">
                         <div className="flex items-center gap-2">
                           <div
-                            className="h-[22px] w-[22px] rounded-full grid place-items-center font-serif text-[9px] font-bold shrink-0"
-                            style={event.actorStyle}
+                            className={cn('grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full font-sans text-[9px] font-bold', event.actorClass)}
                           >
                             {event.actorInitial}
                           </div>

--- a/src/features/settings/pages/EngagementTemplatesPage.tsx
+++ b/src/features/settings/pages/EngagementTemplatesPage.tsx
@@ -458,7 +458,7 @@ const TemplateCard = ({ template, onEdit }: TemplateCardProps) => {
         {/* Left — gist + meta */}
         <div className="flex min-w-0 flex-col gap-2">
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
-            <span className="font-serif text-xl leading-tight tracking-tight text-ink sm:text-2xl">
+            <span className="font-sans text-xl leading-tight tracking-tight text-ink sm:text-2xl">
               {template.name || <span className="text-dim-2">Untitled template</span>}
             </span>
             {draft ? (
@@ -491,7 +491,7 @@ const TemplateCard = ({ template, onEdit }: TemplateCardProps) => {
             <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] text-dim">
               {fee.mode}
             </span>
-            <span className="font-serif text-2xl leading-none tracking-tight text-ink tabular-nums sm:text-[28px]">
+            <span className="font-sans text-2xl leading-none tracking-tight text-ink tabular-nums sm:text-[28px]">
               {fee.amount}
               {fee.unit ? (
                 <span className="ml-0.5 font-mono text-[11px] uppercase tracking-[0.06em] text-dim">
@@ -526,7 +526,7 @@ interface EmptyAreaCardProps {
 const EmptyAreaCard = ({ area, onAsk }: EmptyAreaCardProps) => (
   <div className="flex flex-col items-start gap-4 rounded-r-md border border-dashed border-rule bg-paper p-5 sm:flex-row sm:items-center sm:gap-5 sm:px-[26px] sm:py-[22px]">
     <div className="flex-1">
-      <p className="font-serif text-base text-ink sm:text-[17px]">
+      <p className="font-sans text-base text-ink sm:text-[17px]">
         No {area.toLowerCase()} template yet
       </p>
       <p className="mt-1 text-sm leading-snug text-ink-2">
@@ -564,7 +564,7 @@ const AreaSection = ({ bucket, onAdd, onAsk, onEdit }: AreaSectionProps) => {
         )}
       >
         <div className="flex items-baseline gap-3">
-          <h2 className="font-serif text-xl font-normal leading-none tracking-tight text-ink sm:text-[22px]">
+          <h2 className="font-sans text-xl font-normal leading-none tracking-tight text-ink sm:text-[22px]">
             {bucket.area}
           </h2>
           <span className="font-mono text-[10.5px] uppercase tracking-[0.1em] text-dim">
@@ -700,7 +700,7 @@ function TemplateListView({ templates, onNew, onNewInArea, onEdit, onDraftFromPr
       {/* Page hero */}
       <header className="flex flex-col gap-5 border-b border-rule pb-6 lg:flex-row lg:items-end lg:justify-between lg:gap-8">
         <div className="min-w-0 flex-1">
-          <h1 className="font-serif text-3xl font-normal leading-[1.05] tracking-tight text-ink sm:text-4xl lg:text-[46px]">
+          <h1 className="font-sans text-3xl font-normal leading-[1.05] tracking-tight text-ink sm:text-4xl lg:text-[46px]">
             Letters the assistant <em className="not-italic text-accent">drafts from.</em>
           </h1>
           <p className="mt-3 max-w-[58ch] text-sm leading-relaxed text-ink-2 sm:text-[14px]">
@@ -773,7 +773,7 @@ function TemplateListView({ templates, onNew, onNewInArea, onEdit, onDraftFromPr
       {/* Area sections */}
       {totalCount === 0 ? (
         <div className="flex flex-col items-start gap-3 rounded-r-md border border-dashed border-rule bg-paper p-6 sm:p-8">
-          <p className="font-serif text-lg text-ink">No templates yet</p>
+          <p className="font-sans text-lg text-ink">No templates yet</p>
           <p className="max-w-[56ch] text-sm leading-relaxed text-ink-2">
             Create your first engagement letter template, or describe one above and the assistant will draft it from your prior matters.
           </p>

--- a/src/features/settings/pages/GeneralPage.tsx
+++ b/src/features/settings/pages/GeneralPage.tsx
@@ -55,11 +55,10 @@ const ThemeCard = ({ id, label, selected, onSelect }: ThemeCardProps) => {
       type="button"
       onClick={onSelect}
       aria-pressed={selected}
-      className={cn('card card-hover text-left p-0 overflow-hidden', selected ? 'border-ink' : '')}
-      style={{ borderWidth: 2 }}
+      className={cn('card card-hover overflow-hidden border-2 p-0 text-left', selected ? 'border-ink' : '')}
     >
       {/* Mini preview */}
-      <div className="grid overflow-hidden" style={{ height: 80, gridTemplateColumns: '28% 1fr', background: p.bg }}>
+      <div className="grid h-20 grid-cols-[28%_1fr] overflow-hidden" style={{ background: p.bg }}>
         <div className="p-1.5 flex flex-col gap-1" style={{ background: p.sidebar, borderRight: '1px solid rgba(0,0,0,0.08)' }}>
           {p.bars.map((color, i) => (
             <div key={i} className="rounded-sm" style={{ height: 3, background: color, width: i === 2 ? '90%' : i === 1 ? '60%' : i === 3 ? '70%' : '80%' }} />
@@ -73,14 +72,8 @@ const ThemeCard = ({ id, label, selected, onSelect }: ThemeCardProps) => {
       </div>
       {/* Label */}
       <div className="flex items-center justify-between px-3 py-2.5">
-        <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--ink)' }}>{label}</span>
-        <span style={{
-          width: 16, height: 16, borderRadius: '50%',
-          border: `2px solid ${selected ? 'var(--ink)' : 'var(--rule)'}`,
-          background: selected ? 'var(--ink)' : 'transparent',
-          display: 'grid', placeItems: 'center',
-          fontSize: 10, color: 'var(--accent)',
-        }}>
+        <span className="text-[13px] font-medium text-ink">{label}</span>
+        <span className={cn('grid h-4 w-4 place-items-center rounded-full border-2 text-[10px] text-accent', selected ? 'border-ink bg-ink' : 'border-rule bg-transparent')}>
           {selected ? '✓' : null}
         </span>
       </div>
@@ -235,7 +228,7 @@ export const GeneralPage = () => {
       {/* Theme */}
       <SettingSection first title="Theme" description="Choose a color scheme. All themes maintain WCAG AA contrast for readability.">
         <SettingsCard className="max-w-[820px]">
-        <div className="grid gap-3.5" style={{ gridTemplateColumns: 'repeat(3, 1fr)' }}>
+        <div className="grid grid-cols-3 gap-3.5">
           {(['light', 'dark', 'system'] as const).map((id) => (
             <ThemeCard key={id} id={id} label={id.charAt(0).toUpperCase() + id.slice(1)} selected={theme === id} onSelect={() => handleTheme(id)} />
           ))}

--- a/src/features/settings/pages/IntelligencePage.tsx
+++ b/src/features/settings/pages/IntelligencePage.tsx
@@ -473,7 +473,7 @@ export const IntelligencePage = ({ className }: IntelligencePageProps) => {
           <div className="flex items-start gap-3">
             <Icon icon={ShieldCheck} className="mt-0.5 h-5 w-5 shrink-0 text-neg" aria-hidden="true" />
             <div className="min-w-0 flex-1 space-y-1">
-              <h3 className="font-serif text-lg font-normal leading-tight text-neg">
+              <h3 className="font-sans text-lg font-normal leading-tight text-neg">
                 Danger zone
               </h3>
               <p className="text-sm text-ink-2">

--- a/src/features/settings/pages/NotificationsPage.tsx
+++ b/src/features/settings/pages/NotificationsPage.tsx
@@ -181,10 +181,7 @@ export const NotificationsPage = ({ className = '' }: NotificationsPageProps) =>
         const emailAlwaysDisabled = section.events.every((e) => e.emailDisabled);
         return (
           <SettingSection key={section.title} first={i === 0} title={section.title} description={section.description}>
-            <div
-              className="grid items-center border-b border-rule pb-2"
-              style={{ gridTemplateColumns: '1fr 70px 70px', gap: 14 }}
-            >
+            <div className="grid grid-cols-[1fr_70px_70px] items-center gap-[14px] border-b border-rule pb-2">
               <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">Event</span>
               <div className="flex flex-col items-center gap-1">
                 <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-dim">Email</span>

--- a/src/features/settings/pages/PracticeCoveragePage.tsx
+++ b/src/features/settings/pages/PracticeCoveragePage.tsx
@@ -224,7 +224,7 @@ export const PracticeCoveragePage = ({ className, onBack }: PracticeCoveragePage
           <div className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-dim">Settings · Practice · Coverage</div>
           <div className="flex items-start justify-between gap-4 max-sm:flex-col">
             <div>
-              <h1 className="font-serif text-[48px] font-normal leading-[1.05] tracking-[-0.02em] text-ink [&_em]:text-accent">
+              <h1 className="font-sans text-[48px] font-normal leading-[1.05] tracking-[-0.02em] text-ink [&_em]:text-accent">
                 Where you <em>practice.</em>
               </h1>
               <p className="mt-3 max-w-[60ch] text-[15px] leading-relaxed text-ink-2">

--- a/src/features/settings/pages/PracticePage.tsx
+++ b/src/features/settings/pages/PracticePage.tsx
@@ -375,7 +375,7 @@ export const PracticePage = ({ className }: PracticePageProps) => {
   const practiceInitial = (contactValues.name || currentPractice.name || 'P').charAt(0).toUpperCase();
   const logoUrl = contactValues.logo?.trim() || null;
   const chipClass = (selected: boolean, disabled = false, dashed = false) => cn(
-    'inline-flex items-center gap-1.5 rounded-[var(--r-xs)] border px-3 py-[7px] text-[13px] transition-all',
+    'inline-flex items-center gap-1.5 rounded-[var(--r-xs)] border px-3 py-[7px] text-[13px] transition-[color,background-color,border-color,opacity]',
     selected
       ? 'border-ink bg-ink text-accent'
       : 'bg-card text-ink-2 hover:border-ink',
@@ -406,7 +406,7 @@ export const PracticePage = ({ className }: PracticePageProps) => {
               className="w-auto"
             />
             <div>
-              <div className="font-serif text-[22px] font-normal tracking-[-0.01em] text-ink">
+              <div className="font-sans text-[22px] font-normal tracking-[-0.01em] text-ink">
                 {contactValues.name || currentPractice.name || practiceInitial}
               </div>
               <div className="mt-0.5 font-mono text-xs text-dim">

--- a/src/features/settings/pages/PracticeTeamPage.tsx
+++ b/src/features/settings/pages/PracticeTeamPage.tsx
@@ -256,9 +256,9 @@ export const PracticeTeamPage = ({ className }: PracticeTeamPageProps) => {
                 const isEditing = editMemberData?.userId === member.userId;
                 return (
                   <div key={member.userId} className="border-b border-rule last:border-0">
-                    <div className="grid items-center gap-4 px-4 py-[14px]" style={{ gridTemplateColumns: '40px 1fr 120px 100px auto' }}>
+                    <div className="grid grid-cols-[40px_1fr_120px_100px_auto] items-center gap-4 px-4 py-[14px]">
                       {/* Avatar */}
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-ink font-serif italic text-sm text-accent">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-ink font-sans italic text-sm text-accent">
                         {initial}
                       </div>
                       {/* Name / email */}
@@ -287,7 +287,7 @@ export const PracticeTeamPage = ({ className }: PracticeTeamPageProps) => {
                     {/* Inline manage form */}
                     {isEditing && editMemberData && (
                       <div className="border-t border-rule px-5 py-4 flex flex-wrap items-end gap-3">
-                        <div className="flex-1 min-w-0" style={{ maxWidth: 240 }}>
+                        <div className="min-w-0 max-w-[240px] flex-1">
                           <FormLabel htmlFor="member-role">Role</FormLabel>
                           <Combobox
                             id="member-role"
@@ -308,7 +308,7 @@ export const PracticeTeamPage = ({ className }: PracticeTeamPageProps) => {
 
               {/* Pending invitations */}
               {invitations.map((inv) => (
-                <div key={inv.id} className="grid items-center gap-4 px-4 py-[14px] border-b border-rule last:border-0" style={{ gridTemplateColumns: '40px 1fr 120px 100px auto' }}>
+                <div key={inv.id} className="grid grid-cols-[40px_1fr_120px_100px_auto] items-center gap-4 border-b border-rule px-4 py-[14px] last:border-0">
                   <div className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-dashed border-rule text-sm text-dim">
                     {inv.email.charAt(0).toUpperCase()}
                   </div>
@@ -353,10 +353,10 @@ export const PracticeTeamPage = ({ className }: PracticeTeamPageProps) => {
             description="New members receive their own login and assistant thread. You control what they can see and do."
           >
             <SettingsCard className="max-w-[860px]">
-              <div className="font-serif text-lg mb-1">Send invitation</div>
+              <div className="font-sans text-lg mb-1">Send invitation</div>
               <p className="text-xs text-dim mb-4">They&apos;ll receive an email with a link to join your workspace.</p>
               <div className="flex flex-wrap items-end gap-3">
-                <div className="flex-1" style={{ minWidth: 200 }}>
+                <div className="min-w-[200px] flex-1">
                   <FormLabel htmlFor="invite-email">Email address</FormLabel>
                   <EmailInput
                     id="invite-email"
@@ -367,7 +367,7 @@ export const PracticeTeamPage = ({ className }: PracticeTeamPageProps) => {
                     required
                   />
                 </div>
-                <div style={{ minWidth: 150 }}>
+                <div className="min-w-[150px]">
                   <FormLabel htmlFor="invite-role">Role</FormLabel>
                   <Combobox
                     id="invite-role"
@@ -417,7 +417,7 @@ export const PracticeTeamPage = ({ className }: PracticeTeamPageProps) => {
             </div>
             <div className="h-1.5 w-full rounded-full bg-rule overflow-hidden">
               <div
-                className={cn('h-full rounded-full transition-all', isOverSeat ? 'bg-[var(--neg,#ef4444)]' : 'bg-ink')}
+                className={cn('h-full rounded-full transition-[width,background-color]', isOverSeat ? 'bg-[var(--neg,#ef4444)]' : 'bg-ink')}
                 style={{ width: `${seatsPercent}%` }}
               />
             </div>

--- a/src/features/settings/pages/SecurityPage.tsx
+++ b/src/features/settings/pages/SecurityPage.tsx
@@ -334,7 +334,7 @@ export const SecurityPage = ({
                   Forgot password?
                 </Button>
               </div>
-              {lastChanged && <p className="mt-3" style={{ fontSize: 12.5, color: 'var(--dim)' }}>Last changed: {lastChanged}</p>}
+              {lastChanged && <p className="mt-3 text-[12.5px] text-dim">Last changed: {lastChanged}</p>}
             </>
           ) : (
             <Button variant="primary" size="sm" onClick={() => void handleResetPassword()} disabled={isResettingPassword}>
@@ -399,7 +399,7 @@ export const SecurityPage = ({
       </SettingSection>
 
       <section className="mt-8 rounded-[20px] border border-[color:color-mix(in_oklab,var(--neg)_30%,var(--rule))] bg-[color:color-mix(in_oklab,var(--neg)_6%,var(--card))] px-5 py-5 sm:px-6">
-        <h3 className="font-serif text-2xl font-normal tracking-tight text-[var(--neg)]">Delete account</h3>
+        <h3 className="font-sans text-2xl font-normal tracking-tight text-[var(--neg)]">Delete account</h3>
         <p className="mt-1 max-w-[60ch] text-[13.5px] leading-relaxed text-ink-2">Permanently delete your Blawby account and all associated data. This removes you from the organization but does not delete the practice. Transfer ownership first if you&apos;re the sole owner.</p>
         <Button variant="danger-ghost" size="sm" className="mt-3"
           onClick={() => showError('Contact support', 'To delete your account, please contact support@blawby.com.')}>

--- a/src/features/settings/pages/SessionsPage.tsx
+++ b/src/features/settings/pages/SessionsPage.tsx
@@ -160,8 +160,7 @@ export const SessionsPage = ({ className = '' }: SessionsPageProps) => {
                       {label}
                       {isCurrent && (
                         <span
-                          className="font-mono text-[9.5px] uppercase tracking-[0.04em] text-[var(--pos)] border rounded-full px-[7px] py-0.5"
-                          style={{ background: 'color-mix(in oklab, var(--pos) 12%, var(--card))', borderColor: 'color-mix(in oklab, var(--pos) 25%, var(--rule))' }}
+                          className="rounded-full border border-[color-mix(in_oklab,var(--pos)_25%,var(--rule))] bg-[color-mix(in_oklab,var(--pos)_12%,var(--card))] px-[7px] py-0.5 font-mono text-[9.5px] uppercase tracking-[0.04em] text-pos"
                         >
                           this device
                         </span>

--- a/src/features/settings/pages/SettingsContent.tsx
+++ b/src/features/settings/pages/SettingsContent.tsx
@@ -52,7 +52,7 @@ export interface SettingsContentProps {
 }
 
 // Hero text per view — matches the design file headings exactly.
-// All settings pages use the same flat layout: crumb → serif h1 → lede → content.
+// All settings pages use the same flat layout: crumb → sans h1 → lede → content.
 // The existing editor-shell-hero__* CSS classes in index.css handle the typography.
 interface SettingsViewHero {
   crumb: string;

--- a/src/features/trust/components/TrustAuditTrailPane.tsx
+++ b/src/features/trust/components/TrustAuditTrailPane.tsx
@@ -123,7 +123,7 @@ export const TrustAuditTrailPane: FunctionComponent<TrustAuditTrailPaneProps> = 
     <section className="panel overflow-hidden">
       <header className="flex items-center justify-between border-b border-rule bg-paper-2 px-5 py-3">
         <div className="flex flex-col">
-          <h3 className="font-serif text-lg leading-tight text-ink">Audit trail</h3>
+          <h3 className="font-sans text-lg leading-tight text-ink">Audit trail</h3>
           <span className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
             org-wide · last {days} days
           </span>
@@ -187,7 +187,7 @@ export const TrustAuditTrailPane: FunctionComponent<TrustAuditTrailPaneProps> = 
               <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <div className="flex items-center gap-2">
                   <Pill tone="dim">{actorLabel(event)}</Pill>
-                  <span className="font-serif text-sm leading-snug text-ink">
+                  <span className="font-sans text-sm leading-snug text-ink">
                     {headlineForEvent(event)}
                   </span>
                 </div>

--- a/src/features/trust/components/TrustComplianceRulesPane.tsx
+++ b/src/features/trust/components/TrustComplianceRulesPane.tsx
@@ -103,7 +103,7 @@ export const TrustComplianceRulesPane: FunctionComponent<TrustComplianceRulesPan
     <section className="panel overflow-hidden">
       <header className="flex items-center justify-between border-b border-rule bg-paper-2 px-5 py-3">
         <div className="flex flex-col">
-          <h3 className="font-serif text-lg leading-tight text-ink">Compliance rules</h3>
+          <h3 className="font-sans text-lg leading-tight text-ink">Compliance rules</h3>
           <span className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-dim">
             IOLTA · {activeCount} of {RULES.length} active
           </span>

--- a/src/features/trust/pages/PracticeTrustPage.tsx
+++ b/src/features/trust/pages/PracticeTrustPage.tsx
@@ -487,7 +487,7 @@ const PracticeTrustPage: FunctionComponent = () => {
             <section className="flex flex-col gap-3">
               <div className="flex flex-wrap items-end justify-between gap-2">
                 <div>
-                  <h2 className="font-serif text-xl text-ink">Per-client balances</h2>
+                  <h2 className="font-sans text-xl text-ink">Per-client balances</h2>
                   <p className="mt-1 text-sm text-dim-2">
                     Running balance per client based on the most recent entry in the period.
                   </p>
@@ -517,7 +517,7 @@ const PracticeTrustPage: FunctionComponent = () => {
             <section className="flex flex-col gap-3">
               <div className="flex flex-wrap items-end justify-between gap-2">
                 <div>
-                  <h2 className="font-serif text-xl text-ink">Recent transactions</h2>
+                  <h2 className="font-sans text-xl text-ink">Recent transactions</h2>
                   <p className="mt-1 text-sm text-dim-2">
                     Every deposit, transfer, and refund recorded in the ledger.
                   </p>

--- a/src/index.css
+++ b/src/index.css
@@ -335,7 +335,7 @@
   }
 
   .surface-hover {
-    @apply transition-all duration-200;
+    @apply transition-[background-color,box-shadow] duration-200;
   }
 
   .surface-hover:hover {
@@ -912,7 +912,7 @@
      ============================================================ */
 
   .file-display {
-    @apply flex items-center gap-2 p-2 panel transition-all duration-200;
+    @apply flex items-center gap-2 p-2 panel transition-[background-color,border-color,box-shadow] duration-200;
   }
 
   .file-display-icon {
@@ -1153,7 +1153,7 @@
   }
   .danger h3 {
     color: var(--neg);
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-weight: 400;
     font-size: 20px;
     margin: 0 0 4px;
@@ -1588,7 +1588,7 @@
   }
 
   .focus-drawer-title {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 17px;
     color: var(--ink);
     line-height: 1.3;
@@ -1670,7 +1670,7 @@
   }
 
   .page-header-title {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-weight: 400;
     letter-spacing: -0.012em;
     line-height: 1.1;
@@ -1777,7 +1777,7 @@
     background: var(--pos);
   }
   .ai-summary-body {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 18px;
     line-height: 1.5;
     color: var(--ink);
@@ -1817,7 +1817,7 @@
     color: var(--accent-deep);
   }
   .staged-action-title {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 20px;
     margin-top: 4px;
     line-height: 1.2;
@@ -1922,7 +1922,7 @@
     color: var(--accent-deep);
   }
   .observation-text {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 18px;
     line-height: 1.45;
     color: var(--ink);
@@ -2272,7 +2272,7 @@
     color: var(--dim);
   }
   .stat-strip-value {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 26px;
     line-height: 1;
     letter-spacing: -0.012em;
@@ -2354,7 +2354,7 @@
     box-shadow: 0 0 0 5px var(--accent-soft);
   }
   .journey-step-name {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 14px;
     line-height: 1.25;
     max-width: 14ch;
@@ -2623,7 +2623,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-style: italic;
     font-size: 14px;
     font-weight: 600;
@@ -2639,7 +2639,7 @@
     color: var(--accent-deep);
   }
   .ai-answer-card-lede {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 22px;
     line-height: 1.4;
     color: var(--ink);
@@ -2686,7 +2686,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-style: italic;
     font-size: 12px;
     font-weight: 600;
@@ -2707,7 +2707,7 @@
     gap: 2px;
   }
   .ai-ribbon-title {
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 15px;
     color: var(--ink);
     line-height: 1.3;
@@ -2789,7 +2789,7 @@
     background: color-mix(in oklab, var(--pos) 12%, var(--card));
     border-color: color-mix(in oklab, var(--pos) 35%, transparent);
     color: color-mix(in oklab, var(--pos) 70%, var(--ink));
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-style: italic;
   }
 
@@ -2837,7 +2837,7 @@
     grid-template-columns: 28px minmax(0, 1fr);
     column-gap: 14px;
     align-items: flex-start;
-    font-family: var(--serif);
+    font-family: var(--sans);
     font-size: 18px;
     color: var(--ink);
     line-height: 1.3;

--- a/src/pages/DebugMatterPage.tsx
+++ b/src/pages/DebugMatterPage.tsx
@@ -371,7 +371,7 @@ export default function DebugMatterPage() {
                         className={[
                           'relative px-3 py-3 text-sm font-medium whitespace-nowrap',
                           'transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-t-sm',
-                          'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-all after:duration-150',
+                          'after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full after:transition-colors after:duration-150',
                           isActive
                             ? 'text-ink after:bg-accent'
                             : 'text-dim-2 hover:text-ink after:bg-transparent hover:after:bg-line-glass/20'

--- a/src/shared/ui/Accordion.tsx
+++ b/src/shared/ui/Accordion.tsx
@@ -173,7 +173,7 @@ const AccordionTrigger: FunctionComponent<AccordionTriggerProps> = ({
         aria-expanded={isOpen}
         aria-controls={contentId}
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center justify-between gap-4 px-4 py-3 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 rounded-r-md",
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center justify-between gap-4 px-4 py-3 text-left text-sm font-medium transition-[color,background-color,border-color,box-shadow,opacity] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 rounded-r-md",
           className
         )}
         onClick={handleClick}
@@ -213,7 +213,7 @@ const AccordionContent: FunctionComponent<AccordionContentProps> = ({
       role="region"
       aria-labelledby={triggerId}
       className={cn(
-        "text-sm overflow-hidden transition-all duration-200",
+        "text-sm overflow-hidden transition-[max-height,opacity] duration-200",
         isOpen ? "max-h-screen opacity-100" : "max-h-0 opacity-0",
         className
       )}

--- a/src/shared/ui/ProgressRing.tsx
+++ b/src/shared/ui/ProgressRing.tsx
@@ -85,7 +85,7 @@ export const ProgressRing: FunctionComponent<ProgressRingProps> = ({
             transition: 'stroke-dashoffset 0.5s ease-in-out, stroke 0.5s ease-in-out' 
           }}
           strokeLinecap="round"
-          className={cn('transition-all', progressClassName)}
+          className={cn('transition-[stroke-dashoffset]', progressClassName)}
         />
       </svg>
       {children !== undefined && (

--- a/src/shared/ui/input/Combobox.tsx
+++ b/src/shared/ui/input/Combobox.tsx
@@ -165,7 +165,7 @@ function DropdownOption({
       onClick={onSelect}
       disabled={option.disabled}
       className={cn(
-        'group relative flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-all',
+        'group relative flex w-full items-center justify-between px-3 py-2.5 text-left text-sm transition-colors',
         option.disabled && 'cursor-not-allowed opacity-45',
         isSelected || isFocused
           ? 'bg-accent/15 text-ink'
@@ -584,7 +584,7 @@ export function Combobox({
           onClick={() => (isOpen ? close() : open())}
           onKeyDown={handleKeyDown}
           className={cn(
-            'field relative flex w-full flex-row items-center gap-2 rounded-r-md pl-3 pr-4 py-2.5 transition-all duration-200',
+            'field relative flex w-full flex-row items-center gap-2 rounded-r-md pl-3 pr-4 py-2.5 transition-[color,background-color,border-color,box-shadow] duration-200',
             isOpen && 'is-open',
             !disabled && 'cursor-pointer'
           )}

--- a/src/shared/ui/input/CurrencyInput.tsx
+++ b/src/shared/ui/input/CurrencyInput.tsx
@@ -83,7 +83,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(({
 
   const inputClasses = cn(
     'w-full rounded-r-md text-ink placeholder:text-dim-2',
-    'focus:outline-none transition-all duration-200',
+    'focus:outline-none transition-[color,background-color,border-color,box-shadow] duration-200',
     'field border-none',
     sizeClasses[size],
     variant === 'error' || error ? 'is-error' : '',

--- a/src/shared/ui/input/DatePicker.tsx
+++ b/src/shared/ui/input/DatePicker.tsx
@@ -114,7 +114,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
 
   const inputClasses = cn(
     'w-full min-h-[44px] rounded-r-md text-ink placeholder:text-dim-2',
-    'focus:outline-none transition-all duration-200',
+    'focus:outline-none transition-[color,background-color,border-color,box-shadow] duration-200',
     'appearance-none field border-none',
     sizeClasses[size],
     variantClasses[variant],
@@ -159,8 +159,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(({
       {_displayError && (
         <p
           id={errorId}
-          className="text-xs mt-1"
-          style={{ color: 'rgb(var(--error-foreground))' }}
+          className="mt-1 text-xs text-neg"
           role="alert"
           aria-live="assertive"
         >

--- a/src/shared/ui/input/EmailInput.tsx
+++ b/src/shared/ui/input/EmailInput.tsx
@@ -110,7 +110,7 @@ export const EmailInput = forwardRef<HTMLInputElement, EmailInputProps>(
 
     const inputClasses = cn(
       "input",
-      "transition-all duration-200",
+      "transition-[color,background-color,border-color,box-shadow] duration-200",
       sizeClasses[size],
       iconPaddingClasses[size],
       variantClasses[variant],

--- a/src/shared/ui/input/NumberInput.tsx
+++ b/src/shared/ui/input/NumberInput.tsx
@@ -91,7 +91,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(({
 
   const inputClasses = cn(
     'w-full rounded-r-md text-ink placeholder:text-dim-2',
-    'focus:outline-none transition-all duration-200',
+    'focus:outline-none transition-[color,background-color,border-color,box-shadow] duration-200',
     'field border-none',
     sizeClasses[size],
     showControls && 'pr-20',

--- a/src/shared/ui/input/PINInput.tsx
+++ b/src/shared/ui/input/PINInput.tsx
@@ -122,7 +122,7 @@ export function PINInput({
             'focus-visible:outline-none',
             error && 'field is-error',
             'disabled:opacity-45 disabled:cursor-not-allowed',
-            'transition-all duration-200',
+            'transition-[color,background-color,border-color,box-shadow,opacity] duration-200',
           )}
         />
       ))}

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -94,7 +94,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
 
   const inputClasses = cn(
     'w-full rounded-r-md text-ink placeholder:text-dim-2',
-    'focus:outline-none transition-all duration-200',
+    'focus:outline-none transition-[color,background-color,border-color,box-shadow] duration-200',
     'field border-none',
     sizeClasses[size],
     iconPaddingClasses[size],

--- a/src/shared/ui/input/PhoneInput.tsx
+++ b/src/shared/ui/input/PhoneInput.tsx
@@ -318,7 +318,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(
 
     const inputClasses = cn(
       "w-full h-full rounded-none border-0 bg-transparent text-ink placeholder:text-dim-2",
-      "focus:outline-none transition-all duration-200",
+      "focus:outline-none transition-[color,background-color,border-color,box-shadow] duration-200",
       inputSizeClasses[size],
       showCountryCode ? null : iconPaddingClasses[size],
       showValidation && trimmedValue.length > 0

--- a/src/shared/ui/input/URLInput.tsx
+++ b/src/shared/ui/input/URLInput.tsx
@@ -122,7 +122,7 @@ export const URLInput = forwardRef<HTMLInputElement, URLInputProps>(({
 
   const inputClasses = cn(
     'w-full rounded-r-md text-ink placeholder:text-dim-2',
-    'focus:outline-none transition-all duration-200',
+    'focus:outline-none transition-[color,background-color,border-color,box-shadow] duration-200',
     'field border-none',
     sizeClasses[size],
     iconPaddingClasses[size],

--- a/src/shared/ui/layout/EditorShell.tsx
+++ b/src/shared/ui/layout/EditorShell.tsx
@@ -16,7 +16,7 @@ import { ContentWithPreview } from './ContentWithPreview';
  * as DetailHeader so all chrome in the app is consistent.
  *
  * Chat-first hero (Settings.html treatment): when `crumb`, `accentTitle`, or
- * `lede` is provided, EditorShell renders a serif H1 hero above its children
+ * `lede` is provided, EditorShell renders a sans H1 hero above its children
  * (in the scroll area, not the sticky header). The compact `title` stays in
  * the sticky header bar so the chrome stays consistent app-wide.
  */
@@ -25,7 +25,7 @@ export interface EditorShellProps {
   subtitle?: string;
   /**
    * Mono uppercase crumb (e.g. "Settings · Practice · Intelligence") rendered
-   * above the serif H1 hero. Renders inside the scrollable content, not the
+   * above the sans H1 hero. Renders inside the scrollable content, not the
    * sticky header.
    */
   crumb?: ComponentChildren;

--- a/src/shared/ui/layout/PageHeader.tsx
+++ b/src/shared/ui/layout/PageHeader.tsx
@@ -8,7 +8,7 @@ export interface PageHeaderProps {
    */
   crumb?: ComponentChildren;
   title: string;
-  /** Lede paragraph beneath the title. Source serif body, max 56ch, color ink-2. */
+  /** Lede paragraph beneath the title. Source sans body, max 56ch, color ink-2. */
   subtitle?: string;
   actions?: ComponentChildren;
   className?: string;

--- a/src/shared/ui/markdown/markdownComponents.tsx
+++ b/src/shared/ui/markdown/markdownComponents.tsx
@@ -82,7 +82,7 @@ export const markdownComponents: Components = {
 
   table({ children, ...props }) {
     return (
-      <div className="overflow-x-auto my-4 rounded-r-md" style={{ boxShadow: 'var(--glass-rim-subtle)' }}>
+      <div className="my-4 overflow-x-auto rounded-r-md shadow-[var(--glass-rim-subtle)]">
         <table className="min-w-full text-sm border-collapse" {...props}>
           {children}
         </table>
@@ -147,8 +147,7 @@ export const markdownComponents: Components = {
       <div className="group relative my-3 max-w-full min-w-0">
         {copyableText ? <CopyButton text={copyableText} /> : null}
         <pre
-          className="max-w-full min-w-0 overflow-x-auto rounded-r-md p-4 bg-[rgb(var(--surface-app-frame))]/40 backdrop-blur-sm text-[rgb(var(--input-foreground))] text-sm leading-relaxed"
-          style={{ boxShadow: 'var(--glass-rim-subtle)' }}
+          className="max-w-full min-w-0 overflow-x-auto rounded-r-md p-4 bg-[rgb(var(--surface-app-frame))]/40 backdrop-blur-sm text-[rgb(var(--input-foreground))] text-sm leading-relaxed shadow-[var(--glass-rim-subtle)]"
           {...props}
         >
           {children}

--- a/src/shared/ui/media/Carousel.tsx
+++ b/src/shared/ui/media/Carousel.tsx
@@ -90,7 +90,7 @@ export function Carousel({
               onClick={() => goTo(i)}
               aria-label={`Go to slide ${i + 1}`}
               className={cn(
-                'w-1.5 h-1.5 rounded-full transition-all',
+                'w-1.5 h-1.5 rounded-full transition-[width,background-color]',
                 i === current
                   ? 'bg-accent w-4'
                   : 'bg-paper-2/15',

--- a/src/shared/ui/navigation/Stepper.tsx
+++ b/src/shared/ui/navigation/Stepper.tsx
@@ -59,7 +59,7 @@ export function Stepper({
               <div
                 aria-current={status === 'active' ? 'step' : undefined}
                 className={cn(
-                  'shrink-0 flex items-center justify-center rounded-full transition-all',
+                  'shrink-0 flex items-center justify-center rounded-full transition-[color,background-color,box-shadow]',
                   'w-8 h-8 text-xs font-medium',
                   status === 'completed' && 'bg-accent text-accent-ink',
                   status === 'active' && 'bg-accent/15 text-accent dark:text-accent ring-2 ring-accent/30',

--- a/src/shared/ui/shell/ScrollToTop.tsx
+++ b/src/shared/ui/shell/ScrollToTop.tsx
@@ -31,7 +31,7 @@ export function ScrollToTop({ threshold = 300, className }: ScrollToTopProps) {
       tabIndex={visible ? 0 : -1}
       className={cn(
         'fixed bottom-6 right-6 z-[200] btn btn-secondary btn-icon-md',
-        'transition-all duration-200',
+        'transition-[opacity,transform] duration-200',
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none',
         className,
       )}

--- a/src/shared/ui/upload/atoms/UploadProgressRing.tsx
+++ b/src/shared/ui/upload/atoms/UploadProgressRing.tsx
@@ -69,7 +69,7 @@ export const UploadProgressRing = ({
         strokeWidth="2"
         fill="none"
         strokeLinecap="round"
-        className="text-light-file-progress-fill dark:text-dark-file-progress-fill transition-all duration-300"
+        className="text-light-file-progress-fill dark:text-dark-file-progress-fill transition-[stroke-dashoffset] duration-300"
         strokeDasharray={strokeDasharray}
       />
       </svg>

--- a/src/shared/ui/upload/molecules/FileCard.tsx
+++ b/src/shared/ui/upload/molecules/FileCard.tsx
@@ -66,7 +66,7 @@ export const FileCard = ({
   if (variant === 'tile') {
     const fileType = getFileTypeConfig(fileName, mimeType);
     const tileClassName = cn(
-      'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-card text-left transition-all',
+      'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-line-subtle bg-card text-left transition-[border-color,box-shadow]',
       onClick ? 'cursor-pointer hover:border-line-subtle hover:shadow-md focus:outline-none focus:ring-2 focus:ring-accent' : '',
       className
     );
@@ -166,7 +166,7 @@ export const FileCard = ({
     return (
       <div className={cn(
         'relative rounded-2xl overflow-hidden flex-shrink-0',
-        'panel transition-all duration-200',
+        'panel',
         // Make images square, matching the height of file cards
         size === 'sm' ? 'w-14 h-14' : size === 'md' ? 'w-16 h-16' : 'w-20 h-20',
         className

--- a/tests/unit/design-system/productShellStyleAudit.test.ts
+++ b/tests/unit/design-system/productShellStyleAudit.test.ts
@@ -1,0 +1,51 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  flattenExceptionFiles,
+  INLINE_STYLE_EXCEPTION_FILES,
+  SERIF_EXCEPTION_FILES,
+} from '../../../scripts/lib/productShellStyleAudit.js';
+
+const root = resolve(import.meta.dirname, '../../..');
+const src = resolve(root, 'src');
+
+const sourceFiles = (directory: string): string[] => readdirSync(directory, { withFileTypes: true })
+  .flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : [path];
+  })
+  .filter((path) => ['.css', '.ts', '.tsx'].includes(extname(path)));
+
+const repoPath = (path: string): string => relative(root, path).replaceAll('\\', '/');
+
+describe('product-shell style audit', () => {
+  const files = sourceFiles(src);
+
+  it('uses precise transition properties', () => {
+    const offenders = files
+      .filter((path) => readFileSync(path, 'utf8').includes('transition-all'))
+      .map(repoPath);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps every inline style inside an explicit exception category', () => {
+    const actual = files
+      .filter((path) => extname(path) === '.tsx' && readFileSync(path, 'utf8').includes('style='))
+      .map(repoPath)
+      .sort();
+
+    expect(actual).toEqual(flattenExceptionFiles(INLINE_STYLE_EXCEPTION_FILES));
+  });
+
+  it('keeps serif typography out of product working surfaces', () => {
+    const serifPattern = /font-serif|family-name:var\(--serif\)|fontFamily:\s*['"]var\(--serif\)|font-family:\s*var\(--serif\)/;
+    const actual = files
+      .filter((path) => serifPattern.test(readFileSync(path, 'utf8')))
+      .map(repoPath)
+      .sort();
+
+    expect(actual).toEqual(flattenExceptionFiles(SERIF_EXCEPTION_FILES));
+  });
+});


### PR DESCRIPTION
Closes #725

## Summary
- replace every remaining 	ransition-all with the exact transitioned properties
- move product-shell working surfaces to the sans type voice while preserving documented public-intake and legal-document serif exceptions
- migrate static inline styles to tokenized classes and enforce the exact runtime/rendering exception set
- add a regression audit and an engineering note that make both boundaries executable

## Verification
- 
pm run type-check
- 
pm run lint
- 
pm run test:component -- --run (131 passed)
- 
pm run test:unit (680 passed)
- 
pm run build
- 
pm run build:check-size (284.4 KB / 300 KB)
- git diff --check
- browser review: onboarding and style-debug surfaces across light, dark, midnight, and parchment at mobile, tablet, and desktop widths (24 captures; no console errors)

## Local infrastructure note
The committed Playwright screenshot suite could not reach screenshot execution because local Wrangler's remote-proxy OAuth scope left the Worker unavailable; auth setup received 500 responses. The same public debug surfaces were reviewed through the configured developer tunnel, so this local backend prerequisite is recorded rather than treated as a frontend delivery blocker.