### PR TITLE
feat(ai): connect structured practice skills

### DIFF
--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -90,6 +90,9 @@ export const uploadConfirmPath = (uploadId: string): string =>
 export const intakeTemplatesPath = (practiceId: string): string =>
 	`/api/practice/${encodeSegment(practiceId)}/intake-templates`;
 
+export const practiceSkillsPath = (practiceId: string): string =>
+	`/api/practice/${encodeSegment(practiceId)}/skills`;
+
 export const intakeTemplatePath = (practiceId: string, templateId: string): string =>
 	`${intakeTemplatesPath(practiceId)}/${encodeSegment(templateId)}`;
 

--- a/src/features/settings/pages/IntelligencePage.tsx
+++ b/src/features/settings/pages/IntelligencePage.tsx
@@ -1,14 +1,39 @@
-import { FileLock2, ShieldCheck, SlidersHorizontal, Sparkles } from 'lucide-preact';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
+import {
+  BriefcaseBusiness,
+  FileLock2,
+  ReceiptText,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  UserRoundSearch,
+} from 'lucide-preact';
 
 import { Pill } from '@/design-system/primitives';
 import { SettingSection } from '@/features/settings/components/SettingSection';
 import { SettingsAIPreface } from '@/features/settings/components/SettingsAIPreface';
 import { SettingsCard } from '@/features/settings/components/SettingsCard';
+import { SettingsNotice } from '@/features/settings/components/SettingsNotice';
+import {
+  practiceSkillsApi,
+  type PracticeSkillDefinition,
+  type PracticeSkillKey,
+  type PracticeSkillsContract,
+} from '@/features/settings/services/practiceSkillsApi';
+import { usePracticeManagement } from '@/shared/hooks/usePracticeManagement';
 import { Button } from '@/shared/ui/Button';
+import { Switch } from '@/shared/ui/input/Switch';
+import { LoadingSpinner } from '@/shared/ui/layout/LoadingSpinner';
 
 export interface IntelligencePageProps {
   className?: string;
 }
