### PR TITLE
fix(ui): remove remaining no-op controls

### DIFF
--- a/src/features/calendar/pages/PracticeCalendarPage.tsx
+++ b/src/features/calendar/pages/PracticeCalendarPage.tsx
@@ -169,12 +169,6 @@ export function PracticeCalendarPage({
 
   const handleDrawerClose = useCallback(() => setSelectedEvent(null), []);
 
-  // ── AI ask bar — stubbed query → deterministic answer card. ─────────────
-  // TODO(backend): wire onSubmit to PracticeAssistantQueryEngine for a real
-  // grounded calendar query endpoint. Today we surface a deterministic answer
-  // that uses the aggregated event corpus so the surface isn't an empty shell.
-  // Timestamp captured at submit-time so the answer card grounding label
-  // stays stable instead of ticking on every render.
   // ── Navigation label ─────────────────────────────────────────────────────
   const navLabel =
     view === 'month' ? monthLabel(anchor)

--- a/src/features/clients/components/clientSignals.ts
+++ b/src/features/clients/components/clientSignals.ts
@@ -27,7 +27,7 @@ export const formatLastContact = (days: number | null): string => {
   return `${days} days`;
 };
 
-export type ContactFilterId = 'all' | 'needs_check_in' | 'on_retainer' | 'awaiting_docs' | 'closed';
+export type ContactFilterId = 'all' | 'needs_check_in' | 'on_retainer' | 'closed';
 
 export type ContactSortId = 'a_z' | 'recent_activity' | 'sentiment' | 'risk';
 

--- a/src/features/clients/pages/PracticeContactsPage.tsx
+++ b/src/features/clients/pages/PracticeContactsPage.tsx
@@ -752,7 +752,6 @@ export const PracticeContactsPage = ({
       all: 0,
       needs_check_in: 0,
       on_retainer: 0,
-      awaiting_docs: 0,
       closed: 0,
     };
     for (const c of clients) {
@@ -762,9 +761,6 @@ export const PracticeContactsPage = ({
       if (days !== null && days > 30) counts.needs_check_in += 1;
       const hasRetainer = (c.matters ?? []).some((m) => readRetainerAmount(m) !== null);
       if (hasRetainer) counts.on_retainer += 1;
-      // "Awaiting docs" heuristic — leads with no open matters yet.
-      // TODO(backend): replace with a real `awaiting_docs` flag from intake state.
-      if (c.status === 'lead' && (c.matters ?? []).length === 0) counts.awaiting_docs += 1;
       if (c.status === 'inactive') counts.closed += 1;
     }
     return counts;
@@ -780,8 +776,6 @@ export const PracticeContactsPage = ({
           return days !== null && days > 30;
         case 'on_retainer':
           return (c.matters ?? []).some((m) => readRetainerAmount(m) !== null);
-        case 'awaiting_docs':
-          return c.status === 'lead' && (c.matters ?? []).length === 0;
         case 'closed':
           return c.status === 'inactive';
         default:
@@ -1135,10 +1129,7 @@ export const PracticeContactsPage = ({
     () => clients.filter((c) => c.kind === 'client' && c.status !== 'archived').length,
     [clients]
   );
-  const awaitingReplyCount = useMemo(() => {
-    // TODO(backend): replace with a real "days since lawyer's last outbound
-    // message" derivation once the messages join is exposed per contact.
-    // For now we proxy "awaiting reply" with "no contact activity in 7+ days".
+  const inactiveSevenDaysCount = useMemo(() => {
     return clients.filter((c) => c.kind === 'client' && (c.lastContactDays ?? 0) > 7).length;
   }, [clients]);
   const atRiskCount = useMemo(
@@ -1148,7 +1139,7 @@ export const PracticeContactsPage = ({
 
   const headerStatCells: StatStripCell[] = [
     { label: 'Active', value: String(totalActiveCount) },
-    { label: 'Awaiting reply', value: String(awaitingReplyCount), extraWarn: awaitingReplyCount > 0 },
+    { label: 'No activity 7d', value: String(inactiveSevenDaysCount), extraWarn: inactiveSevenDaysCount > 0 },
     { label: 'At risk', value: String(atRiskCount), extraWarn: atRiskCount > 0 },
   ];
 
@@ -1157,7 +1148,6 @@ export const PracticeContactsPage = ({
     { id: 'all', label: 'All' },
     { id: 'needs_check_in', label: 'Needs check-in', warn: true },
     { id: 'on_retainer', label: 'On retainer' },
-    { id: 'awaiting_docs', label: 'Awaiting docs' },
     { id: 'closed', label: 'Closed' },
   ];
 

--- a/src/features/engagements/components/EngagementWorkbench.tsx
+++ b/src/features/engagements/components/EngagementWorkbench.tsx
@@ -761,7 +761,7 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
   const currencyUpdate = (key: keyof EngagementDraftForm) =>
     (v: number | undefined) => updateField(key, v != null ? String(v) : '');
 
-  // ── AIRibbon actions (stubs) ───────────────────────────────────────────────
+  // ── AIRibbon actions ───────────────────────────────────────────────────────
 
   const handleRegenerate = useCallback(() => {
     if (!isCreate || !selectedIntakeDetail) return;
@@ -771,36 +771,17 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
     // takes proposal_data + practice templates and returns a fresh contract body.
   }, [isCreate, selectedIntakeDetail, selectedTemplate, engagementTemplates, generateFromTemplate]);
 
-  const ribbonActions = useMemo(() => ([
+  const canRegenerate = isCreate
+    && Boolean(selectedIntakeDetail)
+    && Boolean(selectedTemplate ?? engagementTemplates[0]);
+  const ribbonActions = useMemo(() => canRegenerate ? ([
     {
       id: 'regenerate',
-      label: 'Re-generate',
+      label: 'Regenerate draft',
       variant: 'primary' as const,
       onClick: handleRegenerate,
     },
-    {
-      id: 'polish',
-      label: 'Polish',
-      // TODO(backend): wire to a polish/rewrite endpoint that smooths the
-      // tone of the contract body without changing material terms.
-      onClick: () => undefined,
-    },
-    {
-      id: 'translate',
-      label: 'Translate',
-      // TODO(backend): wire to a translate endpoint that produces a
-      // plain-English version of the contract body.
-      onClick: () => undefined,
-    },
-  ]), [handleRegenerate]);
-
-  // ── Placeholders: "Resolve all with AI" stub ───────────────────────────────
-
-  const handleResolveAll = useCallback(() => {
-    // TODO(backend): call a placeholder-resolution endpoint that takes
-    // unresolved placeholder keys + practice defaults and patches the
-    // contract body with sensible values.
-  }, []);
+  ]) : [], [canRegenerate, handleRegenerate]);
 
   // ── Top bar render helpers ─────────────────────────────────────────────────
 
@@ -1519,10 +1500,11 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
         <div className="mt-3 flex flex-wrap gap-1.5">
           <button
             type="button"
-            onClick={handleResolveAll}
             className="chip primary"
+            disabled
+            title="AI placeholder resolution is not available"
           >
-            Resolve all ({placeholderStats.unresolved}) with AI
+            AI resolution unavailable ({placeholderStats.unresolved})
           </button>
         </div>
       )}
@@ -1546,13 +1528,11 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
       <button
         type="button"
         className="chip"
-        // TODO(backend): wire to engagement-contract PDF export endpoint
-        // (not currently exposed; see worker/routes for the engagement
-        // proxy and add a /pdf action when ready).
-        onClick={() => undefined}
+        disabled
+        title="Engagement PDF export is not available"
       >
         <Download className="mr-1 inline h-3 w-3" />
-        Download PDF
+        PDF unavailable
       </button>
       {!isCreate && (
         <Button

--- a/src/features/engagements/pages/ClientEngagementReviewPage.tsx
+++ b/src/features/engagements/pages/ClientEngagementReviewPage.tsx
@@ -474,15 +474,6 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
     }
   }, [engagement, isDeclining, accepted, declined, practiceId, showError, showSuccess]);
 
-  const handleDownloadPdf = useCallback(() => {
-    if (!engagement?.signed_pdf_s3_key) {
-      showInfo('PDF not yet available', 'The signed PDF will be available after signature.');
-      return;
-    }
-    // TODO(backend): expose a presigned-URL endpoint for client engagement PDF downloads.
-    showInfo('Download starting', 'Your engagement letter PDF is being prepared.');
-  }, [engagement?.signed_pdf_s3_key, showInfo]);
-
   /**
    * Ask-a-question handoff — navigates back to the firm conversation when one
    * exists. When no conversation exists yet, we show an info toast.
@@ -687,11 +678,11 @@ export const ClientEngagementReviewPage: FunctionComponent<ClientEngagementRevie
                 variant="secondary"
                 size="md"
                 icon={Download}
-                onClick={handleDownloadPdf}
-                disabled={!engagement.signed_pdf_s3_key}
+                disabled
+                title="Signed PDF download requires a presigned URL endpoint"
                 className="mt-2"
               >
-                Download PDF
+                Signed PDF unavailable
               </Button>
             </div>
           </div>

--- a/src/features/invoices/components/list/InvoiceFilterChips.tsx
+++ b/src/features/invoices/components/list/InvoiceFilterChips.tsx
@@ -3,7 +3,6 @@ import { ChevronDown, Download } from 'lucide-preact';
 import { Button } from '@/shared/ui/Button';
 import { Dialog, DialogBody, DialogFooter } from '@/shared/ui/dialog';
 import { CurrencyInput, Input } from '@/shared/ui/input';
-import { useToastContext } from '@/shared/contexts/ToastContext';
 import { ColumnEditor, type ColumnEditorOption } from '@/shared/ui/table';
 import {
   DEFAULT_INVOICE_COLUMN_DEFS,
@@ -69,7 +68,6 @@ export const InvoiceFilterChips = ({
   visibleOptionalColumns,
   onVisibleColumnsChange,
 }: InvoiceFilterChipsProps) => {
-  const { showInfo } = useToastContext();
   const [dateOpen, setDateOpen] = useState<null | 'created' | 'due'>(null);
   const [totalOpen, setTotalOpen] = useState(false);
   const [draftFilters, setDraftFilters] = useState(filters);
@@ -119,8 +117,8 @@ export const InvoiceFilterChips = ({
           size="sm"
           icon={Download}
           iconClassName="h-4 w-4"
-          onClick={() => showInfo('Export', 'Invoice export is coming soon.')}
           disabled
+          title="Invoice export requires a backend export contract"
         >
           Export
         </Button>

--- a/src/features/trust/pages/PracticeTrustPage.tsx
+++ b/src/features/trust/pages/PracticeTrustPage.tsx
@@ -91,7 +91,7 @@ const PracticeTrustPage: FunctionComponent = () => {
   const { session } = useSessionContext();
   const location = useLocation();
   const { navigate } = useNavigation();
-  const { showSuccess, showError, showInfo } = useToastContext();
+  const { showSuccess, showError } = useToastContext();
 
   // Read the slug from the URL so the resolver picks `currentPractice` for the
   // workspace we're on — mirrors the pattern in PracticeHomePage.
@@ -326,17 +326,6 @@ const PracticeTrustPage: FunctionComponent = () => {
     }
   }, [activePracticeId, showError, showSuccess]);
 
-  // ── "Pause new draws" stub ───────────────────────────────────────────────
-  // TODO(backend): wire to a real preference toggle (e.g. flip the
-  // `lock_matter_on_zero` rule globally, or add a `trust_paused` flag on
-  // `practices`). Today we just acknowledge the click.
-  const handlePauseDraws = useCallback(() => {
-    showInfo(
-      'Pause new draws',
-      'Backend wiring pending — this will lock the staged-action queue once available.',
-    );
-  }, [showInfo]);
-
   // ── AI summary copy ────────────────────────────────────────────────────────
   // Surface ONE actionable observation (lowest client under threshold) plus
   // the deterministic period rollup. Every figure is sourced from the
@@ -384,8 +373,8 @@ const PracticeTrustPage: FunctionComponent = () => {
       <Chip onClick={handleOpenCpaDialog} title="Schedule recurring delivery to your CPA">
         Email to CPA
       </Chip>
-      <Chip onClick={handlePauseDraws} title="Pause staged actions against trust">
-        Pause new draws
+      <Chip title="Practice-wide trust draw controls are not available">
+        Pause draws unavailable
       </Chip>
     </>
   ) : null;

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -89,4 +89,20 @@ describe('honest compliance UI', () => {
     expect(templates).toContain('await onDraftFromPrompt(');
     expect(templates).toContain('Community unavailable');
   });
+
+  it('does not expose no-op engagement or trust controls and avoids proxy labels', () => {
+    const workbench = source('src/features/engagements/components/EngagementWorkbench.tsx');
+    const clientReview = source('src/features/engagements/pages/ClientEngagementReviewPage.tsx');
+    const trust = source('src/features/trust/pages/PracticeTrustPage.tsx');
+    const clients = source('src/features/clients/pages/PracticeContactsPage.tsx');
+    expect(workbench).not.toContain("label: 'Polish'");
+    expect(workbench).not.toContain("label: 'Translate'");
+    expect(workbench).toContain('AI resolution unavailable');
+    expect(workbench).toContain('PDF unavailable');
+    expect(clientReview).toContain('Signed PDF unavailable');
+    expect(trust).toContain('Pause draws unavailable');
+    expect(clients).not.toContain('Awaiting docs');
+    expect(clients).not.toContain('Awaiting reply');
+    expect(clients).toContain('No activity 7d');
+  });
 });


### PR DESCRIPTION
## Summary
- remove no-op engagement Polish and Translate actions
- show Regenerate only when the existing create-flow contract can execute
- disable unsupported placeholder resolution and staff/client PDF downloads with explicit labels
- label practice-wide trust draw pausing unavailable instead of acknowledging a no-op click
- remove heuristic Awaiting docs and rename the 7-day activity count so it no longer claims message direction
- remove the disabled invoice export toast handler and stale calendar stub comments

## Verification
- npm run type-check
- npm run lint
- npm test (113 files / 849 tests)
- npm run build
- npm run build:check-size (284.6 KB / 300 KB)
- git diff --check

Supports #662 and #716.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “No activity 7d” client activity indicator and filter behavior.

* **Updates**
  * Simplified engagement drafting to support only “Regenerate draft.”
  * Updated unavailable actions with clear disabled states, including AI placeholder resolution, PDF downloads, invoice exports, and trust draw controls.
  * Removed the “Awaiting reply” client status and related filter.

* **Bug Fixes**
  * Prevented unavailable actions from appearing clickable or suggesting unsupported functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->