### PR TITLE
fix(ui): align labels with real actions

### DIFF
--- a/src/features/intake/pages/IntakeDetailPage.tsx
+++ b/src/features/intake/pages/IntakeDetailPage.tsx
@@ -918,17 +918,6 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
       ? `${intakeJurisdictionState} · ${cityFromAddress}`
       : intakeJurisdictionState
     : null;
-  // TODO(backend): expose intake source (widget origin / referral) via the
-  // intake row. For now we fall back to a generic practice label.
-  const sourceLabel = `via ${practiceName?.trim() || 'public intake form'}`;
-  // TODO(backend): expose a real response-window from practice settings;
-  // surface "urgent" when the intake is flagged as time-sensitive.
-  const responseWindow = intake.urgency === 'emergency'
-    ? '< 3h response window'
-    : intake.urgency === 'time_sensitive'
-      ? '24h response window'
-      : null;
-
   const stampParts: string[] = [];
   const intakeAgeMin = (() => {
     const created = new Date(intake.created_at).getTime();
@@ -1249,8 +1238,6 @@ export const IntakeDetailPage: FunctionComponent<IntakeDetailPageProps> = ({
         scopeLabel={headerScope}
         practiceArea={headerPracticeArea}
         jurisdiction={jurisdictionLabel}
-        source={sourceLabel}
-        responseWindow={responseWindow}
         statusBadge={statusPill}
         actions={headerActions}
         stamp={stampText}

--- a/src/features/matters/components/MatterOverviewTab.tsx
+++ b/src/features/matters/components/MatterOverviewTab.tsx
@@ -196,8 +196,7 @@ const buildAssistantSummary = (
     actions.push({ id: 'approve-invoice', label: `Approve invoice draft`, variant: 'primary', onClick: () => {} });
   }
   actions.push({ id: 'reply', label: 'Reply to client', onClick: () => {} });
-  actions.push({ id: 'engagement-update', label: 'Draft engagement update', onClick: () => {} });
-  actions.push({ id: 'settlement', label: 'Settlement projection', onClick: () => {} });
+  actions.push({ id: 'engagement-update', label: 'View engagement', onClick: () => {} });
 
   // Source citations — real database tables that ground the summary.
   // TODO(backend): when the AI route exists, the response itself will
@@ -212,7 +211,7 @@ const buildAssistantSummary = (
 
   // Grounding label — count distinct sources surfaced.
   const grounded = sources.reduce((sum, s) => sum + s.count, 0);
-  const groundingLabel = `Practice assistant · grounded in ${grounded} ${grounded === 1 ? 'source' : 'sources'} · ${relativeTimeLabel()}`;
+  const groundingLabel = `Matter summary · grounded in ${grounded} ${grounded === 1 ? 'source' : 'sources'} · ${relativeTimeLabel()}`;
 
   return { lede, actions, sources, groundingLabel };
 };
@@ -245,20 +244,16 @@ const AISummaryCard = ({
   );
 
   // Bind real handlers to the action chips by id.
-  const boundActions = actions.map((action) => {
+  const boundActions = actions.flatMap<AIAnswerCardAction>((action) => {
     switch (action.id) {
       case 'approve-invoice':
-        return { ...action, onClick: onApproveInvoice };
+        return [{ ...action, label: 'Review invoice draft', onClick: onApproveInvoice }];
       case 'reply':
-        return { ...action, onClick: onReplyToClient };
+        return onReplyToClient ? [{ ...action, onClick: onReplyToClient }] : [];
       case 'engagement-update':
-        return { ...action, onClick: onViewEngagement };
-      case 'settlement':
-        // TODO(backend): wire to settlement projection AI route — for now
-        // reuse the engagement view as the closest existing surface.
-        return { ...action, onClick: onViewEngagement };
+        return [{ ...action, onClick: onViewEngagement }];
       default:
-        return action;
+        return [action];
     }
   });
 
@@ -290,12 +285,12 @@ const StagedInvoiceAction = ({
 
   return (
     <StagedAction
-      label="Staged · awaits your approval"
-      title={`Invoice draft · ${formatCurrency(amountMajor)}`}
+      label="Ready to draft · requires review"
+      title={`Invoice opportunity · ${formatCurrency(amountMajor)}`}
       description={
         <>
           {hours.toFixed(hours % 1 === 0 ? 0 : 1)} unbilled {hours === 1 ? 'hour' : 'hours'} aggregated from
-          the current pay period. Approving opens the draft in the invoice editor — the invoice is not sent
+          the current pay period. Drafting opens the invoice editor — the invoice is not sent
           until you review the line items and click <strong>Send</strong>.
         </>
       }
@@ -704,10 +699,6 @@ export const MatterOverviewTab = (props: MatterOverviewTabProps) => {
   } = props;
 
   const approveInvoice = onApproveInvoiceDraft ?? onCreateInvoice;
-  // "Reply to client" defaults to opening the engagement (closest existing
-  // contact surface); a real reply requires the practice-assistant matter
-  // route. TODO(backend): replace with the scoped chat endpoint.
-  const replyToClient = onReplyToClient ?? onViewEngagement;
 
   return (
     <div className="@container">
@@ -721,7 +712,7 @@ export const MatterOverviewTab = (props: MatterOverviewTabProps) => {
             tasks={tasks}
             timelineItems={timelineItems}
             onApproveInvoice={approveInvoice}
-            onReplyToClient={replyToClient}
+            onReplyToClient={onReplyToClient}
             onViewEngagement={onViewEngagement}
           />
 

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -65,4 +65,16 @@ describe('honest compliance UI', () => {
       expect(surface).not.toContain('Live natural-language');
     }
   });
+
+  it('does not relabel navigation as AI work or invent intake service levels', () => {
+    const matterOverview = source('src/features/matters/components/MatterOverviewTab.tsx');
+    const intakeDetail = source('src/features/intake/pages/IntakeDetailPage.tsx');
+    expect(matterOverview).not.toContain("label: 'Draft engagement update'");
+    expect(matterOverview).not.toContain("label: 'Settlement projection'");
+    expect(matterOverview).not.toContain('Staged · awaits your approval');
+    expect(matterOverview).toContain("label: 'View engagement'");
+    expect(intakeDetail).not.toContain("'< 3h response window'");
+    expect(intakeDetail).not.toContain("'24h response window'");
+    expect(intakeDetail).not.toContain('via ${practiceName');
+  });
 });


### PR DESCRIPTION
## Summary
- rename Matter summary actions to describe what they actually do
- remove the unsupported settlement projection action instead of routing it to Engagement
- omit Reply when no reply handler exists instead of opening Engagement
- distinguish an invoice opportunity from an already-staged draft
- remove invented Intake response-time SLAs and unknown origin labels

## Verification
- npm run type-check
- npm run lint
- npm test (113 files / 847 tests)
- npm run build
- npm run build:check-size (284.6 KB / 300 KB)
- git diff --check

Supports #662 and #716.