### PR TITLE
feat(reports): show assistant activity ledger

### DIFF
--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -27,6 +27,7 @@ import {
 import { Bar, Pill } from '@/design-system/primitives';
 import { useNavigation } from '@/shared/utils/navigation';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { useReportData } from '@/features/reports/hooks/useReportData';
 import { useReportExport } from '@/features/reports/hooks/useReportExport';
 import { reportsApi } from '@/features/reports/services/reportsApi';
@@ -39,6 +40,9 @@ import {
 } from '@/features/reports/config/reportCollection';
 import type { IconComponent } from '@/shared/ui/Icon';
 import type {
+  AssistantActivityMeta,
+  AssistantActivityRow,
+  AssistantActivityStatus,
   RevenueMeta,
   RevenueRow,
   UtilizationMeta,
@@ -510,7 +514,7 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
           conversionPercent={conversionPercent}
         />
 
-        <AssistantActivitySection />
+        <AssistantActivitySection practiceId={practiceId} />
 
         <section className="flex flex-col gap-3">
           <div className="flex items-end justify-between border-b border-rule pb-3">
@@ -745,24 +749,21 @@ const IntakeQualitySection: FunctionComponent<IntakeQualitySectionProps> = ({
   );
 };
 
-const AssistantActivitySection: FunctionComponent = () => {
-  // TODO(backend): wire this section to GET /api/reports/:practiceId/assistant-activity
-  // reading from a practice_assistant_actions D1 table (worker-owned, just needs
-  // a route + table). Today the table renders placeholder rows so the chat-first
-  // shape is visible end-to-end and the route gap is documented inline.
-  const placeholderRows: ReadonlyArray<{
-    when: string;
-    what: string;
-    saved: string;
-    status: 'pending' | 'approved' | 'declined';
-  }> = [
-    {
-      when: 'Today',
-      what: 'Recent assistant actions appear here once the activity feed ships.',
-      saved: '—',
-      status: 'pending',
-    },
-  ];
+const ACTIVITY_TONE: Record<AssistantActivityStatus, 'live' | 'warn' | 'urgent' | 'gold' | 'dim'> = {
+  pending: 'gold',
+  approved: 'live',
+  rejected: 'dim',
+  executed: 'live',
+  failed: 'urgent',
+};
+
+const AssistantActivitySection: FunctionComponent<{ practiceId: string }> = ({ practiceId }) => {
+  const { data, loading, error } = useReportData<AssistantActivityRow, AssistantActivityMeta>(
+    practiceId,
+    'assistant-activity'
+  );
+  const minutesSaved = data?.meta?.estimatedMinutesSaved ?? 0;
+  const completed = data?.meta?.executedCount ?? 0;
   return (
     <section className="flex flex-col gap-4">
       <div className="flex items-end justify-between border-b border-rule pb-3">
@@ -770,13 +771,16 @@ const AssistantActivitySection: FunctionComponent = () => {
           Assistant activity log
         </h2>
         <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-dim">
-          Awaiting activity feed
+          {loading ? 'Reading activity' : `${completed} completed · ${minutesSaved}m saved`}
         </span>
       </div>
 
       <Observation>
-        Once the assistant-activity feed ships I will tally hours saved, surface declined actions, and link
-        straight to the source rows for each one.
+        {error
+          ? 'I could not read the assistant activity ledger. Refresh the report to try again.'
+          : data?.items.length
+            ? `The practice assistant completed ${completed} ${completed === 1 ? 'action' : 'actions'} in this view, saving an estimated ${minutesSaved} minutes. Estimates use a fixed action-type rubric and count executed actions only.`
+            : 'No assistant actions have been staged for this practice yet.'}
       </Observation>
 
       <div className="panel overflow-hidden">
@@ -786,19 +790,34 @@ const AssistantActivitySection: FunctionComponent = () => {
           <div className="text-right">Time saved</div>
           <div className="text-center">Status</div>
         </div>
-        {placeholderRows.map((row) => (
+        {loading ? (
+          <div className="flex items-center justify-center gap-3 px-5 py-8 text-sm text-dim-2">
+            <LoadingSpinner size="sm" /> Reading the action ledger…
+          </div>
+        ) : error ? (
+          <div className="px-5 py-8 text-center text-sm text-neg">Assistant activity could not be loaded.</div>
+        ) : data?.items.length ? data.items.map((row) => (
           <div
-            key={row.what}
+            key={row.id}
             className="grid grid-cols-[90px_1fr_90px_90px] items-center gap-4 border-b border-rule px-5 py-3 text-sm last:border-b-0"
           >
-            <div className="font-mono text-[11px] uppercase tracking-[0.04em] text-dim">{row.when}</div>
-            <div className="font-sans text-sm text-ink">{row.what}</div>
-            <div className="text-right font-mono tabular-nums text-ink-2">{row.saved}</div>
+            <time dateTime={row.createdAt} className="font-mono text-[11px] uppercase tracking-[0.04em] text-dim">
+              {formatRelativeTime(row.createdAt)}
+            </time>
+            <div className="min-w-0 font-sans text-sm text-ink">
+              <div className="truncate">{row.title}</div>
+              {row.description ? <div className="truncate text-xs text-dim-2">{row.description}</div> : null}
+            </div>
+            <div className="text-right font-mono tabular-nums text-ink-2">
+              {row.estimatedMinutesSaved ? `${row.estimatedMinutesSaved}m` : '—'}
+            </div>
             <div className="flex justify-center">
-              <Pill tone="dim">{row.status}</Pill>
+              <Pill tone={ACTIVITY_TONE[row.status]}>{row.status}</Pill>
             </div>
           </div>
-        ))}
+        )) : (
+          <div className="px-5 py-8 text-center text-sm text-dim-2">No assistant activity yet.</div>
+        )}
       </div>
     </section>
   );

--- a/src/features/reports/services/reportsTypes.ts
+++ b/src/features/reports/services/reportsTypes.ts
@@ -138,6 +138,27 @@ export interface TaskProductivityMeta extends Record<string, unknown> {
   averageCycleDays: number;
 }
 
+export type AssistantActivityStatus = 'pending' | 'approved' | 'rejected' | 'executed' | 'failed';
+
+export interface AssistantActivityRow {
+  id: string;
+  conversationId: string;
+  title: string;
+  description: string;
+  status: AssistantActivityStatus;
+  createdAt: string;
+  completedAt: string | null;
+  estimatedMinutesSaved: number;
+}
+
+export interface AssistantActivityMeta extends Record<string, unknown> {
+  estimatedMinutesSaved: number;
+  executedCount: number;
+  rejectedCount: number;
+  failedCount: number;
+  pendingCount: number;
+}
+
 export type ReportRow =
   | RevenueRow
   | AgingRow

--- a/tests/unit/worker/services/AssistantActivityReportService.test.ts
+++ b/tests/unit/worker/services/AssistantActivityReportService.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { AssistantActivityReportService } from '../../../../worker/services/practiceAssistant/activityReportService';
+import type { Env } from '../../../../worker/types';
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+  id: 'action-1',
+  conversation_id: 'conversation-1',
+  status: 'executed',
+  approval_summary_json: JSON.stringify({ title: 'Create follow-up task', description: 'Due tomorrow.' }),
+  payload_json: JSON.stringify({ actionType: 'create_entity' }),
+  created_at: '2026-07-12T10:00:00.000Z',
+  executed_at: '2026-07-12T10:01:00.000Z',
+  ...overrides,
+});
+
+const makeEnv = (rows: Array<Record<string, unknown>>) => ({
+  DB: {
+    prepare: () => ({
+      bind: () => ({ all: async () => ({ results: rows }) }),
+    }),
+  },
+} as unknown as Env);
+
+describe('AssistantActivityReportService', () => {
+  it('returns practice activity with deterministic executed-action estimates', async () => {
+    const service = new AssistantActivityReportService(makeEnv([
+      row(),
+      row({ id: 'action-2', status: 'rejected', executed_at: null }),
+    ]));
+
+    const report = await service.get('practice-1');
+
+    expect(report.items).toMatchObject([
+      { id: 'action-1', status: 'executed', estimatedMinutesSaved: 10 },
+      { id: 'action-2', status: 'rejected', estimatedMinutesSaved: 0 },
+    ]);
+    expect(report.meta).toMatchObject({
+      estimatedMinutesSaved: 10,
+      executedCount: 1,
+      rejectedCount: 1,
+    });
+  });
+
+  it('fast fails when an action record violates the stored contract', async () => {
+    const service = new AssistantActivityReportService(makeEnv([
+      row({ approval_summary_json: JSON.stringify({ description: 'Missing title' }) }),
+    ]));
+
+    await expect(service.get('practice-1')).rejects.toThrow('Invalid title');
+  });
+});

--- a/worker/routes/reports.ts
+++ b/worker/routes/reports.ts
@@ -22,6 +22,7 @@ import {
   type ReportFrequency,
 } from '../services/ReportScheduleService.js';
 import { ReportDeliveryService } from '../services/ReportDeliveryService.js';
+import { AssistantActivityReportService } from '../services/practiceAssistant/activityReportService.js';
 import { toCsv, type CsvColumn } from '../utils/csv.js';
 import { parseJsonBody } from '../utils.js';
 
@@ -688,11 +689,22 @@ export async function handleReports(request: Request, env: Env): Promise<Respons
   if (authContext.isAnonymous) throw HttpErrors.forbidden('Access denied');
   await requirePracticeMember(request, env, practiceId, 'paralegal');
 
-  if (!env.BACKEND_API_URL) {
-    throw HttpErrors.internalServerError('BACKEND_API_URL not configured');
-  }
-
   try {
+    if (remainder === 'assistant-activity') {
+      if (request.method !== 'GET') throw HttpErrors.methodNotAllowed('Only GET allowed');
+      const rawLimit = url.searchParams.get('limit');
+      const limit = rawLimit === null ? undefined : Number(rawLimit);
+      if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 100)) {
+        throw HttpErrors.badRequest('limit must be an integer from 1 to 100');
+      }
+      const service = new AssistantActivityReportService(env);
+      return envelope(await service.get(practiceId, limit));
+    }
+
+    if (!env.BACKEND_API_URL) {
+      throw HttpErrors.internalServerError('BACKEND_API_URL not configured');
+    }
+
     if (remainder === 'schedules') {
       if (request.method === 'GET') return await handleSchedulesList(env, practiceId);
       if (request.method === 'POST') return await handleScheduleCreate(request, env, practiceId);

--- a/worker/services/practiceAssistant/activityReportService.ts
+++ b/worker/services/practiceAssistant/activityReportService.ts
@@ -1,0 +1,115 @@
+import type { Env } from '../../types.js';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const ESTIMATED_MINUTES_BY_ACTION: Readonly<Record<string, number>> = {
+  create_entity: 10,
+  update_entity: 5,
+  delete_entity: 3,
+  run_entity_action: 8,
+};
+
+const VALID_STATUSES = new Set(['pending', 'approved', 'rejected', 'executed', 'failed']);
+
+interface ActivityRow {
+  id: string;
+  conversation_id: string;
+  status: string;
+  approval_summary_json: string;
+  payload_json: string;
+  created_at: string;
+  executed_at: string | null;
+}
+
+export interface AssistantActivityItem {
+  id: string;
+  conversationId: string;
+  title: string;
+  description: string;
+  status: 'pending' | 'approved' | 'rejected' | 'executed' | 'failed';
+  createdAt: string;
+  completedAt: string | null;
+  estimatedMinutesSaved: number;
+}
+
+export interface AssistantActivityReport {
+  items: AssistantActivityItem[];
+  total: number;
+  generatedAt: string;
+  filters: Record<string, string | undefined>;
+  meta: {
+    estimatedMinutesSaved: number;
+    executedCount: number;
+    rejectedCount: number;
+    failedCount: number;
+    pendingCount: number;
+  };
+}
+
+const parseObject = (raw: string, field: string): Record<string, unknown> => {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Invalid ${field} in assistant activity record`);
+  }
+  return parsed as Record<string, unknown>;
+};
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Invalid ${field} in assistant activity record`);
+  }
+  return value.trim();
+};
+
+export class AssistantActivityReportService {
+  constructor(private readonly env: Env) {}
+
+  async get(practiceId: string, requestedLimit = DEFAULT_LIMIT): Promise<AssistantActivityReport> {
+    const limit = Math.max(1, Math.min(MAX_LIMIT, Math.trunc(requestedLimit)));
+    const rows = await this.env.DB.prepare(`
+      SELECT id, conversation_id, status, approval_summary_json, payload_json, created_at, executed_at
+      FROM practice_assistant_actions
+      WHERE practice_id = ?
+      ORDER BY created_at DESC
+      LIMIT ?
+    `).bind(practiceId, limit).all<ActivityRow>();
+
+    const items = (rows.results ?? []).map((row): AssistantActivityItem => {
+      if (!VALID_STATUSES.has(row.status)) {
+        throw new Error('Invalid status in assistant activity record');
+      }
+      const summary = parseObject(row.approval_summary_json, 'approval summary');
+      const payload = parseObject(row.payload_json, 'payload');
+      const actionType = requireString(payload.actionType, 'action type');
+      const status = row.status as AssistantActivityItem['status'];
+
+      return {
+        id: row.id,
+        conversationId: row.conversation_id,
+        title: requireString(summary.title, 'title'),
+        description: typeof summary.description === 'string' ? summary.description.trim() : '',
+        status,
+        createdAt: row.created_at,
+        completedAt: status === 'executed' ? row.executed_at : null,
+        estimatedMinutesSaved: status === 'executed'
+          ? (ESTIMATED_MINUTES_BY_ACTION[actionType] ?? 5)
+          : 0,
+      };
+    });
+
+    return {
+      items,
+      total: items.length,
+      generatedAt: new Date().toISOString(),
+      filters: {},
+      meta: {
+        estimatedMinutesSaved: items.reduce((total, item) => total + item.estimatedMinutesSaved, 0),
+        executedCount: items.filter((item) => item.status === 'executed').length,
+        rejectedCount: items.filter((item) => item.status === 'rejected').length,
+        failedCount: items.filter((item) => item.status === 'failed').length,
+        pendingCount: items.filter((item) => item.status === 'pending' || item.status === 'approved').length,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary\n- add a tenant-scoped Worker report over the existing practice assistant action ledger\n- replace the reports placeholder with real loading, empty, error, and activity states\n- calculate a clearly disclosed deterministic time-saved estimate for executed actions only\n- fast-fail malformed stored action contracts instead of hiding them\n\n## Verification\n- \
pm run type-check\\n- \
pm run lint\\n- \
px vitest run tests/unit/worker/services/AssistantActivityReportService.test.ts\ (2 passed)\n- \
pm run test:unit -- --reporter=dot\ (86 files, 695 tests passed)\n- \
pm run build\\n- \git diff --check\\n\nProgresses #662. This is the Worker-owned assistant-activity vertical slice; the broader backend contract tracker remains Blawby/blawby-backend#357.