+
+const skillIcons = {
+  matter_management: BriefcaseBusiness,
+  billing: ReceiptText,
+  client_intake: UserRoundSearch,
+} satisfies Record<PracticeSkillKey, typeof Sparkles>;
 
 const CapabilityRow = ({
   icon: Icon,
@@ -19,7 +44,7 @@ const CapabilityRow = ({
   icon: typeof Sparkles;
   title: string;
   description: string;
-  status: 'unavailable' | 'enforced' | 'pending';
+  status: 'enforced' | 'pending';
 }) => (
   <div className="flex items-start justify-between gap-4 border-b border-line-subtle py-4 last:border-0">
     <div className="flex min-w-0 items-start gap-3">
@@ -31,70 +56,181 @@ const CapabilityRow = ({
         <p className="mt-1 max-w-2xl text-sm leading-relaxed text-dim-2">{description}</p>
       </div>
     </div>
-    <Pill tone={status === 'enforced' ? 'live' : status === 'pending' ? 'warn' : 'dim'}>
-      {status === 'enforced' ? 'Enforced' : status === 'pending' ? 'Pending backend' : 'Unavailable'}
+    <Pill tone={status === 'enforced' ? 'live' : 'warn'}>
+      {status === 'enforced' ? 'Enforced' : 'Pending backend'}
     </Pill>
   </div>
 );
 
-export const IntelligencePage = ({ className }: IntelligencePageProps) => (
-  <div className={className}>
-    <SettingsAIPreface />
-    <div className="mt-8 space-y-10">
-      <SettingSection
-        title="AI behavior"
-        description="Practice AI settings need a durable backend contract before they can change assistant behavior."
-      >
-        <SettingsCard className="max-w-[860px]">
-          <CapabilityRow
-            icon={SlidersHorizontal}
-            title="Structured practice skills"
-            description="Free-text system prompts are intentionally not offered. The backend skills registry is the source of truth for configurable capabilities."
-            status="pending"
-          />
-          <CapabilityRow
-            icon={Sparkles}
-            title="Assistant name, tone, briefings, and observations"
-            description="These controls are not connected. Blawby no longer stores browser-only preferences that appear saved but do not affect the assistant."
-            status="unavailable"
-          />
-        </SettingsCard>
-      </SettingSection>
-
-      <SettingSection
-        title="Grounding and safety"
-        description="Current enforced boundaries are shown separately from future configuration."
-      >
-        <SettingsCard className="max-w-[860px]">
-          <CapabilityRow
-            icon={FileLock2}
-            title="Tenant-scoped grounding"
-            description="Authenticated practice and audience boundaries are enforced. Per-table include/exclude controls and source row counts are not available."
-            status="enforced"
-          />
-          <CapabilityRow
-            icon={ShieldCheck}
-            title="PII and high-risk actions"
-            description="Client-facing sanitization is enforced by the application. Durable cross-client approval and audit behavior remains pending human merge of the backend approval contract."
-            status="pending"
-          />
-        </SettingsCard>
-      </SettingSection>
-
-      <SettingSection
-        title="Operational controls"
-        description="A practice-wide pause must stop real model calls and staged writes, not just change this browser."
-      >
-        <SettingsCard className="flex max-w-[860px] flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h3 className="text-sm font-medium text-ink">Pause AI</h3>
-            <p className="mt-1 text-sm text-dim-2">No backend pause state is connected, so this control cannot safely claim success.</p>
-          </div>
-          <Button variant="secondary" size="sm" disabled title="Requires a backend practice-wide pause contract">
-            Pause unavailable
-          </Button>
-        </SettingsCard>
-      </SettingSection>
+const SkillRow = ({
+  skill,
+  enabled,
+  disabled,
+  onChange,
+}: {
+  skill: PracticeSkillDefinition;
+  enabled: boolean;
+  disabled: boolean;
+  onChange: (skill: PracticeSkillKey, enabled: boolean) => void;
+}) => {
+  const Icon = skillIcons[skill.key];
+  return (
+    <div className="border-b border-line-subtle py-4 last:border-0">
+      <div className="flex items-start gap-3">
+        <div className="mt-1 rounded-md border border-line-subtle bg-paper-2 p-2 text-accent">
+          <Icon className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <Switch
+          id={`practice-skill-${skill.key}`}
+          className="min-w-0 flex-1 py-0"
+          label={skill.label}
+          description={skill.description}
+          value={enabled}
+          disabled={disabled}
+          onChange={(value) => onChange(skill.key, value)}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
+
+export const IntelligencePage = ({ className }: IntelligencePageProps) => {
+  const { currentPractice } = usePracticeManagement({ fetchPracticeDetails: true });
+  const practiceId = useMemo(
+    () => currentPractice?.betterAuthOrgId ?? currentPractice?.id ?? null,
+    [currentPractice?.betterAuthOrgId, currentPractice?.id],
+  );
+  const [contract, setContract] = useState<PracticeSkillsContract | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSaved, setIsSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSkills = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!practiceId) return;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await practiceSkillsApi.get(practiceId, signal);
+        if (signal?.aborted) return;
+        setContract(result);
+        setIsSaved(false);
+      } catch (loadError) {
+        if (signal?.aborted) return;
+        setContract(null);
+        setError(loadError instanceof Error ? loadError.message : 'Unable to load practice AI skills.');
+      } finally {
+        if (!signal?.aborted) setIsLoading(false);
+      }
+    },
+    [practiceId],
+  );
+
+  useEffect(() => {
+    if (!practiceId) return;
+    const controller = new AbortController();
+    void loadSkills(controller.signal);
+    return () => controller.abort();
+  }, [loadSkills, practiceId]);
+
+  const updateSkill = async (skill: PracticeSkillKey, enabled: boolean) => {
+    if (!practiceId || !contract || isSaving) return;
+    const enabledSkills = enabled
+      ? [...contract.enabled_skills, skill]
+      : contract.enabled_skills.filter((candidate) => candidate !== skill);
+    setIsSaving(true);
+    setIsSaved(false);
+    setError(null);
+    try {
+      setContract(await practiceSkillsApi.update(practiceId, enabledSkills));
+      setIsSaved(true);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Unable to update practice AI skills.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <SettingsAIPreface />
+      <div className="mt-8 space-y-10">
+        <SettingSection
+          title="Practice skills"
+          description="Choose the structured capabilities available to your practice assistant and client intake. Changes apply practice-wide."
+        >
+          <SettingsCard className="max-w-[860px]">
+            <div className="flex flex-wrap items-start justify-between gap-3 border-b border-line-subtle pb-4">
+              <div>
+                <h3 className="text-sm font-medium text-ink">Enabled intelligence</h3>
+                <p className="mt-1 max-w-2xl text-sm leading-relaxed text-dim-2">
+                  Each skill is versioned in code and grounded in your saved practice data. There is no free-text system prompt.
+                </p>
+              </div>
+              <Pill tone={isSaving ? 'warn' : isSaved ? 'live' : 'dim'}>
+                {isSaving ? 'Saving' : isSaved ? 'Saved' : 'Practice-wide'}
+              </Pill>
+            </div>
+
+            {!practiceId ? (
+              <SettingsNotice variant="warning" className="mt-4">
+                Select a practice to manage its AI skills.
+              </SettingsNotice>
+            ) : isLoading ? (
+              <div className="flex justify-center py-8">
+                <LoadingSpinner ariaLabel="Loading practice skills" />
+              </div>
+            ) : contract ? (
+              <div>
+                {contract.available_skills.map((skill) => (
+                  <SkillRow
+                    key={skill.key}
+                    skill={skill}
+                    enabled={contract.enabled_skills.includes(skill.key)}
+                    disabled={isSaving}
+                    onChange={updateSkill}
+                  />
+                ))}
+              </div>
+            ) : null}
+
+            {error ? (
+              <SettingsNotice variant="danger" className="mt-4" role="alert">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <span>{error}</span>
+                  {!contract ? (
+                    <Button variant="secondary" size="sm" onClick={() => void loadSkills()}>
+                      <RefreshCw className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+                      Try again
+                    </Button>
+                  ) : null}
+                </div>
+              </SettingsNotice>
+            ) : null}
+          </SettingsCard>
+        </SettingSection>
+
+        <SettingSection
+          title="Grounding and safety"
+          description="Current enforced boundaries are shown separately from future configuration."
+        >
+          <SettingsCard className="max-w-[860px]">
+            <CapabilityRow
+              icon={FileLock2}
+              title="Tenant-scoped grounding"
+              description="Authenticated practice and audience boundaries are enforced. Per-table include/exclude controls and source row counts are not available."
+              status="enforced"
+            />
+            <CapabilityRow
+              icon={ShieldCheck}
+              title="PII and high-risk actions"
+              description="Client-facing sanitization is enforced by the application. Durable cross-client approval and audit behavior remains pending human merge of the backend approval contract."
+              status="pending"
+            />
+          </SettingsCard>
+        </SettingSection>
+      </div>
+    </div>
+  );
+};

--- a/src/features/settings/services/practiceSkillsApi.ts
+++ b/src/features/settings/services/practiceSkillsApi.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+import { practiceSkillsPath } from '@/config/urls';
+import { apiClient } from '@/shared/lib/apiClient';
+
+export const practiceSkillKeySchema = z.enum(['matter_management', 'billing', 'client_intake']);
+
+const practiceSkillDefinitionSchema = z.object({
+  key: practiceSkillKeySchema,
+  label: z.string().min(1),
+  description: z.string().min(1),
+  version: z.number().int().positive(),
+  scopes: z.array(z.string().min(1)),
+});
+
+const practiceSkillsContractSchema = z.object({
+  enabled_skills: z.array(practiceSkillKeySchema),
+  available_skills: z.array(practiceSkillDefinitionSchema),
+  effective_scopes: z.array(z.string().min(1)),
+  prompt_contribution: z.string(),
+});
+
+export type PracticeSkillKey = z.infer<typeof practiceSkillKeySchema>;
+export type PracticeSkillDefinition = z.infer<typeof practiceSkillDefinitionSchema>;
+export type PracticeSkillsContract = z.infer<typeof practiceSkillsContractSchema>;
+
+const parseContract = (payload: unknown): PracticeSkillsContract => {
+  const parsed = practiceSkillsContractSchema.safeParse(payload);
+  if (!parsed.success) throw new Error('Practice AI skills response was malformed.');
+  return parsed.data;
+};
+
+export const practiceSkillsApi = {
+  async get(practiceId: string, signal?: AbortSignal): Promise<PracticeSkillsContract> {
+    const response = await apiClient.get<unknown>(practiceSkillsPath(practiceId), { signal });
+    return parseContract(response.data);
+  },
+
+  async update(practiceId: string, enabledSkills: PracticeSkillKey[]): Promise<PracticeSkillsContract> {
+    const response = await apiClient.put<unknown>(practiceSkillsPath(practiceId), {
+      enabled_skills: enabledSkills,
+    });
+    return parseContract(response.data);
+  },
+};

--- a/tests/unit/design-system/honestComplianceUi.test.ts
+++ b/tests/unit/design-system/honestComplianceUi.test.ts
@@ -51,7 +51,9 @@ describe('honest compliance UI', () => {
     expect(intelligence).not.toContain("showSuccess('Pause requested'");
     expect(intelligence).not.toContain('sonnet-4.5');
     expect(intelligence).not.toContain("{ key: 'matters', rows: 142 }");
-    expect(intelligence).toContain('browser-only preferences that appear saved but do not affect the assistant');
+    expect(intelligence).toContain('practiceSkillsApi.get');
+    expect(intelligence).toContain('practiceSkillsApi.update');
+    expect(intelligence).toContain('There is no free-text system prompt');
   });
 
   it('does not answer arbitrary workspace questions with unrelated summaries', () => {

--- a/tests/unit/settings/practiceSkillsApi.test.ts
+++ b/tests/unit/settings/practiceSkillsApi.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { practiceSkillsApi } from '@/features/settings/services/practiceSkillsApi';
+import { apiClient } from '@/shared/lib/apiClient';
+
+vi.mock('@/shared/lib/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+const contract = {
+  enabled_skills: ['matter_management'],
+  available_skills: [
+    {
+      key: 'matter_management',
+      label: 'Matter management',
+      description: 'Work with matters.',
+      version: 1,
+      scopes: ['matters:read'],
+    },
+  ],
+  effective_scopes: ['matters:read'],
+  prompt_contribution: 'Matter management is enabled.',
+};
+
+describe('practiceSkillsApi', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads and replaces enabled practice skills through the durable API', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: contract } as never);
+    vi.mocked(apiClient.put).mockResolvedValue({ data: contract } as never);
+
+    await expect(practiceSkillsApi.get('practice id')).resolves.toEqual(contract);
+    await expect(practiceSkillsApi.update('practice id', ['matter_management'])).resolves.toEqual(contract);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/practice/practice%20id/skills', { signal: undefined });
+    expect(apiClient.put).toHaveBeenCalledWith('/api/practice/practice%20id/skills', {
+      enabled_skills: ['matter_management'],
+    });
+  });
+
+  it('rejects malformed backend contracts rather than inventing defaults', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { enabled_skills: ['billing'] } } as never);
+    await expect(practiceSkillsApi.get('practice-1')).rejects.toThrow('response was malformed');
+  });
+});

