### PR TITLE
feat(intake): wire revisioned assistant suggestions

### DIFF
--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -93,6 +93,17 @@ export const intakeTemplatesPath = (practiceId: string): string =>
 export const intakeTemplatePath = (practiceId: string, templateId: string): string =>
 	`${intakeTemplatesPath(practiceId)}/${encodeSegment(templateId)}`;
 
+export const intakeTemplateSuggestionsPath = (practiceId: string, templateId: string): string =>
+	`${intakeTemplatePath(practiceId, templateId)}/suggestions`;
+
+export const intakeTemplateSuggestionDecisionPath = (
+	practiceId: string,
+	templateId: string,
+	suggestionId: string,
+	decision: 'approve' | 'dismiss'
+): string =>
+	`${intakeTemplateSuggestionsPath(practiceId, templateId)}/${encodeSegment(suggestionId)}/${decision}`;
+
 export const matterCollectionPath = (practiceId: string): string => `/api/matters/${encodeSegment(practiceId)}`;
 
 export const matterItemPath = (practiceId: string, matterId: string): string =>

--- a/src/features/intake/api/intakeTemplatesApi.ts
+++ b/src/features/intake/api/intakeTemplatesApi.ts
@@ -1,4 +1,9 @@
-import { intakeTemplatesPath, intakeTemplatePath } from '@/config/urls';
+import {
+  intakeTemplatesPath,
+  intakeTemplatePath,
+  intakeTemplateSuggestionsPath,
+  intakeTemplateSuggestionDecisionPath,
+} from '@/config/urls';
 import { apiClient } from '@/shared/lib/apiClient';
 import type {
   FieldCondition,
@@ -61,6 +66,8 @@ function normalizeTemplate(b: BackendIntakeTemplate): IntakeTemplate {
     slug: b.slug,
     name: b.name,
     status: b.status,
+    revision: b.revision,
+    publishedAt: b.published_at,
     is_default: b.is_default,
     isDefault: b.is_default,
     introMessage: b.intro_message ?? undefined,
@@ -105,7 +112,46 @@ export interface CreateIntakeTemplateInput {
   fields?: IntakeTemplateFieldInput[];
 }
 
-export type UpdateIntakeTemplateInput = Partial<CreateIntakeTemplateInput>;
+export type UpdateIntakeTemplateInput = Partial<CreateIntakeTemplateInput> & { expected_revision: number };
+
+export type IntakeTemplateProposedEdit =
+  | { operation: 'add'; field_key: string; field: IntakeTemplateFieldInput }
+  | { operation: 'remove'; field_key: string }
+  | { operation: 'reorder'; field_key: string; changes: { order_index: number } }
+  | {
+      operation: 'rephrase';
+      field_key: string;
+      changes: { label?: string; placeholder?: string | null; help_text?: string | null; prompt_hint?: string | null };
+    }
+  | {
+      operation: 'condition_change';
+      field_key: string;
+      changes: { required?: boolean; phase?: 'required' | 'enrichment'; validation_rules?: Record<string, unknown> | null };
+    };
+
+export interface IntakeTemplateSuggestion {
+  id: string;
+  organization_id: string;
+  template_id: string;
+  request_key: string;
+  base_revision: number;
+  instruction: string;
+  proposed_edits: IntakeTemplateProposedEdit[];
+  analytics_evidence: {
+    status: 'available' | 'unavailable';
+    window: { from: string; to: string } | null;
+    numerator: number | null;
+    denominator: number | null;
+    provenance: string;
+    reason: string | null;
+  };
+  status: 'staged' | 'approved' | 'dismissed';
+  created_by: string;
+  decided_by: string | null;
+  applied_revision: number | null;
+  created_at: string;
+  decided_at: string | null;
+}
 
 // ---------------------------------------------------------------------------
 // API functions
@@ -149,4 +195,46 @@ export async function updateIntakeTemplate(
 
 export async function deleteIntakeTemplate(practiceId: string, templateId: string): Promise<void> {
   await apiClient.delete(intakeTemplatePath(practiceId, templateId));
+}
+
+export async function listIntakeTemplateSuggestions(
+  practiceId: string,
+  templateId: string,
+): Promise<IntakeTemplateSuggestion[]> {
+  const result = await apiClient.get<{ suggestions: IntakeTemplateSuggestion[] }>(
+    intakeTemplateSuggestionsPath(practiceId, templateId),
+  );
+  if (!Array.isArray(result?.data?.suggestions)) {
+    throw new Error('Unexpected response from backend: missing intake template suggestions');
+  }
+  return result.data.suggestions;
+}
+
+export async function approveIntakeTemplateSuggestion(
+  practiceId: string,
+  templateId: string,
+  suggestionId: string,
+  expectedRevision: number,
+): Promise<{ suggestion: IntakeTemplateSuggestion; template: IntakeTemplate }> {
+  const result = await apiClient.post<{ suggestion: IntakeTemplateSuggestion; template: BackendIntakeTemplate }>(
+    intakeTemplateSuggestionDecisionPath(practiceId, templateId, suggestionId, 'approve'),
+    { expected_revision: expectedRevision },
+  );
+  if (!result?.data?.suggestion || !result.data.template) {
+    throw new Error('Failed to apply intake template suggestion');
+  }
+  return { suggestion: result.data.suggestion, template: normalizeTemplate(result.data.template) };
+}
+
+export async function dismissIntakeTemplateSuggestion(
+  practiceId: string,
+  templateId: string,
+  suggestionId: string,
+): Promise<IntakeTemplateSuggestion> {
+  const result = await apiClient.post<{ suggestion: IntakeTemplateSuggestion }>(
+    intakeTemplateSuggestionDecisionPath(practiceId, templateId, suggestionId, 'dismiss'),
+    {},
+  );
+  if (!result?.data?.suggestion) throw new Error('Failed to dismiss intake template suggestion');
+  return result.data.suggestion;
 }

--- a/src/features/intake/components/IntakeAuthoringStrip.tsx
+++ b/src/features/intake/components/IntakeAuthoringStrip.tsx
@@ -1,22 +1,129 @@
-import { Sparkles } from 'lucide-preact';
+import { Check, RefreshCw, Sparkles, X } from 'lucide-preact';
 
+import type { IntakeTemplateSuggestion } from '@/features/intake/api/intakeTemplatesApi';
+import { Pill } from '@/design-system/primitives';
 import { Button } from '@/shared/ui/Button';
 
-export function IntakeAuthoringStrip() {
+type SuggestionLoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+interface IntakeAuthoringStripProps {
+  revision?: number;
+  suggestions: IntakeTemplateSuggestion[];
+  loadState: SuggestionLoadState;
+  actingSuggestionId: string | null;
+  canLoad: boolean;
+  onRefresh: () => void;
+  onApply: (suggestion: IntakeTemplateSuggestion) => void;
+  onDismiss: (suggestion: IntakeTemplateSuggestion) => void;
+}
+
+const operationLabel = (operation: IntakeTemplateSuggestion['proposed_edits'][number]['operation']): string => {
+  if (operation === 'condition_change') return 'condition';
+  return operation;
+};
+
+const describeEdits = (suggestion: IntakeTemplateSuggestion): string => {
+  const operations = [...new Set(suggestion.proposed_edits.map((edit) => operationLabel(edit.operation)))];
+  const noun = suggestion.proposed_edits.length === 1 ? 'edit' : 'edits';
+  return `${suggestion.proposed_edits.length} proposed ${noun}: ${operations.join(', ')}`;
+};
+
+export function IntakeAuthoringStrip({
+  revision,
+  suggestions,
+  loadState,
+  actingSuggestionId,
+  canLoad,
+  onRefresh,
+  onApply,
+  onDismiss,
+}: IntakeAuthoringStripProps) {
+  const stagedSuggestions = suggestions.filter((suggestion) => suggestion.status === 'staged');
+
   return (
-    <section className="mb-6 flex flex-col gap-3 rounded-md border border-line-subtle bg-paper-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex items-start gap-3">
-        <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-gold" aria-hidden="true" />
-        <div>
-          <h3 className="text-sm font-medium text-ink">AI template authoring is not connected</h3>
-          <p className="mt-0.5 text-xs leading-relaxed text-dim-2">
-            Continue editing questions manually. Blawby will not fabricate suggestions, staged changes, or conversion evidence.
-          </p>
+    <section className="mb-6 rounded-md border border-line-subtle bg-paper-2 px-4 py-3" aria-labelledby="assistant-suggestions-title">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-gold" aria-hidden="true" />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 id="assistant-suggestions-title" className="text-sm font-medium text-ink">Assistant suggestions</h3>
+              <Pill tone="dim">{typeof revision === 'number' ? `Revision ${revision}` : 'Unsaved template'}</Pill>
+              {stagedSuggestions.length > 0 ? (
+                <Pill tone="warn">{stagedSuggestions.length} staged</Pill>
+              ) : null}
+            </div>
+            <p className="mt-1 max-w-[70ch] text-xs leading-relaxed text-dim-2">
+              {canLoad
+                ? 'Suggestions staged through the assistant appear here for review. Nothing changes until you apply one.'
+                : 'Save this template before reviewing assistant suggestions.'}
+            </p>
+          </div>
         </div>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={RefreshCw}
+          onClick={onRefresh}
+          disabled={!canLoad || loadState === 'loading' || actingSuggestionId !== null}
+        >
+          {loadState === 'loading' ? 'Checking' : 'Refresh'}
+        </Button>
       </div>
-      <Button variant="secondary" size="sm" disabled title="Requires the backend AI authoring contract">
-        Suggestions unavailable
-      </Button>
+
+      {loadState === 'error' ? (
+        <div className="mt-3 flex flex-col gap-2 rounded-lg border border-line-subtle bg-card px-3 py-2 sm:flex-row sm:items-center sm:justify-between" role="alert">
+          <p className="text-xs text-warn">Suggestions could not be loaded. Retry after the backend contract is available.</p>
+          <Button variant="outline" size="xs" onClick={onRefresh}>Retry</Button>
+        </div>
+      ) : null}
+
+      {loadState === 'ready' && stagedSuggestions.length === 0 ? (
+        <p className="mt-3 border-t border-line-subtle pt-3 text-xs text-dim-2">No staged suggestions for this revision.</p>
+      ) : null}
+
+      {stagedSuggestions.length > 0 ? (
+        <ul className="mt-3 divide-y divide-line-subtle border-t border-line-subtle" aria-label="Staged template suggestions">
+          {stagedSuggestions.map((suggestion) => {
+            const isActing = actingSuggestionId === suggestion.id;
+            return (
+              <li key={suggestion.id} className="flex flex-col gap-3 py-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-ink">{suggestion.instruction}</p>
+                  <p className="mt-0.5 text-xs text-dim-2">{describeEdits(suggestion)}</p>
+                  <p className="mt-1 text-[11px] text-dim-2">
+                    {suggestion.analytics_evidence.status === 'available'
+                      ? `Evidence: ${suggestion.analytics_evidence.numerator ?? 0} of ${suggestion.analytics_evidence.denominator ?? 0}`
+                      : suggestion.analytics_evidence.reason ?? `Evidence unavailable from ${suggestion.analytics_evidence.provenance}`}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    variant="accent-ghost"
+                    size="xs"
+                    icon={Check}
+                    onClick={() => onApply(suggestion)}
+                    disabled={actingSuggestionId !== null}
+                  >
+                    {isActing ? 'Applying' : 'Apply'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    icon={X}
+                    onClick={() => onDismiss(suggestion)}
+                    disabled={actingSuggestionId !== null}
+                  >
+                    Dismiss
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
     </section>
   );
 }
+
+export type { SuggestionLoadState };

--- a/src/features/intake/pages/IntakeTemplatesPage.tsx
+++ b/src/features/intake/pages/IntakeTemplatesPage.tsx
@@ -38,8 +38,12 @@ import {
   createIntakeTemplate,
   updateIntakeTemplate,
   deleteIntakeTemplate,
+  listIntakeTemplateSuggestions,
+  approveIntakeTemplateSuggestion,
+  dismissIntakeTemplateSuggestion,
   type CreateIntakeTemplateInput,
   type IntakeTemplateFieldInput,
+  type IntakeTemplateSuggestion,
 } from '@/features/intake/api/intakeTemplatesApi';
 import { fromMinorUnits, toMinorUnitsValue } from '@/shared/utils/money';
 import { getOnboardingStatusPayload } from '@/shared/lib/apiClient';
@@ -48,7 +52,10 @@ import type { FieldCondition, FieldPhase, IntakeFieldDefinition, IntakeTemplate 
 import { EmbedCodeDialog, getPublicFormUrl, copyTextToClipboard } from '@/features/intake/components/EmbedCodeBlock';
 import { Pill } from '@/design-system/primitives';
 import { IntakeAnalyticsStrip } from '@/features/intake/components/IntakeAnalyticsStrip';
-import { IntakeAuthoringStrip } from '@/features/intake/components/IntakeAuthoringStrip';
+import {
+  IntakeAuthoringStrip,
+  type SuggestionLoadState,
+} from '@/features/intake/components/IntakeAuthoringStrip';
 import {
   IntakePreviewChrome,
   type IntakePreviewMode,
@@ -615,9 +622,10 @@ type TemplateEditorProps = {
     profileImage?: string | null;
   };
   onCancel: () => void;
-  onSaveDraft: (template: IntakeTemplate) => Promise<void>;
-  onPublish: (template: IntakeTemplate) => Promise<void>;
+  onSaveDraft: (template: IntakeTemplate) => Promise<IntakeTemplate>;
+  onPublish: (template: IntakeTemplate) => Promise<IntakeTemplate>;
   onDiscardDraft: (templateId: string) => Promise<void>;
+  onTemplateChanged: () => Promise<void>;
 };
 
 function TemplateEditor({
@@ -636,6 +644,7 @@ function TemplateEditor({
   onSaveDraft,
   onPublish,
   onDiscardDraft,
+  onTemplateChanged,
 }: TemplateEditorProps) {
   const { showError, showSuccess } = useToastContext();
   const { navigate } = useNavigation();
@@ -658,6 +667,10 @@ function TemplateEditor({
   const [stripeStatus, setStripeStatus] = useState<StripeConnectStatus | null>(null);
   const [isStripeLoading, setIsStripeLoading] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<BuilderSelectionId>('contact');
+  const [templateRevision, setTemplateRevision] = useState(initial?.revision);
+  const [suggestions, setSuggestions] = useState<IntakeTemplateSuggestion[]>([]);
+  const [suggestionLoadState, setSuggestionLoadState] = useState<SuggestionLoadState>('idle');
+  const [actingSuggestionId, setActingSuggestionId] = useState<string | null>(null);
 
   // ── Chat-first authoring layer ──────────────────────────────────────────
   // Preview viewport mode — width-only; the inner widget renders the same
@@ -675,11 +688,78 @@ function TemplateEditor({
   const practiceCanvasLogo = practicePreviewConfig.profileImage ?? null;
   const hasStripeAccount = Boolean(stripeStatus?.stripe_account_id);
   const payoutsEnabled = stripeStatus?.payouts_enabled === true;
+  const canLoadSuggestions = Boolean(practiceOrganizationId && initial?.id && typeof templateRevision === 'number');
   const stripeStatusLabel = hasStripeAccount
     ? payoutsEnabled
       ? 'Ready'
       : 'Verification in progress'
     : 'Not connected';
+
+  const loadSuggestions = useCallback(async () => {
+    if (!practiceOrganizationId || !initial?.id || typeof templateRevision !== 'number') return;
+    setSuggestionLoadState('loading');
+    try {
+      const next = await listIntakeTemplateSuggestions(practiceOrganizationId, initial.id);
+      setSuggestions(next);
+      setSuggestionLoadState('ready');
+    } catch {
+      setSuggestionLoadState('error');
+    }
+  }, [initial?.id, practiceOrganizationId, templateRevision]);
+
+  useEffect(() => {
+    setTemplateRevision(initial?.revision);
+  }, [initial?.id, initial?.revision]);
+
+  useEffect(() => {
+    if (!canLoadSuggestions) {
+      setSuggestions([]);
+      setSuggestionLoadState('idle');
+      return;
+    }
+    void loadSuggestions();
+  }, [canLoadSuggestions, loadSuggestions]);
+
+  const handleApplySuggestion = useCallback(async (suggestion: IntakeTemplateSuggestion) => {
+    if (!practiceOrganizationId || !initial?.id || typeof templateRevision !== 'number') return;
+    setActingSuggestionId(suggestion.id);
+    try {
+      const result = await approveIntakeTemplateSuggestion(
+        practiceOrganizationId,
+        initial.id,
+        suggestion.id,
+        templateRevision,
+      );
+      const nextState = buildEditorState(result.template, editorDefaults);
+      setState(nextState);
+      setSavedSnapshot(serializeTemplate(editorStateToTemplate(nextState)));
+      setHasSavedDraft(result.template.status === 'draft');
+      setTemplateRevision(result.template.revision);
+      setSuggestions((current) => current.filter((item) => item.id !== suggestion.id));
+      await onTemplateChanged();
+      showSuccess('Suggestion applied', `Template revision ${result.template.revision} is ready for review.`);
+    } catch (error) {
+      showError('Suggestion not applied', error instanceof Error ? error.message : 'Unable to apply suggestion.');
+      await loadSuggestions();
+    } finally {
+      setActingSuggestionId(null);
+    }
+  }, [editorDefaults, initial?.id, loadSuggestions, onTemplateChanged, practiceOrganizationId, showError, showSuccess, templateRevision]);
+
+  const handleDismissSuggestion = useCallback(async (suggestion: IntakeTemplateSuggestion) => {
+    if (!practiceOrganizationId || !initial?.id) return;
+    setActingSuggestionId(suggestion.id);
+    try {
+      await dismissIntakeTemplateSuggestion(practiceOrganizationId, initial.id, suggestion.id);
+      setSuggestions((current) => current.filter((item) => item.id !== suggestion.id));
+      showSuccess('Suggestion dismissed');
+    } catch (error) {
+      showError('Suggestion not dismissed', error instanceof Error ? error.message : 'Unable to dismiss suggestion.');
+      await loadSuggestions();
+    } finally {
+      setActingSuggestionId(null);
+    }
+  }, [initial?.id, loadSuggestions, practiceOrganizationId, showError, showSuccess]);
 
   const lockedRequiredFields = useMemo(
     () => state.requiredFields.filter((field) => LOCKED_REQUIRED_KEYS.has(field.key)),
@@ -950,9 +1030,16 @@ function TemplateEditor({
 
     setIsSaving(true);
     try {
-      const template = editorStateToTemplate(state);
-      await onSaveDraft(template);
-      setSavedSnapshot(serializeTemplate(template));
+      const template = {
+        ...editorStateToTemplate(state),
+        id: initial?.id,
+        status: initial?.status,
+        revision: templateRevision,
+        publishedAt: initial?.publishedAt,
+      };
+      const saved = await onSaveDraft(template);
+      setTemplateRevision(saved.revision);
+      setSavedSnapshot(serializeTemplate(saved));
       setHasSavedDraft(true);
       setDiscardPending(false);
       showSuccess('Draft saved', `"${template.name}" draft saved.`);
@@ -968,9 +1055,16 @@ function TemplateEditor({
 
     setIsPublishing(true);
     try {
-      const template = editorStateToTemplate(state);
-      await onPublish(template);
-      setSavedSnapshot(serializeTemplate(template));
+      const template = {
+        ...editorStateToTemplate(state),
+        id: initial?.id,
+        status: initial?.status,
+        revision: templateRevision,
+        publishedAt: initial?.publishedAt,
+      };
+      const saved = await onPublish(template);
+      setTemplateRevision(saved.revision);
+      setSavedSnapshot(serializeTemplate(saved));
       setHasSavedDraft(false);
       setDiscardPending(false);
       showSuccess('Published', `"${template.name}" is live.`);
@@ -1428,7 +1522,16 @@ function TemplateEditor({
       <div className="px-2 pt-4 sm:px-4">
         <IntakeAnalyticsStrip usesLast30Days={null} conversionPercent={null} />
         <div className="mt-3">
-          <IntakeAuthoringStrip />
+          <IntakeAuthoringStrip
+            revision={templateRevision}
+            suggestions={suggestions}
+            loadState={suggestionLoadState}
+            actingSuggestionId={actingSuggestionId}
+            canLoad={canLoadSuggestions}
+            onRefresh={() => void loadSuggestions()}
+            onApply={(suggestion) => void handleApplySuggestion(suggestion)}
+            onDismiss={(suggestion) => void handleDismissSuggestion(suggestion)}
+          />
         </div>
       </div>
       <div className="min-h-0 flex-1">{livePreview}</div>
@@ -2013,7 +2116,16 @@ function TemplateEditor({
             */}
             <div className="mb-4 flex flex-col gap-3">
               <IntakeAnalyticsStrip usesLast30Days={null} conversionPercent={null} />
-              <IntakeAuthoringStrip />
+              <IntakeAuthoringStrip
+                revision={templateRevision}
+                suggestions={suggestions}
+                loadState={suggestionLoadState}
+                actingSuggestionId={actingSuggestionId}
+                canLoad={canLoadSuggestions}
+                onRefresh={() => void loadSuggestions()}
+                onApply={(suggestion) => void handleApplySuggestion(suggestion)}
+                onDismiss={(suggestion) => void handleDismissSuggestion(suggestion)}
+              />
             </div>
             {formStructure}
           </div>
@@ -2390,8 +2502,8 @@ export default function IntakeTemplatesPage({
       };
     }), []);
 
-  const handleSaveDraft = async (template: IntakeTemplate) => {
-    if (!resolvedPracticeId) return;
+  const handleSaveDraft = async (template: IntakeTemplate): Promise<IntakeTemplate> => {
+    if (!resolvedPracticeId) throw new Error('No practice selected.');
     setIsSaving(true);
     try {
       const input: CreateIntakeTemplateInput = {
@@ -2408,7 +2520,13 @@ export default function IntakeTemplatesPage({
 
       let saved: IntakeTemplate;
       if (template.id && template.id !== 'new') {
-        saved = await updateIntakeTemplate(resolvedPracticeId, template.id, input);
+        if (typeof template.revision !== 'number') {
+          throw new Error('Intake template response is missing its revision.');
+        }
+        saved = await updateIntakeTemplate(resolvedPracticeId, template.id, {
+          ...input,
+          expected_revision: template.revision,
+        });
       } else {
         saved = await createIntakeTemplate(resolvedPracticeId, input);
       }
@@ -2416,6 +2534,7 @@ export default function IntakeTemplatesPage({
       if (routeTemplateId === 'new' || !routeTemplateId) {
         navigate(`${basePath}/${encodeURIComponent(saved.id ?? saved.slug)}/edit`);
       }
+      return saved;
     } catch (error) {
       showError('Draft save failed', error instanceof Error ? error.message : 'Unable to save draft.');
       throw error;
@@ -2424,8 +2543,8 @@ export default function IntakeTemplatesPage({
     }
   };
 
-  const handlePublishTemplate = async (template: IntakeTemplate) => {
-    if (!resolvedPracticeId) return;
+  const handlePublishTemplate = async (template: IntakeTemplate): Promise<IntakeTemplate> => {
+    if (!resolvedPracticeId) throw new Error('No practice selected.');
     setIsSaving(true);
     try {
       const input: CreateIntakeTemplateInput = {
@@ -2442,12 +2561,19 @@ export default function IntakeTemplatesPage({
 
       let saved: IntakeTemplate;
       if (template.id && template.id !== 'new') {
-        saved = await updateIntakeTemplate(resolvedPracticeId, template.id, input);
+        if (typeof template.revision !== 'number') {
+          throw new Error('Intake template response is missing its revision.');
+        }
+        saved = await updateIntakeTemplate(resolvedPracticeId, template.id, {
+          ...input,
+          expected_revision: template.revision,
+        });
       } else {
         saved = await createIntakeTemplate(resolvedPracticeId, input);
       }
       await reloadTemplates();
       navigate(`${basePath}/${encodeURIComponent(saved.id ?? saved.slug)}`);
+      return saved;
     } catch (error) {
       showError('Publish failed', error instanceof Error ? error.message : 'Unable to publish form.');
       throw error;
@@ -2532,6 +2658,7 @@ export default function IntakeTemplatesPage({
         onSaveDraft={handleSaveDraft}
         onPublish={handlePublishTemplate}
         onDiscardDraft={handleDiscardDraft}
+        onTemplateChanged={reloadTemplates}
       />
     );
   }

--- a/src/shared/types/intake.ts
+++ b/src/shared/types/intake.ts
@@ -106,6 +106,9 @@ export interface IntakeTemplate {
   slug: string;
   name: string;
   status?: IntakeTemplateStatus;
+  /** Durable optimistic-concurrency revision returned by the backend. */
+  revision?: number;
+  publishedAt?: string | null;
   is_default?: boolean;
   /** @deprecated use is_default */
   isDefault?: boolean;

--- a/tests/component/intake-authoring-strip.test.tsx
+++ b/tests/component/intake-authoring-strip.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/preact';
+import { describe, expect, it, vi } from 'vitest';
+
+import { IntakeAuthoringStrip } from '@/features/intake/components/IntakeAuthoringStrip';
+import type { IntakeTemplateSuggestion } from '@/features/intake/api/intakeTemplatesApi';
+
+const suggestion: IntakeTemplateSuggestion = {
+  id: '33333333-3333-4333-8333-333333333333',
+  organization_id: '11111111-1111-4111-8111-111111111111',
+  template_id: '22222222-2222-4222-8222-222222222222',
+  request_key: '44444444-4444-4444-8444-444444444444',
+  base_revision: 4,
+  instruction: 'Clarify the court deadline question',
+  proposed_edits: [
+    { operation: 'rephrase', field_key: 'court_deadline', changes: { label: 'Next court deadline' } },
+  ],
+  analytics_evidence: {
+    status: 'unavailable',
+    window: null,
+    numerator: null,
+    denominator: null,
+    provenance: 'practice_client_intakes',
+    reason: 'Revision attribution is unavailable.',
+  },
+  status: 'staged',
+  created_by: '55555555-5555-4555-8555-555555555555',
+  decided_by: null,
+  applied_revision: null,
+  created_at: '2026-07-12T00:00:00.000Z',
+  decided_at: null,
+};
+
+const renderStrip = (overrides: Partial<Parameters<typeof IntakeAuthoringStrip>[0]> = {}) => {
+  const props: Parameters<typeof IntakeAuthoringStrip>[0] = {
+    revision: 4,
+    suggestions: [],
+    loadState: 'ready',
+    actingSuggestionId: null,
+    canLoad: true,
+    onRefresh: vi.fn(),
+    onApply: vi.fn(),
+    onDismiss: vi.fn(),
+    ...overrides,
+  };
+  render(<IntakeAuthoringStrip {...props} />);
+  return props;
+};
+
+describe('IntakeAuthoringStrip', () => {
+  it('shows the current durable revision and an honest empty state', () => {
+    renderStrip();
+    expect(screen.getByText('Revision 4')).toBeInTheDocument();
+    expect(screen.getByText('No staged suggestions for this revision.')).toBeInTheDocument();
+  });
+
+  it('applies or dismisses a real staged suggestion through explicit actions', () => {
+    const props = renderStrip({ suggestions: [suggestion] });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(props.onApply).toHaveBeenCalledWith(suggestion);
+    expect(props.onDismiss).toHaveBeenCalledWith(suggestion);
+  });
+
+  it('keeps backend load failure visible and retryable', () => {
+    const props = renderStrip({ loadState: 'error' });
+    expect(screen.getByRole('alert')).toHaveTextContent('Suggestions could not be loaded');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(props.onRefresh).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -25,7 +25,8 @@ describe('honest compliance UI', () => {
     expect(templates).not.toContain('DEMO_STAGED_QUESTIONS');
     expect(templates).not.toContain('v.{headerVersionNumber}');
     expect(authoring).not.toContain('Your instruction was saved');
-    expect(authoring).toContain('AI template authoring is not connected');
+    expect(authoring).toContain('Suggestions staged through the assistant appear here for review');
+    expect(authoring).toContain('suggestion.analytics_evidence');
   });
 
   it('does not claim unsupported exports, travel estimates, or intake side effects', () => {

--- a/tests/unit/intake/intakeTemplatesApi.test.ts
+++ b/tests/unit/intake/intakeTemplatesApi.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApiClient } = vi.hoisted(() => ({
+  mockApiClient: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({ apiClient: mockApiClient }));
+
+import {
+  approveIntakeTemplateSuggestion,
+  dismissIntakeTemplateSuggestion,
+  getIntakeTemplate,
+  listIntakeTemplateSuggestions,
+  updateIntakeTemplate,
+} from '@/features/intake/api/intakeTemplatesApi';
+
+const practiceId = '11111111-1111-4111-8111-111111111111';
+const templateId = '22222222-2222-4222-8222-222222222222';
+const suggestionId = '33333333-3333-4333-8333-333333333333';
+
+const backendTemplate = {
+  id: templateId,
+  organization_id: practiceId,
+  slug: 'general-intake',
+  name: 'General intake',
+  description: null,
+  status: 'draft' as const,
+  revision: 4,
+  published_at: null,
+  is_default: false,
+  intro_message: null,
+  legal_disclaimer: null,
+  payment_link_enabled: false,
+  consultation_fee: null,
+  archived_at: null,
+  created_at: '2026-07-01T00:00:00.000Z',
+  updated_at: '2026-07-12T00:00:00.000Z',
+  fields: [],
+};
+
+const suggestion = {
+  id: suggestionId,
+  organization_id: practiceId,
+  template_id: templateId,
+  request_key: '44444444-4444-4444-8444-444444444444',
+  base_revision: 4,
+  instruction: 'Clarify the court deadline question',
+  proposed_edits: [
+    { operation: 'rephrase' as const, field_key: 'court_deadline', changes: { label: 'Next court deadline' } },
+  ],
+  analytics_evidence: {
+    status: 'unavailable' as const,
+    window: null,
+    numerator: null,
+    denominator: null,
+    provenance: 'practice_client_intakes',
+    reason: 'Revision attribution is unavailable.',
+  },
+  status: 'staged' as const,
+  created_by: '55555555-5555-4555-8555-555555555555',
+  decided_by: null,
+  applied_revision: null,
+  created_at: '2026-07-12T00:00:00.000Z',
+  decided_at: null,
+};
+
+describe('intakeTemplatesApi revision and suggestion contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes the durable template revision', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ data: { template: backendTemplate } });
+    await expect(getIntakeTemplate(practiceId, templateId)).resolves.toMatchObject({ revision: 4, publishedAt: null });
+  });
+
+  it('sends the expected revision on manual updates', async () => {
+    mockApiClient.put.mockResolvedValueOnce({ data: { template: { ...backendTemplate, revision: 5 } } });
+    await expect(
+      updateIntakeTemplate(practiceId, templateId, { name: 'Updated intake', expected_revision: 4 }),
+    ).resolves.toMatchObject({ revision: 5 });
+    expect(mockApiClient.put).toHaveBeenCalledWith(
+      `/api/practice/${practiceId}/intake-templates/${templateId}`,
+      { name: 'Updated intake', expected_revision: 4 },
+    );
+  });
+
+  it('lists staged suggestions from the tenant-scoped template path', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ data: { suggestions: [suggestion] } });
+    await expect(listIntakeTemplateSuggestions(practiceId, templateId)).resolves.toEqual([suggestion]);
+    expect(mockApiClient.get).toHaveBeenCalledWith(
+      `/api/practice/${practiceId}/intake-templates/${templateId}/suggestions`,
+    );
+  });
+
+  it('applies a suggestion with optimistic concurrency and returns the next revision', async () => {
+    mockApiClient.post.mockResolvedValueOnce({
+      data: { suggestion: { ...suggestion, status: 'approved', applied_revision: 5 }, template: { ...backendTemplate, revision: 5 } },
+    });
+    await expect(approveIntakeTemplateSuggestion(practiceId, templateId, suggestionId, 4)).resolves.toMatchObject({
+      template: { revision: 5 },
+      suggestion: { status: 'approved' },
+    });
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      `/api/practice/${practiceId}/intake-templates/${templateId}/suggestions/${suggestionId}/approve`,
+      { expected_revision: 4 },
+    );
+  });
+
+  it('dismisses a staged suggestion without mutating the template', async () => {
+    mockApiClient.post.mockResolvedValueOnce({ data: { suggestion: { ...suggestion, status: 'dismissed' } } });
+    await expect(dismissIntakeTemplateSuggestion(practiceId, templateId, suggestionId)).resolves.toMatchObject({
+      status: 'dismissed',
+    });
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      `/api/practice/${practiceId}/intake-templates/${templateId}/suggestions/${suggestionId}/dismiss`,
+      {},
+    );
+  });
+});

--- a/worker/types/wire/intake.ts
+++ b/worker/types/wire/intake.ts
@@ -143,6 +143,8 @@ export const BackendIntakeTemplateSchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
   status: z.enum(['draft', 'published', 'archived']),
+  revision: z.number().int().positive(),
+  published_at: z.string().nullable(),
   is_default: z.boolean(),
   intro_message: z.string().nullable(),
   legal_disclaimer: z.string().nullable(),


### PR DESCRIPTION
## Summary
- carry backend intake-template revision and published-at fields through the shared wire and app models
- send expected_revision on every existing-template draft save and publish
- preserve template identity in the editor so existing templates update instead of being recreated
- replace the unavailable authoring placeholder with real list, apply, dismiss, refresh, empty, loading, and failure states
- surface the current durable revision and backend-provided analytics provenance without inventing conversion evidence

## User impact
Practice owners can review assistant-staged template edits inline. Applying a suggestion is explicit and revision-checked, stale changes fail visibly, dismissing does not mutate the template, and manual editing remains available.

## Backend dependency
This frontend targets Blawby/blawby-backend#381 at exact backend commit 099fdd491b943df2c57a211a77b260467558e4ac. Backend review, merge, and deployment remain human-owned. The frontend is safe to merge into staging now, but live integration is not production evidence until that backend PR is deployed.

## Verification
- all three TypeScript projects passed
- ESLint passed for src and worker
- full Vitest suite: 114 files, 851 tests passed
- focused API and authoring component tests: 17 passed
- production Vite build passed with VITE_APP_BASE_URL=https://local.blawby.com
- first-load bundle: 284.5 KB gzipped, below the 300 KB budget
- git diff --check passed

Part of #662 and #716.