### PR TITLE
fix(ui): wire real drafting and honest reports

### DIFF
--- a/src/features/reports/pages/reports/AllReportsHub.tsx
+++ b/src/features/reports/pages/reports/AllReportsHub.tsx
@@ -30,7 +30,6 @@ import { formatCurrency } from '@/shared/utils/currencyFormatter';
 import { formatRelativeTime } from '@/features/matters/utils/formatRelativeTime';
 import { useReportData } from '@/features/reports/hooks/useReportData';
 import { useReportExport } from '@/features/reports/hooks/useReportExport';
-import { reportsApi } from '@/features/reports/services/reportsApi';
 import { Sparkline, BarChart, type BarChartDatum } from '@/features/reports/components/InlineCharts';
 import {
   REPORT_DEFINITIONS,
@@ -233,7 +232,6 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
   const { showSuccess, showError, showInfo } = useToastContext();
   const { exportReport, exporting } = useReportExport();
   const [period, setPeriod] = useState<ReportPeriod>('month');
-  const [sendingEmail, setSendingEmail] = useState(false);
 
   const queryPeriod = period;
   const queryParams = useMemo(() => ({ period: queryPeriod }), [queryPeriod]);
@@ -286,38 +284,14 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
     navigate(`/practice/${encodeURIComponent(practiceSlug)}/reports/${def.id}`);
   }, [navigate, practiceSlug]);
 