--- a/tests/unit/worker/services/practiceSkills.test.ts
+++ b/tests/unit/worker/services/practiceSkills.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  appendPracticeSkillPrompt,
+  fetchAuthenticatedPracticeSkillPrompt,
+  fetchPublicPracticeSkillPrompt,
+} from '../../../../worker/services/practiceSkills';
+import type { Env } from '../../../../worker/types';
+
+const env = { BACKEND_API_URL: 'https://staging-api.blawby.com/' } as Env;
+const request = new Request('https://dev.blawby.com/api/ai/chat', {
+  headers: { Cookie: 'better-auth.session_token=opaque' },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('practice skill prompt contract', () => {
+  it('loads the authenticated practice contract and forwards session authority', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          enabled_skills: ['matter_management'],
+          prompt_contribution: 'Matter management is enabled.',
+          available_skills: [],
+          effective_scopes: ['matters:read'],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuthenticatedPracticeSkillPrompt(env, request, 'practice id');
+
+    expect(result.promptContribution).toBe('Matter management is enabled.');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://staging-api.blawby.com/api/practice/practice%20id/skills',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get('Cookie')).toBe('better-auth.session_token=opaque');
+  });
+
+  it('uses the public slug endpoint for client-facing chat', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          enabled_skills: ['client_intake'],
+          prompt_contribution: 'Client intake assistance is enabled.',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchPublicPracticeSkillPrompt(env, request, 'example law');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://staging-api.blawby.com/api/practice/details/example%20law/skills',
+      expect.any(Object),
+    );
+  });
+
+  it('fast-fails malformed or missing prompt context instead of hiding it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ enabled_skills: ['billing'], prompt_contribution: '' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    await expect(fetchPublicPracticeSkillPrompt(env, request, 'example-law')).rejects.toThrow(
+      'omitted prompt context',
+    );
+  });
+
+  it('appends structured skill context without a free-text override channel', () => {
+    expect(appendPracticeSkillPrompt('Base rules', 'Client intake assistance is enabled.')).toBe(
+      'Base rules\n\nPRACTICE_SKILLS:\nClient intake assistance is enabled.',
+    );
+    expect(appendPracticeSkillPrompt('Base rules', '')).toBe('Base rules');
+  });
+});

