### PR TITLE
Resolve intake invitations from opaque backend tokens

### DIFF
--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -8,7 +8,12 @@ import { useNavigation } from '@/shared/utils/navigation';
 import { getClient } from '@/shared/lib/authClient';
 import { useToastContext } from '@/shared/contexts/ToastContext';
 import { signOut } from '@/shared/utils/auth';
-import { linkConversationToUser } from '@/shared/lib/apiClient';
+import {
+  isAbortError,
+  linkConversationToUser,
+  resolveIntakeInvitationPrefill,
+  type IntakeInvitationPrefill,
+} from '@/shared/lib/apiClient';
 import { peekAnonymousUserId } from '@/shared/utils/anonymousIdentity';
 import AuthForm from '@/shared/components/AuthForm';
 import { cn } from '@/shared/utils/cn';
@@ -34,33 +39,16 @@ type InviteFetchState =
   | { status: 'ready'; invitation: InvitationDetails; invitationId: string }
   | { status: 'error'; message: string; invitationId: string | null };
 
-type IntakeInvitePayload = {
-  email: string;
-  orgName: string;
-  orgSlug: string;
-  type: 'intake';
-  intakeId: string;
-  conversationId: string;
-};
-
-type PrefillDetails = {
-  email: string;
-  practiceName: string;
-  practiceSlug: string;
-  intakeId?: string;
-  conversationId?: string;
-  payloadType?: string;
-};
-
 type PracticeSummary = {
   id: string;
   slug?: string | null;
 };
 