-  const handleDownloadPdf = useCallback(async () => {
-    // Worker exports CSV today (no server-side PDF rendering yet); we surface
-    // that to the user so they don't expect a binary PDF blob.
-    // TODO(backend): add `format=pdf` support to `/api/reports/:practiceId/export/:type`
-    // so this button can deliver a real PDF instead of CSV.
+  const handleDownloadCsv = useCallback(async () => {
     try {
       await exportReport(practiceId, 'revenue', { period: queryPeriod });
-      showSuccess('Export downloaded', 'CSV saved. PDF export coming soon.');
+      showSuccess('Export downloaded', 'Revenue CSV saved.');
     } catch (err) {
       showError('Export failed', err instanceof Error ? err.message : 'Try again in a moment.');
     }
   }, [exportReport, practiceId, queryPeriod, showSuccess, showError]);
-
-  const handleEmailCpa = useCallback(async () => {
-    // No recipient picker on the hub yet — fall back to the practice's owner
-    // recipients (server resolves when array is empty).
-    // TODO(backend): add owner-mailing-list resolution + per-user "my CPA"
-    // contact so this can ship a stored address without showing a modal.
-    setSendingEmail(true);
-    try {
-      await reportsApi.sendNow(practiceId, {
-        reportType: 'revenue',
-        recipients: [],
-        filters: { period: queryPeriod },
-      });
-      showSuccess('Sent to your CPA', 'Open Deliveries to track the email.');
-    } catch (err) {
-      showError('Send failed', err instanceof Error ? err.message : 'Try again in a moment.');
-    } finally {
-      setSendingEmail(false);
-    }
-  }, [practiceId, queryPeriod, showSuccess, showError]);
 
   const handleDrillRevenue = useCallback(() => {
     if (!practiceSlug) return;
@@ -355,20 +329,15 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={handleEmailCpa}
-                  disabled={sendingEmail}
+                  disabled
+                  title="Requires a configured CPA recipient"
                 >
-                  {sendingEmail && (
-                    <span className="mr-1.5 inline-flex">
-                      <LoadingSpinner size="sm" ariaLabel="Sending report" announce={false} />
-                    </span>
-                  )}
-                  Email this to my CPA
+                  Email CPA unavailable
                 </Button>
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={handleDownloadPdf}
+                  onClick={handleDownloadCsv}
                   disabled={exporting}
                 >
                   {exporting && (
@@ -376,7 +345,7 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
                       <LoadingSpinner size="sm" ariaLabel="Exporting report" announce={false} />
                     </span>
                   )}
-                  Download PDF
+                  Download CSV
                 </Button>
               </div>
             </div>
@@ -390,7 +359,6 @@ export const AllReportsHub: FunctionComponent<AllReportsHubProps> = ({ practiceI
             : summaryMeta?.narrative ?? 'Reading revenue, utilization, intake, and matter records…'}
           actions={[
             { id: 'math', label: 'Show me the math', variant: 'primary', onClick: handleShowMath },
-            { id: 'email', label: 'Email this to my CPA', onClick: handleEmailCpa },
             { id: 'drill-revenue', label: 'Drill into revenue', onClick: handleDrillRevenue },
             { id: 'drill-util', label: 'Drill into utilization', onClick: handleDrillUtilization },
           ]}

--- a/src/features/settings/pages/EngagementTemplatesPage.tsx
+++ b/src/features/settings/pages/EngagementTemplatesPage.tsx
@@ -530,7 +530,7 @@ const EmptyAreaCard = ({ area, onAsk }: EmptyAreaCardProps) => (
         No {area.toLowerCase()} template yet
       </p>
       <p className="mt-1 text-sm leading-snug text-ink-2">
-        The assistant can draft one from your prior {area.toLowerCase()} matters.
+        The assistant can draft a starting point for you to review and edit.
       </p>
     </div>
     <Button type="button" size="sm" variant="secondary" onClick={onAsk}>
@@ -610,7 +610,7 @@ type ListViewProps = {
 };
 
 function TemplateListView({ templates, onNew, onNewInArea, onEdit, onDraftFromPrompt }: ListViewProps) {
-  const { showSuccess, showError } = useToastContext();
+  const { showError } = useToastContext();
 
   const [areaFilters, setAreaFilters] = useState<Set<string>>(new Set());
   const [statusFilters, setStatusFilters] = useState<Set<StatusFilter>>(new Set());
@@ -679,18 +679,17 @@ function TemplateListView({ templates, onNew, onNewInArea, onEdit, onDraftFromPr
     }
   }, [onDraftFromPrompt, showError]);
 
-  const handleAskAssistant = useCallback((area: string) => {
-    // TODO(backend): wire to assistant authoring; for now open a blank
-    // template pre-seeded with the area so the user can keep going.
-    onNewInArea(area);
-  }, [onNewInArea]);
-
-  const handleBrowseCommunity = useCallback(() => {
-    // TODO(backend): replace with a community-templates gallery dialog
-    // (read-only browse + import). The endpoint and UI both don't exist
-    // yet — surface the intent for now.
-    showSuccess('Community templates', 'A community template gallery is on the roadmap.');
-  }, [showSuccess]);
+  const handleAskAssistant = useCallback(async (area: string) => {
+    try {
+      await onDraftFromPrompt(
+        `Draft a reusable engagement letter template for ${area.toLowerCase()} matters.`,
+        area,
+        undefined,
+      );
+    } catch (err) {
+      showError('Draft failed', err instanceof Error ? err.message : 'Unable to draft template.');
+    }
+  }, [onDraftFromPrompt, showError]);
 
   const totalCount = templates.length;
   const allActive = areaFilters.size === 0 && statusFilters.size === 0;
@@ -709,8 +708,8 @@ function TemplateListView({ templates, onNew, onNewInArea, onEdit, onDraftFromPr
           </p>
         </div>
         <div className="flex shrink-0 flex-wrap items-center gap-2">
-          <Button type="button" variant="ghost" size="sm" onClick={handleBrowseCommunity}>
-            Browse community
+          <Button type="button" variant="ghost" size="sm" disabled title="Community template gallery is not available">
+            Community unavailable
           </Button>
           <Button type="button" variant="primary" size="sm" icon={Plus} onClick={onNew}>
             New template

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -77,4 +77,16 @@ describe('honest compliance UI', () => {
     expect(intakeDetail).not.toContain("'24h response window'");
     expect(intakeDetail).not.toContain('via ${practiceName');
   });
+
+  it('uses real report and template capabilities without false success', () => {
+    const reports = source('src/features/reports/pages/reports/AllReportsHub.tsx');
+    const templates = source('src/features/settings/pages/EngagementTemplatesPage.tsx');
+    expect(reports).not.toContain("showSuccess('Sent to your CPA'");
+    expect(reports).not.toContain('Download PDF');
+    expect(reports).toContain('Download CSV');
+    expect(reports).toContain('Email CPA unavailable');
+    expect(templates).not.toContain("showSuccess('Community templates'");
+    expect(templates).toContain('await onDraftFromPrompt(');
+    expect(templates).toContain('Community unavailable');
+  });
 });


### PR DESCRIPTION
## Summary
- wire empty-area engagement-template drafting to the existing Worker AI endpoint
- remove the unsupported community-gallery success toast and label it unavailable
- rename the real revenue export from PDF to CSV
- disable CPA email until a recipient is configured instead of submitting an empty recipient list and claiming delivery

## Verification
- npm run type-check
- npm run lint
- npm test (113 files / 848 tests)
- npm run build
- npm run build:check-size (284.6 KB / 300 KB)
- git diff --check

Supports #662 and #716.