### PR TITLE
AI: read conversation context from PostgreSQL

### DIFF
--- a/tests/unit/practiceAssistant/conversationHistoryService.test.ts
+++ b/tests/unit/practiceAssistant/conversationHistoryService.test.ts
@@ -27,7 +27,7 @@ describe('loadBackendConversationHistory', () => {
       }), { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await loadBackendConversationHistory(env, request, 'practice/1', 'conversation/1', 20);
+    const result = await loadBackendConversationHistory(env, request, 'practice/1', 'conversation/1', 42, 20);
 
     expect(result).toEqual([
       { role: 'user', content: 'Earlier question' },
@@ -51,7 +51,7 @@ describe('loadBackendConversationHistory', () => {
   it('fails fast when the backend response is malformed', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not json', { status: 200 })));
 
-    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation')).rejects.toThrow(
+    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation', 1)).rejects.toThrow(
       'Conversation history lookup returned malformed JSON',
     );
   });
@@ -59,8 +59,21 @@ describe('loadBackendConversationHistory', () => {
   it('fails fast when the backend source is unavailable', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ message: 'not replicated' }), { status: 404 })));
 
-    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation')).rejects.toThrow(
+    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation', 1)).rejects.toThrow(
       'Conversation history lookup failed: not replicated',
     );
+  });
+
+  it('waits for the durable projection to reach the Worker sequence before reading messages', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { latest_seq: 4 } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { latest_seq: 5 } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [{ role: 'user', content: 'Current' }] }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation', 5, 20)).resolves.toEqual([
+      { role: 'user', content: 'Current' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/unit/practiceAssistant/conversationHistoryService.test.ts
+++ b/tests/unit/practiceAssistant/conversationHistoryService.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadBackendConversationHistory } from '../../../worker/services/practiceAssistant/conversationHistoryService.js';
+import type { Env } from '../../../worker/types.js';
+
+const env = { BACKEND_API_URL: 'https://api.example.com/' } as Env;
+const request = new Request('https://app.example.com/api/ai/chat', {
+  headers: {
+    Authorization: 'Bearer session-token',
+    Cookie: 'session=cookie',
+  },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('loadBackendConversationHistory', () => {
+  it('loads the latest backend-persisted messages with forwarded authentication', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { latest_seq: 42 } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        data: [
+          { role: 'system', content: 'hidden' },
+          { role: 'user', content: ' Earlier question ' },
+          { role: 'assistant', content: 'Earlier answer' },
+        ],
+      }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await loadBackendConversationHistory(env, request, 'practice/1', 'conversation/1', 20);
+
+    expect(result).toEqual([
+      { role: 'user', content: 'Earlier question' },
+      { role: 'assistant', content: 'Earlier answer' },
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.com/api/intake-conversations/practice%2F1/conversation%2F1',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.com/api/intake-conversations/practice%2F1/conversation%2F1/messages?from_seq=23&limit=20',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer session-token');
+    expect(headers.get('Cookie')).toBe('session=cookie');
+  });
+
+  it('fails fast when the backend response is malformed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not json', { status: 200 })));
+
+    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation')).rejects.toThrow(
+      'Conversation history lookup returned malformed JSON',
+    );
+  });
+
+  it('fails fast when the backend source is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ message: 'not replicated' }), { status: 404 })));
+
+    await expect(loadBackendConversationHistory(env, request, 'practice', 'conversation')).rejects.toThrow(
+      'Conversation history lookup failed: not replicated',
+    );
+  });
+});

--- a/tests/unit/practiceAssistant/toolRegistry.test.ts
+++ b/tests/unit/practiceAssistant/toolRegistry.test.ts
@@ -438,11 +438,14 @@ describe('practice assistant tool registry', () => {
     expect(routeSource).not.toContain('executePracticeAssistantTools');
   });
 
