### PR TITLE
Use canonical REST routes

### DIFF
--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -21,7 +21,7 @@ export const getFormsApiUrl = () => {
 };
 
 export const getFormsEndpoint = () => {
-  return `${getFormsApiUrl()}/api/practice-client-intakes/create`;
+  return `${getFormsApiUrl()}/api/practice-client-intakes`;
 };
 
 export const getPracticeClientIntakeSettingsEndpoint = (slug: string) => {
@@ -29,7 +29,7 @@ export const getPracticeClientIntakeSettingsEndpoint = (slug: string) => {
 };
 
 export const getPracticeClientIntakeCreateEndpoint = () => {
-  return `${getFormsApiUrl()}/api/practice-client-intakes/create`;
+  return `${getFormsApiUrl()}/api/practice-client-intakes`;
 };
 
 export const getPracticeClientIntakeUpdateEndpoint = (uuid: string) => {
@@ -70,7 +70,7 @@ export const getSubscriptionBillingPortalEndpoint = () => {
 };
 
 export const getSubscriptionCancelEndpoint = () => {
-  return `${getWorkerApiUrl()}/api/subscriptions/cancel`;
+  return `${getWorkerApiUrl()}/api/subscriptions`;
 };
 
 export const getSubscriptionListEndpoint = () => {

--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -70,7 +70,10 @@ export const clientIntakeStatus = (intakeId: string): string =>
 	`/api/practice-client-intakes/${encodeSegment(intakeId)}/status`;
 
 export const clientIntakeInvite = (intakeId: string): string =>
-	`/api/practice-client-intakes/${encodeSegment(intakeId)}/invite`;
+	`/api/practice-client-intakes/${encodeSegment(intakeId)}/invitations`;
+
+export const clientIntakeConversions = (intakeId: string): string =>
+	`/api/practice-client-intakes/${encodeSegment(intakeId)}/conversions`;
 
 export const uploadDownloadPath = (uploadId: string): string =>
 	`/api/uploads/${encodeSegment(uploadId)}/download`;
@@ -317,14 +320,14 @@ export const urls = {
 	clientIntake,
 	clientIntakeStatus,
 	clientIntakeInvite,
+	clientIntakeConversions,
 	practiceAssistantDecision,
 	invoices: (practiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}`,
 	invoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}`,
 	createInvoice: (practiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}`,
 	updateInvoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}`,
 	deleteInvoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}`,
-	sendInvoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}/send`,
-	voidInvoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}/void`,
+	invoiceStatus: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}/status`,
 	syncInvoice: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}/sync`,
 	invoiceRefundRequests: (practiceId: string, invoiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/${encodeURIComponent(invoiceId)}/refund-requests`,
 	practiceRefundRequests: (practiceId: string) => `/api/invoices/${encodeURIComponent(practiceId)}/refund-requests`,

--- a/src/features/matters/pages/PracticeMatterCreatePage.tsx
+++ b/src/features/matters/pages/PracticeMatterCreatePage.tsx
@@ -210,7 +210,7 @@ export function PracticeMatterCreatePage({
       throw new Error('Practice ID and intake UUID are required to convert an intake.');
     }
 
-    const endpoint = `${urls.clientIntake(practiceId, convertIntakeUuid)}/convert`;
+    const endpoint = urls.clientIntakeConversions(convertIntakeUuid);
     const response = await fetch(endpoint, {
       method: 'POST',
       credentials: 'include',

--- a/src/features/matters/services/invoicesApi.ts
+++ b/src/features/matters/services/invoicesApi.ts
@@ -420,9 +420,9 @@ export const sendInvoice = async (
 ): Promise<Invoice | null> => {
   if (!practiceId || !invoiceId) return null;
   const payload = await requestData(
-    apiClient.post(
-      urls.sendInvoice(practiceId, invoiceId),
-      {},
+    apiClient.patch(
+      urls.invoiceStatus(practiceId, invoiceId),
+      { status: 'sent' },
       { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to send invoice'
@@ -468,9 +468,9 @@ export const voidInvoice = async (
 ): Promise<Invoice | null> => {
   if (!practiceId || !invoiceId) return null;
   const payload = await requestData(
-    apiClient.post(
-      urls.voidInvoice(practiceId, invoiceId),
-      {},
+    apiClient.patch(
+      urls.invoiceStatus(practiceId, invoiceId),
+      { status: 'cancelled' },
       { signal: options.signal, invalidates: INVOICE_CACHE_INVALIDATIONS }
     ),
     'Failed to void invoice'

--- a/src/features/matters/services/mattersApi.ts
+++ b/src/features/matters/services/mattersApi.ts
@@ -378,7 +378,7 @@ export const updateMatter = async (
   const normalizedPayload = normalizeMatterPayload(payload);
   // Debug log removed for security/cleanliness
   const json = await requestData(
-    apiClient.put(
+    apiClient.patch(
       matterItemPath(practiceId, matterId),
       normalizedPayload,
       { signal: options.signal, invalidates: [`matters:${practiceId}:`] }
@@ -525,7 +525,7 @@ export const updateMatterNote = async (
     throw new Error('content is required');
   }
   const payload = await requestData(
-    apiClient.put(
+    apiClient.patch(
       matterNestedItemPath(practiceId, matterId, 'notes', noteId),
       { content },
       { signal: options.signal }
@@ -631,7 +631,7 @@ export const updateMatterTimeEntry = async (
     throw new Error('start_time and end_time are required');
   }
   const json = await requestData(
-    apiClient.put(
+    apiClient.patch(
       matterNestedItemPath(practiceId, matterId, 'time-entries', timeEntryId),
       payload,
       { signal: options.signal }
@@ -772,7 +772,7 @@ export const updateMatterExpense = async (
     throw new Error('date is required');
   }
   const json = await requestData(
-    apiClient.put(
+    apiClient.patch(
       matterNestedItemPath(practiceId, matterId, 'expenses', expenseId),
       normalizeExpensePayload(payload),
       { signal: options.signal }
@@ -894,7 +894,7 @@ export const updateMatterMilestone = async (
     throw new Error('due_date is required');
   }
   const json = await requestData(
-    apiClient.put(
+    apiClient.patch(
       matterNestedItemPath(practiceId, matterId, 'milestones', milestoneId),
       normalizeMilestonePayload(payload),
       { signal: options.signal }

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -992,14 +992,15 @@ export async function listMatterConversations(
   return data as Conversation[];
 }
 
-async function postSubscriptionEndpoint(
+async function requestSubscriptionEndpoint(
+  method: 'POST' | 'DELETE',
   url: string,
   body: Record<string, unknown>
 ): Promise<SubscriptionEndpointResult> {
   try {
-    const response = await apiClient.post(url, body, {
-      baseURL: undefined
-    });
+    const response = method === 'POST'
+      ? await apiClient.post(url, body, { baseURL: undefined })
+      : await apiClient.delete(url, { baseURL: undefined, body });
     return {
       ok: true,
       status: response.status,
@@ -1199,7 +1200,7 @@ export async function listPractices(configOrOptions?: ListPracticesOptions): Pro
   const practices = await queryCache.coalesceGet(
     'practices:list',
     async (signal) => {
-      const response = await apiClient.get('/api/practice/list', { signal });
+      const response = await apiClient.get('/api/practice', { signal });
       return unwrapPracticeListResponse(response.data);
     },
     { ttl: 60_000, signal: opts.signal as AbortSignal | undefined }
@@ -1248,7 +1249,7 @@ export async function updatePractice(
   if (import.meta.env.DEV) {
     console.info('[apiClient] updatePractice payload', { practiceId, payload: normalized });
   }
-  const response = await apiClient.put(
+  const response = await apiClient.patch(
     `/api/practice/${encodeURIComponent(practiceId)}`,
     normalized,
     {
@@ -1825,7 +1826,7 @@ export async function updatePracticeDetails(
     throw new Error('practiceId is required');
   }
   const normalized = normalizePracticeDetailsPayload(details);
-  const response = await apiClient.put(
+  const response = await apiClient.patch(
     `/api/practice/${encodeURIComponent(practiceId)}/details`,
     normalized,
     {
@@ -2419,7 +2420,7 @@ export function normalizePracticeDetailsResponse(payload: unknown): PracticeDeta
 export async function requestBillingPortalSession(
   payload: BillingPortalPayload
 ): Promise<SubscriptionEndpointResult> {
-  return postSubscriptionEndpoint(getSubscriptionBillingPortalEndpoint(), {
+  return requestSubscriptionEndpoint('POST', getSubscriptionBillingPortalEndpoint(), {
     referenceId: payload.practiceId,
     customerType: payload.customerType,
     returnUrl: payload.returnUrl
@@ -2496,7 +2497,7 @@ export async function getCurrentSubscription(
 export async function requestSubscriptionCancellation(
   practiceId: string
 ): Promise<SubscriptionEndpointResult> {
-  return postSubscriptionEndpoint(getSubscriptionCancelEndpoint(), { practiceId });
+  return requestSubscriptionEndpoint('DELETE', getSubscriptionCancelEndpoint(), { practiceId });
 }
 
 export interface SubscriptionListItem {

--- a/src/shared/lib/preferencesApi.ts
+++ b/src/shared/lib/preferencesApi.ts
@@ -50,7 +50,7 @@ export async function updatePreferencesCategory<T extends object>(
   category: PreferenceCategory,
   data: T
 ): Promise<T> {
-  const response = await apiClient.put(`/api/preferences/${category}`, data);
+  const response = await apiClient.patch(`/api/preferences/${category}`, data);
   const result = unwrapApiResponse<T | null | undefined>(response.data);
   if (result === null || result === undefined) {
     throw new Error(`Preferences update for '${category}' returned no data`);

--- a/tests/e2e/billing-invoicing.spec.ts
+++ b/tests/e2e/billing-invoicing.spec.ts
@@ -265,7 +265,7 @@ const api = async (page: ApiPage, url: string, init?: Parameters<typeof fetchJso
 };
 
 const resolveOwnerPracticeContext = async (ownerPage: ApiPage) => {
-  const practiceList = await api(ownerPage, '/api/practice/list');
+  const practiceList = await api(ownerPage, '/api/practice');
   const practices = arrayFrom(practiceList.data, ['practices', 'data', 'items']);
   const practice = practices.find((item) => textFrom(item, ['slug']) === PRACTICE_SLUG)
     ?? practices.find((item) => textFrom(item, ['id']) === PRACTICE_ID);
@@ -417,10 +417,10 @@ const createPracticeBillingScenario = async (
   let hostedInvoiceUrl: string | null = null;
   let ownerInvoiceDetail: JsonRecord | null = null;
   if (options.sendInvoice) {
-    const sentInvoice = requireRecord(await api(ownerPage, `/api/invoices/${encodeURIComponent(PRACTICE_ID)}/${encodeURIComponent(invoiceId)}/send`, {
-      method: 'POST',
+    const sentInvoice = requireRecord(await api(ownerPage, `/api/invoices/${encodeURIComponent(PRACTICE_ID)}/${encodeURIComponent(invoiceId)}/status`, {
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: '{}',
+      body: JSON.stringify({ status: 'sent' }),
     }), ['invoice', 'invoices'], 'send invoice');
     expect(['sent', 'open', 'pending'].includes((textFrom(sentInvoice, ['status']) ?? '').toLowerCase())).toBe(true);
 

--- a/tests/e2e/globalSetupSupport.ts
+++ b/tests/e2e/globalSetupSupport.ts
@@ -424,7 +424,7 @@ const createSignedInState = async (options: {
         await page.evaluate(async () => {
           try {
             await fetch('/api/preferences/onboarding', {
-              method: 'PUT',
+              method: 'PATCH',
               credentials: 'include',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({

--- a/tests/e2e/helpers/createTestUser.ts
+++ b/tests/e2e/helpers/createTestUser.ts
@@ -61,7 +61,7 @@ export async function createTestUser(
   await page.evaluate(async () => {
     try {
       await fetch('/api/preferences/onboarding', {
-        method: 'PUT',
+        method: 'PATCH',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/tests/e2e/production-smoke.spec.ts
+++ b/tests/e2e/production-smoke.spec.ts
@@ -250,7 +250,7 @@ test.describe("bounded production launch smoke", () => {
         ),
       ).toBe(config.practice.id);
 
-      const practiceList = await owner.request.get("/api/practice/list");
+      const practiceList = await owner.request.get("/api/practice");
       expect(practiceList.ok()).toBe(true);
       const configuredPractice = records(await practiceList.json()).find(
         (practice) => text(practice, "id") === config.practice.id,

--- a/tests/e2e/widget-intake-ai-failure.spec.ts
+++ b/tests/e2e/widget-intake-ai-failure.spec.ts
@@ -12,7 +12,7 @@
  *
  * Verifies (U11 of docs/plans/2026-05-18-002-feat-strengthen-intake-ai-observability-plan.md):
  *   - widget renders the hard-error UI with the canonical copy
- *   - backend `POST /api/practice-client-intakes/create` fires with
+ *   - backend `POST /api/practice-client-intakes` fires with
  *     custom_fields._worker_conversation_id (partial-intake submission per U7)
  *   - composer is disabled and inline error region has role=alert
  */
@@ -46,7 +46,7 @@ test.describe('Public widget intake — AI failure path (U11)', () => {
     // independent of the assertion ordering below.
     const partialSubmitWaiter = anonPage.waitForRequest(
       (request) =>
-        request.url().includes('/api/practice-client-intakes/create') &&
+        request.url().endsWith('/api/practice-client-intakes') &&
         request.method() === 'POST',
       { timeout: 60_000 },
     );

--- a/tests/unit/lib/apiClient.test.ts
+++ b/tests/unit/lib/apiClient.test.ts
@@ -2,8 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   apiClient,
   isHttpError,
+  listPractices,
   parseOffsetPaginatedResponse,
+  requestSubscriptionCancellation,
   resolveIntakeInvitationPrefill,
+  updatePractice,
+  updatePracticeDetails,
 } from '@/shared/lib/apiClient';
 
 beforeEach(() => {
@@ -88,5 +92,55 @@ describe('apiClient', () => {
         'Invalid matters list response'
       )
     ).toThrow('Invalid matters list response');
+  });
+
+  it('uses canonical practice routes and PATCH updates', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ practices: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ practice: { id: 'practice-1', name: 'Updated', slug: 'updated' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ details: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    await listPractices({ force: true });
+    await updatePractice('practice-1', { name: 'Updated' });
+    await updatePracticeDetails('practice-1', { introMessage: 'Welcome' });
+
+    const calls = fetchMock.mock.calls;
+    expect(new URL(String(calls[0]?.[0])).pathname).toBe('/api/practice');
+    expect(calls[1]?.[1]?.method).toBe('PATCH');
+    expect(new URL(String(calls[1]?.[0])).pathname).toBe('/api/practice/practice-1');
+    expect(calls[2]?.[1]?.method).toBe('PATCH');
+    expect(new URL(String(calls[2]?.[0])).pathname).toBe('/api/practice/practice-1/details');
+  });
+
+  it('uses DELETE on the canonical subscription resource for cancellation', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: 'https://billing.example.com' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await requestSubscriptionCancellation('practice-1');
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(new URL(String(url)).pathname).toBe('/api/subscriptions');
+    expect(init?.method).toBe('DELETE');
+    expect(JSON.parse(String(init?.body))).toEqual({ practiceId: 'practice-1' });
   });
 });

--- a/tests/unit/services/canonicalApiRoutes.test.ts
+++ b/tests/unit/services/canonicalApiRoutes.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fromMinorUnits } from '@/shared/utils/money';
+
+const { mockApiClient } = vi.hoisted(() => ({
+  mockApiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/lib/apiClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/lib/apiClient')>();
+  return { ...actual, apiClient: mockApiClient };
+});
+
+import { triggerIntakeInvite } from '@/features/intake/api/intakesApi';
+import { sendInvoice, voidInvoice } from '@/features/matters/services/invoicesApi';
+import {
+  updateMatter,
+  updateMatterExpense,
+  updateMatterMilestone,
+  updateMatterNote,
+  updateMatterTimeEntry,
+} from '@/features/matters/services/mattersApi';
+import { updatePreferencesCategory } from '@/shared/lib/preferencesApi';
+
+describe('canonical API consumers', () => {
+  beforeEach(() => {
+    Object.values(mockApiClient).forEach((mock) => mock.mockReset());
+    mockApiClient.patch.mockResolvedValue({ data: {} });
+    mockApiClient.post.mockResolvedValue({ data: {} });
+  });
+
+  it('uses PATCH for partial updates', async () => {
+    await updateMatter('practice-1', 'matter-1', { title: 'Updated' });
+    await updateMatterNote('practice-1', 'matter-1', 'note-1', 'Updated note');
+    await updateMatterTimeEntry('practice-1', 'matter-1', 'entry-1', {
+      start_time: '2026-07-14T10:00:00Z',
+      end_time: '2026-07-14T11:00:00Z',
+    });
+    await updateMatterExpense('practice-1', 'matter-1', 'expense-1', {
+      description: 'Filing fee',
+      amount: fromMinorUnits(5_000),
+      date: '2026-07-14',
+    });
+    await updateMatterMilestone('practice-1', 'matter-1', 'milestone-1', {
+      description: 'Discovery complete',
+      amount: fromMinorUnits(50_000),
+      due_date: '2026-08-01',
+    });
+    await updatePreferencesCategory('general', { timezone: 'America/Chicago' });
+
+    expect(mockApiClient.patch).toHaveBeenCalledTimes(6);
+    expect(mockApiClient.put).not.toHaveBeenCalled();
+  });
+
+  it('uses the invoice status resource for send and void', async () => {
+    await sendInvoice('practice-1', 'invoice-1');
+    await voidInvoice('practice-1', 'invoice-1');
+
+    expect(mockApiClient.patch).toHaveBeenNthCalledWith(
+      1,
+      '/api/invoices/practice-1/invoice-1/status',
+      { status: 'sent' },
+      expect.any(Object)
+    );
+    expect(mockApiClient.patch).toHaveBeenNthCalledWith(
+      2,
+      '/api/invoices/practice-1/invoice-1/status',
+      { status: 'cancelled' },
+      expect.any(Object)
+    );
+  });
+
+  it('creates intake invitation sub-resources', async () => {
+    await triggerIntakeInvite('intake-1');
+
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      '/api/practice-client-intakes/intake-1/invitations',
+      {},
+      expect.any(Object)
+    );
+  });
+});

--- a/tests/unit/utils/forms.test.ts
+++ b/tests/unit/utils/forms.test.ts
@@ -55,7 +55,7 @@ describe('submitContactForm', () => {
           })
         });
       }
-      if (url.includes('/api/practice-client-intakes/create')) {
+      if (url.endsWith('/api/practice-client-intakes')) {
         return Promise.resolve({
           ok: true,
           status: 201,
@@ -97,11 +97,11 @@ describe('submitContactForm', () => {
     );
 
     const createCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).includes('/api/practice-client-intakes/create')
+      String(url).endsWith('/api/practice-client-intakes')
     );
 
     expect(createCall).toBeTruthy();
-    expect(String(createCall?.[0])).toContain('/api/practice-client-intakes/create');
+    expect(String(createCall?.[0])).toMatch(/\/api\/practice-client-intakes$/);
     expect(String(createCall?.[0])).not.toContain('/api/practice/client-intakes/create');
 
     const body = JSON.parse(String(createCall?.[1]?.body ?? '{}')) as { amount?: number };
@@ -143,7 +143,7 @@ describe('submitContactForm', () => {
           })
         });
       }
-      if (url.includes('/api/practice-client-intakes/create')) {
+      if (url.endsWith('/api/practice-client-intakes')) {
         return Promise.resolve({
           ok: true,
           status: 201,


### PR DESCRIPTION
## Summary
- migrate frontend API consumers to the canonical practice, intake, subscription, invoice, preference, and matter routes
- use PATCH for partial updates and DELETE for subscription cancellation
- fix intake conversion to address the intake resource directly
- update unit and E2E route expectations and add canonical route regression coverage

## Validation
- npm run type-check
- npm run lint:src
- VITE_WORKER_API_URL=http://worker.test npm run test:unit
- VITE_WORKER_API_URL=http://worker.test npm run build

Part of #716. Coordinates with Blawby/blawby-backend#341 and backend PR Blawby/blawby-backend#406.

The backend PR adds the canonical endpoints and deprecated compatibility aliases. Per delivery policy, backend review/merge is human-owned and does not block this frontend PR from landing in staging.