-type PayloadParseResult = {
-  data: PrefillDetails | null;
-  error: string | null;
-};
+type IntakePrefillState =
+  | { status: 'idle' }
+  | { status: 'loading'; token: string }
+  | { status: 'ready'; token: string; prefill: IntakeInvitationPrefill }
+  | { status: 'error'; token: string; message: string };
 
 
 const resolveQueryValue = (value: string | string[] | undefined) => {
@@ -102,53 +90,10 @@ const isValidDate = (d: unknown): d is string | number | Date => {
   return !isNaN(date.getTime());
 };
 
-const decodeBase64Url = (value: string): string => {
-  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
-  const padding = (4 - (normalized.length % 4)) % 4;
-  const padded = normalized + '='.repeat(padding);
-  const binary = atob(padded);
-  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-};
-
-const parsePrefillPayload = (raw: string): PayloadParseResult => {
-  if (!raw) return { data: null, error: null };
-
-  try {
-    const decoded = decodeBase64Url(raw);
-    const payload = JSON.parse(decoded) as Partial<IntakeInvitePayload> & Record<string, unknown>;
-
-    const email = typeof payload.email === 'string' ? payload.email.trim() : '';
-    const orgName = typeof payload.orgName === 'string' ? payload.orgName.trim() : '';
-    const orgSlug = typeof payload.orgSlug === 'string' ? payload.orgSlug.trim() : '';
-    const intakeId = typeof payload.intakeId === 'string' ? payload.intakeId.trim() : '';
-    const conversationId = typeof payload.conversationId === 'string' ? payload.conversationId.trim() : '';
-    const payloadType = typeof payload.type === 'string' ? payload.type.trim() : '';
-
-    if (!email || !orgName || !orgSlug) {
-      return { data: null, error: 'Invitation data is incomplete.' };
-    }
-
-    return {
-      data: {
-        email,
-        practiceName: orgName,
-        practiceSlug: orgSlug,
-        intakeId,
-        conversationId,
-        payloadType
-      },
-      error: null
-    };
-  } catch {
-    return { data: null, error: 'Invitation data is invalid.' };
-  }
-};
-
-const buildRedirectTarget = (invitationId: string, dataParam: string) => {
+const buildRedirectTarget = (invitationId: string, intakeToken: string) => {
   const params = new URLSearchParams();
   if (invitationId) params.set('invitationId', invitationId);
-  if (dataParam) params.set('data', dataParam);
+  if (intakeToken) params.set('intakeToken', intakeToken);
   const query = params.toString();
   return query ? `/auth/accept-invitation?${query}` : '/auth/accept-invitation';
 };
@@ -177,21 +122,26 @@ export const AcceptInvitationPage = () => {
   const [accepting, setAccepting] = useState(false);
   const [recipientMismatch, setRecipientMismatch] = useState(false);
   const [isLinkingConversation, setIsLinkingConversation] = useState(false);
+  const [intakePrefillState, setIntakePrefillState] = useState<IntakePrefillState>({ status: 'idle' });
 
   const invitationId = useMemo(() => resolveQueryValue(location.query?.invitationId), [location.query?.invitationId]);
-  const dataParam = useMemo(() => resolveQueryValue(location.query?.data), [location.query?.data]);
-  const payloadResult = useMemo(() => parsePrefillPayload(dataParam), [dataParam]);
+  const intakeToken = useMemo(() => resolveQueryValue(location.query?.intakeToken), [location.query?.intakeToken]);
 
   const isAuthenticated = Boolean(session?.user && !session.user.is_anonymous);
-  const redirectTarget = useMemo(() => buildRedirectTarget(invitationId, dataParam), [dataParam, invitationId]);
+  const redirectTarget = useMemo(
+    () => buildRedirectTarget(invitationId, intakeToken),
+    [intakeToken, invitationId]
+  );
 
-  const flowType = invitationId ? 'invite' : dataParam ? 'intake' : 'invalid';
-  const prefill = payloadResult.data;
+  const flowType = invitationId ? 'invite' : intakeToken ? 'intake' : 'invalid';
+  const prefill =
+    intakePrefillState.status === 'ready' && intakePrefillState.token === intakeToken
+      ? intakePrefillState.prefill
+      : null;
   const invitedEmail = prefill?.email ?? '';
-  const practiceName = prefill?.practiceName ?? '';
-  const practiceSlug = prefill?.practiceSlug ?? '';
+  const practiceName = prefill?.orgName ?? '';
+  const practiceSlug = prefill?.orgSlug ?? '';
   const intakeConversationId = prefill?.conversationId ?? '';
-  const payloadType = prefill?.payloadType?.toLowerCase() ?? '';
 
   const sessionEmail = typeof session?.user?.email === 'string' ? session.user.email.trim() : '';
   const effectiveInvitedEmail = invitedEmail || (inviteState.status === 'ready' ? inviteState.invitation.email : '');
@@ -203,23 +153,40 @@ export const AcceptInvitationPage = () => {
 
   const preAuthError = useMemo(() => {
     if (flowType === 'invalid') {
-      return payloadResult.error ?? 'This link is missing required information. Please request a new invite.';
+      return 'This link is missing required information. Please request a new invite.';
     }
 
-    if (flowType === 'intake') {
-      if (!prefill) {
-        return payloadResult.error ?? 'This link is missing required invitation details. Please use the latest email from your practice.';
-      }
-      if (payloadType !== 'intake') {
-        return 'Invitation data is invalid.';
-      }
-      if (!prefill.intakeId || !prefill.conversationId) {
-        return 'Invitation data is incomplete.';
-      }
+    if (
+      flowType === 'intake' &&
+      intakePrefillState.status === 'error' &&
+      intakePrefillState.token === intakeToken
+    ) {
+      return intakePrefillState.message;
     }
 
     return null;
-  }, [flowType, payloadResult.error, payloadType, prefill]);
+  }, [flowType, intakePrefillState, intakeToken]);
+
+  useEffect(() => {
+    if (!isAuthenticated || flowType !== 'intake' || !intakeToken) return;
+
+    const controller = new AbortController();
+    setIntakePrefillState({ status: 'loading', token: intakeToken });
+    void resolveIntakeInvitationPrefill(intakeToken, { signal: controller.signal })
+      .then((resolvedPrefill) => {
+        setIntakePrefillState({ status: 'ready', token: intakeToken, prefill: resolvedPrefill });
+      })
+      .catch((error: unknown) => {
+        if (isAbortError(error)) return;
+        setIntakePrefillState({
+          status: 'error',
+          token: intakeToken,
+          message: error instanceof Error ? error.message : 'Invitation link could not be resolved.',
+        });
+      });
+
+    return () => controller.abort();
+  }, [flowType, intakeToken, isAuthenticated]);
 
   const fetchInvitation = useCallback(async () => {
     if (!invitationId) {
@@ -444,9 +411,11 @@ export const AcceptInvitationPage = () => {
 
   if (!isAuthenticated) {
     const inviterLabel = practiceName || 'the practice';
-    const subtitle = practiceName
-      ? `Sign up to accept ${inviterLabel}'s invitation to join Blawby.`
-      : 'Sign up to accept your invitation to join Blawby.';
+    const subtitle = flowType === 'intake'
+      ? 'Sign in or create an account to continue your intake securely.'
+      : practiceName
+        ? `Sign up to accept ${inviterLabel}'s invitation to join Blawby.`
+        : 'Sign up to accept your invitation to join Blawby.';
 
     return (
       <Card>
@@ -455,7 +424,9 @@ export const AcceptInvitationPage = () => {
         </div>
         <div className="text-center">
           <h1 className="text-2xl font-semibold text-ink">
-            Accept your invitation to sign up{practiceName ? ` | ${practiceName}` : ''}
+            {flowType === 'intake'
+              ? 'Continue your intake'
+              : `Accept your invitation to sign up${practiceName ? ` | ${practiceName}` : ''}`}
           </h1>
           <p className="mt-2 text-sm text-dim-2">
             {subtitle}
@@ -473,6 +444,10 @@ export const AcceptInvitationPage = () => {
         </div>
       </Card>
     );
+  }
+
+  if (flowType === 'intake' && !prefill) {
+    return <LoadingScreen label={'Loading invitation\u2026'} showLabel={false} />;
   }
 
   if (flowType === 'intake') {

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -782,6 +782,43 @@ interface LinkConversationOptions {
   anonymousSessionId?: string | null;
 }
 
+export interface IntakeInvitationPrefill {
+  type: 'intake';
+  intakeId: string;
+  conversationId: string;
+  email: string;
+  orgName: string;
+  orgSlug: string;
+}
+
+const isIntakeInvitationPrefill = (value: unknown): value is IntakeInvitationPrefill =>
+  isRecord(value) &&
+  value.type === 'intake' &&
+  typeof value.intakeId === 'string' &&
+  typeof value.conversationId === 'string' &&
+  typeof value.email === 'string' &&
+  typeof value.orgName === 'string' &&
+  typeof value.orgSlug === 'string';
+
+export async function resolveIntakeInvitationPrefill(
+  token: string,
+  config?: ApiRequestConfig
+): Promise<IntakeInvitationPrefill> {
+  if (!token) {
+    throw new Error('intakeToken is required');
+  }
+
+  const response = await apiClient.get<unknown>('/api/practice-client-intakes/invitation-prefill', {
+    signal: config?.signal,
+    params: { token },
+  });
+  const data = unwrapApiData(response.data);
+  if (!isIntakeInvitationPrefill(data)) {
+    throw new Error('Invitation prefill response is malformed');
+  }
+  return data;
+}
+
 export async function linkConversationToUser(
   conversationId: string,
   practiceId: string,

--- a/tests/unit/lib/apiClient.test.ts
+++ b/tests/unit/lib/apiClient.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { apiClient, isHttpError } from '@/shared/lib/apiClient';
+import { apiClient, isHttpError, resolveIntakeInvitationPrefill } from '@/shared/lib/apiClient';
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -23,5 +23,44 @@ describe('apiClient', () => {
       expect(error.response.status).toBe(502);
       expect(error.message).toContain('<!DOCTYPE html>');
     }
+  });
+
+  it('resolves opaque intake invitation tokens through the authenticated backend endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          type: 'intake',
+          intakeId: '10000000-0000-4000-8000-000000000001',
+          conversationId: '10000000-0000-4000-8000-000000000002',
+          email: 'client@example.com',
+          orgName: 'Test Practice',
+          orgSlug: 'test-practice',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    await expect(resolveIntakeInvitationPrefill('opaque_token')).resolves.toMatchObject({
+      type: 'intake',
+      email: 'client@example.com',
+      orgSlug: 'test-practice',
+    });
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    expect(String(url)).toContain('/api/practice-client-intakes/invitation-prefill?token=opaque_token');
+    expect(init).toMatchObject({ credentials: 'include', method: 'GET' });
+  });
+
+  it('fast-fails malformed invitation prefill responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ type: 'intake' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await expect(resolveIntakeInvitationPrefill('opaque_token')).rejects.toThrow(
+      'Invitation prefill response is malformed'
+    );
   });
 });


### PR DESCRIPTION
Frontend companion for Blawby/blawby-backend#334 and backend PR Blawby/blawby-backend#397.

## What changed
- remove browser-side base64url decoding of intake invitation payloads
- preserve only the opaque intakeToken through sign-in/sign-up redirects
- resolve authoritative prefill data from the authenticated backend endpoint
- include cookies, validate the response shape, and fast-fail malformed/invalid/expired/wrong-email responses
- show transparent secure-intake copy while authentication is required
- retain abort-safe loading behavior when the token or session changes

## Verification
- focused API client tests: 3 passed
- full frontend typecheck passed
- scoped ESLint passed with zero warnings
- production Vite build passed

The backend PR is human-review/merge only. Per project policy, this frontend PR does not wait for that merge; greenfield token links will begin working as soon as #397 lands.