-  it('sends conversation history through the query engine instead of keeping fake memory', () => {
+  it('loads conversation history from the backend source of truth instead of request or D1 state', () => {
     const routeSource = readFileSync(resolve(process.cwd(), 'worker/routes/aiChat.ts'), 'utf8');
     const engineSource = readFileSync(resolve(process.cwd(), 'worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts'), 'utf8');
-    expect(routeSource).toContain('messages: body.messages.map');
+    expect(routeSource).not.toContain('messages: body.messages.map');
     expect(engineSource).toContain('loadMessages');
+    expect(engineSource).toContain('loadBackendConversationHistory');
+    expect(engineSource).not.toContain('ConversationService');
+    expect(engineSource).not.toContain('initialMessages');
     expect(engineSource).toContain('...conversationMessages');
     expect(engineSource).not.toContain("private readonly messages: Array<{ role: 'user' | 'assistant'; content: string }> = []");
   });

--- a/worker/routes/aiChat.ts
+++ b/worker/routes/aiChat.ts
@@ -439,7 +439,6 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
       auth,
       env,
       request,
-      messages: body.messages.map((message) => ({ role: message.role, content: message.content })),
     });
   }
 

--- a/worker/routes/aiChat.ts
+++ b/worker/routes/aiChat.ts
@@ -439,6 +439,7 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
       auth,
       env,
       request,
+      expectedLatestSeq: conversation.latest_seq,
     });
   }
 