--- a/worker/routes/aiChat.ts
+++ b/worker/routes/aiChat.ts
@@ -17,6 +17,11 @@ import {
 } from '../services/PartialIntakeSubmissionService.js';
 import { createWorkersAiClient, resolveWorkersAiModel } from '../utils/workersAiClient.js';
 import { fetchPracticeDetailsWithCache } from '../utils/practiceDetailsCache.js';
+import {
+  appendPracticeSkillPrompt,
+  fetchAuthenticatedPracticeSkillPrompt,
+  fetchPublicPracticeSkillPrompt,
+} from '../services/practiceSkills.js';
 import { Logger } from '../utils/logger.js';
 import { resolveConsultationState } from '../../src/shared/utils/consultationState';
 
@@ -777,6 +782,15 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
   // Streaming path
   // ------------------------------------------------------------------
 
+  const publicPracticeSlug = practiceSlug || (typeof details?.slug === 'string' ? details.slug.trim() : '');
+  const practiceSkillPrompt = isOnboardingMode
+    ? ''
+    : (
+        isPublic
+          ? await fetchPublicPracticeSkillPrompt(env, request, publicPracticeSlug)
+          : await fetchAuthenticatedPracticeSkillPrompt(env, request, practiceId)
+      ).promptContribution;
+
   const aiPromptContext = buildCompactPracticeContextForPrompt(details);
   const aiClient = createWorkersAiClient(env);
   const model = resolveWorkersAiModel(env, DEFAULT_AI_MODEL);
