### PR TITLE
fix(compliance): remove fabricated audit signals

### DIFF
--- a/src/features/invoices/components/detail/PracticeInvoiceDetailView.tsx
+++ b/src/features/invoices/components/detail/PracticeInvoiceDetailView.tsx
@@ -2,7 +2,7 @@ import type { ComponentChildren } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { useNavigation } from '@/shared/utils/navigation';
-import { asMajor, getMajorAmountValue, safeAdd } from '@/shared/utils/money';
+import { asMajor, safeAdd } from '@/shared/utils/money';
 import {
   sendInvoice,
   syncInvoice,
@@ -10,9 +10,6 @@ import {
   createPracticeRefundRequest,
 } from '@/features/invoices/services/invoicesService';
 import type { InvoiceDetail, InvoiceRefundRequestEvent } from '@/features/invoices/types';
-import { formatCurrency } from '@/shared/utils/currencyFormatter';
-import { StagedAction } from '@/design-system/patterns/StagedAction';
-import { Chip } from '@/design-system/primitives/Chip';
 import { InvoicePreview } from '@/features/invoices/components/InvoicePreview';
 import { InvoiceActionBar } from './InvoiceActionBar';
 import { InvoiceActivityPanel } from './InvoiceActivityPanel';
@@ -41,35 +38,6 @@ interface PracticeInvoiceDetailController {
   actionBar: ComponentChildren;
   mainContent: ComponentChildren;
 }
-
-const ONE_HOUR_MS = 60 * 60 * 1000;
-
-/**
- * Heuristic for "this draft was probably staged by the assistant".
- *
- * Real signal lives in TODO(backend): persist `invoice.staged_by_assistant`
- * so we don't have to guess. Until then we surface the StagedAction whenever
- * the invoice (a) is still a draft AND (b) was created in the last hour AND
- * (c) has at least one line item.
- *
- * False positives (a lawyer drafted manually in the last hour) just see an
- * extra "Staged by assistant" banner; the underlying actions are the same
- * existing send/edit/discard flow, so the worst case is mild visual noise.
- */
-const deriveIsStagedByAssistant = (detail: InvoiceDetail): boolean => {
-  if (detail.status.toLowerCase() !== 'draft') return false;
-  const createdAt = detail.createdAt ? Date.parse(detail.createdAt) : NaN;
-  if (Number.isNaN(createdAt)) return false;
-  if (Date.now() - createdAt > ONE_HOUR_MS) return false;
-  if (detail.lineItems.length === 0) return false;
-  return true;
-};
-
-const sumLineItemTotals = (detail: InvoiceDetail): number =>
-  detail.lineItems.reduce((acc, item) => acc + getMajorAmountValue(item.line_total), 0);
-
-const sumLineItemHours = (detail: InvoiceDetail): number =>
-  detail.lineItems.reduce((acc, item) => acc + Number(item.quantity ?? 0), 0);
 
 export const usePracticeInvoiceDetailController = ({
   practiceId,
@@ -196,44 +164,6 @@ export const usePracticeInvoiceDetailController = ({
     />
   );
 
-  // ---- Staged-by-assistant banner (heuristic; see deriveIsStagedByAssistant) ----
-  const isStaged = deriveIsStagedByAssistant(detail);
-  const stagedHours = isStaged ? sumLineItemHours(detail) : 0;
-  const stagedAmount = isStaged ? sumLineItemTotals(detail) : 0;
-
-  const stagedBanner = isStaged ? (
-    <div className="px-4 pt-4 sm:px-6">
-      <div className="mx-auto w-full max-w-[720px]">
-        <StagedAction
-          label="Staged by assistant · awaits your approval"
-          title={`AI drafted this invoice · ${formatCurrency(stagedAmount)}`}
-          description={
-            <>
-              Aggregated from <strong>{detail.lineItems.length} unbilled line {detail.lineItems.length === 1 ? 'item' : 'items'}</strong>
-              {stagedHours > 0 ? (
-                <>
-                  {' '}({stagedHours.toFixed(stagedHours % 1 === 0 ? 0 : 1)} {stagedHours === 1 ? 'hour' : 'hours'})
-                </>
-              ) : null}
-              . Review the line items below before approving. Nothing is sent until you click <strong>Approve &amp; send</strong>.
-            </>
-          }
-          actions={
-            <>
-              <Chip variant="primary" onClick={() => setSendOpen(true)}>
-                Approve &amp; send
-              </Chip>
-              <Chip onClick={handleEditDraft}>Edit lines</Chip>
-              <Chip variant="warn" onClick={() => setVoidOpen(true)}>
-                Discard draft
-              </Chip>
-            </>
-          }
-        />
-      </div>
-    </div>
-  ) : null;
-
   const letterPaperBody = (
     <div className="px-4 pb-2 pt-4 sm:px-6">
       <InvoicePreview
@@ -262,7 +192,6 @@ export const usePracticeInvoiceDetailController = ({
 
   const mainContent = (
     <div className="flex-1 overflow-y-auto">
-      {stagedBanner}
       {letterPaperBody}
       {auditActivity}
 

--- a/src/features/invoices/types.ts
+++ b/src/features/invoices/types.ts
@@ -1,9 +1,8 @@
 import type { Invoice } from '@/features/matters/types/billing.types';
 
 export type InvoiceStatus =
-  // 'staged' is a derived label surfaced when the AI-staged heuristic
-  // (see PracticeInvoiceDetailView) matches a draft invoice. Backend
-  // returns 'draft' today — TODO(backend): persist invoice.staged_by_assistant.
+  // Reserved for an explicit backend-owned staged-assistant state. The
+  // frontend never derives this status from invoice age or line items.
   | 'staged'
   | 'draft'
   | 'pending'

--- a/src/features/settings/pages/AuditLogPage.tsx
+++ b/src/features/settings/pages/AuditLogPage.tsx
@@ -1,194 +1,39 @@
-// TODO(backend): Required endpoints:
-//   - GET /api/practices/:id/audit-log?search=&type=&actor=&range=  → paginated event log
-//   - GET /api/practices/:id/audit-log/export?format=csv  → trigger CSV export (sent by email)
+import { FileClock } from 'lucide-preact';
 
-import { useState, useEffect } from 'preact/hooks';
-import { useToastContext } from '@/shared/contexts/ToastContext';
-import { Button } from '@/shared/ui/Button';
-import { cn } from '@/shared/utils/cn';
 import { SettingSection } from '@/features/settings/components/SettingSection';
 import { SettingsCard } from '@/features/settings/components/SettingsCard';
-
-// ---------------------------------------------------------------------------
-// Demo data
-// ---------------------------------------------------------------------------
-
-type EventType = 'ai' | 'update' | 'create' | 'delete' | 'auth';
-
-const DEMO_EVENTS: Array<{ id: string; ts: string; actor: string; actorInitial: string; actorClass: string; type: EventType; action: string; target: string }> = [
-  { id: 'e1', ts: 'Jun 1, 10:42 AM', actor: 'Assistant', actorInitial: 'B', actorClass: 'bg-ink text-accent italic', type: 'ai', action: 'Drafted invoice for Chen v. Williams — awaiting approval', target: 'invoice_0047' },
-  { id: 'e2', ts: 'Jun 1, 10:38 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'update', action: 'Approved staged invoice for matter_0012', target: 'invoice_0047' },
-  { id: 'e3', ts: 'Jun 1, 10:22 AM', actor: 'Assistant', actorInitial: 'B', actorClass: 'bg-ink text-accent italic', type: 'ai', action: 'Sent morning briefing email', target: 'sarah@sarahchenlaw.com' },
-  { id: 'e4', ts: 'Jun 1, 09:14 AM', actor: 'Stripe', actorInitial: 'S', actorClass: 'bg-accent text-accent-ink', type: 'create', action: 'Payment received $2,500.00 from Janet Williams', target: 'pay_3Q8xN2' },
-  { id: 'e5', ts: 'Jun 1, 08:50 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'auth', action: 'Signed in from 74.125.xx.xx (Charlotte, NC)', target: 'session_a8f2' },
-  { id: 'e6', ts: 'May 31, 4:55 PM', actor: 'Assistant', actorInitial: 'B', actorClass: 'bg-ink text-accent italic', type: 'ai', action: 'Created calendar event "Thompson custody hearing" for Jul 14', target: 'event_0089' },
-  { id: 'e7', ts: 'May 31, 3:20 PM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'create', action: 'Created new matter Thompson v. Thompson', target: 'matter_0015' },
-  { id: 'e8', ts: 'May 31, 2:44 PM', actor: 'System', actorInitial: 'SY', actorClass: 'bg-paper-2 text-dim', type: 'update', action: 'Intake form submitted by new lead (family law, DV flagged)', target: 'intake_0041' },
-  { id: 'e9', ts: 'May 31, 11:30 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'update', action: 'Updated retainer threshold to 30% for Services & pricing', target: 'settings' },
-  { id: 'e10', ts: 'May 31, 10:15 AM', actor: 'Sarah Chen', actorInitial: 'SC', actorClass: 'bg-paper-2 text-ink', type: 'delete', action: 'Removed draft engagement letter for intake_0038', target: 'doc_0072' },
-];
-
-const TYPE_STYLES: Record<EventType, string> = {
-  ai: 'text-accent bg-ink border-ink',
-  update: 'text-amber-600 bg-amber-50 border-amber-200',
-  create: 'text-[var(--pos,#22c55e)] bg-[color-mix(in_oklab,var(--pos,#22c55e)_10%,white)] border-[color-mix(in_oklab,var(--pos,#22c55e)_25%,var(--rule,#e5e7eb))]',
-  delete: 'text-[var(--neg,#ef4444)] bg-[color-mix(in_oklab,var(--neg,#ef4444)_10%,white)] border-[color-mix(in_oklab,var(--neg,#ef4444)_25%,var(--rule,#e5e7eb))]',
-  auth: 'text-blue-600 bg-blue-50 border-blue-200',
-};
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
-
-const PAGE_SIZE = 10;
+import { Button } from '@/shared/ui/Button';
 
 export interface AuditLogPageProps {
   className?: string;
 }
 
-export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => {
-  const { showSuccess } = useToastContext();
-  const [search, setSearch] = useState('');
-  const [typeFilter, setTypeFilter] = useState('all');
-  const [actorFilter, setActorFilter] = useState('all');
-  const [rangeFilter, setRangeFilter] = useState('7d');
-  const [currentPage, setCurrentPage] = useState(1);
-
-  useEffect(() => { setCurrentPage(1); }, [search, typeFilter, actorFilter, rangeFilter]);
-
-  const filtered = DEMO_EVENTS.filter((e) => {
-    if (search && !e.action.toLowerCase().includes(search.toLowerCase()) && !e.actor.toLowerCase().includes(search.toLowerCase())) return false;
-    if (typeFilter !== 'all' && e.type !== typeFilter) return false;
-    if (actorFilter !== 'all' && e.actor !== actorFilter) return false;
-    return true;
-  });
-
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
-  const pageStart = (currentPage - 1) * PAGE_SIZE;
-  const paginated = filtered.slice(pageStart, pageStart + PAGE_SIZE);
-  const from = filtered.length === 0 ? 0 : pageStart + 1;
-  const to = Math.min(pageStart + PAGE_SIZE, filtered.length);
-
-  const handleExport = () => {
-    // TODO(backend): GET /api/practices/:id/audit-log/export?format=csv
-    showSuccess('Export requested', "You'll receive a CSV via email once the export endpoint ships.");
-  };
-
-  return (
-    <div className={className}>
-      <SettingSection first title="Audit log" description="Every action in your workspace is recorded. Use this for compliance reviews, bar audits, and troubleshooting.">
-        <SettingsCard className="mb-5 max-w-[860px]">
-        <div className="flex flex-wrap items-center gap-[10px]">
-          <input
-            className="input min-w-[260px] flex-1"
-            placeholder="Search events…"
-            value={search}
-            onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
-          />
-          <select className="select" value={typeFilter} onChange={(e) => setTypeFilter((e.target as HTMLSelectElement).value)}>
-            <option value="all">All types</option>
-            <option value="create">Creates</option>
-            <option value="update">Updates</option>
-            <option value="delete">Deletes</option>
-            <option value="auth">Auth events</option>
-            <option value="ai">AI actions</option>
-          </select>
-          <select className="select" value={actorFilter} onChange={(e) => setActorFilter((e.target as HTMLSelectElement).value)}>
-            <option value="all">All actors</option>
-            <option value="Sarah Chen">Sarah Chen</option>
-            <option value="Assistant">Assistant</option>
-            <option value="System">System</option>
-          </select>
-          <select className="select w-[140px]" value={rangeFilter} onChange={(e) => setRangeFilter((e.target as HTMLSelectElement).value)}>
-            <option value="7d">Last 7 days</option>
-            <option value="30d">Last 30 days</option>
-            <option value="90d">Last 90 days</option>
-            <option value="all">All time</option>
-          </select>
-          <Button variant="ghost" size="sm" className="ml-auto" onClick={handleExport}>Export CSV</Button>
-        </div>
-        </SettingsCard>
-
-        {filtered.length > 0 ? (
-          <SettingsCard className="max-w-[860px] px-0 py-0">
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-rule">
-                    {['Timestamp', 'Actor', 'Type', 'Action', 'Target'].map((col) => (
-                      <th key={col} className="font-mono text-[10px] uppercase tracking-widest text-dim text-left pb-2 pr-3">{col}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {paginated.map((event) => (
-                    <tr key={event.id} className="border-b border-rule last:border-0">
-                      <td className="py-3 pr-3 font-mono text-xs text-dim whitespace-nowrap">{event.ts}</td>
-                      <td className="py-3 pr-3">
-                        <div className="flex items-center gap-2">
-                          <div
-                            className={cn('grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full font-sans text-[9px] font-bold', event.actorClass)}
-                          >
-                            {event.actorInitial}
-                          </div>
-                          <span className="text-xs text-ink whitespace-nowrap">{event.actor}</span>
-                        </div>
-                      </td>
-                      <td className="py-3 pr-3">
-                        <span className={cn('font-mono text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded border', TYPE_STYLES[event.type])}>
-                          {event.type}
-                        </span>
-                      </td>
-                      <td className="py-3 pr-3 text-xs text-ink">{event.action}</td>
-                      <td className="py-3 font-mono text-xs text-dim">{event.target}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => (
+  <div className={className}>
+    <SettingSection
+      first
+      title="Audit log"
+      description="A practice-wide compliance log needs one authoritative backend event stream."
+    >
+      <SettingsCard className="max-w-[860px]">
+        <div className="flex flex-col items-start gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="rounded-md border border-line-subtle bg-paper-2 p-2 text-dim-2">
+              <FileClock className="h-5 w-5" aria-hidden="true" />
             </div>
-          </SettingsCard>
-        ) : (
-          <SettingsCard className="max-w-[860px]">
-            <div className="py-8 text-center">
-              <p className="text-sm font-medium text-ink">No audit events found</p>
-              <p className="mx-auto mt-1 max-w-md text-sm text-dim">
-                Adjust the audit filters to find logged changes, sign-ins, assistant actions, or record updates.
+            <div>
+              <h2 className="text-sm font-medium text-ink">Practice-wide audit events are not connected</h2>
+              <p className="mt-1 max-w-xl text-sm leading-relaxed text-dim-2">
+                Invoice, matter, upload, authentication, and assistant events currently live in separate systems.
+                Blawby will not present sample entries as compliance evidence or claim an export was requested.
               </p>
             </div>
-          </SettingsCard>
-        )}
-
-        {/* Pagination */}
-        <div className="flex items-center justify-between mt-5 pt-4 border-t border-rule">
-          <span className="text-xs text-dim">
-            {filtered.length === 0 ? 'No events' : `Showing ${from}–${to} of ${filtered.length} events`}
-          </span>
-          {totalPages > 1 && (
-            <div className="flex gap-1">
-              <button
-                type="button"
-                className="h-7 w-7 rounded font-mono text-xs text-dim hover:bg-rule disabled:opacity-40"
-                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                disabled={currentPage === 1}
-              >←</button>
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((pg) => (
-                <button
-                  key={pg}
-                  type="button"
-                  className={cn('h-7 w-7 rounded font-mono text-xs', pg === currentPage ? 'bg-ink text-accent' : 'text-dim hover:bg-rule')}
-                  onClick={() => setCurrentPage(pg)}
-                >{pg}</button>
-              ))}
-              <button
-                type="button"
-                className="h-7 w-7 rounded font-mono text-xs text-dim hover:bg-rule disabled:opacity-40"
-                onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                disabled={currentPage === totalPages}
-              >→</button>
-            </div>
-          )}
+          </div>
+          <Button variant="secondary" size="sm" disabled title="Requires the backend audit-log contract">
+            Export unavailable
+          </Button>
         </div>
-      </SettingSection>
-    </div>
-  );
-};
+      </SettingsCard>
+    </SettingSection>
+  </div>
+);

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string): string => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+describe('honest compliance UI', () => {
+  it('does not render sample audit events as practice evidence', () => {
+    const auditLog = source('src/features/settings/pages/AuditLogPage.tsx');
+    expect(auditLog).not.toContain('DEMO_EVENTS');
+    expect(auditLog).toContain('will not present sample entries as compliance evidence');
+    expect(auditLog).toContain('Export unavailable');
+  });
+
+  it('does not infer assistant authorship from invoice age or line items', () => {
+    const invoiceDetail = source('src/features/invoices/components/detail/PracticeInvoiceDetailView.tsx');
+    expect(invoiceDetail).not.toContain('deriveIsStagedByAssistant');
+    expect(invoiceDetail).not.toContain('Staged by assistant');
+  });
+});


### PR DESCRIPTION
## Summary
- remove the one-hour invoice heuristic that falsely labeled recent manual drafts as assistant-staged
- remove hard-coded sample audit events from the real Settings audit screen
- stop claiming a CSV export was requested when no backend export exists
- show a clear, disabled audit-log state until an authoritative backend event stream lands
- add regression tests preventing both fabricated compliance patterns from returning

## Verification
- npm run type-check
- npm run lint
- npm test (113 files, 842 tests)
- npm run build
- npm run build:check-size (284.6 KB / 300 KB)

## Backend follow-up
- Blawby/blawby-backend#376 tracks the authoritative practice-wide audit contract
- Backend review and merge remain human-owned; this frontend honesty fix does not wait

Supports #716 and #662