### PR TITLE
Use client-scoped file sources

### DIFF
--- a/src/features/files/hooks/pagination.ts
+++ b/src/features/files/hooks/pagination.ts
@@ -1,7 +1,7 @@
 // Files-specific paging helpers shared by the Files page and upload destination picker.
 // This is not a replacement for broader list hooks; these callers need raw arrays from
 // both matter and intake sources with identical page-size behavior.
-import { listMatters, type BackendMatter } from '@/features/matters/services/mattersApi';
+import { listClientMatters, listMatters, type BackendMatter } from '@/features/matters/services/mattersApi';
 import { listIntakes, type IntakeListItem } from '@/features/intake/api/intakesApi';
 import { ORG_FILES_FAN_OUT_LIMIT } from '@/features/files/constants';
 
@@ -13,6 +13,21 @@ export const listAllFileMatters = async (
   let page = 1;
   while (true) {
     const pageItems = await listMatters(practiceId, { page, limit: ORG_FILES_FAN_OUT_LIMIT, signal });
+    matters.push(...pageItems);
+    if (pageItems.length < ORG_FILES_FAN_OUT_LIMIT) break;
+    page += 1;
+  }
+  return matters;
+};
+
+export const listAllClientFileMatters = async (
+  practiceId: string,
+  signal?: AbortSignal,
+): Promise<BackendMatter[]> => {
+  const matters: BackendMatter[] = [];
+  let page = 1;
+  while (true) {
+    const pageItems = await listClientMatters(practiceId, { page, limit: ORG_FILES_FAN_OUT_LIMIT, signal });
     matters.push(...pageItems);
     if (pageItems.length < ORG_FILES_FAN_OUT_LIMIT) break;
     page += 1;

--- a/src/features/files/hooks/useOrgFiles.ts
+++ b/src/features/files/hooks/useOrgFiles.ts
@@ -5,21 +5,16 @@ import { policyTtl } from '@/shared/lib/cachePolicy';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 import type { IntakeListItem } from '@/features/intake/api/intakesApi';
 import { resolveIntakeTitle } from '@/features/intake/utils/intakeTitle';
-import { listAllFileIntakes, listAllFileMatters } from '@/features/files/hooks/pagination';
+import {
+  listAllClientFileMatters,
+  listAllFileIntakes,
+  listAllFileMatters,
+} from '@/features/files/hooks/pagination';
 import { listUploadsByScope } from '@/shared/lib/uploadsApi';
 import { listIntakeFiles } from '@/features/intake/api/intakeFilesApi';
 import type { OrgFile } from '@/features/files/utils/fileCategory';
 
 export type OrgFilesScope = 'practice' | 'client';
-
-const matterMatchesViewer = (matter: BackendMatter, userId: string): boolean => (
-  typeof matter.client_id === 'string' && matter.client_id === userId
-);
-
-const intakeMatchesViewer = (intake: IntakeListItem, userId: string): boolean => {
-  const meta = intake.metadata as Record<string, unknown> | null | undefined;
-  return typeof meta?.user_id === 'string' && meta.user_id === userId;
-};
 
 export interface UseOrgFilesOptions {
   practiceId: string | null | undefined;
@@ -95,12 +90,14 @@ const collectIntakeFiles = async (
 const fetchAllOrgFiles = async (
   practiceId: string,
   scope: OrgFilesScope,
-  userId: string | null,
+  _userId: string | null,
   signal?: AbortSignal,
 ): Promise<OrgFile[]> => {
   const [mattersResult, intakesResult] = await Promise.allSettled([
-    listAllFileMatters(practiceId, signal),
-    listAllFileIntakes(practiceId, signal),
+    scope === 'client'
+      ? listAllClientFileMatters(practiceId, signal)
+      : listAllFileMatters(practiceId, signal),
+    scope === 'client' ? Promise.resolve([] as IntakeListItem[]) : listAllFileIntakes(practiceId, signal),
   ]);
   if (mattersResult.status === 'rejected' && intakesResult.status === 'rejected') {
     const reason = mattersResult.reason ?? intakesResult.reason;
@@ -111,16 +108,9 @@ const fetchAllOrgFiles = async (
   const matters = mattersResult.status === 'fulfilled' ? mattersResult.value : [];
   const intakes = intakesResult.status === 'fulfilled' ? intakesResult.value : [];
 
-  const visibleMatters = scope === 'client'
-    ? userId ? matters.filter((m) => matterMatchesViewer(m, userId)) : []
-    : matters;
-  const visibleIntakes = scope === 'client'
-    ? userId ? intakes.filter((i) => intakeMatchesViewer(i, userId)) : []
-    : intakes;
-
   const [matterFiles, intakeFiles] = await Promise.all([
-    collectMatterFiles(visibleMatters, signal),
-    collectIntakeFiles(visibleIntakes, signal),
+    collectMatterFiles(matters, signal),
+    collectIntakeFiles(intakes, signal),
   ]);
 
   const all = [...matterFiles, ...intakeFiles];

--- a/src/features/files/hooks/useUploadDestinations.ts
+++ b/src/features/files/hooks/useUploadDestinations.ts
@@ -4,7 +4,11 @@ import { useQuery } from '@/shared/hooks/useQuery';
 import { policyTtl } from '@/shared/lib/cachePolicy';
 import type { BackendMatter } from '@/features/matters/services/mattersApi';
 import type { IntakeListItem } from '@/features/intake/api/intakesApi';
-import { listAllFileIntakes, listAllFileMatters } from '@/features/files/hooks/pagination';
+import {
+  listAllClientFileMatters,
+  listAllFileIntakes,
+  listAllFileMatters,
+} from '@/features/files/hooks/pagination';
 
 export interface UseUploadDestinationsOptions {
   practiceId: string | null | undefined;
@@ -21,22 +25,14 @@ export interface UploadDestinationsResult {
   refetch: () => Promise<void>;
 }
 
-const matterMatchesViewer = (matter: BackendMatter, userId: string): boolean => (
-  typeof matter.client_id === 'string' && matter.client_id === userId
-);
-
-const intakeMatchesViewer = (intake: IntakeListItem, userId: string): boolean => {
-  const meta = intake.metadata as Record<string, unknown> | null | undefined;
-  return typeof meta?.user_id === 'string' && meta.user_id === userId;
-};
-
 const fetchDestinations = async (
   practiceId: string,
+  isClient: boolean,
   signal?: AbortSignal,
 ): Promise<{ matters: BackendMatter[]; intakes: IntakeListItem[] }> => {
   const [mattersResult, intakesResult] = await Promise.allSettled([
-    listAllFileMatters(practiceId, signal),
-    listAllFileIntakes(practiceId, signal),
+    isClient ? listAllClientFileMatters(practiceId, signal) : listAllFileMatters(practiceId, signal),
+    isClient ? Promise.resolve([] as IntakeListItem[]) : listAllFileIntakes(practiceId, signal),
   ]);
   // If both calls fail, surface an error rather than caching an empty
   // success — otherwise the dropdown silently looks empty for 30s after a
@@ -66,7 +62,7 @@ export const useUploadDestinations = ({
   enabled = true,
 }: UseUploadDestinationsOptions): UploadDestinationsResult => {
   const practiceKey = getPracticeCacheKey(practiceId);
-  const cacheKey = `intake:upload-destinations:${practiceKey}`;
+  const cacheKey = `intake:upload-destinations:${practiceKey}:${clientUserId ? 'client' : 'practice'}`;
   const { data, isLoading, error, refetch } = useQuery<{ matters: BackendMatter[]; intakes: IntakeListItem[] }>({
     key: cacheKey,
     enabled: enabled && Boolean(practiceId),
@@ -74,6 +70,7 @@ export const useUploadDestinations = ({
     fetcher: (signal) => fetchDestinations(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       practiceId!,
+      Boolean(clientUserId),
       signal,
     ),
   });
@@ -83,15 +80,12 @@ export const useUploadDestinations = ({
   return useMemo(() => {
     const matters = data?.matters ?? [];
     const intakes = data?.intakes ?? [];
-    if (!clientUserId) {
-      return { matters, intakes, isLoading, error, refetch: refetchVoid };
-    }
     return {
-      matters: matters.filter((matter) => matterMatchesViewer(matter, clientUserId)),
-      intakes: intakes.filter((intake) => intakeMatchesViewer(intake, clientUserId)),
+      matters,
+      intakes,
       isLoading,
       error,
       refetch: refetchVoid,
     };
-  }, [data, clientUserId, isLoading, error, refetchVoid]);
+  }, [data, isLoading, error, refetchVoid]);
 };

--- a/tests/unit/files/filePagination.test.ts
+++ b/tests/unit/files/filePagination.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listClientMatters, listMatters } from '@/features/matters/services/mattersApi';
+import { listIntakes } from '@/features/intake/api/intakesApi';
+import {
+  listAllClientFileMatters,
+  listAllFileIntakes,
+  listAllFileMatters,
+} from '@/features/files/hooks/pagination';
+
+vi.mock('@/features/matters/services/mattersApi', () => ({
+  listClientMatters: vi.fn(),
+  listMatters: vi.fn(),
+}));
+
+vi.mock('@/features/intake/api/intakesApi', () => ({
+  listIntakes: vi.fn(),
+}));
+
+describe('file pagination sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listClientMatters).mockResolvedValue([]);
+    vi.mocked(listMatters).mockResolvedValue([]);
+    vi.mocked(listIntakes).mockResolvedValue({ data: [], pagination: { page: 1, limit: 100, total: 0 } });
+  });
+
+  it('uses the authenticated client matter collection for client files', async () => {
+    await listAllClientFileMatters('practice-1');
+
+    expect(listClientMatters).toHaveBeenCalledWith('practice-1', expect.objectContaining({ page: 1 }));
+    expect(listMatters).not.toHaveBeenCalled();
+  });
+
+  it('keeps practice matter and intake collections for practice files', async () => {
+    await Promise.all([listAllFileMatters('practice-1'), listAllFileIntakes('practice-1')]);
+
+    expect(listMatters).toHaveBeenCalledWith('practice-1', expect.objectContaining({ page: 1 }));
+    expect(listIntakes).toHaveBeenCalledWith(
+      'practice-1',
+      expect.objectContaining({ page: 1 }),
+      expect.any(Object),
+    );
+  });
+});

--- a/tests/unit/lib/apiClient.test.ts
+++ b/tests/unit/lib/apiClient.test.ts
@@ -116,7 +116,7 @@ describe('apiClient', () => {
         })
       );
 
-    await listPractices({ force: true });
+    await listPractices();
     await updatePractice('practice-1', { name: 'Updated' });
     await updatePracticeDetails('practice-1', { introMessage: 'Welcome' });
 


### PR DESCRIPTION
## Summary
- load client Files and upload destinations from the authenticated client-matters collection
- stop calling practice-wide matter and intake collections from the client workspace
- remove the incorrect comparison between a matter client-record ID and the session user ID
- preserve practice Files behavior and add source-selection regression tests
- repair the stale listPractices test option found by the full type-check

## Validation
- npm run type-check
- npx eslint on all changed files
- VITE_WORKER_API_URL=http://worker.test npx vitest run tests/unit/files/filePagination.test.ts tests/unit/lib/apiClient.test.ts
- VITE_WORKER_API_URL=http://worker.test npm run build

Part of #716. Coordinates with Blawby/blawby-backend#294 and its safe demo-file seed PR.

The backend PR remains human-review/human-merge only and does not block this frontend correction from landing in staging.