### PR TITLE
feat(settings): wire audit log and durable exports

### DIFF
--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -104,6 +104,18 @@ export const intakeTemplateSuggestionDecisionPath = (
 ): string =>
 	`${intakeTemplateSuggestionsPath(practiceId, templateId)}/${encodeSegment(suggestionId)}/${decision}`;
 
+export const practiceAuditLogPath = (practiceId: string): string =>
+	`/api/practices/${encodeSegment(practiceId)}/audit-log`;
+
+export const practiceAuditLogExportPath = (practiceId: string): string =>
+	`${practiceAuditLogPath(practiceId)}/export`;
+
+export const practiceExportsPath = (practiceId: string): string =>
+	`/api/practices/${encodeSegment(practiceId)}/exports`;
+
+export const practiceExportPath = (practiceId: string, exportId: string): string =>
+	`${practiceExportsPath(practiceId)}/${encodeSegment(exportId)}`;
+
 export const matterCollectionPath = (practiceId: string): string => `/api/matters/${encodeSegment(practiceId)}`;
 
 export const matterItemPath = (practiceId: string, matterId: string): string =>

--- a/src/features/settings/pages/AuditLogPage.tsx
+++ b/src/features/settings/pages/AuditLogPage.tsx
@@ -1,39 +1,222 @@
-import { FileClock } from 'lucide-preact';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import { Download, FileClock, RefreshCw, Search } from 'lucide-preact';
 
 import { SettingSection } from '@/features/settings/components/SettingSection';
 import { SettingsCard } from '@/features/settings/components/SettingsCard';
+import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
+import { auditLogApi, type AuditLogEntry } from '@/features/settings/services/auditLogApi';
+import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
+import { useToastContext } from '@/shared/contexts/ToastContext';
 import { Button } from '@/shared/ui/Button';
+import { Input } from '@/shared/ui/input';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
+import { triggerDownload } from '@/shared/utils/fileDownload';
 
 export interface AuditLogPageProps {
   className?: string;
 }
 