--- a/worker/routes/practiceAssistant.ts
+++ b/worker/routes/practiceAssistant.ts
@@ -31,16 +31,14 @@ export interface PracticeAssistantTurnParams {
   auth: AuthContext & { memberRole: string };
   env: Env;
   request: Request;
-  messages?: Array<{ role: 'user' | 'assistant'; content: string }>;
 }
 
 export function runPracticeAssistantTurn(params: PracticeAssistantTurnParams): Response {
-  const { conversationId, practiceId, practiceSlug, userMessage, userId, auth, env, request, messages } = params;
+  const { conversationId, practiceId, practiceSlug, userMessage, userId, auth, env, request } = params;
   const { response, write, close } = createSseResponse();
   Logger.info('practice_assistant.sse.prepared', {
     conversationId,
     practiceId,
-    messageCount: messages?.length ?? null,
     userMessageLength: userMessage.length,
   });
   void Promise.resolve().then(async () => {
@@ -51,7 +49,6 @@ export function runPracticeAssistantTurn(params: PracticeAssistantTurnParams): R
     });
     const engine = new PracticeAssistantQueryEngine({
       conversationId, practiceId, practiceSlug, userId, auth, env, request,
-      initialMessages: messages,
     });
     try {
       for await (const event of engine.submitMessage(userMessage)) {

--- a/worker/routes/practiceAssistant.ts
+++ b/worker/routes/practiceAssistant.ts
@@ -31,10 +31,11 @@ export interface PracticeAssistantTurnParams {
   auth: AuthContext & { memberRole: string };
   env: Env;
   request: Request;
+  expectedLatestSeq: number;
 }
 
 export function runPracticeAssistantTurn(params: PracticeAssistantTurnParams): Response {
-  const { conversationId, practiceId, practiceSlug, userMessage, userId, auth, env, request } = params;
+  const { conversationId, practiceId, practiceSlug, userMessage, userId, auth, env, request, expectedLatestSeq } = params;
   const { response, write, close } = createSseResponse();
   Logger.info('practice_assistant.sse.prepared', {
     conversationId,
@@ -48,7 +49,7 @@ export function runPracticeAssistantTurn(params: PracticeAssistantTurnParams): R
       practiceId,
     });
     const engine = new PracticeAssistantQueryEngine({
-      conversationId, practiceId, practiceSlug, userId, auth, env, request,
+      conversationId, practiceId, practiceSlug, userId, auth, env, request, expectedLatestSeq,
     });
     try {
       for await (const event of engine.submitMessage(userMessage)) {

--- a/worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts
+++ b/worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts
@@ -6,7 +6,7 @@ import { executePracticeAssistantTools } from './toolExecutor.js';
 import { toOpenAiTools } from './toolRegistry.js';
 import { PracticeAssistantAuditService } from './auditService.js';
 import { buildTurnMetadata, persistAssistantMessage } from './messageAdapter.js';
-import { ConversationService } from '../ConversationService.js';
+import { loadBackendConversationHistory } from './conversationHistoryService.js';
 import { Logger } from '../../utils/logger.js';
 import type {
   PracticeAssistantProgress,
@@ -47,7 +47,6 @@ export interface PracticeAssistantQueryEngineConfig {
   auth: AuthContext & { memberRole: string };
   env: Env;
   request: Request;
-  initialMessages?: PracticeAssistantModelMessage[];
 }
 
 const systemPrompt = [
@@ -202,11 +201,13 @@ export class PracticeAssistantQueryEngine {
   }
 
   private async loadMessages(userMessage: string): Promise<PracticeAssistantModelMessage[]> {
-    const sourceMessages = this.config.initialMessages?.length
-      ? this.config.initialMessages
-      : (await new ConversationService(this.config.env).getMessages(this.config.conversationId, this.config.practiceId, { limit: 20 }))
-        .messages
-        .map((message) => ({ role: message.role, content: message.content }));
+    const sourceMessages = await loadBackendConversationHistory(
+      this.config.env,
+      this.config.request,
+      this.config.practiceId,
+      this.config.conversationId,
+      20,
+    );
     const normalized = sourceMessages
       .filter((message): message is PracticeAssistantModelMessage =>
         (message.role === 'user' || message.role === 'assistant') && message.content.trim().length > 0)

--- a/worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts
+++ b/worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts
@@ -47,6 +47,7 @@ export interface PracticeAssistantQueryEngineConfig {
   auth: AuthContext & { memberRole: string };
   env: Env;
   request: Request;
+  expectedLatestSeq: number;
 }
 
 const systemPrompt = [
@@ -206,6 +207,7 @@ export class PracticeAssistantQueryEngine {
       this.config.request,
       this.config.practiceId,
       this.config.conversationId,
+      this.config.expectedLatestSeq,
       20,
     );
     const normalized = sourceMessages

--- a/worker/services/practiceAssistant/conversationHistoryService.ts
+++ b/worker/services/practiceAssistant/conversationHistoryService.ts
@@ -1,0 +1,81 @@
+import type { Env } from '../../types.js';
+
+export interface PracticeAssistantHistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const getBackendBaseUrl = (env: Env): string => {
+  const base = env.BACKEND_API_URL?.trim();
+  if (!base) throw new Error('BACKEND_API_URL is required for conversation history');
+  return base.replace(/\/+$/, '');
+};
+
+const forwardHeaders = (request: Request): Headers => {
+  const headers = new Headers({ Accept: 'application/json' });
+  const cookie = request.headers.get('Cookie');
+  const authorization = request.headers.get('Authorization');
+  if (cookie) headers.set('Cookie', cookie);
+  if (authorization) headers.set('Authorization', authorization);
+  return headers;
+};
+
+const fetchJson = async (url: string, headers: Headers, label: string): Promise<unknown> => {
+  const response = await fetch(url, { headers });
+  const text = await response.text();
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error(`${label} returned malformed JSON`);
+  }
+  if (!response.ok) {
+    const record = payload && typeof payload === 'object' && !Array.isArray(payload)
+      ? payload as Record<string, unknown>
+      : {};
+    const message = typeof record.message === 'string' ? record.message : `HTTP ${response.status}`;
+    throw new Error(`${label} failed: ${message}`);
+  }
+  return payload;
+};
+
+const unwrapData = (payload: unknown): unknown => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return undefined;
+  return (payload as Record<string, unknown>).data;
+};
+
+export const loadBackendConversationHistory = async (
+  env: Env,
+  request: Request,
+  practiceId: string,
+  conversationId: string,
+  limit = 20,
+): Promise<PracticeAssistantHistoryMessage[]> => {
+  const base = getBackendBaseUrl(env);
+  const headers = forwardHeaders(request);
+  const resource = `${base}/api/intake-conversations/${encodeURIComponent(practiceId)}/${encodeURIComponent(conversationId)}`;
+  const conversation = unwrapData(await fetchJson(resource, headers, 'Conversation history lookup'));
+  if (!conversation || typeof conversation !== 'object' || Array.isArray(conversation)) {
+    throw new Error('Conversation history lookup returned an invalid conversation');
+  }
+  const latestSeq = (conversation as Record<string, unknown>).latest_seq;
+  if (typeof latestSeq !== 'number' || !Number.isInteger(latestSeq) || latestSeq < 0) {
+    throw new Error('Conversation history lookup returned an invalid latest_seq');
+  }
+
+  const boundedLimit = Math.max(1, Math.min(limit, 100));
+  const fromSeq = Math.max(0, latestSeq - boundedLimit + 1);
+  const messagesUrl = `${resource}/messages?from_seq=${fromSeq}&limit=${boundedLimit}`;
+  const messages = unwrapData(await fetchJson(messagesUrl, headers, 'Conversation messages lookup'));
+  if (!Array.isArray(messages)) {
+    throw new Error('Conversation messages lookup returned an invalid message list');
+  }
+
+  return messages.flatMap((message): PracticeAssistantHistoryMessage[] => {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return [];
+    const record = message as Record<string, unknown>;
+    if ((record.role !== 'user' && record.role !== 'assistant') || typeof record.content !== 'string') return [];
+    const content = record.content.trim();
+    return content ? [{ role: record.role, content }] : [];
+  });
+};

--- a/worker/services/practiceAssistant/conversationHistoryService.ts
+++ b/worker/services/practiceAssistant/conversationHistoryService.ts
@@ -5,6 +5,8 @@ export interface PracticeAssistantHistoryMessage {
   content: string;
 }
 
+const PROJECTION_RETRY_DELAYS_MS = [0, 100, 300, 700] as const;
+
 const getBackendBaseUrl = (env: Env): string => {
   const base = env.BACKEND_API_URL?.trim();
   if (!base) throw new Error('BACKEND_API_URL is required for conversation history');
@@ -49,18 +51,28 @@ export const loadBackendConversationHistory = async (
   request: Request,
   practiceId: string,
   conversationId: string,
+  expectedLatestSeq: number,
   limit = 20,
 ): Promise<PracticeAssistantHistoryMessage[]> => {
   const base = getBackendBaseUrl(env);
   const headers = forwardHeaders(request);
   const resource = `${base}/api/intake-conversations/${encodeURIComponent(practiceId)}/${encodeURIComponent(conversationId)}`;
-  const conversation = unwrapData(await fetchJson(resource, headers, 'Conversation history lookup'));
-  if (!conversation || typeof conversation !== 'object' || Array.isArray(conversation)) {
-    throw new Error('Conversation history lookup returned an invalid conversation');
-  }
-  const latestSeq = (conversation as Record<string, unknown>).latest_seq;
-  if (typeof latestSeq !== 'number' || !Number.isInteger(latestSeq) || latestSeq < 0) {
-    throw new Error('Conversation history lookup returned an invalid latest_seq');
+  let latestSeq = -1;
+  for (const [attempt, delayMs] of PROJECTION_RETRY_DELAYS_MS.entries()) {
+    if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+    const conversation = unwrapData(await fetchJson(resource, headers, 'Conversation history lookup'));
+    if (!conversation || typeof conversation !== 'object' || Array.isArray(conversation)) {
+      throw new Error('Conversation history lookup returned an invalid conversation');
+    }
+    const projectedSeq = (conversation as Record<string, unknown>).latest_seq;
+    if (typeof projectedSeq !== 'number' || !Number.isInteger(projectedSeq) || projectedSeq < 0) {
+      throw new Error('Conversation history lookup returned an invalid latest_seq');
+    }
+    latestSeq = projectedSeq;
+    if (latestSeq >= expectedLatestSeq) break;
+    if (attempt === PROJECTION_RETRY_DELAYS_MS.length - 1) {
+      throw new Error(`Conversation history projection is behind: expected seq ${expectedLatestSeq}, received ${latestSeq}`);
+    }
   }
 
   const boundedLimit = Math.max(1, Math.min(limit, 100));


### PR DESCRIPTION
Advances #666.

## What changed
- Practice Assistant context now loads the persisted intake-conversation projection from the backend instead of trusting request-provided messages or querying D1
- waits with bounded retries until PostgreSQL reaches the Worker's expected `latest_seq`, then requests the latest bounded message window
- forwards the authenticated session to the backend and fast-fails on unavailable, malformed, or persistently stale history
- keeps D1/Durable Objects responsible for live transport and in-flight UI reads

## Why
The worker already writes conversation events through the durable queue into PostgreSQL, but AI context assembly still read the edge store or accepted client-provided history. This closes that source-of-truth gap without replacing the real-time architecture.

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` — 85 files, 693 tests passed
- focused Practice Assistant tests — 85 passed
- `npm run build`
- `npm run build:check-size` — 284.4 KB / 300 KB
- `git diff --check`

`npm run test:worker` currently selects `tests/integration/**` and reports no matching files; it did not execute a suite.