### PR TITLE
feat: establish durable recovery controls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,13 @@ jobs:
         run: >-
           npx tsx scripts/capture-cloudflare-release.ts
           https://ai-staging.blawby.com/api/health blawby-ai-chatbot-frontend-staging staging
+      - name: Apply additive staging D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          npx wrangler d1 migrations apply DB --env staging
+          --config worker/wrangler.toml --remote
       - name: Deploy Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/launch-production.yml
+++ b/.github/workflows/launch-production.yml
@@ -133,6 +133,13 @@ jobs:
           set -euo pipefail
           npx wrangler secret list --env production --config worker/wrangler.toml --format json > "${RUNNER_TEMP}/worker-secret-names.json"
           npm run validate:production-config -- --worker-secrets "${RUNNER_TEMP}/worker-secret-names.json"
+      - name: Apply additive production D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          npx wrangler d1 migrations apply DB --env production
+          --config worker/wrangler.toml --remote
       - name: Deploy Worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/operations/durable-recovery.md
+++ b/docs/operations/durable-recovery.md
@@ -1,0 +1,170 @@
+# Durable data recovery
+
+Public launch is blocked until the provider rehearsals in this runbook have a
+completed evidence record. Repository tests and provider documentation are not
+substitutes for a timed restore.
+
+## Objectives
+
+- Recovery point objective (RPO): no more than 15 minutes of durable writes.
+- Recovery time objective (RTO): service restored and tenant integrity verified
+  within four hours of declaring recovery.
+- Rollback model: restore data forward into compatible code. Never reverse a
+  destructive migration in place.
+
+## Data classification and ownership
+
+| Data | Classification after launch | Source of truth | Recovery dependency |
+| --- | --- | --- | --- |
+| Identity, sessions, memberships, roles, OAuth grants, API keys | Durable | Railway PostgreSQL / Better Auth | Railway PostgreSQL PITR |
+| Practices, clients, matters, tasks, time, billing, trust, subscriptions | Durable | Railway PostgreSQL | Railway PostgreSQL PITR |
+| Intakes, approvals/audit records, engagement records, backend upload metadata | Durable | Railway PostgreSQL | Railway PostgreSQL PITR |
+| Conversations, messages, reactions, Worker approvals/actions, intake diagnostics | Durable until #666 completes | Worker D1 | D1 Time Travel |
+| Report schedules, saved search pins, and report-delivery metadata | Durable | Worker D1 | D1 Time Travel |
+| Worker-uploaded objects and generated report artifacts | Durable | Worker R2 `blawby-ai-files` | R2 durability plus bucket-lock retention |
+| Backend-uploaded objects and signed engagement artifacts | Durable | Backend-configured R2 bucket | R2 durability plus bucket-lock retention |
+| KV practice-detail cache, status/subscription TTLs, rate/idempotency counters, search-backfill cookies | Rebuildable | `CHAT_SESSIONS` KV | Refill from PostgreSQL/D1 or allow TTL recreation |
+| Search documents/vectors | Rebuildable | D1 search projection + Vectorize | Run the existing backfill from PostgreSQL/D1 |
+| Presence, WebSocket membership, counters, pending broadcast state, matter progress | Rebuildable coordination | Durable Objects | Reconnect/recompute from durable records |
+| Notification, search, and intake-event queue work | Rebuildable/retryable | Queue + DLQ while in flight | Replay idempotent source events after repair |
+
+No customer-authored record may live only in KV, a queue, Vectorize, or a
+Durable Object. Report schedules and saved search pins therefore persist in
+D1; the migration from the earlier KV implementation happens before launch
+while there are no users.
+
+## Provider mechanisms and required configuration
+
+### Railway PostgreSQL
+
+Required mechanism: Railway PostgreSQL Point-in-Time Recovery (PITR), not the
+daily volume snapshot alone. Railway's PITR archives WAL continuously, uses a
+60-second archive timeout, and restores into a new sibling service without
+modifying the source. The ordinary volume backup cadence is only daily/weekly/
+monthly and cannot prove a 15-minute RPO.
+
+- Enable PITR on the production PostgreSQL service.
+- Retain at least 30 days of WAL/base backups.
+- Wait for the first base backup and confirm the displayed restore window.
+- Keep daily, weekly, and monthly volume schedules as a second recovery layer.
+- Never wipe the source volume; cut over only after the restored sibling passes
+  the verification queries below.
+
+Provider references: [Railway PITR](https://docs.railway.com/volumes/point-in-time-recovery),
+[Railway volume backups](https://docs.railway.com/volumes/backups).
+
+### Worker D1
+
+Required mechanism: D1 Time Travel on the production storage backend. Time
+Travel resolves a stable bookmark for any minute in the retention window and
+can restore to that bookmark. Workers Paid retains 30 days; Free retains 7.
+
+- Verify `wrangler d1 info blawby-ai-chatbot` reports `version: production`.
+- Verify a bookmark can be resolved for the current time and 15 minutes ago.
+- Record the current bookmark immediately before any recovery.
+- Export the current database to controlled encrypted storage before an
+  in-place Time Travel restore.
+- Retain the `previous_bookmark` returned by restore so the operation can be
+  undone.
+
+Time Travel currently restores in place; it does not clone a database. The
+isolated rehearsal must therefore use a temporary D1 database populated only
+with synthetic records. Provider reference: [D1 Time Travel and backups](https://developers.cloudflare.com/d1/reference/time-travel/).
+
+### R2 objects
+
+R2 provides eleven-nines hardware durability, but an ordinary delete is
+irreversible. Both production upload buckets must have bucket-lock rules that
+prevent deletion and overwrite for 30 days. Application deletes remain metadata
+soft-deletes; object erasure happens only after the retention window and the
+documented deletion workflow.
+
+- Apply a 30-day bucket-lock rule to `blawby-ai-files`.
+- Apply the same rule to the backend-configured production upload bucket.
+- Do not configure an expiration lifecycle on durable upload prefixes.
+- Record object key, size, ETag, and checksum in the owning PostgreSQL/D1 row.
+- Generated/rebuildable exports may use a separate prefix with a shorter
+  lifecycle, but original uploads may not.
+
+Provider references: [R2 durability](https://developers.cloudflare.com/r2/reference/durability/),
+[R2 bucket locks](https://developers.cloudflare.com/r2/buckets/bucket-locks/),
+[R2 delete semantics](https://developers.cloudflare.com/r2/objects/delete-objects/).
+
+### KV, Durable Objects, queues, and search
+
+These systems are not backup authorities. KV is eventually consistent and is
+used only for TTL/cache/counter state. Current Durable Object classes use the
+legacy key-value storage backend and are treated as disposable coordination;
+their state is rebuilt from D1/PostgreSQL. Queue/DLQ contents are retried only
+when the source event is idempotent. Vectorize is rebuilt from durable records.
+
+If a future Durable Object stores customer-authored state, create it with the
+SQLite storage backend and add its 30-day PITR rehearsal before launch. Provider
+references: [Workers KV consistency](https://developers.cloudflare.com/kv/concepts/how-kv-works/),
+[SQLite Durable Object PITR](https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api/).
+
+## Migration and compatibility order
+
+1. Apply additive PostgreSQL migrations and the Worker D1 migration set.
+2. Deploy code that can read the old and new shape only for the bounded
+   migration window.
+3. Backfill or regenerate derived projections.
+4. Verify counts, foreign keys, tenant ownership, and checksums.
+5. Stop writing the old shape.
+6. Remove compatibility code in a later release after the recovery window.
+
+During an incident, deploy code compatible with the selected restore point or
+roll forward with additive migrations. Do not run `down` migrations, drop newer
+columns, wipe volumes, empty buckets, or delete a D1 database as rollback.
+
+## Isolated rehearsal
+
+Use only the marked launch-test practice and synthetic identifiers. Record UTC
+timestamps for every step.
+
+1. PostgreSQL: insert a synthetic owner, membership, practice, client, matter,
+   invoice, intake, approval, upload metadata row, and cross-tenant negative
+   control. Record commit time `T0`.
+2. D1: insert a synthetic conversation, two sequenced messages, an approval
+   action, report schedule, and cross-tenant negative control. Record bookmark
+   and commit time `T0`.
+3. R2: upload a synthetic object whose checksum is also recorded in its metadata
+   row. Confirm a delete/overwrite attempt is rejected by bucket lock.
+4. Wait at least one minute, then mutate/delete the synthetic database records.
+5. Railway: restore a sibling PostgreSQL service to `T0`; never replace the
+   source during rehearsal.
+6. D1: run Time Travel against a temporary rehearsal database to the recorded
+   bookmark, preserving the returned previous bookmark.
+7. Verify the restored rows and R2 bytes with the checks below. Rebuild search,
+   presence, counters, and derived work rather than restoring those systems.
+8. Record the newest durable write absent from the restore (RPO) and elapsed
+   time from recovery declaration through verification (RTO).
+
+### Required verification
+
+- Every synthetic durable record exists exactly once.
+- Membership and role still reference the restored identity and practice.
+- Matter, invoice, intake, approval, conversation, and upload metadata retain
+  the same practice ID.
+- The negative-control tenant cannot read or mutate the restored records.
+- Message sequence is contiguous and no approval is silently executed.
+- R2 object size, ETag/checksum, and downloaded bytes match the metadata row.
+- Search and other derived views rebuild from the restored sources.
+- Measured RPO is `<= 15 minutes`; measured RTO is `<= 4 hours`.
+
+## Evidence record
+
+Store a sanitized `durable-recovery-evidence.json` artifact for 90 days with:
+
+- rehearsal start/end and selected restore timestamps;
+- exact frontend and backend Git commits;
+- Railway source/restored deployment IDs and restore-window bounds;
+- D1 database ID, storage version, selected bookmark, previous bookmark, and
+  restore completion time;
+- R2 bucket names, lock-rule IDs, retention, and synthetic object checksum;
+- counts and boolean integrity outcomes only (no names, emails, object bytes,
+  tokens, connection strings, or row payloads);
+- measured RPO/RTO and pass/fail status.
+
+Until that artifact exists and every result passes, #723 and the public cutover
+in #724 remain open.

--- a/docs/operations/production-topology.md
+++ b/docs/operations/production-topology.md
@@ -10,10 +10,10 @@ This inventory is the source-of-truth checklist for the production configuration
 | Cloudflare Worker | Worker `blawby-ai-chatbot`; route `ai.blawby.com/api/*` | Frontend repository. Wrangler config, dry-run, and live bindings are validated before deploy. |
 | Backend API | `https://api.blawby.com` on Railway | Backend repository and human-owned backend deployment. Frontend validates the URL shape; it does not deploy or roll back the backend. |
 | PostgreSQL | Railway-managed backend database | Backend repository / Railway. Schema migration and recovery are human-owned backend gates. |
-| D1 | Binding `DB`, database `blawby-ai-chatbot` | Worker. Durable conversations, messages, approvals, assistant actions, and intake diagnostics currently live here. |
-| KV | Binding `CHAT_SESSIONS` | Worker. Ephemeral/session and counter support; not the durable business-record store. |
+| D1 | Binding `DB`, database `blawby-ai-chatbot` | Worker. Durable conversations, messages, approvals, assistant actions, intake diagnostics, report schedules, saved search pins, and report-delivery metadata currently live here. |
+| KV | Binding `CHAT_SESSIONS` | Worker. Rebuildable TTL caches, subscriptions, and counters only; never a durable business-record store. |
 | Durable Objects | `CHAT_ROOM`, `CHAT_COUNTER`, `MATTER_PROGRESS`, `PRESENCE_ROOM` | Worker. Realtime coordination, atomic rate limits, and presence. |
-| R2 | Binding `FILES_BUCKET`, bucket `blawby-ai-files` | Worker. Uploaded file objects; recovery evidence belongs to #723. |
+| R2 | Binding `FILES_BUCKET`, bucket `blawby-ai-files` | Worker. Uploaded file objects are durable and require 30-day bucket-lock retention plus the #723 rehearsal. |
 | Notification queue | `NOTIFICATION_EVENTS` / `notification-events` plus DLQ | Worker. In-app/push notification processing. |
 | Search queue | `SEARCH_INDEX_EVENTS` / `search-index-events` plus DLQ | Worker. Search indexing; Vectorize binding is `SEARCH_VECTORS`. |
 | Intake event queue | `INTAKE_CONVERSATION_EVENTS` / `intake-conversation-events` plus DLQ | Worker producer/consumer. Consumer authenticates backend delivery with the named Worker secret `WORKER_EVENT_SECRET`. |

--- a/tests/unit/scripts/durableRecovery.test.ts
+++ b/tests/unit/scripts/durableRecovery.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string): string => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+describe('durable recovery contract', () => {
+  it('keeps customer-authored report schedules and search pins out of rebuildable KV', () => {
+    const schedules = source('worker/services/ReportScheduleService.ts');
+    const search = source('worker/routes/search.ts');
+    const migration = source('worker/migrations/20260712_add_report_schedules.sql');
+
+    expect(schedules).toContain('this.env.DB.prepare');
+    expect(schedules).not.toContain('CHAT_SESSIONS');
+    expect(search).toContain('FROM search_pins');
+    expect(search).toContain('INSERT INTO search_pins');
+    expect(search).not.toContain('search-pin:');
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS report_schedules');
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS search_pins');
+  });
+
+  it('applies additive D1 migrations before staging and production Worker deploys', () => {
+    const staging = source('.github/workflows/deploy.yml');
+    const production = source('.github/workflows/launch-production.yml');
+
+    const stagingMigration = staging.indexOf('wrangler d1 migrations apply DB --env staging');
+    const productionMigration = production.indexOf('wrangler d1 migrations apply DB --env production');
+    expect(stagingMigration).toBeGreaterThan(0);
+    expect(staging.indexOf('wrangler deploy --env staging', stagingMigration)).toBeGreaterThan(stagingMigration);
+    expect(productionMigration).toBeGreaterThan(0);
+    expect(production.indexOf('wrangler deploy --env production', productionMigration)).toBeGreaterThan(
+      productionMigration,
+    );
+  });
+
+  it('documents durable and rebuildable ownership plus explicit provider gates', () => {
+    const runbook = source('docs/operations/durable-recovery.md');
+
+    for (const required of [
+      'Railway PostgreSQL PITR',
+      'D1 Time Travel',
+      'bucket-lock',
+      'Recovery point objective (RPO)',
+      'Recovery time objective (RTO)',
+      'Until that artifact exists',
+    ]) {
+      expect(runbook).toContain(required);
+    }
+  });
+});

--- a/tests/unit/worker/services/ReportScheduleService.test.ts
+++ b/tests/unit/worker/services/ReportScheduleService.test.ts
@@ -5,20 +5,96 @@ import {
 } from '../../../../worker/services/ReportScheduleService';
 import type { Env } from '../../../../worker/types';
 
-class FakeKV {
-  store = new Map<string, string>();
-  async get(key: string) { return this.store.get(key) ?? null; }
-  async put(key: string, value: string) { this.store.set(key, value); }
-  async delete(key: string) { this.store.delete(key); }
-  async list({ prefix }: { prefix: string }) {
-    const keys = Array.from(this.store.keys())
-      .filter((k) => k.startsWith(prefix))
-      .map((name) => ({ name }));
-    return { keys, list_complete: true as const };
+type StoredRow = Record<string, string | number | null>;
+
+class FakeD1 {
+  rows = new Map<string, StoredRow>();
+
+  prepare(query: string) {
+    let args: unknown[] = [];
+    const statement = {
+      bind: (...values: unknown[]) => {
+        args = values;
+        return statement;
+      },
+      all: async <T>() => ({
+        results: [...this.rows.values()]
+          .filter((row) => row.practice_id === args[0])
+          .sort((left, right) => String(left.created_at).localeCompare(String(right.created_at))) as T[],
+        success: true,
+        meta: {},
+      }),
+      first: async <T>() =>
+        ([...this.rows.values()].find((row) => row.practice_id === args[0] && row.id === args[1]) ?? null) as T | null,
+      run: async () => {
+        if (query.startsWith('INSERT')) {
+          const [
+            report_type,
+            frequency,
+            day_of_week,
+            day_of_month,
+            hour_utc,
+            recipients_json,
+            filters_json,
+            active,
+            updated_at,
+            next_delivery_at,
+            id,
+            practice_id,
+            created_at,
+          ] = args;
+          this.rows.set(String(id), {
+            id: String(id),
+            practice_id: String(practice_id),
+            report_type: String(report_type),
+            frequency: String(frequency),
+            day_of_week: day_of_week as number | null,
+            day_of_month: day_of_month as number | null,
+            hour_utc: hour_utc as number,
+            recipients_json: String(recipients_json),
+            filters_json: String(filters_json),
+            active: active as number,
+            created_at: String(created_at),
+            updated_at: String(updated_at),
+            next_delivery_at: next_delivery_at as string | null,
+          });
+          return { success: true, meta: { changes: 1 } };
+        }
+        if (query.startsWith('UPDATE')) {
+          const id = String(args[10]);
+          const practiceId = String(args[11]);
+          const row = this.rows.get(id);
+          if (!row || row.practice_id !== practiceId) return { success: true, meta: { changes: 0 } };
+          const keys = [
+            'report_type',
+            'frequency',
+            'day_of_week',
+            'day_of_month',
+            'hour_utc',
+            'recipients_json',
+            'filters_json',
+            'active',
+            'updated_at',
+            'next_delivery_at',
+          ];
+          keys.forEach((key, index) => {
+            row[key] = args[index] as string | number | null;
+          });
+          return { success: true, meta: { changes: 1 } };
+        }
+        const practiceId = String(args[0]);
+        const id = String(args[1]);
+        const row = this.rows.get(id);
+        const deleted = row?.practice_id === practiceId;
+        if (deleted) this.rows.delete(id);
+        return { success: true, meta: { changes: deleted ? 1 : 0 } };
+      },
+    };
+    return statement;
   }
 }
 
-const makeEnv = (kv: FakeKV) => ({ CHAT_SESSIONS: kv as unknown as KVNamespace } as unknown as Env);
+const makeEnv = (db: FakeD1) => ({ DB: db as unknown as D1Database }) as Env;
 
 describe('computeNextDelivery', () => {
   it('rolls daily forward to next-day occurrence if same-day hour has passed', () => {
@@ -61,11 +137,11 @@ describe('computeNextDelivery', () => {
 });
 
 describe('ReportScheduleService', () => {
-  let kv: FakeKV;
+  let db: FakeD1;
   let service: ReportScheduleService;
   beforeEach(() => {
-    kv = new FakeKV();
-    service = new ReportScheduleService(makeEnv(kv));
+    db = new FakeD1();
+    service = new ReportScheduleService(makeEnv(db));
   });
 
   it('create -> get round-trip works and key is scoped to practice', async () => {
@@ -79,7 +155,7 @@ describe('ReportScheduleService', () => {
     });
     expect(created.practiceId).toBe('p1');
     expect(created.id).toBeTruthy();
-    expect(kv.store.has(`report-schedule:p1:${created.id}`)).toBe(true);
+    expect(db.rows.get(created.id)?.practice_id).toBe('p1');
     const got = await service.get('p1', created.id);
     expect(got?.recipients).toEqual(['u1']);
   });

--- a/worker/migrations/20260712_add_report_schedules.sql
+++ b/worker/migrations/20260712_add_report_schedules.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS report_schedules (
+  id TEXT PRIMARY KEY,
+  practice_id TEXT NOT NULL,
+  report_type TEXT NOT NULL,
+  frequency TEXT NOT NULL CHECK (frequency IN ('daily', 'weekly', 'monthly')),
+  day_of_week INTEGER CHECK (day_of_week IS NULL OR day_of_week BETWEEN 0 AND 6),
+  day_of_month INTEGER CHECK (day_of_month IS NULL OR day_of_month BETWEEN 1 AND 28),
+  hour_utc INTEGER NOT NULL CHECK (hour_utc BETWEEN 0 AND 23),
+  recipients_json TEXT NOT NULL DEFAULT '[]',
+  filters_json TEXT NOT NULL DEFAULT '{}',
+  active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  next_delivery_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_report_schedules_practice_created
+  ON report_schedules(practice_id, created_at ASC, id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_report_schedules_due
+  ON report_schedules(active, next_delivery_at ASC);
+
+CREATE TABLE IF NOT EXISTS search_pins (
+  id TEXT PRIMARY KEY,
+  practice_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_pins_practice_user_created
+  ON search_pins(practice_id, user_id, created_at ASC, id ASC);

--- a/worker/routes/search.ts
+++ b/worker/routes/search.ts
@@ -125,12 +125,6 @@ async function loadSuggestions(
   return suggestions;
 }
 
-function pinKey(practiceId: string, userId: string, pinId?: string): string {
-  return pinId
-    ? `search-pin:${practiceId}:${userId}:${pinId}`
-    : `search-pin:${practiceId}:${userId}:`;
-}
-
 function parsePath(pathname: string): {
   practiceId: string;
   action: string | null;
@@ -890,24 +884,17 @@ async function handlePins(
 ): Promise<Response> {
   const auth = await requirePracticeMember(request, env, practiceId, 'paralegal');
   const userId = auth.user.id;
-  if (!env.CHAT_SESSIONS) {
-    throw HttpErrors.internalServerError('Pin storage unavailable');
-  }
 
   if (method === 'GET') {
-    const list = await env.CHAT_SESSIONS.list({ prefix: pinKey(practiceId, userId) });
-    const pins = await Promise.all(
-      list.keys.map(async (k) => {
-        const raw = await env.CHAT_SESSIONS.get(k.name);
-        if (!raw) return null;
-        try {
-          return { id: k.name.split(':').pop(), ...JSON.parse(raw) };
-        } catch {
-          return null;
-        }
-      }),
-    );
-    return SUCCESS(pins.filter(Boolean));
+    const pins = await env.DB.prepare(
+      `SELECT id, entity_type AS entityType, entity_id AS entityId, created_at AS createdAt
+       FROM search_pins
+       WHERE practice_id = ? AND user_id = ?
+       ORDER BY created_at ASC, id ASC`,
+    )
+      .bind(practiceId, userId)
+      .all<{ id: string; entityType: string; entityId: string; createdAt: string }>();
+    return SUCCESS(pins.results);
   }
 
   if (method === 'POST') {
@@ -918,21 +905,21 @@ async function handlePins(
       throw HttpErrors.badRequest('entityType and entityId are required');
     }
     const pinId = crypto.randomUUID();
-    await env.CHAT_SESSIONS.put(
-      pinKey(practiceId, userId, pinId),
-      JSON.stringify({
-        entityType: body.entityType,
-        entityId: body.entityId,
-        createdAt: new Date().toISOString(),
-      }),
-    );
+    await env.DB.prepare(
+      `INSERT INTO search_pins (id, practice_id, user_id, entity_type, entity_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(pinId, practiceId, userId, body.entityType, body.entityId, new Date().toISOString())
+      .run();
     return SUCCESS({ id: pinId }, { status: 201 });
   }
 
   if (method === 'DELETE') {
     const pinId = rest[0];
     if (!pinId) throw HttpErrors.badRequest('Pin id required');
-    await env.CHAT_SESSIONS.delete(pinKey(practiceId, userId, pinId));
+    await env.DB.prepare('DELETE FROM search_pins WHERE id = ? AND practice_id = ? AND user_id = ?')
+      .bind(pinId, practiceId, userId)
+      .run();
     return SUCCESS({ ok: true });
   }
 

--- a/worker/services/ReportScheduleService.ts
+++ b/worker/services/ReportScheduleService.ts
@@ -1,9 +1,9 @@
 /**
- * KV-backed CRUD for report schedules. Keys live under
- * `report-schedule:${practiceId}:${id}`.
+ * D1-backed CRUD for durable report schedules.
  *
- * `computeNextDelivery` is exported separately so unit tests can exercise
- * the cron math without the KV layer.
+ * KV is reserved for rebuildable cache/session state. A report schedule is a
+ * user-authored instruction and must recover with the rest of the practice's
+ * durable records.
  */
 
 import type { Env } from '../types.js';
@@ -26,53 +26,84 @@ export interface ReportSchedule {
   nextDeliveryAt?: string;
 }
 
-const KEY_PREFIX = 'report-schedule:';
-
-const buildKey = (practiceId: string, scheduleId: string) =>
-  `${KEY_PREFIX}${practiceId}:${scheduleId}`;
-
-const listPrefix = (practiceId: string) => `${KEY_PREFIX}${practiceId}:`;
+interface ReportScheduleRow {
+  id: string;
+  practice_id: string;
+  report_type: string;
+  frequency: ReportFrequency;
+  day_of_week: number | null;
+  day_of_month: number | null;
+  hour_utc: number;
+  recipients_json: string;
+  filters_json: string;
+  active: number;
+  created_at: string;
+  updated_at: string;
+  next_delivery_at: string | null;
+}
 
 const requireDayOfWeek = (value: number | undefined): number => {
-  const target = value ?? 1; // Monday default
+  const target = value ?? 1;
   if (!Number.isInteger(target) || target < 0 || target > 6) {
     throw new Error('dayOfWeek must be an integer from 0-6');
   }
   return target;
 };
 
+const parseRecipients = (raw: string): string[] => {
+  const value: unknown = JSON.parse(raw);
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error('Stored report schedule recipients are malformed');
+  }
+  return value;
+};
+
+const parseFilters = (raw: string): Record<string, string> => {
+  const value: unknown = JSON.parse(raw);
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Stored report schedule filters are malformed');
+  }
+  if (!Object.values(value).every((item) => typeof item === 'string')) {
+    throw new Error('Stored report schedule filters are malformed');
+  }
+  return value as Record<string, string>;
+};
+
+const fromRow = (row: ReportScheduleRow): ReportSchedule => ({
+  id: row.id,
+  practiceId: row.practice_id,
+  reportType: row.report_type,
+  frequency: row.frequency,
+  dayOfWeek: row.day_of_week ?? undefined,
+  dayOfMonth: row.day_of_month ?? undefined,
+  hourUtc: row.hour_utc,
+  recipients: parseRecipients(row.recipients_json),
+  filters: parseFilters(row.filters_json),
+  active: row.active === 1,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+  nextDeliveryAt: row.next_delivery_at ?? undefined,
+});
+
 export const computeNextDelivery = (
   frequency: ReportFrequency,
   hourUtc: number,
-  options: { dayOfWeek?: number; dayOfMonth?: number; from?: Date } = {}
+  options: { dayOfWeek?: number; dayOfMonth?: number; from?: Date } = {},
 ): string => {
   const from = options.from ?? new Date();
-  const candidate = new Date(Date.UTC(
-    from.getUTCFullYear(),
-    from.getUTCMonth(),
-    from.getUTCDate(),
-    hourUtc,
-    0,
-    0,
-    0
-  ));
+  const candidate = new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), hourUtc, 0, 0, 0),
+  );
   if (candidate <= from) candidate.setUTCDate(candidate.getUTCDate() + 1);
 
-  if (frequency === 'daily') {
-    return candidate.toISOString();
-  }
+  if (frequency === 'daily') return candidate.toISOString();
   if (frequency === 'weekly') {
     const target = requireDayOfWeek(options.dayOfWeek);
-    while (candidate.getUTCDay() !== target) {
-      candidate.setUTCDate(candidate.getUTCDate() + 1);
-    }
+    while (candidate.getUTCDay() !== target) candidate.setUTCDate(candidate.getUTCDate() + 1);
     return candidate.toISOString();
   }
-  // monthly
   const targetDay = Math.max(1, Math.min(28, options.dayOfMonth ?? 1));
-  if (candidate.getUTCDate() > targetDay) {
-    candidate.setUTCMonth(candidate.getUTCMonth() + 1);
-  }
+  if (candidate.getUTCDate() > targetDay) candidate.setUTCMonth(candidate.getUTCMonth() + 1);
   candidate.setUTCDate(targetDay);
   return candidate.toISOString();
 };
@@ -81,65 +112,48 @@ export class ReportScheduleService {
   constructor(private readonly env: Env) {}
 
   async list(practiceId: string): Promise<ReportSchedule[]> {
-    const prefix = listPrefix(practiceId);
-    const out: ReportSchedule[] = [];
-    let cursor: string | undefined;
-    do {
-      const page = await this.env.CHAT_SESSIONS.list({ prefix, cursor });
-      for (const key of page.keys) {
-        const raw = await this.env.CHAT_SESSIONS.get(key.name);
-        if (!raw) continue;
-        try {
-          out.push(JSON.parse(raw) as ReportSchedule);
-        } catch {
-          /* skip corrupt rows */
-        }
-      }
-      cursor = page.list_complete
-        ? undefined
-        : (page as { cursor?: string }).cursor;
-    } while (cursor);
-    return out;
+    const result = await this.env.DB.prepare(
+      'SELECT * FROM report_schedules WHERE practice_id = ? ORDER BY created_at ASC, id ASC',
+    )
+      .bind(practiceId)
+      .all<ReportScheduleRow>();
+    return result.results.map(fromRow);
   }
 
   async get(practiceId: string, scheduleId: string): Promise<ReportSchedule | null> {
-    const raw = await this.env.CHAT_SESSIONS.get(buildKey(practiceId, scheduleId));
-    if (!raw) return null;
-    try { return JSON.parse(raw) as ReportSchedule; } catch { return null; }
+    const row = await this.env.DB.prepare(
+      'SELECT * FROM report_schedules WHERE practice_id = ? AND id = ? LIMIT 1',
+    )
+      .bind(practiceId, scheduleId)
+      .first<ReportScheduleRow>();
+    return row ? fromRow(row) : null;
   }
 
   async create(
     practiceId: string,
-    input: Omit<ReportSchedule, 'id' | 'practiceId' | 'createdAt' | 'updatedAt' | 'nextDeliveryAt' | 'active'> & { active?: boolean }
+    input: Omit<ReportSchedule, 'id' | 'practiceId' | 'createdAt' | 'updatedAt' | 'nextDeliveryAt' | 'active'> & {
+      active?: boolean;
+    },
   ): Promise<ReportSchedule> {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
     const record: ReportSchedule = {
+      ...input,
       id,
       practiceId,
-      reportType: input.reportType,
-      frequency: input.frequency,
-      dayOfWeek: input.dayOfWeek,
-      dayOfMonth: input.dayOfMonth,
-      hourUtc: input.hourUtc,
-      recipients: input.recipients,
-      filters: input.filters,
       active: input.active ?? true,
       createdAt: now,
       updatedAt: now,
-      nextDeliveryAt: computeNextDelivery(input.frequency, input.hourUtc, {
-        dayOfWeek: input.dayOfWeek,
-        dayOfMonth: input.dayOfMonth,
-      }),
+      nextDeliveryAt: computeNextDelivery(input.frequency, input.hourUtc, input),
     };
-    await this.env.CHAT_SESSIONS.put(buildKey(practiceId, id), JSON.stringify(record));
+    await this.persist(record, 'INSERT');
     return record;
   }
 
   async update(
     practiceId: string,
     scheduleId: string,
-    patch: Partial<Omit<ReportSchedule, 'id' | 'practiceId' | 'createdAt'>>
+    patch: Partial<Omit<ReportSchedule, 'id' | 'practiceId' | 'createdAt'>>,
   ): Promise<ReportSchedule | null> {
     const existing = await this.get(practiceId, scheduleId);
     if (!existing) return null;
@@ -151,18 +165,50 @@ export class ReportScheduleService {
       createdAt: existing.createdAt,
       updatedAt: new Date().toISOString(),
     };
-    merged.nextDeliveryAt = computeNextDelivery(merged.frequency, merged.hourUtc, {
-      dayOfWeek: merged.dayOfWeek,
-      dayOfMonth: merged.dayOfMonth,
-    });
-    await this.env.CHAT_SESSIONS.put(buildKey(practiceId, scheduleId), JSON.stringify(merged));
+    merged.nextDeliveryAt = computeNextDelivery(merged.frequency, merged.hourUtc, merged);
+    await this.persist(merged, 'UPDATE');
     return merged;
   }
 
   async delete(practiceId: string, scheduleId: string): Promise<boolean> {
-    const existing = await this.get(practiceId, scheduleId);
-    if (!existing) return false;
-    await this.env.CHAT_SESSIONS.delete(buildKey(practiceId, scheduleId));
-    return true;
+    const result = await this.env.DB.prepare('DELETE FROM report_schedules WHERE practice_id = ? AND id = ?')
+      .bind(practiceId, scheduleId)
+      .run();
+    return (result.meta.changes ?? 0) > 0;
+  }
+
+  private async persist(record: ReportSchedule, operation: 'INSERT' | 'UPDATE'): Promise<void> {
+    const values = [
+      record.reportType,
+      record.frequency,
+      record.dayOfWeek ?? null,
+      record.dayOfMonth ?? null,
+      record.hourUtc,
+      JSON.stringify(record.recipients),
+      JSON.stringify(record.filters),
+      record.active ? 1 : 0,
+      record.updatedAt,
+      record.nextDeliveryAt ?? null,
+    ];
+    if (operation === 'INSERT') {
+      await this.env.DB.prepare(
+        `INSERT INTO report_schedules (
+          report_type, frequency, day_of_week, day_of_month, hour_utc,
+          recipients_json, filters_json, active, updated_at, next_delivery_at,
+          id, practice_id, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(...values, record.id, record.practiceId, record.createdAt)
+        .run();
+      return;
+    }
+    await this.env.DB.prepare(
+      `UPDATE report_schedules SET
+        report_type = ?, frequency = ?, day_of_week = ?, day_of_month = ?, hour_utc = ?,
+        recipients_json = ?, filters_json = ?, active = ?, updated_at = ?, next_delivery_at = ?
+       WHERE id = ? AND practice_id = ?`,
+    )
+      .bind(...values, record.id, record.practiceId)
+      .run();
   }
 }


### PR DESCRIPTION
## Summary
- move customer-authored report schedules and saved search pins from indefinite KV storage to D1
- apply additive D1 migrations before staging and human-gated production Worker deploys
- document durable ownership, provider recovery controls, migration ordering, and the timed rehearsal evidence required before launch

## Verification
- npm run type-check
- npm run lint
- npm run test:unit (96 files, 732 tests)
- npm run build
- focused recovery/service tests (13 tests)
- git diff --check

## Coordination
- Closes the frontend implementation portion of #723.
- Backend recovery runbook: Blawby/blawby-backend#389 (human review/merge).
- #723 must remain open until Railway PITR and R2 bucket locks are enabled and a timed isolated restore artifact proves the stated RPO/RTO. This PR intentionally does not hide that provider gate.