-export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => (
-  <div className={className}>
-    <SettingSection
-      first
-      title="Audit log"
-      description="A practice-wide compliance log needs one authoritative backend event stream."
-    >
-      <SettingsCard className="max-w-[860px]">
-        <div className="flex flex-col items-start gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-start gap-3">
-            <div className="rounded-md border border-line-subtle bg-paper-2 p-2 text-dim-2">
-              <FileClock className="h-5 w-5" aria-hidden="true" />
+const sourceLabel: Record<AuditLogEntry['source']['system'], string> = {
+  domain_event: 'Domain event',
+  matter_activity: 'Matter activity',
+  upload_audit: 'File activity',
+};
+
+const formatOccurredAt = (value: string): string =>
+  new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+
+const actorLabel = (entry: AuditLogEntry): string =>
+  entry.actor.name ?? entry.actor.email ?? (entry.actor.type === 'user' ? 'Unknown user' : entry.actor.type);
+
+export const AuditLogPage = ({ className = '' }: AuditLogPageProps) => {
+  const { currentPractice } = usePracticeManagement({ fetchPracticeDetails: true });
+  const { showError, showSuccess } = useToastContext();
+  const practiceId = useMemo(
+    () => currentPractice?.betterAuthOrgId ?? currentPractice?.id ?? null,
+    [currentPractice?.betterAuthOrgId, currentPractice?.id],
+  );
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadFirstPage = useCallback(async (signal?: AbortSignal) => {
+    if (!practiceId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await auditLogApi.list(practiceId, { limit: 50, search: search || undefined }, signal);
+      if (signal?.aborted) return;
+      setEntries(result.data);
+      setNextCursor(result.page_info.next_cursor);
+    } catch (loadError) {
+      if (signal?.aborted) return;
+      setEntries([]);
+      setNextCursor(null);
+      setError(loadError instanceof Error ? loadError.message : 'Unable to load the audit log.');
+    } finally {
+      if (!signal?.aborted) setIsLoading(false);
+    }
+  }, [practiceId, search]);
+
+  useEffect(() => {
+    if (!practiceId) return;
+    const controller = new AbortController();
+    void loadFirstPage(controller.signal);
+    return () => controller.abort();
+  }, [loadFirstPage, practiceId]);
+
+  const loadMore = async () => {
+    if (!practiceId || !nextCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const result = await auditLogApi.list(practiceId, {
+        cursor: nextCursor,
+        limit: 50,
+        search: search || undefined,
+      });
+      setEntries((current) => [...current, ...result.data]);
+      setNextCursor(result.page_info.next_cursor);
+    } catch (loadError) {
+      showError('Audit events not loaded', loadError instanceof Error ? loadError.message : 'Unable to load more events.');
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
+
+  const exportCsv = async () => {
+    if (!practiceId || isExporting) return;
+    setIsExporting(true);
+    try {
+      const { blob, filename } = await auditLogApi.exportCsv(practiceId, { search: search || undefined });
+      const url = URL.createObjectURL(blob);
+      triggerDownload(url, filename);
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+      showSuccess('Audit log downloaded', filename);
+    } catch (exportError) {
+      showError('Audit export failed', exportError instanceof Error ? exportError.message : 'Unable to export audit events.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <SettingSection
+        first
+        title="Audit log"
+        description="Immutable practice events with actor, target, timestamp, and source provenance."
+      >
+        {!practiceId ? (
+          <SettingsNotice variant="warning">Select a practice to review its audit history.</SettingsNotice>
+        ) : (
+          <SettingsCard className="max-w-[860px]">
+            <div className="flex flex-col gap-3 border-b border-rule py-4 sm:flex-row sm:items-end sm:justify-between">
+              <form
+                className="flex min-w-0 flex-1 items-end gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  setSearch(searchDraft.trim());
+                }}
+              >
+                <div className="min-w-0 flex-1">
+                  <label className="mb-1 block text-xs font-medium text-ink" htmlFor="audit-search">Search events</label>
+                  <Input
+                    id="audit-search"
+                    value={searchDraft}
+                    onChange={setSearchDraft}
+                    placeholder="Action, actor, matter, or file"
+                    disabled={isLoading}
+                  />
+                </div>
+                <Button type="submit" variant="secondary" size="sm" icon={Search} disabled={isLoading}>Search</Button>
+              </form>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={RefreshCw}
+                  onClick={() => void loadFirstPage()}
+                  disabled={isLoading}
+                >
+                  Refresh
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  icon={Download}
+                  onClick={() => void exportCsv()}
+                  disabled={isExporting || isLoading}
+                >
+                  {isExporting ? <LoadingSpinner size="sm" ariaLabel="Exporting audit log" /> : null}
+                  Download CSV
+                </Button>
+              </div>
             </div>
-            <div>
-              <h2 className="text-sm font-medium text-ink">Practice-wide audit events are not connected</h2>
-              <p className="mt-1 max-w-xl text-sm leading-relaxed text-dim-2">
-                Invoice, matter, upload, authentication, and assistant events currently live in separate systems.
-                Blawby will not present sample entries as compliance evidence or claim an export was requested.
-              </p>
-            </div>
-          </div>
-          <Button variant="secondary" size="sm" disabled title="Requires the backend audit-log contract">
-            Export unavailable
-          </Button>
-        </div>
-      </SettingsCard>
-    </SettingSection>
-  </div>
-);
+
+            {error ? (
+              <div className="py-5">
+                <SettingsNotice variant="warning">{error}</SettingsNotice>
+              </div>
+            ) : isLoading ? (
+              <div className="space-y-3 py-5" aria-label="Loading audit events">
+                {[0, 1, 2].map((row) => (
+                  <div key={row} className="h-14 rounded-lg bg-paper-2" />
+                ))}
+              </div>
+            ) : entries.length === 0 ? (
+              <div className="flex items-start gap-3 py-6">
+                <div className="rounded-md border border-line-subtle bg-paper-2 p-2 text-dim-2">
+                  <FileClock className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <div>
+                  <h2 className="text-sm font-medium text-ink">No matching audit events</h2>
+                  <p className="mt-1 text-sm text-dim-2">Change the search or check again after workspace activity.</p>
+                </div>
+              </div>
+            ) : (
+              <>
+                <ol className="divide-y divide-rule" aria-label="Practice audit events">
+                  {entries.map((entry) => (
+                    <li key={`${entry.source.system}:${entry.id}`} className="grid gap-2 py-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <p className="text-sm font-medium text-ink">{entry.summary}</p>
+                          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-dim-2">
+                            {sourceLabel[entry.source.system]}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-dim-2">
+                          {actorLabel(entry)} · {entry.action_type} · {entry.target.type} {entry.target.id}
+                        </p>
+                        <p className="mt-1 text-[11px] text-dim-2">Source: {entry.source.producer}</p>
+                      </div>
+                      <time className="text-xs text-dim-2 sm:text-right" dateTime={entry.occurred_at}>
+                        {formatOccurredAt(entry.occurred_at)}
+                      </time>
+                    </li>
+                  ))}
+                </ol>
+                {nextCursor ? (
+                  <div className="border-t border-rule py-4 text-center">
+                    <Button variant="secondary" size="sm" onClick={() => void loadMore()} disabled={isLoadingMore}>
+                      {isLoadingMore ? <LoadingSpinner size="sm" ariaLabel="Loading more audit events" /> : null}
+                      Load more
+                    </Button>
+                  </div>
+                ) : null}
+              </>
+            )}
+          </SettingsCard>
+        )}
+      </SettingSection>
+    </div>
+  );
+};

--- a/src/features/settings/pages/ExportDataPage.tsx
+++ b/src/features/settings/pages/ExportDataPage.tsx
@@ -1,76 +1,242 @@
-// TODO(backend): Required endpoints:
-//   - POST /api/practices/:id/export?type=full|matters|billing|trust|audit
-//     → triggers async export job, sends download link via email when ready
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { Download, LoaderCircle, RotateCcw } from 'lucide-preact';
 
+import { Pill } from '@/design-system/primitives';
 import { Button } from '@/shared/ui/Button';
 import { SettingSection } from '@/features/settings/components/SettingSection';
 import { SettingsCard } from '@/features/settings/components/SettingsCard';
+import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
+import {
+  practiceExportsApi,
+  type PracticeExportJob,
+  type PracticeExportType,
+} from '@/features/settings/services/practiceExportsApi';
+import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
+import { useToastContext } from '@/shared/contexts/ToastContext';
+import { triggerDownload } from '@/shared/utils/fileDownload';
 
-// ---------------------------------------------------------------------------
-// Export cards
-// ---------------------------------------------------------------------------
-
-interface ExportCardProps {
+interface ExportDefinition {
+  type: PracticeExportType;
   name: string;
-  format: string;
   description: string;
   primary?: boolean;
 }
 
-const ExportCard = ({ name, format, description, primary = false }: ExportCardProps) => (
-  <div className="flex items-center justify-between gap-6 py-4 border-b border-rule last:border-0 max-sm:flex-col max-sm:items-start">
-    <div>
-      <div className="flex items-center gap-2 text-sm font-medium text-ink">
-        {name}
-        <span className="font-mono text-[10px] uppercase tracking-wider text-dim border border-rule rounded px-1.5 py-px">{format}</span>
-      </div>
-      <p className="text-xs text-dim mt-0.5">{description}</p>
-    </div>
-    <Button variant={primary ? 'primary' : 'ghost'} size="sm" className="shrink-0" disabled title="Requires the backend export contract">
-      Export unavailable
-    </Button>
-  </div>
-);
+const exportDefinitions: ExportDefinition[] = [
+  {
+    type: 'full_practice_archive',
+    name: 'Full practice archive',
+    description: 'Practice, team, intake, matter, billing, trust, audit, conversation, and file-metadata records.',
+    primary: true,
+  },
+  {
+    type: 'matters_contacts',
+    name: 'Matters & contacts',
+    description: 'Matter records, activity history, and contact information.',
+  },
+  {
+    type: 'billing_invoices',
+    name: 'Billing & invoices',
+    description: 'Invoices and their persisted line items.',
+  },
+  {
+    type: 'trust_ledger',
+    name: 'Trust ledger',
+    description: 'Trust transactions and reconciliation evidence with source provenance.',
+  },
+  {
+    type: 'audit_events',
+    name: 'Audit events',
+    description: 'Domain, matter, and file audit records with source provenance.',
+  },
+];
 
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
+type JobsByType = Partial<Record<PracticeExportType, PracticeExportJob>>;
+type ErrorsByType = Partial<Record<PracticeExportType, string>>;
+
+const activeJob = (job: PracticeExportJob | undefined): job is PracticeExportJob =>
+  job?.status === 'queued' || job?.status === 'running';
+
+const formatBytes = (bytes: number | null): string | null => {
+  if (bytes === null) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+};
+
+const statusTone = (job: PracticeExportJob): 'live' | 'warn' | 'urgent' | 'dim' => {
+  if (job.status === 'completed') return 'live';
+  if (job.status === 'failed') return 'urgent';
+  if (job.status === 'running') return 'warn';
+  return 'dim';
+};
+
+interface ExportCardProps {
+  definition: ExportDefinition;
+  job?: PracticeExportJob;
+  error?: string;
+  isBusy: boolean;
+  onRequest: () => void;
+  onDownload: () => void;
+}
+
+const ExportCard = ({ definition, job, error, isBusy, onRequest, onDownload }: ExportCardProps) => {
+  const isPreparing = job?.status === 'queued' || job?.status === 'running';
+  const action = job?.status === 'completed' ? onDownload : onRequest;
+  const label = isBusy
+    ? job?.status === 'completed' ? 'Opening' : 'Requesting'
+    : job?.status === 'completed'
+      ? 'Download'
+      : job?.status === 'failed'
+        ? 'Try again'
+        : isPreparing
+          ? job.status === 'running' ? 'Preparing' : 'Queued'
+          : 'Request export';
+  const icon = job?.status === 'completed' ? Download : job?.status === 'failed' ? RotateCcw : isPreparing ? LoaderCircle : undefined;
+
+  return (
+    <div className="border-b border-rule py-4 last:border-0">
+      <div className="flex items-start justify-between gap-6 max-sm:flex-col">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2 text-sm font-medium text-ink">
+            {definition.name}
+            <span className="rounded border border-rule px-1.5 py-px font-mono text-[10px] uppercase tracking-wider text-dim">JSON</span>
+            {job ? <Pill tone={statusTone(job)}>{job.status}</Pill> : null}
+          </div>
+          <p className="mt-0.5 max-w-[65ch] text-xs text-dim">{definition.description}</p>
+          {job?.status === 'completed' ? (
+            <p className="mt-1 text-[11px] text-dim-2">
+              Completed {job.completed_at ? new Date(job.completed_at).toLocaleString() : ''}
+              {formatBytes(job.byte_size) ? ` · ${formatBytes(job.byte_size)}` : ''}
+            </p>
+          ) : null}
+          {job?.status === 'failed' && job.error ? (
+            <p className="mt-1 text-xs text-neg" role="alert">{job.error.message}</p>
+          ) : error ? (
+            <p className="mt-1 text-xs text-neg" role="alert">{error}</p>
+          ) : null}
+        </div>
+        <Button
+          variant={definition.primary ? 'primary' : 'secondary'}
+          size="sm"
+          className="shrink-0"
+          icon={icon}
+          onClick={action}
+          disabled={isBusy || isPreparing}
+        >
+          {label}
+        </Button>
+      </div>
+    </div>
+  );
+};
 
 export interface ExportDataPageProps {
   className?: string;
 }
 
-export const ExportDataPage = ({ className = '' }: ExportDataPageProps) => (
+export const ExportDataPage = ({ className = '' }: ExportDataPageProps) => {
+  const { currentPractice } = usePracticeManagement({ fetchPracticeDetails: true });
+  const { showError, showSuccess } = useToastContext();
+  const practiceId = useMemo(
+    () => currentPractice?.betterAuthOrgId ?? currentPractice?.id ?? null,
+    [currentPractice?.betterAuthOrgId, currentPractice?.id],
+  );
+  const [jobs, setJobs] = useState<JobsByType>({});
+  const [errors, setErrors] = useState<ErrorsByType>({});
+  const [busyType, setBusyType] = useState<PracticeExportType | null>(null);
+  const pendingKeys = useRef<Partial<Record<PracticeExportType, string>>>({});
+
+  useEffect(() => {
+    const active = Object.values(jobs).filter(activeJob);
+    if (!practiceId || active.length === 0) return;
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void Promise.allSettled(active.map((job) => practiceExportsApi.get(practiceId, job.id))).then((results) => {
+        if (cancelled) return;
+        results.forEach((result, index) => {
+          const previous = active[index];
+          if (!previous) return;
+          if (result.status === 'fulfilled') {
+            const next = result.value;
+            setJobs((current) => ({ ...current, [next.type]: next }));
+            setErrors((current) => ({ ...current, [next.type]: undefined }));
+            if (next.status === 'completed' || next.status === 'failed') delete pendingKeys.current[next.type];
+          } else {
+            setErrors((current) => ({ ...current, [previous.type]: 'Status could not be refreshed.' }));
+            setJobs((current) => ({ ...current }));
+          }
+        });
+      });
+    }, 3000);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [jobs, practiceId]);
+
+  const requestExport = async (type: PracticeExportType) => {
+    if (!practiceId || busyType) return;
+    setBusyType(type);
+    setErrors((current) => ({ ...current, [type]: undefined }));
+    const idempotencyKey = pendingKeys.current[type] ?? crypto.randomUUID();
+    pendingKeys.current[type] = idempotencyKey;
+    try {
+      const job = await practiceExportsApi.request(practiceId, type, idempotencyKey);
+      setJobs((current) => ({ ...current, [type]: job }));
+      if (job.status === 'completed' || job.status === 'failed') delete pendingKeys.current[type];
+      showSuccess('Export requested', `${exportDefinitions.find((item) => item.type === type)?.name ?? 'Export'} is ${job.status}.`);
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'Unable to request this export.';
+      setErrors((current) => ({ ...current, [type]: message }));
+      showError('Export request failed', message);
+    } finally {
+      setBusyType(null);
+    }
+  };
+
+  const downloadExport = async (type: PracticeExportType) => {
+    const current = jobs[type];
+    if (!practiceId || !current || busyType) return;
+    setBusyType(type);
+    try {
+      const fresh = await practiceExportsApi.get(practiceId, current.id);
+      setJobs((jobsByType) => ({ ...jobsByType, [type]: fresh }));
+      if (fresh.status !== 'completed' || !fresh.download) {
+        throw new Error('This export is not ready to download.');
+      }
+      triggerDownload(fresh.download.url, `blawby-${type}-${new Date().toISOString().slice(0, 10)}.json`, true);
+    } catch (downloadError) {
+      showError('Export download failed', downloadError instanceof Error ? downloadError.message : 'Unable to download this export.');
+    } finally {
+      setBusyType(null);
+    }
+  };
+
+  return (
     <div className={className}>
-      <SettingSection first title="Available exports" description="Practice-wide exports are not connected yet. No export request is sent from this screen.">
-        <SettingsCard className="max-w-[820px]">
-        <ExportCard
-          name="Full practice export"
-          format="ZIP"
-          description="Everything — matters, contacts, billing, trust ledger, documents, and conversation history."
-          primary
-        />
-        <ExportCard
-          name="Matters & contacts"
-          format="CSV"
-          description="All matter records, events, notes, and contact information."
-        />
-        <ExportCard
-          name="Billing & invoices"
-          format="CSV"
-          description="Invoice history, time entries, and payment records."
-        />
-        <ExportCard
-          name="Trust ledger"
-          format="CSV"
-          description="Complete IOLTA trust account transaction history with running balances."
-        />
-        <ExportCard
-          name="Audit log"
-          format="CSV"
-          description="Full event log with timestamps, actors, and actions."
-        />
-        </SettingsCard>
+      <SettingSection
+        first
+        title="Available exports"
+        description="Exports run as durable background jobs. Completed files receive a fresh five-minute download link when opened."
+      >
+        {!practiceId ? (
+          <SettingsNotice variant="warning">Select a practice before requesting an export.</SettingsNotice>
+        ) : (
+          <SettingsCard className="max-w-[820px]">
+            {exportDefinitions.map((definition) => (
+              <ExportCard
+                key={definition.type}
+                definition={definition}
+                job={jobs[definition.type]}
+                error={errors[definition.type]}
+                isBusy={busyType === definition.type}
+                onRequest={() => void requestExport(definition.type)}
+                onDownload={() => void downloadExport(definition.type)}
+              />
+            ))}
+          </SettingsCard>
+        )}
       </SettingSection>
     </div>
-);
+  );
+};

--- a/src/features/settings/pages/SettingsContent.tsx
+++ b/src/features/settings/pages/SettingsContent.tsx
@@ -89,7 +89,7 @@ const SETTINGS_VIEW_HERO: Partial<Record<SettingsView, SettingsViewHero>> = {
   'audit-log': {
     crumb: 'Settings · Account',
     accentTitle: <>Audit <em>log.</em></>,
-    lede: 'Every action in your workspace is recorded. Use this for compliance reviews, bar audits, and troubleshooting.',
+    lede: 'Review recorded domain, matter, and file activity with source provenance for compliance and troubleshooting.',
   },
   'export-data': {
     crumb: 'Settings · Account',
@@ -275,6 +275,8 @@ export const SettingsContent = (props: SettingsContentProps) => {
   const isPracticeScopedView = view === 'practice-payouts'
     || view === 'practice-team'
     || view === 'engagement-templates'
+    || view === 'audit-log'
+    || view === 'export-data'
     || view === 'intelligence'
     || view === 'practice'
     || view === 'apps'

--- a/src/features/settings/services/auditLogApi.ts
+++ b/src/features/settings/services/auditLogApi.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+import { practiceAuditLogExportPath, practiceAuditLogPath, getWorkerApiUrl } from '@/config/urls';
+import { apiClient } from '@/shared/lib/apiClient';
+
+const auditLogEntrySchema = z.object({
+  id: z.string().uuid(),
+  occurred_at: z.string().datetime({ offset: true }),
+  actor: z.object({
+    id: z.string().uuid().nullable(),
+    type: z.enum(['user', 'system', 'webhook', 'cron', 'api', 'organization']),
+    name: z.string().nullable(),
+    email: z.string().email().nullable(),
+  }),
+  action_type: z.string().min(1),
+  target: z.object({ type: z.string().min(1), id: z.string().min(1) }),
+  summary: z.string().min(1),
+  source: z.object({
+    system: z.enum(['domain_event', 'matter_activity', 'upload_audit']),
+    producer: z.string().min(1),
+    record_id: z.string().uuid(),
+  }),
+});
+
+const auditLogResponseSchema = z.object({
+  data: z.array(auditLogEntrySchema),
+  page_info: z.object({
+    has_next_page: z.boolean(),
+    has_previous_page: z.boolean(),
+    next_cursor: z.string().nullable(),
+    previous_cursor: z.null(),
+  }),
+});
+
+export type AuditLogEntry = z.infer<typeof auditLogEntrySchema>;
+export type AuditLogResponse = z.infer<typeof auditLogResponseSchema>;
+
+export interface AuditLogQuery {
+  cursor?: string;
+  limit?: number;
+  search?: string;
+  type?: string;
+  actor?: string;
+  from?: string;
+  to?: string;
+}
+
+const compactQuery = (query: AuditLogQuery): Record<string, string | number> =>
+  Object.fromEntries(
+    Object.entries(query).filter((entry): entry is [string, string | number] => entry[1] !== undefined && entry[1] !== ''),
+  );
+
+const filenameFromDisposition = (disposition: string | null): string => {
+  const match = disposition ? /filename="([^"]+)"/i.exec(disposition) : null;
+  return match?.[1] ?? `blawby-audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+};
+
+export const auditLogApi = {
+  async list(practiceId: string, query: AuditLogQuery = {}, signal?: AbortSignal): Promise<AuditLogResponse> {
+    const result = await apiClient.get<unknown>(practiceAuditLogPath(practiceId), {
+      params: compactQuery(query),
+      signal,
+    });
+    const parsed = auditLogResponseSchema.safeParse(result.data);
+    if (!parsed.success) throw new Error('Audit log response was malformed.');
+    return parsed.data;
+  },
+
+  async exportCsv(practiceId: string, query: Omit<AuditLogQuery, 'cursor' | 'limit'> = {}): Promise<{ blob: Blob; filename: string }> {
+    const search = new URLSearchParams(compactQuery(query) as Record<string, string>);
+    const suffix = search.size > 0 ? `?${search.toString()}` : '';
+    const response = await fetch(`${getWorkerApiUrl()}${practiceAuditLogExportPath(practiceId)}${suffix}`, {
+      credentials: 'include',
+    });
+    if (!response.ok) throw new Error(`Audit export failed with status ${response.status}.`);
+    return {
+      blob: await response.blob(),
+      filename: filenameFromDisposition(response.headers.get('Content-Disposition')),
+    };
+  },
+};

--- a/src/features/settings/services/practiceExportsApi.ts
+++ b/src/features/settings/services/practiceExportsApi.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+import { practiceExportPath, practiceExportsPath } from '@/config/urls';
+import { apiClient } from '@/shared/lib/apiClient';
+
+export const practiceExportTypeSchema = z.enum([
+  'full_practice_archive',
+  'matters_contacts',
+  'billing_invoices',
+  'trust_ledger',
+  'audit_events',
+]);
+
+const practiceExportJobSchema = z.object({
+  id: z.string().uuid(),
+  organization_id: z.string().uuid(),
+  requested_by: z.string().uuid(),
+  idempotency_key: z.string().uuid(),
+  type: practiceExportTypeSchema,
+  status: z.enum(['queued', 'running', 'completed', 'failed']),
+  content_type: z.string().nullable(),
+  byte_size: z.number().int().nonnegative().nullable(),
+  manifest: z.record(z.string(), z.unknown()).nullable(),
+  error: z.object({ code: z.string(), message: z.string() }).nullable(),
+  created_at: z.string().datetime(),
+  started_at: z.string().datetime().nullable(),
+  completed_at: z.string().datetime().nullable(),
+  failed_at: z.string().datetime().nullable(),
+  download: z.object({ url: z.string().url(), expires_at: z.string().datetime() }).nullable(),
+});
+
+export type PracticeExportType = z.infer<typeof practiceExportTypeSchema>;
+export type PracticeExportJob = z.infer<typeof practiceExportJobSchema>;
+
+const parseJob = (payload: unknown): PracticeExportJob => {
+  const parsed = z.object({ export: practiceExportJobSchema }).safeParse(payload);
+  if (!parsed.success) throw new Error('Practice export response was malformed.');
+  return parsed.data.export;
+};
+
+export const practiceExportsApi = {
+  async request(practiceId: string, type: PracticeExportType, idempotencyKey: string): Promise<PracticeExportJob> {
+    const result = await apiClient.post<unknown>(practiceExportsPath(practiceId), {
+      type,
+      idempotency_key: idempotencyKey,
+    });
+    return parseJob(result.data);
+  },
+
+  async get(practiceId: string, exportId: string, signal?: AbortSignal): Promise<PracticeExportJob> {
+    const result = await apiClient.get<unknown>(practiceExportPath(practiceId, exportId), { signal });
+    return parseJob(result.data);
+  },
+};

--- a/tests/component/settings-audit-export.test.tsx
+++ b/tests/component/settings-audit-export.test.tsx
@@ -1,0 +1,171 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  auditList: vi.fn(),
+  auditExport: vi.fn(),
+  requestExport: vi.fn(),
+  getExport: vi.fn(),
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+  triggerDownload: vi.fn(),
+}));
+
+vi.mock('@/shared/hooks/usePracticeManagement', () => ({
+  usePracticeManagement: () => ({
+    currentPractice: {
+      id: 'practice-local',
+      betterAuthOrgId: '11111111-1111-4111-8111-111111111111',
+    },
+  }),
+}));
+vi.mock('@/shared/i18n/hooks', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/shared/contexts/ToastContext', () => ({
+  useToastContext: () => ({ showError: mocks.showError, showSuccess: mocks.showSuccess }),
+}));
+vi.mock('@/features/settings/services/auditLogApi', () => ({
+  auditLogApi: { list: mocks.auditList, exportCsv: mocks.auditExport },
+}));
+vi.mock('@/features/settings/services/practiceExportsApi', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/features/settings/services/practiceExportsApi')>();
+  return {
+    ...original,
+    practiceExportsApi: { request: mocks.requestExport, get: mocks.getExport },
+  };
+});
+vi.mock('@/shared/utils/fileDownload', () => ({ triggerDownload: mocks.triggerDownload }));
+
+import { AuditLogPage } from '@/features/settings/pages/AuditLogPage';
+import { ExportDataPage } from '@/features/settings/pages/ExportDataPage';
+
+const practiceId = '11111111-1111-4111-8111-111111111111';
+const exportId = '22222222-2222-4222-8222-222222222222';
+const requestKey = '33333333-3333-4333-8333-333333333333';
+const userId = '44444444-4444-4444-8444-444444444444';
+
+const auditPage = {
+  data: [
+    {
+      id: '55555555-5555-4555-8555-555555555555',
+      occurred_at: '2026-07-12T12:00:00.000Z',
+      actor: { id: userId, type: 'user', name: 'Practice Owner', email: 'owner@example.test' },
+      action_type: 'invoice.paid',
+      target: { type: 'invoice', id: 'invoice-1' },
+      summary: 'Invoice paid',
+      source: {
+        system: 'domain_event',
+        producer: 'invoice.webhook',
+        record_id: '55555555-5555-4555-8555-555555555555',
+      },
+    },
+  ],
+  page_info: {
+    has_next_page: false,
+    has_previous_page: false,
+    next_cursor: null,
+    previous_cursor: null,
+  },
+};
+
+const queuedJob = {
+  id: exportId,
+  organization_id: practiceId,
+  requested_by: userId,
+  idempotency_key: requestKey,
+  type: 'full_practice_archive' as const,
+  status: 'queued' as const,
+  content_type: null,
+  byte_size: null,
+  manifest: null,
+  error: null,
+  created_at: '2026-07-12T12:00:00.000Z',
+  started_at: null,
+  completed_at: null,
+  failed_at: null,
+  download: null,
+};
+
+const completedJob = {
+  ...queuedJob,
+  status: 'completed' as const,
+  content_type: 'application/json',
+  byte_size: 1024,
+  manifest: { schema_version: 1 },
+  completed_at: '2026-07-12T12:01:00.000Z',
+  download: {
+    url: 'https://storage.example.test/signed',
+    expires_at: '2026-07-12T12:06:00.000Z',
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.auditList.mockResolvedValue(auditPage);
+  mocks.requestExport.mockResolvedValue(queuedJob);
+  mocks.getExport.mockResolvedValue(completedJob);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('settings audit and export surfaces', () => {
+  it('renders authoritative events and applies server-side search', async () => {
+    render(<AuditLogPage />);
+    expect(await screen.findByText('Invoice paid')).toBeInTheDocument();
+    fireEvent.input(screen.getByLabelText('Search events'), { target: { value: 'invoice' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => {
+      expect(mocks.auditList).toHaveBeenLastCalledWith(
+        practiceId,
+        { limit: 50, search: 'invoice' },
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
+  it('polls a durable export to completion and refreshes the signed URL before download', async () => {
+    vi.useFakeTimers();
+    render(<ExportDataPage />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Request export' })[0]);
+    await act(async () => Promise.resolve());
+    expect(mocks.requestExport).toHaveBeenCalledWith(
+      practiceId,
+      'full_practice_archive',
+      expect.any(String),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(await screen.findByRole('button', { name: 'Download' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+    await act(async () => Promise.resolve());
+    expect(mocks.getExport).toHaveBeenLastCalledWith(practiceId, exportId);
+    expect(mocks.triggerDownload).toHaveBeenCalledWith(
+      'https://storage.example.test/signed',
+      expect.stringContaining('full_practice_archive'),
+      true,
+    );
+  });
+
+  it('shows a polling failure and retries without converting it into success', async () => {
+    vi.useFakeTimers();
+    mocks.getExport.mockRejectedValueOnce(new Error('backend unavailable')).mockResolvedValueOnce(completedJob);
+    render(<ExportDataPage />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Request export' })[0]);
+    await act(async () => Promise.resolve());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent('Status could not be refreshed.');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(await screen.findByRole('button', { name: 'Download' })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -7,9 +7,11 @@ const source = (path: string): string => readFileSync(resolve(process.cwd(), pat
 describe('honest compliance UI', () => {
   it('does not render sample audit events as practice evidence', () => {
     const auditLog = source('src/features/settings/pages/AuditLogPage.tsx');
+    const settingsContent = source('src/features/settings/pages/SettingsContent.tsx');
     expect(auditLog).not.toContain('DEMO_EVENTS');
-    expect(auditLog).toContain('will not present sample entries as compliance evidence');
-    expect(auditLog).toContain('Export unavailable');
+    expect(auditLog).toContain('auditLogApi.list');
+    expect(auditLog).toContain('auditLogApi.exportCsv');
+    expect(settingsContent).not.toContain('Every action in your workspace is recorded');
   });
 
   it('does not infer assistant authorship from invoice age or line items', () => {
@@ -33,8 +35,9 @@ describe('honest compliance UI', () => {
     const exportsPage = source('src/features/settings/pages/ExportDataPage.tsx');
     const calendarDrawer = source('src/features/calendar/components/CalendarFocusDrawer.tsx');
     const intakeDetail = source('src/features/intake/pages/IntakeDetailPage.tsx');
-    expect(exportsPage).not.toContain("showSuccess('Export requested'");
-    expect(exportsPage).toContain('Export unavailable');
+    expect(exportsPage).toContain('practiceExportsApi.request');
+    expect(exportsPage).toContain('practiceExportsApi.get');
+    expect(exportsPage).not.toContain('No export request is sent');
     expect(calendarDrawer).not.toContain("value: '~22 min'");
     expect(intakeDetail).not.toContain('Math.round((intake.amount * 4) / 3)');
     expect(intakeDetail).not.toContain('<IntakeAcceptancePreview');

--- a/tests/unit/settings/auditLogApi.test.ts
+++ b/tests/unit/settings/auditLogApi.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApiClient } = vi.hoisted(() => ({
+  mockApiClient: { get: vi.fn() },
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({ apiClient: mockApiClient }));
+vi.mock('@/config/urls', () => ({
+  practiceAuditLogPath: (practiceId: string) => `/api/practices/${practiceId}/audit-log`,
+  practiceAuditLogExportPath: (practiceId: string) => `/api/practices/${practiceId}/audit-log/export`,
+  getWorkerApiUrl: () => 'https://local.blawby.com',
+}));
+
+import { auditLogApi } from '@/features/settings/services/auditLogApi';
+
+const practiceId = '11111111-1111-4111-8111-111111111111';
+const entry = {
+  id: '22222222-2222-4222-8222-222222222222',
+  occurred_at: '2026-07-12T12:00:00.000Z',
+  actor: {
+    id: '33333333-3333-4333-8333-333333333333',
+    type: 'user',
+    name: 'Practice Owner',
+    email: 'owner@example.test',
+  },
+  action_type: 'invoice.paid',
+  target: { type: 'invoice', id: 'invoice-1' },
+  summary: 'Invoice paid',
+  source: {
+    system: 'domain_event',
+    producer: 'invoice.webhook',
+    record_id: '22222222-2222-4222-8222-222222222222',
+  },
+};
+
+describe('auditLogApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads a cursor page with server-side filters', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        data: [entry],
+        page_info: {
+          has_next_page: true,
+          has_previous_page: false,
+          next_cursor: 'cursor-2',
+          previous_cursor: null,
+        },
+      },
+    });
+
+    await expect(auditLogApi.list(practiceId, { limit: 25, search: 'invoice' })).resolves.toMatchObject({
+      data: [{ action_type: 'invoice.paid' }],
+      page_info: { next_cursor: 'cursor-2' },
+    });
+    expect(mockApiClient.get).toHaveBeenCalledWith(`/api/practices/${practiceId}/audit-log`, {
+      params: { limit: 25, search: 'invoice' },
+      signal: undefined,
+    });
+  });
+
+  it('fast-fails malformed audit rows', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ data: { data: [{ ...entry, source: null }], page_info: {} } });
+    await expect(auditLogApi.list(practiceId)).rejects.toThrow('Audit log response was malformed.');
+  });
+
+  it('downloads authenticated CSV and preserves the server filename', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'Content-Disposition': 'attachment; filename="practice-audit.csv"' }),
+      blob: vi.fn().mockResolvedValue(new Blob(['occurred_at,action_type'])),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(auditLogApi.exportCsv(practiceId, { search: 'invoice' })).resolves.toMatchObject({
+      filename: 'practice-audit.csv',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://local.blawby.com/api/practices/${practiceId}/audit-log/export?search=invoice`,
+      { credentials: 'include' },
+    );
+  });
+});

