### PR TITLE
feat(trust): add reconciliation readiness

### DIFF
--- a/src/features/trust/components/ReconcileTrustDialog.tsx
+++ b/src/features/trust/components/ReconcileTrustDialog.tsx
@@ -1,0 +1,156 @@
+import type { FunctionComponent } from 'preact';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+
+import { trustReadinessApi, type TrustReadiness } from '@/features/trust/services/trustReadinessApi';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { Button } from '@/shared/ui/Button';
+import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
+import { CurrencyInput, Input, Textarea } from '@/shared/ui/input';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+
+interface ReconcileTrustDialogProps {
+  practiceId: string | null;
+  readiness: TrustReadiness | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onReconciled: () => void | Promise<void>;
+}
+
+const todayUtc = (): string => new Date().toISOString().slice(0, 10);
+
+const createIdempotencyKey = (): string => {
+  if (typeof crypto === 'undefined' || typeof crypto.randomUUID !== 'function') {
+    throw new Error('This browser cannot create a reconciliation request ID.');
+  }
+  return crypto.randomUUID();
+};
+
+export const ReconcileTrustDialog: FunctionComponent<ReconcileTrustDialogProps> = ({
+  practiceId,
+  readiness,
+  isOpen,
+  onClose,
+  onReconciled,
+}) => {
+  const { showError, showSuccess } = useToastContext();
+  const [statementDate, setStatementDate] = useState(todayUtc());
+  const [bankBalance, setBankBalance] = useState<number | undefined>();
+  const [bookBalance, setBookBalance] = useState<number | undefined>();
+  const [notes, setNotes] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setStatementDate(todayUtc());
+    setBankBalance(undefined);
+    setBookBalance(undefined);
+    setNotes('');
+    setValidationError(null);
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    if (!submitting) onClose();
+  }, [onClose, submitting]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!practiceId) return;
+    if (!statementDate || bankBalance === undefined || bookBalance === undefined) {
+      setValidationError('Statement date, bank balance, and trust-book balance are required.');
+      return;
+    }
+    setValidationError(null);
+    setSubmitting(true);
+    try {
+      const result = await trustReadinessApi.reconcile(practiceId, {
+        idempotency_key: createIdempotencyKey(),
+        statement_ending_at: new Date(`${statementDate}T23:59:59.999Z`).toISOString(),
+        bank_statement_balance: Math.round(bankBalance * 100),
+        trust_book_balance: Math.round(bookBalance * 100),
+        notes: notes.trim() || undefined,
+      });
+      await onReconciled();
+      showSuccess(
+        result.status === 'balanced' ? 'Trust account balanced' : 'Reconciliation recorded with variance',
+        result.status === 'balanced'
+          ? 'Bank statement, trust books, and client ledgers agree.'
+          : 'Review the two variance amounts before moving or distributing funds.',
+      );
+      onClose();
+    } catch (error) {
+      showError('Could not record reconciliation', error instanceof Error ? error.message : 'Try again in a moment.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [bankBalance, bookBalance, notes, onClose, onReconciled, practiceId, showError, showSuccess, statementDate]);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Record trust reconciliation"
+      description="Compare three independent balances. This creates immutable compliance evidence; it does not move funds."
+      disableBackdropClick={submitting}
+    >
+      <DialogBody>
+        <div className="flex flex-col gap-4">
+          <div className="rounded-md border border-line-subtle bg-paper-2 px-4 py-3">
+            <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-dim">Client-ledger snapshot</span>
+            <strong className="mt-1 block font-mono text-lg tabular-nums text-ink">
+              {readiness ? formatCurrency(readiness.ledger.client_ledger_balance / 100) : 'Unavailable'}
+            </strong>
+            <p className="mt-1 text-xs text-dim-2">Calculated by Blawby from the latest balance for every client and matter.</p>
+          </div>
+          <Input
+            type="date"
+            label="Statement ending date"
+            value={statementDate}
+            onChange={setStatementDate}
+            disabled={submitting}
+            required
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <CurrencyInput
+              label="Bank statement balance"
+              description="Ending balance printed on the trust bank statement."
+              value={bankBalance}
+              onChange={setBankBalance}
+              disabled={submitting}
+              required
+            />
+            <CurrencyInput
+              label="Trust-book balance"
+              description="Independent balance from the practice trust-account books."
+              value={bookBalance}
+              onChange={setBookBalance}
+              disabled={submitting}
+              required
+            />
+          </div>
+          <Textarea
+            label="Notes"
+            value={notes}
+            onChange={setNotes}
+            rows={3}
+            maxLength={2000}
+            placeholder="Statement reference or variance follow-up"
+            disabled={submitting}
+          />
+          {validationError ? <p className="text-sm text-neg" role="alert">{validationError}</p> : null}
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="ghost" onClick={handleClose} disabled={submitting}>Cancel</Button>
+        <Button variant="primary" onClick={handleSubmit} disabled={submitting || !practiceId || !readiness}>
+          {submitting ? (
+            <span className="mr-1.5 inline-flex"><LoadingSpinner size="sm" ariaLabel="Recording reconciliation" announce={false} /></span>
+          ) : null}
+          Record reconciliation
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+
+export { createIdempotencyKey };

--- a/src/features/trust/components/TrustReadinessPanel.tsx
+++ b/src/features/trust/components/TrustReadinessPanel.tsx
@@ -1,0 +1,133 @@
+import type { FunctionComponent } from 'preact';
+import { AlertTriangle, Landmark, Scale, ShieldCheck } from 'lucide-preact';
+
+import { Pill } from '@/design-system/primitives';
+import { Button } from '@/shared/ui/Button';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { formatCurrency } from '@/shared/utils/currencyFormatter';
+import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
+import type { TrustReadiness } from '@/features/trust/services/trustReadinessApi';
+
+const formatCents = (cents: number): string => formatCurrency(cents / 100);
+
+const formatVariance = (cents: number): string => {
+  if (cents === 0) return formatCents(0);
+  return `${cents > 0 ? '+' : '−'}${formatCents(Math.abs(cents))}`;
+};
+
+interface TrustReadinessPanelProps {
+  data: TrustReadiness | null;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  onReconcile: () => void;
+}
+
+export const TrustReadinessPanel: FunctionComponent<TrustReadinessPanelProps> = ({
+  data,
+  loading,
+  error,
+  onRetry,
+  onReconcile,
+}) => {
+  if (loading && !data) {
+    return (
+      <section className="panel flex min-h-40 items-center justify-center" aria-label="Loading trust readiness">
+        <LoadingSpinner size="md" ariaLabel="Loading trust readiness" />
+      </section>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <section className="panel flex items-center justify-between gap-4 px-5 py-4">
+        <div className="flex items-center gap-3 text-sm text-neg">
+          <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error ?? 'Trust readiness is unavailable.'}</span>
+        </div>
+        <Button variant="secondary" size="sm" onClick={onRetry}>Retry</Button>
+      </section>
+    );
+  }
+
+  const latest = data.latest_reconciliation;
+  const lowTargets = data.retainer_targets.filter((target) => target.status === 'low');
+  const statusTone = !latest ? 'dim' : latest.status === 'balanced' ? 'live' : 'warn';
+  const statusLabel = !latest ? 'Not reconciled' : latest.status === 'balanced' ? 'Balanced' : 'Variance found';
+
+  return (
+    <section className="panel overflow-hidden" aria-labelledby="trust-readiness-heading">
+      <div className="flex flex-wrap items-start justify-between gap-4 border-b border-line-subtle px-5 py-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-md border border-line-subtle bg-paper-2 p-2 text-gold">
+            <Scale className="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 id="trust-readiness-heading" className="font-sans text-lg text-ink">Reconciliation readiness</h2>
+              <Pill tone={statusTone}>{statusLabel}</Pill>
+            </div>
+            <p className="mt-1 text-sm text-dim-2">
+              Bank statement, trust books, and client ledgers remain separate evidence sources.
+            </p>
+          </div>
+        </div>
+        <Button variant="secondary" size="sm" onClick={onReconcile}>Reconcile</Button>
+      </div>
+
+      <div className="grid gap-px bg-line-subtle sm:grid-cols-3">
+        <div className="bg-paper px-5 py-4">
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-dim">Bank statement</span>
+          <strong className="mt-1 block font-mono text-base tabular-nums text-ink">
+            {latest ? formatCents(latest.bank_statement_balance) : '—'}
+          </strong>
+        </div>
+        <div className="bg-paper px-5 py-4">
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-dim">Trust books</span>
+          <strong className="mt-1 block font-mono text-base tabular-nums text-ink">
+            {latest ? formatCents(latest.trust_book_balance) : '—'}
+          </strong>
+        </div>
+        <div className="bg-paper px-5 py-4">
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-dim">Client ledgers now</span>
+          <strong className="mt-1 block font-mono text-base tabular-nums text-ink">
+            {formatCents(data.ledger.client_ledger_balance)}
+          </strong>
+        </div>
+      </div>
+
+      <div className="grid gap-4 px-5 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+        <div className="flex flex-col gap-2">
+          {latest ? (
+            <div className="flex flex-wrap gap-x-5 gap-y-1 font-mono text-xs tabular-nums">
+              <span className={latest.bank_to_book_variance === 0 ? 'text-pos' : 'text-warn'}>
+                Bank ↔ books {formatVariance(latest.bank_to_book_variance)}
+              </span>
+              <span className={latest.book_to_client_variance === 0 ? 'text-pos' : 'text-warn'}>
+                Books ↔ clients {formatVariance(latest.book_to_client_variance)}
+              </span>
+            </div>
+          ) : (
+            <span className="text-sm text-dim-2">No immutable reconciliation snapshot has been recorded.</span>
+          )}
+          <span className="text-xs text-dim">
+            {latest
+              ? `Recorded ${formatRelativeTime(latest.created_at)} · ${latest.source === 'bank_integration' ? 'bank integration' : 'manual statement'}`
+              : 'Start with a statement ending date and independent bank and book balances.'}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Pill tone={lowTargets.length > 0 ? 'warn' : 'live'}>
+            {lowTargets.length} of {data.retainer_targets.length} retainers below target
+          </Pill>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-line-subtle bg-paper-2 px-5 py-3 font-mono text-[10px] uppercase tracking-[0.06em] text-dim">
+        <span className="inline-flex items-center gap-1.5"><Landmark className="h-3 w-3" />Operating account not connected</span>
+        <span className="inline-flex items-center gap-1.5"><ShieldCheck className="h-3 w-3" />Invoice receivables excluded</span>
+        <span>Operating revenue excluded</span>
+      </div>
+    </section>
+  );
+};

--- a/src/features/trust/hooks/useTrustReadiness.ts
+++ b/src/features/trust/hooks/useTrustReadiness.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@/shared/hooks/useQuery';
+import { policyTtl } from '@/shared/lib/cachePolicy';
+import {
+  trustReadinessApi,
+  type TrustReadiness,
+} from '@/features/trust/services/trustReadinessApi';
+
+export const trustReadinessCacheKey = (practiceId: string): string => `trust:readiness:${practiceId}`;
+
+export const useTrustReadiness = (practiceId: string) => {
+  const key = trustReadinessCacheKey(practiceId);
+  const query = useQuery<TrustReadiness>({
+    key,
+    fetcher: (signal) => trustReadinessApi.getReadiness(practiceId, signal),
+    ttl: policyTtl(key),
+    enabled: Boolean(practiceId),
+    swr: false,
+  });
+
+  return {
+    data: query.data ?? null,
+    loading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};

--- a/src/features/trust/pages/PracticeTrustPage.tsx
+++ b/src/features/trust/pages/PracticeTrustPage.tsx
@@ -28,10 +28,13 @@ import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime'
 import { reportsApi } from '@/features/reports/services/reportsApi';
 
 import { useTrustLedger, type TrustClientBalance } from '../hooks/useTrustLedger';
+import { useTrustReadiness } from '../hooks/useTrustReadiness';
 import { TrustLedgerEntryRow } from '../components/TrustLedgerEntryRow';
 import { TrustAuditTrailPane } from '../components/TrustAuditTrailPane';
 import { TrustComplianceRulesPane } from '../components/TrustComplianceRulesPane';
 import { EmailCpaDialog } from '../components/EmailCpaDialog';
+import { ReconcileTrustDialog } from '../components/ReconcileTrustDialog';
+import { TrustReadinessPanel } from '../components/TrustReadinessPanel';
 
 const formatCentsMajor = (cents: number): string => formatCurrency(cents / 100);
 
@@ -57,16 +60,6 @@ const formatGeneratedAt = (iso: string | null): string => {
   if (Number.isNaN(d.getTime())) return iso;
   return formatRelativeTime(iso);
 };
-
-/**
- * Rough "low balance" threshold for the AI lede observation. We don't
- * have a per-client retainer target yet (`practices.retainer_target_cents`
- * is in the backend backlog — see PR #662), so a flat $1,000 cents value
- * is the most we can ground without inventing data.
- */
-const LOW_BALANCE_CENTS = 100_000;
-/** Threshold the lede suggests as the typical replenishment amount. */
-const SUGGESTED_REPLENISH_CENTS = 300_000;
 
 /*
  * TODO(backend): expose `matter_id` on `TrustLedgerRow` so per-client
@@ -136,6 +129,12 @@ const PracticeTrustPage: FunctionComponent = () => {
     error,
     refetch,
   } = useTrustLedger(activePracticeId ?? '');
+  const {
+    data: readiness,
+    loading: readinessLoading,
+    error: readinessError,
+    refetch: refetchReadiness,
+  } = useTrustReadiness(activePracticeId ?? '');
 
   // Filter the ledger by client when a chip is clicked.
   const [clientFilter, setClientFilter] = useState<string | null>(null);
@@ -248,16 +247,15 @@ const PracticeTrustPage: FunctionComponent = () => {
   ) : null;
 
   // ── Actionable observation ───────────────────────────────────────────────
-  // Single client with the lowest balance below LOW_BALANCE_CENTS — the
-  // lede surfaces it by name so the user has somewhere to act. We don't
-  // synthesize a name when no one is below threshold; the second sentence
-  // (net flow / period totals) carries the lede instead.
-  const lowestBelowThreshold = useMemo<TrustClientBalance | null>(() => {
-    if (clientBalances.length === 0) return null;
-    const below = clientBalances.filter((b) => b.balanceCents > 0 && b.balanceCents < LOW_BALANCE_CENTS);
-    if (below.length === 0) return null;
-    return below.reduce((min, b) => (b.balanceCents < min.balanceCents ? b : min), below[0]);
-  }, [clientBalances]);
+  // Use the backend's agreed retainer targets; never substitute invoice totals
+  // or a flat client-side threshold for trust funding readiness.
+  const lowestRetainerTarget = useMemo(() => {
+    const lowTargets = readiness?.retainer_targets.filter((target) => target.status === 'low') ?? [];
+    return lowTargets.reduce<(typeof lowTargets)[number] | null>(
+      (lowest, target) => (!lowest || target.funded_percent < lowest.funded_percent ? target : lowest),
+      null,
+    );
+  }, [readiness?.retainer_targets]);
 
   const netFlowCents = totalCreditsCents - totalDebitsCents;
   const isNetOutflow = totalDebitsCents > 0 && netFlowCents < 0;
@@ -266,6 +264,13 @@ const PracticeTrustPage: FunctionComponent = () => {
   const [cpaDialogOpen, setCpaDialogOpen] = useState(false);
   const handleOpenCpaDialog = useCallback(() => setCpaDialogOpen(true), []);
   const handleCloseCpaDialog = useCallback(() => setCpaDialogOpen(false), []);
+  const [reconcileDialogOpen, setReconcileDialogOpen] = useState(false);
+  const handleOpenReconcileDialog = useCallback(() => setReconcileDialogOpen(true), []);
+  const handleCloseReconcileDialog = useCallback(() => setReconcileDialogOpen(false), []);
+  const handleReconciled = useCallback(() => {
+    void refetchReadiness();
+    refetch();
+  }, [refetch, refetchReadiness]);
 
   // ── Generate IOLTA report (send-now → Reports → Deliveries) ──────────────
   const [generatingReport, setGeneratingReport] = useState(false);
@@ -349,11 +354,11 @@ const PracticeTrustPage: FunctionComponent = () => {
     }
     return (
       <>
-        {lowestBelowThreshold ? (
+        {lowestRetainerTarget ? (
           <>
-            I noticed: <em>{lowestBelowThreshold.clientName}</em> retainer is at{' '}
-            <em>{formatCentsMajor(lowestBelowThreshold.balanceCents)}</em> — practices
-            typically replenish at <em>{formatCentsMajor(SUGGESTED_REPLENISH_CENTS)}</em>.
+            I noticed: one matter retainer is at <em>{lowestRetainerTarget.funded_percent}%</em> —{' '}
+            <em>{formatCentsMajor(lowestRetainerTarget.current_balance)}</em> held against a{' '}
+            <em>{formatCentsMajor(lowestRetainerTarget.target_balance)}</em> agreed target.
             {' '}
           </>
         ) : null}
@@ -396,14 +401,14 @@ const PracticeTrustPage: FunctionComponent = () => {
     </Tooltip>
   );
 
-  // Reconcile is also gated on the bank-integration track. Render disabled
-  // so the affordance is visible but the user can't trigger it.
   const reconcileButton = (
-    <Tooltip content="Reconciliation pending bank integration">
-      <Button variant="secondary" disabled>
-        Reconcile
-      </Button>
-    </Tooltip>
+    <Button
+      variant="secondary"
+      onClick={handleOpenReconcileDialog}
+      disabled={!activePracticeId || readinessLoading || !readiness}
+    >
+      Reconcile
+    </Button>
   );
 
   const handleExportCsv = () => {
@@ -458,6 +463,14 @@ const PracticeTrustPage: FunctionComponent = () => {
         >
           {aiSummaryBody}
         </AISummary>
+
+        <TrustReadinessPanel
+          data={readiness}
+          loading={readinessLoading}
+          error={readinessError}
+          onRetry={refetchReadiness}
+          onReconcile={handleOpenReconcileDialog}
+        />
 
         <StatStrip cells={statCells} />
 
@@ -596,6 +609,13 @@ const PracticeTrustPage: FunctionComponent = () => {
         practiceId={activePracticeId}
         isOpen={cpaDialogOpen}
         onClose={handleCloseCpaDialog}
+      />
+      <ReconcileTrustDialog
+        practiceId={activePracticeId}
+        readiness={readiness}
+        isOpen={reconcileDialogOpen}
+        onClose={handleCloseReconcileDialog}
+        onReconciled={handleReconciled}
       />
     </div>
   );

--- a/src/features/trust/services/trustReadinessApi.ts
+++ b/src/features/trust/services/trustReadinessApi.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+
+import { apiClient, unwrapApiResponse } from '@/shared/lib/apiClient';
+
+const reconciliationSchema = z.object({
+  id: z.uuid(),
+  organization_id: z.uuid(),
+  idempotency_key: z.uuid(),
+  statement_ending_at: z.iso.datetime({ offset: true }),
+  bank_statement_balance: z.number().int(),
+  trust_book_balance: z.number().int(),
+  client_ledger_balance: z.number().int(),
+  bank_to_book_variance: z.number().int(),
+  book_to_client_variance: z.number().int(),
+  status: z.enum(['balanced', 'variance']),
+  source: z.enum(['manual_statement', 'bank_integration']),
+  notes: z.string().nullable(),
+  created_by: z.uuid(),
+  created_at: z.iso.datetime({ offset: true }),
+});
+
+const retainerTargetSchema = z.object({
+  client_id: z.uuid(),
+  matter_id: z.uuid(),
+  current_balance: z.number().int(),
+  target_balance: z.number().int().min(0),
+  funded_percent: z.number().int().min(0),
+  status: z.enum(['funded', 'low']),
+});
+
+const trustReadinessSchema = z.object({
+  ledger: z.object({
+    client_ledger_balance: z.number().int(),
+    as_of_at: z.iso.datetime({ offset: true }).nullable(),
+  }),
+  latest_reconciliation: reconciliationSchema.nullable(),
+  retainer_targets: z.array(retainerTargetSchema),
+  boundaries: z.object({
+    bank_source: z.enum(['not_configured', 'manual_statement', 'bank_integration']),
+    operating_account_status: z.literal('not_connected'),
+    invoice_receivables_included: z.literal(false),
+    operating_revenue_included: z.literal(false),
+  }),
+});
+
+const parseResponse = <T>(schema: z.ZodType<T>, payload: unknown, label: string): T => {
+  const result = schema.safeParse(payload);
+  if (!result.success) {
+    throw new Error(`${label} response was malformed.`);
+  }
+  return result.data;
+};
+
+const basePath = (practiceId: string): string => {
+  if (!practiceId) {
+    throw new Error('Practice ID is required.');
+  }
+  return `/api/trust/${encodeURIComponent(practiceId)}`;
+};
+
+export type TrustReconciliation = z.infer<typeof reconciliationSchema>;
+export type TrustRetainerTarget = z.infer<typeof retainerTargetSchema>;
+export type TrustReadiness = z.infer<typeof trustReadinessSchema>;
+
+export interface CreateTrustReconciliationInput {
+  idempotency_key: string;
+  statement_ending_at: string;
+  bank_statement_balance: number;
+  trust_book_balance: number;
+  notes?: string;
+}
+
+export const trustReadinessApi = {
+  async getReadiness(practiceId: string, signal?: AbortSignal): Promise<TrustReadiness> {
+    const { data } = await apiClient.get<unknown>(`${basePath(practiceId)}/readiness`, { signal });
+    return parseResponse(trustReadinessSchema, unwrapApiResponse<unknown>(data), 'Trust readiness');
+  },
+
+  async reconcile(
+    practiceId: string,
+    input: CreateTrustReconciliationInput,
+  ): Promise<TrustReconciliation> {
+    const { data } = await apiClient.post<unknown>(`${basePath(practiceId)}/reconciliations`, input);
+    return parseResponse(reconciliationSchema, unwrapApiResponse<unknown>(data), 'Trust reconciliation');
+  },
+
+  async listReconciliations(
+    practiceId: string,
+    limit = 25,
+    signal?: AbortSignal,
+  ): Promise<TrustReconciliation[]> {
+    const query = new URLSearchParams({ limit: String(limit) });
+    const { data } = await apiClient.get<unknown>(
+      `${basePath(practiceId)}/reconciliations?${query.toString()}`,
+      { signal },
+    );
+    return parseResponse(z.array(reconciliationSchema), unwrapApiResponse<unknown>(data), 'Trust reconciliation history');
+  },
+};

--- a/tests/unit/trust/trustReadinessApi.test.ts
+++ b/tests/unit/trust/trustReadinessApi.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApiClient } = vi.hoisted(() => ({
+  mockApiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({
+  apiClient: mockApiClient,
+  unwrapApiResponse: (payload: unknown) => {
+    if (typeof payload === 'object' && payload !== null && 'data' in payload) {
+      return (payload as { data: unknown }).data;
+    }
+    return payload;
+  },
+}));
+
+import { trustReadinessApi } from '@/features/trust/services/trustReadinessApi';
+
+const practiceId = '11111111-1111-4111-8111-111111111111';
+const reconciliation = {
+  id: '22222222-2222-4222-8222-222222222222',
+  organization_id: practiceId,
+  idempotency_key: '33333333-3333-4333-8333-333333333333',
+  statement_ending_at: '2026-06-30T23:59:59.999Z',
+  bank_statement_balance: 10_000,
+  trust_book_balance: 10_000,
+  client_ledger_balance: 10_000,
+  bank_to_book_variance: 0,
+  book_to_client_variance: 0,
+  status: 'balanced',
+  source: 'manual_statement',
+  notes: null,
+  created_by: '44444444-4444-4444-8444-444444444444',
+  created_at: '2026-07-01T00:00:00.000Z',
+};
+
+describe('trustReadinessApi', () => {
+  beforeEach(() => {
+    mockApiClient.get.mockReset();
+    mockApiClient.post.mockReset();
+  });
+
+  it('loads and validates the readiness boundary contract', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          ledger: { client_ledger_balance: 10_000, as_of_at: '2026-07-01T00:00:00.000Z' },
+          latest_reconciliation: reconciliation,
+          retainer_targets: [],
+          boundaries: {
+            bank_source: 'manual_statement',
+            operating_account_status: 'not_connected',
+            invoice_receivables_included: false,
+            operating_revenue_included: false,
+          },
+        },
+      },
+    });
+
+    await expect(trustReadinessApi.getReadiness(practiceId)).resolves.toMatchObject({
+      latest_reconciliation: { status: 'balanced' },
+      boundaries: { operating_account_status: 'not_connected' },
+    });
+    expect(mockApiClient.get).toHaveBeenCalledWith(`/api/trust/${practiceId}/readiness`, { signal: undefined });
+  });
+
+  it('fast-fails malformed readiness responses', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ data: { data: { ledger: { client_ledger_balance: '100.00' } } } });
+    await expect(trustReadinessApi.getReadiness(practiceId)).rejects.toThrow('Trust readiness response was malformed.');
+  });
+
+  it('posts immutable reconciliation inputs and validates the response', async () => {
+    mockApiClient.post.mockResolvedValueOnce({ data: { data: reconciliation } });
+    const input = {
+      idempotency_key: reconciliation.idempotency_key,
+      statement_ending_at: reconciliation.statement_ending_at,
+      bank_statement_balance: 10_000,
+      trust_book_balance: 10_000,
+    };
+
+    await expect(trustReadinessApi.reconcile(practiceId, input)).resolves.toMatchObject({ status: 'balanced' });
+    expect(mockApiClient.post).toHaveBeenCalledWith(`/api/trust/${practiceId}/reconciliations`, input);
+  });
+});

--- a/tests/unit/worker/route-table.test.ts
+++ b/tests/unit/worker/route-table.test.ts
@@ -64,6 +64,8 @@ describe('worker route table', () => {
     expectRoute('/api/preferences', 'proxy');
     expectRoute('/api/subscriptions', 'proxy');
     expectRoute('/api/subscription', 'proxy');
+    expectRoute('/api/trust/practice-1/readiness', 'proxy');
+    expectRoute('/api/trust/practice-1/reconciliations', 'proxy');
     expectRoute('/api/uploads', 'proxy');
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,6 +83,7 @@ const workerEndpoints = [
 	'engagement-contracts',
 	'matters',
 	'tasks',
+	'trust',
 	'uploads',
 	'widget',
 	'presence',

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -124,6 +124,7 @@ const matchesBackendProxy: RouteMatcher = (path) =>
   path.startsWith('/api/preferences') ||
   path.startsWith('/api/subscriptions') ||
   path.startsWith('/api/subscription') ||
+  path.startsWith('/api/trust') ||
   path.startsWith('/api/uploads');
 
 // Order is significant: more specific patterns must come before more general


### PR DESCRIPTION
## Summary
- add strict trust readiness and reconciliation API contracts
- show bank statement, trust books, and client-ledger balances as separate evidence sources
- enable immutable manual reconciliation with independent balances and explicit variances
- replace the invented frontend low-balance threshold with backend retainer targets
- proxy the new trust routes through the Worker and local Vite routing

## Verification
- npm run type-check
- npm run lint
- npm test (110 files, 835 tests)
- npm run build

## Dependencies
- Backend contract: Blawby/blawby-backend#375 (human review and merge required; this frontend PR does not wait on that merge)

Supports #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trust reconciliation readiness panel with balances, variance, status, and retainer target alerts.
  * Added the ability to record trust reconciliations with statement details, balances, and notes.
  * Reconciliation results now provide confirmation for balanced accounts or identified variances.
  * Added retry and loading states for readiness information.
  * Reconciliation actions are enabled only when the practice is active and required data is available.

* **Bug Fixes**
  * Improved trust balance and retainer observations using current readiness data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->