### PR TITLE
refactor: consume standard API list envelopes

### DIFF
--- a/src/features/chat/components/PracticeAssistantBriefing.tsx
+++ b/src/features/chat/components/PracticeAssistantBriefing.tsx
@@ -310,7 +310,7 @@ export function PracticeAssistantBriefing({
     void listIntakes(practiceId, { page: 1, limit: 10 }, { signal: controller.signal })
       .then((result) => {
         if (controller.signal.aborted) return;
-        setRecentIntakes(result.intakes);
+        setRecentIntakes(result.data);
       })
       .catch((error) => {
         if (isAbortError(error) || controller.signal.aborted) return;

--- a/src/features/engagements/components/EngagementWorkbench.tsx
+++ b/src/features/engagements/components/EngagementWorkbench.tsx
@@ -468,10 +468,10 @@ export const EngagementWorkbench: FunctionComponent<EngagementWorkbenchProps> = 
     listIntakes(practiceId, { page: 1, limit: 100, triage_status: 'accepted' }, { signal: controller.signal })
       .then((result) => {
         if (controller.signal.aborted) return;
-        setIntakes(result.intakes);
+        setIntakes(result.data);
         const initialIntakeId = props.mode === 'create' ? props.initialIntakeId : null;
         if (initialIntakeId) {
-          const match = result.intakes.find((i) => i.uuid === initialIntakeId);
+          const match = result.data.find((i) => i.uuid === initialIntakeId);
           if (match) setForm((prev) => buildEngagementDraftFormFromIntake(match, prev));
         }
       })

--- a/src/features/files/hooks/pagination.ts
+++ b/src/features/files/hooks/pagination.ts
@@ -28,8 +28,8 @@ export const listAllFileIntakes = async (
   let page = 1;
   while (true) {
     const pageResult = await listIntakes(practiceId, { page, limit: ORG_FILES_FAN_OUT_LIMIT }, { signal });
-    intakes.push(...pageResult.intakes);
-    if (pageResult.intakes.length < ORG_FILES_FAN_OUT_LIMIT) break;
+    intakes.push(...pageResult.data);
+    if (pageResult.data.length < ORG_FILES_FAN_OUT_LIMIT) break;
     page += 1;
   }
   return intakes;

--- a/src/features/intake/api/intakesApi.ts
+++ b/src/features/intake/api/intakesApi.ts
@@ -1,5 +1,10 @@
 import { clientIntake, clientIntakeInvite, clientIntakeStatus, clientIntakes } from '@/config/urls';
-import { apiClient, isHttpError } from '@/shared/lib/apiClient';
+import {
+  apiClient,
+  isHttpError,
+  parseOffsetPaginatedResponse,
+  type OffsetPaginatedResponse,
+} from '@/shared/lib/apiClient';
 
 export interface IntakeListParams {
   page: number;
@@ -44,13 +49,7 @@ export interface IntakeListItem {
   created_at: string;
 }
 
-export interface IntakeListResponse {
-  intakes: IntakeListItem[];
-  total: number;
-  page: number;
-  total_pages: number;
-  limit?: number;
-}
+export type IntakeListResponse = OffsetPaginatedResponse<IntakeListItem>;
 
 export interface PracticeIntakeDetail {
   uuid: string;
@@ -131,7 +130,11 @@ const errorFromHttp = (error: unknown, fallback: string): Error => {
   return error instanceof Error ? error : new Error(fallback);
 };
 
-export async function listIntakes(practiceId: string, params: IntakeListParams, options: { signal?: AbortSignal } = {}) {
+export async function listIntakes(
+  practiceId: string,
+  params: IntakeListParams,
+  options: { signal?: AbortSignal } = {}
+): Promise<IntakeListResponse> {
   if (!practiceId) {
     throw new Error('practiceId is required');
   }
@@ -158,20 +161,7 @@ export async function listIntakes(practiceId: string, params: IntakeListParams, 
     throw errorFromHttp(error, 'Failed to fetch intakes');
   }
 
-  const env = unwrapEnvelope(raw);
-  if (!env) throw new Error('Failed to fetch intakes');
-  const { json, data } = env;
-  if (json.success === false || (!Array.isArray(data.intakes) && typeof data.total !== 'number')) {
-    throw new Error('Failed to fetch intakes');
-  }
-
-  return {
-    intakes: Array.isArray(data.intakes) ? data.intakes : [],
-    total: typeof data.total === 'number' ? data.total : 0,
-    page: typeof data.page === 'number' ? data.page : params.page,
-    total_pages: typeof data.total_pages === 'number' ? data.total_pages : 0,
-    limit: typeof data.limit === 'number' ? data.limit : undefined,
-  };
+  return parseOffsetPaginatedResponse<IntakeListItem>(raw, 'Invalid intakes list response');
 }
 
 export async function getPracticeIntake(

--- a/src/features/intake/hooks/useIntakesData.ts
+++ b/src/features/intake/hooks/useIntakesData.ts
@@ -40,9 +40,8 @@ export function intakesFilterToApiStatus(filter: IntakesFilter): IntakeListParam
 }
 
 type IntakesPayload = {
-  intakes: IntakeListItem[];
-  total: number;
-  total_pages: number;
+  data: IntakeListItem[];
+  pagination: { page: number; limit: number; total: number };
 };
 
 export function useIntakesData(
@@ -96,7 +95,7 @@ export function useIntakesData(
   }, [options.page]);
 
   return {
-    items: data?.intakes ?? [],
+    items: data?.data ?? [],
     isLoading,
     // post-Phase-C3 contract: isLoading is permanently false after first
     // successful fetch, so `!isLoading && data !== undefined` is the
@@ -104,8 +103,8 @@ export function useIntakesData(
     isLoaded: data !== undefined,
     error,
     page: effectivePage,
-    totalPages: data?.total_pages ?? 0,
-    total: data?.total ?? 0,
+    totalPages: data ? Math.ceil(data.pagination.total / data.pagination.limit) : 0,
+    total: data?.pagination.total ?? 0,
     filter: effectiveFilter,
     setFilter,
     setPage,

--- a/src/features/intake/pages/IntakeTemplatesPage.tsx
+++ b/src/features/intake/pages/IntakeTemplatesPage.tsx
@@ -2214,7 +2214,7 @@ function TemplateListView({
     listIntakes(practiceId, { page: 1, limit: 100 }, { signal: controller.signal })
       .then((result) => {
         if (controller.signal.aborted) return;
-        const counts = result.intakes.reduce<Record<string, number>>((acc, intake) => {
+        const counts = result.data.reduce<Record<string, number>>((acc, intake) => {
           const slug = getResponseTemplateSlug(intake);
           if (slug) acc[slug] = (acc[slug] ?? 0) + 1;
           return acc;

--- a/src/features/intake/pages/IntakesPage.tsx
+++ b/src/features/intake/pages/IntakesPage.tsx
@@ -171,9 +171,9 @@ export const IntakesPage: FunctionComponent<IntakesPageProps> = ({
         { ttl: policyTtl(cacheKey), swr: false },
       );
       if (signal.aborted || requestSeqRef.current !== localSeq) return;
-      setItems((prev) => (targetPage === 1 ? result.intakes : [...prev, ...result.intakes]));
+      setItems((prev) => (targetPage === 1 ? result.data : [...prev, ...result.data]));
       setPage(targetPage);
-      setHasMore(targetPage < result.total_pages);
+      setHasMore(targetPage * result.pagination.limit < result.pagination.total);
       setError(null);
     } catch (err) {
       if (signal.aborted || requestSeqRef.current !== localSeq) return;

--- a/src/features/matters/pages/PracticeMattersPage.tsx
+++ b/src/features/matters/pages/PracticeMattersPage.tsx
@@ -746,7 +746,7 @@ export const PracticeMattersPage = ({
         if (signal?.aborted) break;
 
         allClients.push(...response.data.map(buildClientOption));
-        lastTotal = response.total ?? 0;
+        lastTotal = response.pagination.total;
         hasMore = lastTotal > 0 ? allClients.length < lastTotal : response.data.length === limit;
         if (hasMore) offset += limit;
       }

--- a/src/features/matters/services/mattersApi.ts
+++ b/src/features/matters/services/mattersApi.ts
@@ -3,6 +3,7 @@ import {
   isAbortError,
   pluckCollection,
   pluckRecord,
+  parseOffsetPaginatedResponse,
   unwrapApiResponse,
   apiClient,
 } from '@/shared/lib/apiClient';
@@ -226,23 +227,6 @@ const requestData = async <T>(promise: Promise<{ data: T }>, fallbackMessage: st
 // Extract helpers — all delegate to the shared `pluckCollection` /
 // `pluckRecord` primitives in `apiClient.ts`. Each helper just declares
 // the keys the backend uses for its resource.
-const extractMatterArray = (payload: unknown): BackendMatter[] => {
-  const unwrapped = unwrapApiResponse<unknown>(payload, 'Failed to load matters');
-  const list = pluckCollection<BackendMatter>(unwrapped, ['matters', 'items']);
-  if (list.length > 0) return list;
-  // Fallback: backend occasionally returns a single matter at the top level.
-  if (unwrapped && typeof unwrapped === 'object' && !Array.isArray(unwrapped)) {
-    const record = unwrapped as Record<string, unknown>;
-    if (record.matter && typeof record.matter === 'object' && !Array.isArray(record.matter)) {
-      return [record.matter as BackendMatter];
-    }
-    if (record.id && ('title' in record || 'slug' in record || 'organization_id' in record)) {
-      return [record as BackendMatter];
-    }
-  }
-  return [];
-};
-
 const extractMatter = (payload: unknown): BackendMatter | null =>
   pluckRecord<BackendMatter>(unwrapApiResponse<unknown>(payload), ['matter']);
 
@@ -291,8 +275,8 @@ export const listMatters = async (
     'Failed to load matters'
   );
   
-  const matters = extractMatterArray(payload);
-  return matters.map(normalizeMatter);
+  const result = parseOffsetPaginatedResponse<BackendMatter>(payload, 'Invalid matters list response');
+  return result.data.map(normalizeMatter);
 };
 
 export const getMatter = async (
@@ -338,8 +322,8 @@ export const listClientMatters = async (
     'Failed to load client matters'
   );
 
-  const matters = extractMatterArray(payload);
-  return matters.map(normalizeMatter);
+  const result = parseOffsetPaginatedResponse<BackendMatter>(payload, 'Invalid client matters list response');
+  return result.data.map(normalizeMatter);
 };
 
 export const getClientMatter = async (

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -404,9 +404,8 @@ async function apiUpload<T>(
  * pass an optional `pluck` to lift the inner array/object after unwrapping
  * the envelope.
  *
- * Replaces the inline `.data ?? .matters ?? .items ?? recurse` patterns
- * (`extractMatterArray`, `extractNotesArray`, `requestData`, …) that each
- * service file used to reinvent.
+ * Replaces the inline `.data ?? .resource ?? .items ?? recurse` patterns
+ * that older service files used to reinvent.
  */
 export function unwrapApiResponse<T>(payload: unknown, fallbackMessage = 'Request failed'): T {
   if (payload && typeof payload === 'object' && 'success' in payload) {
@@ -422,6 +421,47 @@ export function unwrapApiResponse<T>(payload: unknown, fallbackMessage = 'Reques
     if ('data' in env) return env.data as T;
   }
   return payload as T;
+}
+
+export type OffsetPagination = {
+  page: number;
+  limit: number;
+  total: number;
+};
+
+export type OffsetPaginatedResponse<T> = {
+  data: T[];
+  pagination: OffsetPagination;
+};
+
+export function parseOffsetPaginatedResponse<T>(
+  payload: unknown,
+  invalidResponseMessage: string
+): OffsetPaginatedResponse<T> {
+  const unwrapped = unwrapApiResponse<unknown>(payload, invalidResponseMessage);
+  if (!isRecord(unwrapped) || !Array.isArray(unwrapped.data) || !isRecord(unwrapped.pagination)) {
+    throw new Error(invalidResponseMessage);
+  }
+
+  const { page, limit, total } = unwrapped.pagination;
+  if (
+    typeof page !== 'number' ||
+    !Number.isInteger(page) ||
+    page < 1 ||
+    typeof limit !== 'number' ||
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    typeof total !== 'number' ||
+    !Number.isInteger(total) ||
+    total < 0
+  ) {
+    throw new Error(invalidResponseMessage);
+  }
+
+  return {
+    data: unwrapped.data as T[],
+    pagination: { page, limit, total },
+  };
 }
 
 /**
@@ -1425,7 +1465,7 @@ export type UserDetailRecord = {
 
 export type UserDetailListResponse = {
   data: UserDetailRecord[];
-  total: number;
+  pagination: OffsetPagination;
 };
 
 export async function listUserDetails(
@@ -1448,17 +1488,7 @@ export async function listUserDetails(
     `/api/clients/${encodeURIComponent(practiceId)}`,
     { params: queryParams, signal }
   );
-  const payload = response.data;
-  if (isRecord(payload) && Array.isArray(payload.data)) {
-    return {
-      data: payload.data as UserDetailRecord[],
-      total: typeof payload.total === 'number' ? payload.total : payload.data.length
-    };
-  }
-  return {
-    data: [],
-    total: 0
-  };
+  return parseOffsetPaginatedResponse<UserDetailRecord>(response.data, 'Invalid clients list response');
 }
 
 export async function getUserDetail(

--- a/tests/unit/lib/apiClient.test.ts
+++ b/tests/unit/lib/apiClient.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { apiClient, isHttpError, resolveIntakeInvitationPrefill } from '@/shared/lib/apiClient';
+import {
+  apiClient,
+  isHttpError,
+  parseOffsetPaginatedResponse,
+  resolveIntakeInvitationPrefill,
+} from '@/shared/lib/apiClient';
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -62,5 +67,26 @@ describe('apiClient', () => {
     await expect(resolveIntakeInvitationPrefill('opaque_token')).rejects.toThrow(
       'Invitation prefill response is malformed'
     );
+  });
+
+  it('accepts the shared offset pagination envelope', () => {
+    expect(
+      parseOffsetPaginatedResponse<{ id: string }>(
+        { data: [{ id: 'one' }], pagination: { page: 2, limit: 10, total: 11 } },
+        'Invalid list response'
+      )
+    ).toEqual({ data: [{ id: 'one' }], pagination: { page: 2, limit: 10, total: 11 } });
+  });
+
+  it('fast-fails legacy and malformed list envelopes', () => {
+    expect(() =>
+      parseOffsetPaginatedResponse({ matters: [], total: 0 }, 'Invalid matters list response')
+    ).toThrow('Invalid matters list response');
+    expect(() =>
+      parseOffsetPaginatedResponse(
+        { data: [], pagination: { page: 1, limit: 0, total: 0 } },
+        'Invalid matters list response'
+      )
+    ).toThrow('Invalid matters list response');
   });
 });

--- a/tests/unit/services/clientMattersApi.test.ts
+++ b/tests/unit/services/clientMattersApi.test.ts
@@ -34,6 +34,12 @@ vi.mock('@/shared/lib/apiClient', () => {
     return record as T;
   }
 
+  function parseOffsetPaginatedResponse<T>(payload: unknown): { data: T[]; pagination: object } {
+    const record = payload as { data: T[]; pagination: object };
+    if (!Array.isArray(record.data) || !record.pagination) throw new Error('Invalid list response');
+    return record;
+  }
+
   return {
     apiClient: mockApiClient,
     isAbortError: (e: unknown) => e instanceof Error && e.name === 'AbortError',
@@ -49,6 +55,7 @@ vi.mock('@/shared/lib/apiClient', () => {
     },
     pluckCollection,
     pluckRecord,
+    parseOffsetPaginatedResponse,
   };
 });
 
@@ -66,7 +73,9 @@ describe('client matter API endpoints', () => {
   });
 
   it('lists client matters without using the practice matter list route', async () => {
-    mockApiClient.get.mockResolvedValueOnce({ data: { matters: [{ id: 'matter-1' }] } });
+    mockApiClient.get.mockResolvedValueOnce({
+      data: { data: [{ id: 'matter-1' }], pagination: { page: 2, limit: 10, total: 1 } },
+    });
 
     const result = await listClientMatters('practice-1', { page: 2, limit: 10 });
 

--- a/tests/unit/services/mattersApi.tasks.test.ts
+++ b/tests/unit/services/mattersApi.tasks.test.ts
@@ -32,6 +32,11 @@ vi.mock('@/shared/lib/apiClient', () => {
     if (record.data) return pluckRecord<T>(record.data, candidates);
     return record as T;
   }
+  function parseOffsetPaginatedResponse<T>(payload: unknown): { data: T[]; pagination: object } {
+    const record = payload as { data: T[]; pagination: object };
+    if (!Array.isArray(record.data) || !record.pagination) throw new Error('Invalid list response');
+    return record;
+  }
   return {
     apiClient: mockApiClient,
     isAbortError: (e: unknown) => e instanceof Error && e.name === 'AbortError',
@@ -47,6 +52,7 @@ vi.mock('@/shared/lib/apiClient', () => {
     },
     pluckCollection,
     pluckRecord,
+    parseOffsetPaginatedResponse,
   };
 });
 


### PR DESCRIPTION
## Summary
- consume the standard `{ data, pagination: { page, limit, total } }` contract for clients, matters, and staff intakes
- add one strict shared parser that rejects legacy or malformed list shapes
- remove the matter-list empty-array fallback and update every affected intake consumer
- coordinate with backend PR https://github.com/Blawby/blawby-backend/pull/405

## Verification
- `npm run type-check`
- `npm run lint:src`
- `VITE_WORKER_API_URL=http://worker.test npm run test:unit` — 98 files, 740 tests passed
- `npm run build`

Backend dependency: Blawby/blawby-backend#405. This frontend intentionally fast-fails until that API contract is present; there is no legacy response fallback.