--- a/tests/unit/settings/practiceExportsApi.test.ts
+++ b/tests/unit/settings/practiceExportsApi.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockApiClient } = vi.hoisted(() => ({
+  mockApiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock('@/shared/lib/apiClient', () => ({ apiClient: mockApiClient }));
+
+import { practiceExportsApi } from '@/features/settings/services/practiceExportsApi';
+
+const practiceId = '11111111-1111-4111-8111-111111111111';
+const exportId = '22222222-2222-4222-8222-222222222222';
+const requestKey = '33333333-3333-4333-8333-333333333333';
+const userId = '44444444-4444-4444-8444-444444444444';
+
+const job = {
+  id: exportId,
+  organization_id: practiceId,
+  requested_by: userId,
+  idempotency_key: requestKey,
+  type: 'full_practice_archive',
+  status: 'queued',
+  content_type: null,
+  byte_size: null,
+  manifest: null,
+  error: null,
+  created_at: '2026-07-12T12:00:00.000Z',
+  started_at: null,
+  completed_at: null,
+  failed_at: null,
+  download: null,
+};
+
+describe('practiceExportsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests a durable export with its idempotency key', async () => {
+    mockApiClient.post.mockResolvedValueOnce({ data: { export: job } });
+    await expect(practiceExportsApi.request(practiceId, 'full_practice_archive', requestKey)).resolves.toMatchObject({
+      id: exportId,
+      status: 'queued',
+    });
+    expect(mockApiClient.post).toHaveBeenCalledWith(`/api/practices/${practiceId}/exports`, {
+      type: 'full_practice_archive',
+      idempotency_key: requestKey,
+    });
+  });
+
+  it('gets a completed job with a time-limited download URL', async () => {
+    mockApiClient.get.mockResolvedValueOnce({
+      data: {
+        export: {
+          ...job,
+          status: 'completed',
+          content_type: 'application/json',
+          byte_size: 512,
+          manifest: { schema_version: 1 },
+          completed_at: '2026-07-12T12:01:00.000Z',
+          download: {
+            url: 'https://storage.example.test/signed',
+            expires_at: '2026-07-12T12:06:00.000Z',
+          },
+        },
+      },
+    });
+    await expect(practiceExportsApi.get(practiceId, exportId)).resolves.toMatchObject({
+      status: 'completed',
+      download: { url: 'https://storage.example.test/signed' },
+    });
+    expect(mockApiClient.get).toHaveBeenCalledWith(`/api/practices/${practiceId}/exports/${exportId}`, {
+      signal: undefined,
+    });
+  });
+
+  it('fast-fails malformed job state', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ data: { export: { ...job, status: 'pretend-complete' } } });
+    await expect(practiceExportsApi.get(practiceId, exportId)).rejects.toThrow('Practice export response was malformed.');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the disabled Audit log placeholder with authoritative cursor-paginated events, search, source provenance, retryable failures, and real CSV download
- replace disabled Export data controls with durable queued/running/completed/failed jobs for all five backend export types
- poll active jobs, keep polling failures visible, reuse request idempotency keys after ambiguous network failures, and mint a fresh five-minute URL immediately before download
- validate every backend response at the API boundary and fast-fail malformed rows or job states
- keep audit/export routes practice-only in the frontend shell
- remove the inaccurate claim that every workspace action is recorded

## User impact
Practice owners can review recorded domain, matter, and file activity and can request portable JSON archives without false success. Empty, loading, failure, in-progress, completed, and expired-link recovery paths are explicit.

## Backend dependencies
- authoritative audit contract: Blawby/blawby-backend#380 at 7cf0a41cea78c744a2086014dee19015a61ac36d
- durable export jobs: Blawby/blawby-backend#382 at 72251b9c34a0a8119ac56275c6aa982ddbfce703

Backend review, merge, and deployment remain human-owned. This frontend may merge to staging now, but live production integration is not proven until those PRs are deployed.

## Verification
- all three TypeScript projects passed on the rebased head
- ESLint passed for src and worker
- full Vitest suite: 117 files, 860 tests passed
- production Vite build passed with VITE_APP_BASE_URL=https://local.blawby.com
- first-load bundle: 284.7 KB gzipped, below the 300 KB budget
- git diff --check passed

Part of #662 and #716.