### PR TITLE
fix(ai): disable pretend workspace queries

### DIFF
--- a/src/design-system/patterns/AIAskBar.tsx
+++ b/src/design-system/patterns/AIAskBar.tsx
@@ -15,12 +15,13 @@ export interface AIAskBarProps {
   placeholder?: string;
   contextChips?: readonly AIAskBarContextChip[];
   suggestions?: readonly string[];
-  onSubmit: (query: string, contextIds: string[]) => void;
+  onSubmit?: (query: string, contextIds: string[]) => void;
   onVoice?: () => void;
   onAddContext?: () => void;
   sticky?: boolean;
   /** Pass a string to override, null to hide entirely, undefined for default kbd hint. */
   disclaimer?: string | null;
+  disabled?: boolean;
   className?: string;
 }
 
@@ -39,6 +40,7 @@ export function AIAskBar({
   onAddContext,
   sticky = true,
   disclaimer = undefined,
+  disabled = false,
   className,
 }: AIAskBarProps) {
   const [value, setValue] = useState('');
@@ -46,12 +48,12 @@ export function AIAskBar({
   const submit = useCallback(
     (query: string) => {
       const trimmed = query.trim();
-      if (!trimmed) return;
+      if (!trimmed || disabled || !onSubmit) return;
       const contextIds = contextChips?.map((chip) => chip.id) ?? [];
       onSubmit(trimmed, contextIds);
       setValue('');
     },
-    [contextChips, onSubmit]
+    [contextChips, disabled, onSubmit]
   );
 
   const handleSubmit: JSX.GenericEventHandler<HTMLFormElement> = (event) => {
@@ -78,10 +80,12 @@ export function AIAskBar({
       onSubmit={handleSubmit}
       role="search"
       aria-label="Ask the assistant"
+      data-disabled={disabled || undefined}
     >
       <Composer
         placeholder={placeholder}
         value={value}
+        inputDisabled={disabled}
         inputMode="single-line"
         onInput={(event) => setValue((event.currentTarget as HTMLTextAreaElement).value)}
         onKeyDown={handleKeyDown}
@@ -93,6 +97,7 @@ export function AIAskBar({
                 key={suggestion}
                 type="button"
                 className="composer-suggestion"
+                disabled={disabled}
                 onClick={() => submit(suggestion)}
               >
                 {suggestion}
@@ -123,7 +128,7 @@ export function AIAskBar({
               type="submit"
               className="composer-send-button"
               aria-label="Send"
-              disabled={!value.trim()}
+              disabled={disabled || !value.trim()}
             >
               <Icon icon={ArrowUp} className="h-4 w-4" />
             </button>

--- a/src/features/calendar/pages/PracticeCalendarPage.tsx
+++ b/src/features/calendar/pages/PracticeCalendarPage.tsx
@@ -6,7 +6,6 @@ import { Page } from '@/shared/ui/layout/Page';
 import { Button } from '@/shared/ui/Button';
 import {
   AIAskBar,
-  AIAnswerCard,
   Seg,
   StatStrip,
   type SegOption
@@ -31,12 +30,6 @@ const VIEW_OPTIONS: ReadonlyArray<SegOption<ViewMode>> = [
   { value: 'agenda', label: 'Agenda' }
 ];
 
-const ASK_SUGGESTIONS = [
-  'Court dates this week',
-  'Overdue tasks',
-  'Upcoming engagement expiries'
-] as const;
-
 const startOfDay = (date: Date): Date => {
   const copy = new Date(date);
   copy.setHours(0, 0, 0, 0);
@@ -60,8 +53,6 @@ const weekLabel = (date: Date): string => {
   const fmt: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
   return `${start.toLocaleDateString('en-US', fmt)} — ${end.toLocaleDateString('en-US', fmt)}`;
 };
-
-const now = () => Date.now();
 
 interface PracticeCalendarPageProps {
   /** Practice id resolved from the route (`/practice/:slug/calendar`). */
@@ -99,7 +90,6 @@ export function PracticeCalendarPage({
   const [anchor, setAnchor] = useState<Date>(() => startOfDay(new Date()));
   const [filters, setFilters] = useState<Set<CalendarFilterKind>>(new Set());
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
-  const [askedQuery, setAskedQuery] = useState<string | null>(null);
 
   const { events, isLoading, error, truncated, refresh } = useCalendarEvents(practiceId ?? null);
 
@@ -185,20 +175,6 @@ export function PracticeCalendarPage({
   // that uses the aggregated event corpus so the surface isn't an empty shell.
   // Timestamp captured at submit-time so the answer card grounding label
   // stays stable instead of ticking on every render.
-  const [askedAt, setAskedAt] = useState<string | null>(null);
-  const handleAskSubmit = useCallback((query: string) => {
-    setAskedQuery(query);
-    setAskedAt(
-      new Date(now()).toLocaleTimeString('en-US', {
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      })
-    );
-  }, []);
-
-  const answerSourceCount = events.length;
-
   // ── Navigation label ─────────────────────────────────────────────────────
   const navLabel =
     view === 'month' ? monthLabel(anchor)
@@ -254,45 +230,11 @@ export function PracticeCalendarPage({
 
           {/* AI ask bar — non-sticky, chat-first composer. ------------------ */}
           <AIAskBar
-            placeholder="What's coming up? · 'court dates this week' · 'overdue tasks'"
-            suggestions={ASK_SUGGESTIONS}
+            placeholder="Grounded calendar questions are not available yet"
             sticky={false}
-            onSubmit={handleAskSubmit}
-            disclaimer="Blawby never writes without your approval"
+            disabled
+            disclaimer="Requires a grounded calendar-query backend contract"
           />
-
-          {/* AI answer card — appears only after a query has been asked. --- */}
-          {askedQuery && (
-            <AIAnswerCard
-              groundingLabel={`Practice assistant · grounded in ${answerSourceCount} ${answerSourceCount === 1 ? 'event' : 'events'}${askedAt ? ` · ${askedAt}` : ''}`}
-              lede={
-                <>
-                  Here&apos;s what I see for <em className="not-italic text-accent-deep">&quot;{askedQuery}&quot;</em>.
-                  {/* TODO(backend): replace deterministic lede with real AI narrative
-                      from PracticeAssistantQueryEngine. */}
-                </>
-              }
-              body={
-                <p className="m-0">
-                  I aggregated across tasks, time, engagements, invoices, court
-                  dates and milestones. Filter the list below to drill in, or
-                  open any row to see prep status.
-                </p>
-              }
-              actions={[
-                { id: 'show-list', label: 'Show as list', onClick: () => setView('agenda') },
-                { id: 'open-court', label: 'Filter to court', onClick: () => setFilters(new Set(['court'])) },
-                { id: 'dismiss', label: 'Dismiss', onClick: () => setAskedQuery(null) }
-              ]}
-              sources={[
-                { table: 'matter_tasks', count: events.filter((e) => e.kind === 'task').length },
-                { table: 'milestones', count: events.filter((e) => e.kind === 'milestone').length },
-                { table: 'engagements', count: events.filter((e) => e.kind === 'engagement').length },
-                { table: 'invoices', count: events.filter((e) => e.kind === 'invoice').length },
-                { table: 'court_dates', count: events.filter((e) => e.kind === 'court').length }
-              ]}
-            />
-          )}
 
           {/* Error + truncation banners --------------------------------- */}
           {error && (

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -43,7 +43,6 @@ import {
 import { getPracticeRoleLabel, normalizePracticeRole } from '@/shared/utils/practiceRoles';
 import {
   AIAskBar,
-  AIAnswerCard,
   Observation,
   StatStrip,
   MatterChip,
@@ -561,7 +560,6 @@ export const PracticeContactsPage = ({
   // ── chat-first list controls ─────────────────────────────────────────
   const [activeFilter, setActiveFilter] = useState<ContactFilterId>('all');
   const [sortMode, setSortMode] = useState<ContactSortId>('recent_activity');
-  const [askAnswer, setAskAnswer] = useState<{ query: string } | null>(null);
 
   const pathSuffix = location.path.startsWith(basePath) ? location.path.slice(basePath.length) : '';
   const pathSegments = pathSuffix.replace(/^\/+/, '').split('/').filter(Boolean);
@@ -1154,16 +1152,6 @@ export const PracticeContactsPage = ({
     { label: 'At risk', value: String(atRiskCount), extraWarn: atRiskCount > 0 },
   ];
 
-  // ── Ask submit ───────────────────────────────────────────────────────
-  const handleAskSubmit = useCallback((query: string) => {
-    // TODO(backend): wire to /api/practice/:id/clients/ask once the natural-
-    // language clients-query endpoint (PracticeAssistantQueryEngine) exists.
-    // Today the AIAnswerCard renders a grounded narration of the current
-    // filter state so the chat-first shape is present end-to-end without
-    // fabricating answers.
-    setAskAnswer({ query });
-  }, []);
-
   // ── Filter chip definitions (counts come from filterCounts memo) ─────
   const FILTER_CHIPS: ReadonlyArray<{ id: ContactFilterId; label: string; warn?: boolean }> = [
     { id: 'all', label: 'All' },
@@ -1591,77 +1579,11 @@ export const PracticeContactsPage = ({
           <div className="mt-6">
             <AIAskBar
               sticky={false}
-              placeholder="Find clients who haven't been heard from in 30 days..."
-              suggestions={[
-                'Who’s been silent the longest?',
-                'Clients with overdue invoices',
-                'Clients with active matters at risk',
-              ]}
-              onSubmit={handleAskSubmit}
+              placeholder="Grounded client questions are not available yet"
+              disabled
+              disclaimer="Requires a grounded client-query backend contract"
             />
           </div>
-
-          {/* ── AI answer card ─────────────────────────────────────── */}
-          {askAnswer ? (
-            <div className="mt-5">
-              <AIAnswerCard
-                groundingLabel={`Practice assistant · grounded in ${totalForCrumb} contacts · ${mattersData.items.length} matters · just now`}
-                lede={
-                  <>
-                    {atRiskCount > 0 ? (
-                      <>
-                        <em>{atRiskCount}</em> {atRiskCount === 1 ? 'client is' : 'clients are'} flagged at risk — frustrated or silent for over 30 days.
-                      </>
-                    ) : awaitingReplyCount > 0 ? (
-                      <>
-                        <em>{awaitingReplyCount}</em> {awaitingReplyCount === 1 ? 'client is' : 'clients are'} awaiting a reply from you.
-                      </>
-                    ) : (
-                      <>Everyone has been heard from recently. Quiet day.</>
-                    )}
-                  </>
-                }
-                body={
-                  <p className="text-sm leading-relaxed text-ink-2">
-                    You asked: <span className="italic text-ink">&ldquo;{askAnswer.query}&rdquo;</span>. Live natural-language clients search is coming soon — for now I&rsquo;ve applied the closest matching filter and surfaced the rows below.
-                  </p>
-                }
-                actions={[
-                  {
-                    id: 'show-needs-check-in',
-                    label: 'Show me as a list',
-                    variant: 'primary',
-                    onClick: () => {
-                      setActiveFilter('needs_check_in');
-                      setSortMode('recent_activity');
-                      setAskAnswer(null);
-                    },
-                  },
-                  {
-                    id: 'message-all',
-                    label: 'Message all',
-                    onClick: () => {
-                      // TODO(backend): stage a multi-recipient draft via the
-                      // assistant when grounded clients-query is live.
-                      setAskAnswer(null);
-                    },
-                  },
-                  {
-                    id: 'schedule-check-ins',
-                    label: 'Schedule check-ins',
-                    onClick: () => {
-                      // TODO(backend): hand off to calendar bulk-schedule.
-                      setAskAnswer(null);
-                    },
-                  },
-                ]}
-                sources={[
-                  { table: 'contacts', count: clients.length },
-                  { table: 'matters', count: mattersData.items.length },
-                ]}
-              />
-            </div>
-          ) : null}
 
           {/* ── Filter row ──────────────────────────────────────────── */}
           {renderFilterRow()}

--- a/src/features/invoices/pages/PracticeInvoicesPage.tsx
+++ b/src/features/invoices/pages/PracticeInvoicesPage.tsx
@@ -25,7 +25,6 @@ import { SplitDetail } from '@/design-system/layout';
 import {
   Seg,
   AIAskBar,
-  AIAnswerCard,
 } from '@/design-system/patterns';
 import { usePaginatedList } from '@/shared/hooks/usePaginatedList';
 import { formatCurrency } from '@/shared/utils/currencyFormatter';
@@ -140,14 +139,13 @@ export function PracticeInvoicesPage({
   onCreateInvoice?: () => void;
 }) {
   const { navigate } = useNavigation();
-  const { showError, showSuccess, showInfo } = useToastContext();
+  const { showError, showSuccess } = useToastContext();
   const [visibleOptionalColumns, setVisibleOptionalColumns] = useState<InvoiceColumnKey[]>([]);
   const [chipFilters, setChipFilters] = useState<InvoiceListFilterState>(EMPTY_FILTERS);
   const [pendingVoidInvoice, setPendingVoidInvoice] = useState<InvoiceSummary | null>(null);
   const [isVoidLoading, setIsVoidLoading] = useState(false);
   const [statusTab, setStatusTab] = useState<StatusTabId>('all');
   const [viewMode, setViewMode] = useState<ViewMode>('cards');
-  const [askAnswer, setAskAnswer] = useState<{ query: string } | null>(null);
 
   const aggregates = useInvoiceListAggregates(practiceId);
 
@@ -252,15 +250,6 @@ export function PracticeInvoicesPage({
       setIsVoidLoading(false);
     }
   }, [practiceId, pendingVoidInvoice, refetch, showError, showSuccess]);
-
-  // ── AI ask submit ─────────────────────────────────────────────────────
-  const handleAskSubmit = useCallback((query: string) => {
-    // TODO(backend): wire to /api/practice/:id/invoices/ask once the
-    // natural-language invoices-query endpoint exists. Today the
-    // AIAnswerCard narrates the current filter state so the chat-first
-    // shape is end-to-end without fabricating answers.
-    setAskAnswer({ query });
-  }, []);
 
   if (renderMode === 'detailOnly') {
     return null;
@@ -375,59 +364,10 @@ export function PracticeInvoicesPage({
     <>
       <AIAskBar
         sticky={false}
-        placeholder="Find invoices ready to send..."
-        suggestions={[
-          'Drafts ready to send',
-          'Overdue this week',
-          'Paid last 30 days',
-        ]}
-        onSubmit={handleAskSubmit}
+        placeholder="Grounded invoice questions are not available yet"
+        disabled
+        disclaimer="Requires a grounded invoice-query backend contract"
       />
-      {askAnswer ? (
-        <AIAnswerCard
-          groundingLabel={`Practice assistant · grounded in invoices · ${invoices.length} rows · just now`}
-          lede={
-            <>
-              <em>{invoices.length}</em> {invoices.length === 1 ? 'invoice' : 'invoices'} match your filters
-              {aggregates.outstanding.amount > 0
-                ? <> · <em>{formatCurrency(aggregates.outstanding.amount)}</em> outstanding</>
-                : null}
-            </>
-          }
-          body={
-            <p className="text-sm text-dim-2">
-              You asked: <span className="italic text-ink">&ldquo;{askAnswer.query}&rdquo;</span>. Live natural-language invoice search is coming soon &mdash; for now I&apos;ve narrated the filtered set.
-            </p>
-          }
-          actions={[
-            {
-              id: 'send-all',
-              label: 'Send all',
-              variant: 'primary',
-              // TODO(backend): bulk send endpoint not yet wired.
-              onClick: () => showInfo('Send all', 'Bulk send is coming soon.'),
-            },
-            {
-              id: 'mark-paid',
-              label: 'Mark paid',
-              // TODO(backend): bulk mark-paid endpoint not yet wired.
-              onClick: () => showInfo('Mark paid', 'Bulk mark-paid is coming soon.'),
-            },
-            {
-              id: 'export',
-              label: 'Export to CSV',
-              // TODO(backend): CSV export endpoint not yet wired.
-              onClick: () => showInfo('Export', 'Invoice export is coming soon.'),
-            },
-            {
-              id: 'dismiss',
-              label: 'Dismiss',
-              onClick: () => setAskAnswer(null),
-            },
-          ]}
-          sources={[{ table: 'invoices', count: invoices.length }]}
-        />
-      ) : null}
     </>
   );
 
@@ -520,7 +460,7 @@ export function PracticeInvoicesPage({
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto p-6">
         {aiBlock}
-        {askAnswer ? null : <DetailEmptyState />}
+        <DetailEmptyState />
       </div>
     </div>
   );

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -5,7 +5,7 @@ import { Page } from '@/shared/ui/layout/Page';
 import { WorkspacePlaceholderState } from '@/shared/ui/layout/WorkspacePlaceholderState';
 import { Button } from '@/shared/ui/Button';
 import { CurrencyInput, Input } from '@/shared/ui/input';
-import { Seg, AIAskBar, AIAnswerCard, type StatStripCell } from '@/design-system/patterns';
+import { Seg, AIAskBar, type StatStripCell } from '@/design-system/patterns';
 import { Bar, Pill, SignalPill, type SignalPillSignal, type PillTone } from '@/design-system/primitives';
 import { type TimelineItem, type TimelinePerson } from '@/shared/ui/activity/ActivityTimeline';
 import { Dialog, DialogBody } from '@/shared/ui/dialog';
@@ -446,7 +446,6 @@ export const PracticeMattersPage = ({
   const [activeFilters, setActiveFilters] = useState<ReadonlySet<MatterRiskFilter>>(() => new Set());
   const [viewMode, setViewMode] = useState<MatterViewMode>('table');
   const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false);
-  const [askAnswer, setAskAnswer] = useState<{ query: string } | null>(null);
   const [isShortcutsHelpOpen, setIsShortcutsHelpOpen] = useState(false);
 
   const toggleFilter = useCallback((id: MatterRiskFilter) => {
@@ -466,11 +465,6 @@ export const PracticeMattersPage = ({
       if (event.metaKey || event.ctrlKey || event.altKey) return;
 
       if (event.key === 'Escape') {
-        if (askAnswer) {
-          event.preventDefault();
-          setAskAnswer(null);
-          return;
-        }
         if (activeFilters.size > 0) {
           event.preventDefault();
           setActiveFilters(new Set());
@@ -498,7 +492,7 @@ export const PracticeMattersPage = ({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [activePracticeId, navigate, basePath, location.url, activeFilters, askAnswer]);
+  }, [activePracticeId, navigate, basePath, location.url, activeFilters]);
 
   // ── Activity / notes ──────────────────────────────────────────────────────
   const [activityRecords, setActivityRecords] = useState<BackendMatterActivity[]>([]);
@@ -2382,21 +2376,6 @@ export const PracticeMattersPage = ({
 
   const crumb = `Workspace · ${formatCount(openMattersCount)} active`;
 
-  const handleAskSubmit = (query: string) => {
-    // TODO(backend): wire to /api/practice/:id/matters/ask once the natural-
-    // language matters-query endpoint exists. Today we surface a placeholder
-    // AIAnswerCard so the surface composes the canonical chat-first shape;
-    // the model never fabricates numbers — the lede is grounded narration
-    // of the current filter state instead.
-    setAskAnswer({ query });
-  };
-
-  // TODO(backend): replace with a real CSV stream via
-  // /api/practice/:id/matters/export?format=csv. Stub until then.
-  const handleExport = () => {
-    setAskAnswer({ query: '__export_pending__' });
-  };
-
   // Mobile reflow strategy:
   // - H1: 32px on mobile, 44px from sm+
   // - Hero stats stack under the title on mobile, align right on desktop
@@ -2454,53 +2433,11 @@ export const PracticeMattersPage = ({
         <div className="mt-6">
           <AIAskBar
             sticky={false}
-            placeholder='Ask anything — "which matters are at risk?" · "open Martinez" · "draft an invoice for Johnson"'
-            suggestions={[
-              'Show matters at risk',
-              'Retainer below 30%',
-              'No activity > 2 weeks',
-            ]}
-            onSubmit={handleAskSubmit}
+            placeholder="Grounded matter questions are not available yet"
+            disabled
+            disclaimer="Requires a grounded matter-query backend contract"
           />
         </div>
-
-        {/* ── AI ANSWER CARD (shown after ask) ─────────────────────────── */}
-        {askAnswer ? (
-          <div className="mt-5">
-            <AIAnswerCard
-              groundingLabel={`Practice assistant · grounded in matters · ${totalMatters} rows · just now`}
-              lede={
-                askAnswer.query === '__export_pending__'
-                  ? <>Exporting <em>{formatCount(totalMatters)}</em> matters to CSV. The download will start shortly.</>
-                  : <>Showing <em>{formatCount(visibleMatterEntries.length)}</em> of <em>{formatCount(totalMatters)}</em> matters{activeFilters.size > 0 ? ' that match the active filters' : ''}. Sorted by most recent activity.</>
-              }
-              body={
-                askAnswer.query === '__export_pending__'
-                  ? undefined
-                  : <p className="text-sm text-dim-2">
-                      You asked: <span className="italic text-ink">&ldquo;{askAnswer.query}&rdquo;</span>. Live natural-language matters search is coming soon &mdash; for now I&rsquo;ve applied the closest matching filter and surfaced the rows below.
-                    </p>
-              }
-              actions={[
-                {
-                  id: 'show-at-risk',
-                  label: 'Show at risk',
-                  variant: 'primary',
-                  onClick: () => {
-                    setActiveFilters(new Set(['at_risk']));
-                    setAskAnswer(null);
-                  },
-                },
-                {
-                  id: 'dismiss',
-                  label: 'Dismiss',
-                  onClick: () => setAskAnswer(null),
-                },
-              ]}
-              sources={[{ table: 'matters', count: totalMatters }]}
-            />
-          </div>
-        ) : null}
 
         {/* ── TOOLBAR (filter chips + view toggle) ─────────────────────── */}
         <div className="mt-7 flex flex-wrap items-center gap-3">
@@ -2561,8 +2498,8 @@ export const PracticeMattersPage = ({
             size="sm"
             variant="ghost"
             icon={Download}
-            onClick={handleExport}
-            disabled={!activePracticeId || totalMatters === 0}
+            disabled
+            title="Matter export requires a backend export contract"
             className="min-h-[44px] sm:min-h-0"
           >
             Export

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -49,4 +49,20 @@ describe('honest compliance UI', () => {
     expect(intelligence).not.toContain("{ key: 'matters', rows: 142 }");
     expect(intelligence).toContain('browser-only preferences that appear saved but do not affect the assistant');
   });
+
+  it('does not answer arbitrary workspace questions with unrelated summaries', () => {
+    const surfaces = [
+      source('src/features/clients/pages/PracticeContactsPage.tsx'),
+      source('src/features/matters/pages/PracticeMattersPage.tsx'),
+      source('src/features/invoices/pages/PracticeInvoicesPage.tsx'),
+      source('src/features/calendar/pages/PracticeCalendarPage.tsx'),
+    ];
+
+    for (const surface of surfaces) {
+      expect(surface).toContain('<AIAskBar');
+      expect(surface).toContain('disabled');
+      expect(surface).toContain('Requires a grounded');
+      expect(surface).not.toContain('Live natural-language');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- keep Clients, Matters, Invoices, and Calendar AI query surfaces visible but disabled until grounded query contracts exist
- remove deterministic answer cards that ignored the user's question
- disable the Matters export action that previously promised a download without producing one
- add disabled support to the shared AI ask pattern and regression coverage for honest states

## Verification
- npm run type-check
- npm run lint
- npm test (113 files / 846 tests)
- npm run build
- npm run build:check-size (284.6 KB / 300 KB)
- git diff --check

Supports #662 and #716. Backend work can be reviewed and merged independently; this frontend does not wait for it.