@@ -891,6 +905,7 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
       templateFields,
       requiredComplete,
     );
+    systemPrompt = appendPracticeSkillPrompt(systemPrompt, practiceSkillPrompt);
 
     const intakeTools = templateFields.length > 0
       ? buildIntakeTools(templateFields)
@@ -929,6 +944,7 @@ export async function handleAiChat(request: Request, env: Env, ctx?: ExecutionCo
         ? [`SEARCH_CONTEXT: ${body.additionalContext}`]
         : []),
     ].join('\n\n');
+    systemPrompt = appendPracticeSkillPrompt(systemPrompt, practiceSkillPrompt);
 
     if (isAnthropicModel) {
       requestPayload.system = systemPrompt;

--- a/worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts
+++ b/worker/services/practiceAssistant/PracticeAssistantQueryEngine.ts
@@ -8,6 +8,7 @@ import { PracticeAssistantAuditService } from './auditService.js';
 import { buildTurnMetadata, persistAssistantMessage } from './messageAdapter.js';
 import { loadBackendConversationHistory } from './conversationHistoryService.js';
 import { Logger } from '../../utils/logger.js';
+import { appendPracticeSkillPrompt, fetchAuthenticatedPracticeSkillPrompt } from '../practiceSkills.js';
 import type {
   PracticeAssistantProgress,
   PracticeAssistantToolCall,
@@ -233,7 +234,12 @@ export class PracticeAssistantQueryEngine {
       events.push({ type: 'tool_progress', progress: progressEvent });
     };
     try {
-      const conversationMessages = await this.loadMessages(userMessage);
+      const [conversationMessages, skillPromptContract] = await Promise.all([
+        this.loadMessages(userMessage),
+        fetchAuthenticatedPracticeSkillPrompt(env, request, practiceId),
+      ]);
+      const turnSystemPrompt = appendPracticeSkillPrompt(systemPrompt, skillPromptContract.promptContribution);
+      const turnFinalSystemPrompt = appendPracticeSkillPrompt(finalSystemPrompt, skillPromptContract.promptContribution);
       Logger.info('practice_assistant.turn.started', {
         requestId,
         conversationId,
@@ -262,7 +268,7 @@ export class PracticeAssistantQueryEngine {
         model, temperature: 0.1, max_tokens: 1200, stream: true,
         tools: toOpenAiTools(), tool_choice: 'auto',
         messages: [
-          { role: 'system', content: systemPrompt },
+          { role: 'system', content: turnSystemPrompt },
           ...conversationMessages,
         ],
       }, this.abortController.signal);
@@ -315,7 +321,7 @@ export class PracticeAssistantQueryEngine {
       const finalResponse = await aiClient.requestChatCompletions({
         model, temperature: 0.2, max_tokens: 1600, stream: true,
         messages: [
-          { role: 'system', content: finalSystemPrompt },
+          { role: 'system', content: turnFinalSystemPrompt },
           { role: 'user', content: finalUserPrompt },
         ],
       }, this.abortController.signal);

--- a/worker/services/practiceSkills.ts
+++ b/worker/services/practiceSkills.ts
@@ -1,0 +1,75 @@
+import type { Env } from '../types.js';
+
+const skillKeys = new Set(['matter_management', 'billing', 'client_intake']);
+
+export interface PracticeSkillPromptContract {
+  enabledSkills: string[];
+  promptContribution: string;
+}
+
+const backendBaseUrl = (env: Env): string => {
+  const baseUrl = env.BACKEND_API_URL?.trim();
+  if (!baseUrl) throw new Error('BACKEND_API_URL is required for practice AI skills');
+  return baseUrl.replace(/\/+$/, '');
+};
+
+const forwardedAuthHeaders = (request: Request): Headers => {
+  const headers = new Headers({ Accept: 'application/json' });
+  const cookie = request.headers.get('Cookie');
+  const authorization = request.headers.get('Authorization');
+  if (cookie) headers.set('Cookie', cookie);
+  if (authorization) headers.set('Authorization', authorization);
+  return headers;
+};
+
+const parsePromptContract = (payload: unknown): PracticeSkillPromptContract => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Practice AI skills response was malformed');
+  }
+  const record = payload as Record<string, unknown>;
+  const enabledSkills = record.enabled_skills;
+  const promptContribution = record.prompt_contribution;
+  if (
+    !Array.isArray(enabledSkills) ||
+    !enabledSkills.every((skill) => typeof skill === 'string' && skillKeys.has(skill)) ||
+    typeof promptContribution !== 'string'
+  ) {
+    throw new Error('Practice AI skills response was malformed');
+  }
+  if (enabledSkills.length > 0 && !promptContribution.trim()) {
+    throw new Error('Practice AI skills response omitted prompt context for enabled skills');
+  }
+  return { enabledSkills, promptContribution };
+};
+
+const fetchPrompt = async (env: Env, request: Request, path: string): Promise<PracticeSkillPromptContract> => {
+  const response = await fetch(`${backendBaseUrl(env)}${path}`, {
+    headers: forwardedAuthHeaders(request),
+  });
+  if (!response.ok) {
+    throw new Error(`Practice AI skills request failed with HTTP ${response.status}`);
+  }
+  return parsePromptContract(await response.json());
+};
+
+export const fetchAuthenticatedPracticeSkillPrompt = (
+  env: Env,
+  request: Request,
+  practiceId: string,
+): Promise<PracticeSkillPromptContract> =>
+  fetchPrompt(env, request, `/api/practice/${encodeURIComponent(practiceId)}/skills`);
+
+export const fetchPublicPracticeSkillPrompt = (
+  env: Env,
+  request: Request,
+  practiceSlug: string,
+): Promise<PracticeSkillPromptContract> => {
+  const slug = practiceSlug.trim();
+  if (!slug) throw new Error('Practice slug is required for public practice AI skills');
+  return fetchPrompt(env, request, `/api/practice/details/${encodeURIComponent(slug)}/skills`);
+};
+
+export const appendPracticeSkillPrompt = (basePrompt: string, promptContribution: string): string => {
+  const contribution = promptContribution.trim();
+  return contribution ? `${basePrompt}\n\nPRACTICE_SKILLS:\n${contribution}` : basePrompt;
+};


### PR DESCRIPTION
Implements the frontend and Worker portion of Blawby/blawby-backend#316.

## Summary
- replace the placeholder Intelligence page with real practice-wide skill toggles backed by a strict GET/PUT contract
- show explicit loading, saved, retry, and malformed-contract states with no browser persistence or free-text prompt field
- append the backend-generated structured prompt to client-facing intake/general chat and both practice-assistant model passes
- fast-fail missing, malformed, or unavailable skill prompt contracts instead of hiding the failure
- use the authenticated staff endpoint for internal/private practice turns and the public-practice slug endpoint for client-facing public turns

## Backend dependency
- human-review-only backend PR: https://github.com/Blawby/blawby-backend/pull/388
- frontend work is complete against that contract and does not wait for its human merge

## Verification
- npx tsc --noEmit
- npm run lint
- 729 unit tests across 95 files
- production build with VITE_WORKER_API_URL=https://dev.blawby.com
- git diff --check