### PR TITLE
feat(reports): add weekly period support

### DIFF
--- a/src/features/reports/components/ReportFilters.tsx
+++ b/src/features/reports/components/ReportFilters.tsx
@@ -5,7 +5,7 @@ import { Seg } from '@/design-system/patterns';
 import { cn } from '@/shared/utils/cn';
 import type { FilterSpec } from '@/features/reports/config/reportCollection';
 
-export type ReportPeriod = 'month' | 'quarter' | 'year';
+export type ReportPeriod = 'week' | 'month' | 'quarter' | 'year';
 
 export interface ReportFilterValues {
   period?: ReportPeriod;
@@ -23,6 +23,7 @@ interface ReportFiltersProps {
 }
 
 const PERIOD_OPTIONS: ReadonlyArray<{ value: ReportPeriod; label: string }> = [
+  { value: 'week', label: 'Week' },
   { value: 'month', label: 'Month' },
   { value: 'quarter', label: 'Quarter' },
   { value: 'year', label: 'Year' },

--- a/src/features/reports/config/reportCollection.ts
+++ b/src/features/reports/config/reportCollection.ts
@@ -29,7 +29,7 @@ export type ReportIconName =
   | 'calendar';
 
 export type FilterSpec =
-  | { id: string; label: string; kind: 'period'; defaultValue?: 'month' | 'quarter' | 'year' }
+  | { id: string; label: string; kind: 'period'; defaultValue?: 'week' | 'month' | 'quarter' | 'year' }
   | { id: string; label: string; kind: 'date-range' }
   | { id: string; label: string; kind: 'text'; placeholder?: string }
   | { id: string; label: string; kind: 'number'; placeholder?: string; min?: number; max?: number }
@@ -66,7 +66,7 @@ export interface ReportDefinition {
   description: string;
   icon: ReportIconName;
   phase: ReportPhase;
-  defaultPeriod?: 'month' | 'quarter' | 'year';
+  defaultPeriod?: 'week' | 'month' | 'quarter' | 'year';
   filters: FilterSpec[];
   columns: ColumnSpec[];
   summaryCards?: SummaryCardSpec[];

--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -185,7 +185,13 @@ const buildSixMonthBars = (rows: readonly RevenueRow[]): BarChartDatum[] => {
   if (rows.length === 0) return [];
   const tail = rows.slice(-6);
   return tail.map((row) => {
-    const label = row.periodLabel.split(' ')[0]?.toUpperCase().slice(0, 3) ?? row.periodLabel;
+    const label = row.periodLabel.startsWith('Week of ')
+      ? new Date(row.periodStart).toLocaleDateString('en-US', {
+          month: 'numeric',
+          day: 'numeric',
+          timeZone: 'UTC',
+        })
+      : row.periodLabel.split(' ')[0]?.toUpperCase().slice(0, 3) ?? row.periodLabel;
     return { label, value: row.paidAmountCents };
   });
 };

--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -57,7 +57,6 @@ interface AllReportsHubProps {
 }
 
 type ReportPeriod = 'week' | 'month' | 'quarter' | 'year';
-type QueryPeriod = 'month' | 'quarter' | 'year';
 
 const PERIOD_OPTIONS: ReadonlyArray<{ value: ReportPeriod; label: string }> = [
   { value: 'week', label: 'Week' },
@@ -78,22 +77,6 @@ const PERIOD_NOUN: Record<ReportPeriod, string> = {
   month: 'month',
   quarter: 'quarter',
   year: 'year',
-};
-
-/**
- * Map the user-facing period to the backend query period.
- *
- * TODO(backend): `resolveDateRange` only understands `month | quarter | year`.
- * Until we extend it to honour `week`, the hub asks for `month` data when the
- * Seg shows "Week" and notes the gap in the AI summary verifier. `ytd` aliases
- * to `year`, which today returns 12-month trailing data — close enough to
- * year-to-date for the hub's narrative purposes.
- */
-const toQueryPeriod = (period: ReportPeriod): QueryPeriod => {
-  if (period === 'quarter') return 'quarter';
-  if (period === 'year') return 'year';
-  // week + month both map to 'month' (backend exposes no week granularity yet).
-  return 'month';
 };
 
 const ICON_BY_NAME: Record<ReportIconName, IconComponent> = {
@@ -224,7 +207,7 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
   const [period, setPeriod] = useState<ReportPeriod>('month');
   const [sendingEmail, setSendingEmail] = useState(false);
 
-  const queryPeriod = toQueryPeriod(period);
+  const queryPeriod = period;
   const queryParams = useMemo(() => ({ period: queryPeriod }), [queryPeriod]);
   const enabled = Boolean(practiceId);
 

--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -324,9 +324,6 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
   if (medianTimeToClose != null) {
     ledeFragments.push(`Median time-to-close is ${formatDays(medianTimeToClose)} across ${closedMatterCount} closed matter${closedMatterCount === 1 ? '' : 's'}.`);
   }
-  const periodNote = period === 'week'
-    ? ' Week view falls back to monthly aggregations until the backend ships a week bucket.'
-    : '';
   const utilizationLine = avgUtilization != null && totalBillableHours != null
     ? `Billable utilization is averaging ${avgUtilization.toFixed(0)}% (${totalBillableHours.toFixed(1)} hrs).`
     : '';
@@ -397,7 +394,7 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
           groundingLabel={groundingLabel}
           lede={
             <>
-              {ledeFragments.join(' ')}{periodNote}
+              {ledeFragments.join(' ')}
               {utilizationLine && (
                 <>
                   {' '}{utilizationLine}

--- a/src/features/reports/services/reportsApi.ts
+++ b/src/features/reports/services/reportsApi.ts
@@ -29,7 +29,7 @@ const queryString = (params: Record<string, string | number | null | undefined>)
 };
 
 export interface ReportQueryParams {
-  period?: 'month' | 'quarter' | 'year';
+  period?: 'week' | 'month' | 'quarter' | 'year';
   start?: string;
   end?: string;
   hourlyRate?: number;

--- a/tests/unit/worker/services/ReportService.aggregation.test.ts
+++ b/tests/unit/worker/services/ReportService.aggregation.test.ts
@@ -58,6 +58,13 @@ describe('resolveDateRange', () => {
     expect(new Date(r.startIso).getUTCMonth()).toBe(5);
   });
 
+  it('uses the current Monday UTC as the start of a weekly range', () => {
+    const now = new Date('2026-05-14T15:30:00Z');
+    const r = resolveDateRange(null, null, 'week', now);
+    expect(r.startIso).toBe('2026-05-11T00:00:00.000Z');
+    expect(r.endMs).toBe(now.getTime());
+  });
+
   it('throws when start is after end', () => {
     expect(() => resolveDateRange('2026-05-01', '2026-01-01', 'month')).toThrow();
   });
@@ -102,6 +109,23 @@ describe('groupRevenue', () => {
     expect(result.rows[0].invoiceCount).toBe(2);
     expect(result.totalPaidCents).toBe(155000);
     expect(result.totalInvoiceCount).toBe(3);
+  });
+
+  it('buckets weekly revenue from Monday through Sunday in UTC', () => {
+    const weeklyRange = resolveDateRange('2026-05-01', '2026-05-31', 'week');
+    const result = groupRevenue([
+      invoice({ paid_at: '2026-05-11T00:00:00Z', amount_paid: 1000, status: 'paid' }),
+      invoice({ paid_at: '2026-05-17T23:59:59Z', amount_paid: 2000, status: 'paid' }),
+      invoice({ paid_at: '2026-05-18T00:00:00Z', amount_paid: 3000, status: 'paid' }),
+    ], 'week', weeklyRange);
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]).toMatchObject({
+      periodLabel: 'Week of May 11, 2026',
+      invoiceCount: 2,
+      paidAmountCents: 3000,
+    });
+    expect(result.rows[1].periodLabel).toBe('Week of May 18, 2026');
   });
 
   it('ignores invoices outside the range', () => {

--- a/worker/routes/reports.ts
+++ b/worker/routes/reports.ts
@@ -15,6 +15,7 @@ import {
   BackendUnavailableError,
   ReportService,
   resolveDateRange,
+  type ReportPeriod,
   type ResolvedDateRange,
 } from '../services/ReportService.js';
 import {
@@ -39,7 +40,7 @@ const VALID_REPORT_TYPES = new Set<string>([
   'task-productivity',
 ]);
 
-const VALID_PERIODS = new Set(['month', 'quarter', 'year']);
+const VALID_PERIODS = new Set<ReportPeriod>(['week', 'month', 'quarter', 'year']);
 
 interface ReportEnvelope<T> {
   items: T[];
@@ -74,12 +75,12 @@ const backendUnavailable = (reportType: string): Response =>
     { status: 503, headers: { 'Content-Type': 'application/json' } }
   );
 
-const parsePeriod = (raw: string | null): 'month' | 'quarter' | 'year' => {
-  if (raw && VALID_PERIODS.has(raw)) return raw as 'month' | 'quarter' | 'year';
+const parsePeriod = (raw: string | null): ReportPeriod => {
+  if (raw && VALID_PERIODS.has(raw as ReportPeriod)) return raw as ReportPeriod;
   return 'month';
 };
 
-const parseRange = (url: URL, period: 'month' | 'quarter' | 'year'): ResolvedDateRange => {
+const parseRange = (url: URL, period: ReportPeriod): ResolvedDateRange => {
   return resolveDateRange(
     url.searchParams.get('start'),
     url.searchParams.get('end'),

--- a/worker/services/ReportService.ts
+++ b/worker/services/ReportService.ts
@@ -112,6 +112,13 @@ export interface ResolvedDateRange {
   endIso: string;
 }
 
+export type ReportPeriod = 'week' | 'month' | 'quarter' | 'year';
+
+const startOfWeek = (d: Date) => {
+  const day = d.getUTCDay();
+  const daysSinceMonday = (day + 6) % 7;
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - daysSinceMonday));
+};
 const startOfMonth = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
 const startOfQuarter = (d: Date) => {
   const q = Math.floor(d.getUTCMonth() / 3) * 3;
@@ -126,7 +133,7 @@ const startOfYear = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
 export const resolveDateRange = (
   start: string | null | undefined,
   end: string | null | undefined,
-  period: 'month' | 'quarter' | 'year' | undefined,
+  period: ReportPeriod | undefined,
   now: Date = new Date()
 ): ResolvedDateRange => {
   let startMs: number;
@@ -143,7 +150,9 @@ export const resolveDateRange = (
     endMs = now.getTime();
     const yearsBack = period === 'year' ? 1 : period === 'quarter' ? 0 : 0;
     const monthsBack = period === 'month' ? 11 : 0;
-    const baseStart = period === 'year'
+    const baseStart = period === 'week'
+      ? startOfWeek(now)
+      : period === 'year'
       ? startOfYear(new Date(now.getTime() - yearsBack * 365 * 24 * 60 * 60 * 1000))
       : period === 'quarter'
         ? startOfQuarter(now)
@@ -160,10 +169,14 @@ export const resolveDateRange = (
 
 const formatPeriodLabel = (
   bucketStartMs: number,
-  granularity: 'month' | 'quarter' | 'year'
+  granularity: ReportPeriod
 ): string => {
   const d = new Date(bucketStartMs);
   const year = d.getUTCFullYear();
+  if (granularity === 'week') {
+    const month = d.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' });
+    return `Week of ${month} ${d.getUTCDate()}, ${year}`;
+  }
   if (granularity === 'year') return String(year);
   if (granularity === 'quarter') {
     const q = Math.floor(d.getUTCMonth() / 3) + 1;
@@ -175,8 +188,9 @@ const formatPeriodLabel = (
 
 const bucketStartFor = (
   d: Date,
-  granularity: 'month' | 'quarter' | 'year'
+  granularity: ReportPeriod
 ): number => {
+  if (granularity === 'week') return startOfWeek(d).getTime();
   if (granularity === 'year') return startOfYear(d).getTime();
   if (granularity === 'quarter') return startOfQuarter(d).getTime();
   return startOfMonth(d).getTime();
@@ -215,13 +229,13 @@ const parseDateMs = (raw: unknown): number | null => {
 };
 
 /**
- * Group invoices by period (month/quarter/year). An invoice is bucketed by
+ * Group invoices by period (week/month/quarter/year). An invoice is bucketed by
  * `paid_at` when present (falling back to `created_at`). Unpaid invoices
  * contribute to `outstandingAmountCents` but not `invoiceCount`.
  */
 export const groupRevenue = (
   invoices: readonly BackendInvoice[],
-  granularity: 'month' | 'quarter' | 'year',
+  granularity: ReportPeriod,
   range: ResolvedDateRange
 ): RevenueAggregate => {
   const buckets = new Map<number, RevenueAggregateRow>();
@@ -908,7 +922,7 @@ export class ReportService {
   async revenue(
     practiceId: string,
     headers: Record<string, string>,
-    options: { period: 'month' | 'quarter' | 'year'; range: ResolvedDateRange }
+    options: { period: ReportPeriod; range: ResolvedDateRange }
   ): Promise<RevenueAggregate> {
     const invoices = await this.fetchInvoices(practiceId, headers);
     return groupRevenue(invoices, options.period, options.range);


### PR DESCRIPTION
## Summary\n- make \week\ a real Worker reports period instead of silently requesting month data\n- bucket weekly revenue Monday through Sunday in UTC\n- expose Week in shared report filters and the reports API contract\n- cover current-week range and week-boundary aggregation behavior\n\n## Verification\n- \
pm run type-check\\n- \
pm run lint\\n- \
px vitest run tests/unit/worker/services/ReportService.aggregation.test.ts\ (19 passed)\n- \
pm run test:unit -- --reporter=dot\ (86 files, 697 tests passed)\n- \
pm run build\\n- \git diff --check\\n\nProgresses #662 by completing the explicit weekly report bucket gap.