### PR TITLE
Validate and retain durable recovery evidence

### DIFF
--- a/.github/workflows/record-durable-recovery.yml
+++ b/.github/workflows/record-durable-recovery.yml
@@ -1,0 +1,50 @@
+name: Record durable recovery evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_json:
+        description: Sanitized JSON from the completed production recovery rehearsal
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-and-record:
+    name: Validate and retain recovery proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: Require the production branch
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REF}" == "refs/heads/main" ]] || {
+            echo "Recovery evidence must be recorded from main." >&2
+            exit 1
+          }
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Validate and sanitize evidence
+        env:
+          RECOVERY_EVIDENCE_JSON: ${{ inputs.evidence_json }}
+        run: npx tsx scripts/write-durable-recovery-evidence.ts durable-recovery-evidence.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: durable-recovery-evidence-${{ github.run_id }}
+          path: durable-recovery-evidence.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Publish sanitized recovery summary
+        run: |
+          echo '```json' >> "${GITHUB_STEP_SUMMARY}"
+          cat durable-recovery-evidence.json >> "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/operations/durable-recovery-evidence.example.json
+++ b/docs/operations/durable-recovery-evidence.example.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "environment": "production",
+  "rehearsal": {
+    "startedAt": "2026-07-15T00:00:00Z",
+    "recoveryDeclaredAt": "2026-07-15T00:10:00Z",
+    "latestDurableWriteAt": "2026-07-15T00:09:00Z",
+    "latestRecoveredWriteAt": "2026-07-15T00:00:00Z",
+    "restorePointAt": "2026-07-15T00:05:00Z",
+    "verificationCompletedAt": "2026-07-15T02:10:00Z"
+  },
+  "releases": {
+    "frontendWorkerCommit": "1111111111111111111111111111111111111111",
+    "backendGitCommit": "2222222222222222222222222222222222222222"
+  },
+  "railway": {
+    "pitrEnabled": true,
+    "retentionDays": 30,
+    "restoreWindowStart": "2026-06-15T00:00:00Z",
+    "restoreWindowEnd": "2026-07-15T00:10:00Z",
+    "sourceServiceId": "example-source-service",
+    "restoredServiceId": "example-restored-service",
+    "sourceDeploymentId": "example-source-deployment",
+    "restoredDeploymentId": "example-restored-deployment"
+  },
+  "d1": {
+    "databaseId": "example-rehearsal-database",
+    "storageVersion": "production",
+    "selectedBookmark": "example-selected-bookmark",
+    "previousBookmark": "example-previous-bookmark",
+    "restoreCompletedAt": "2026-07-15T01:00:00Z"
+  },
+  "r2": {
+    "buckets": [
+      {
+        "role": "worker-uploads",
+        "name": "example-worker-uploads",
+        "lockRuleId": "example-worker-lock",
+        "retentionDays": 30,
+        "objectChecksum": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "overwriteRejected": true,
+        "deleteRejected": true
+      },
+      {
+        "role": "backend-uploads",
+        "name": "example-backend-uploads",
+        "lockRuleId": "example-backend-lock",
+        "retentionDays": 30,
+        "objectChecksum": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "overwriteRejected": true,
+        "deleteRejected": true
+      }
+    ]
+  },
+  "recordCounts": {
+    "identities": 1,
+    "memberships": 1,
+    "practices": 2,
+    "clients": 1,
+    "matters": 1,
+    "invoices": 1,
+    "intakes": 1,
+    "approvals": 1,
+    "uploads": 2,
+    "conversations": 1,
+    "messages": 2,
+    "reportSchedules": 1,
+    "crossTenantControls": 1
+  },
+  "integrity": {
+    "referentialIntegrity": true,
+    "tenantIsolation": true,
+    "financialIntegrity": true,
+    "approvalsSafe": true,
+    "objectBytesMatch": true,
+    "derivedStateRebuilt": true
+  }
+}

--- a/docs/operations/durable-recovery.md
+++ b/docs/operations/durable-recovery.md
@@ -166,5 +166,36 @@ Store a sanitized `durable-recovery-evidence.json` artifact for 90 days with:
   tokens, connection strings, or row payloads);
 - measured RPO/RTO and pass/fail status.
 
+After the human operator completes the provider rehearsal, run the **Record
+durable recovery evidence** workflow from `main`. Paste only the sanitized JSON
+described by the workflow input. Copy
+[`durable-recovery-evidence.example.json`](./durable-recovery-evidence.example.json),
+replace every example value with observed rehearsal evidence, and never submit
+the example unchanged. The validator derives RPO and RTO from the UTC
+timestamps, requires Railway PITR and a sibling restore, requires one 30-day
+lock result for each upload bucket, requires every integrity result to pass,
+rejects unexpected fields, and uploads the normalized artifact for 90 days.
+
+The accepted document has these top-level fields:
+
+- `schemaVersion` (`1`) and `environment` (`production`);
+- `rehearsal`: start, declaration, latest durable/recovered write, restore-point,
+  and verification timestamps;
+- `releases`: exact 40-character frontend/Worker and backend Git commits;
+- `railway`: PITR state, retention, restore window, and distinct source/restored
+  service and deployment IDs;
+- `d1`: rehearsal database ID, production storage version, selected/previous
+  bookmarks, and restore completion time;
+- `r2.buckets`: exactly one `worker-uploads` and one `backend-uploads` result,
+  including lock rule, retention, SHA-256 checksum, and rejected overwrite/delete;
+- `recordCounts`: positive synthetic counts for every representative durable
+  domain and the cross-tenant negative control;
+- `integrity`: referential, tenant, financial, approval, object-byte, and
+  derived-state outcomes.
+
+The workflow validates and retains evidence; it does not perform or simulate
+the Railway, D1, or R2 restore itself. Provider console/API evidence and the
+timed human rehearsal remain mandatory.
+
 Until that artifact exists and every result passes, #723 and the public cutover
 in #724 remain open.

--- a/scripts/lib/durableRecoveryEvidence.ts
+++ b/scripts/lib/durableRecoveryEvidence.ts
@@ -1,0 +1,284 @@
+type JsonRecord = Record<string, unknown>;
+
+const REQUIRED_RECORD_COUNTS = [
+  'identities',
+  'memberships',
+  'practices',
+  'clients',
+  'matters',
+  'invoices',
+  'intakes',
+  'approvals',
+  'uploads',
+  'conversations',
+  'messages',
+  'reportSchedules',
+  'crossTenantControls',
+] as const;
+
+const REQUIRED_INTEGRITY_CHECKS = [
+  'referentialIntegrity',
+  'tenantIsolation',
+  'financialIntegrity',
+  'approvalsSafe',
+  'objectBytesMatch',
+  'derivedStateRebuilt',
+] as const;
+
+const asRecord = (value: unknown, path: string): JsonRecord => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  return value as JsonRecord;
+};
+
+const requireExactKeys = (record: JsonRecord, expected: readonly string[], path: string): void => {
+  const actual = Object.keys(record).sort();
+  const wanted = [...expected].sort();
+  const missing = wanted.filter((key) => !actual.includes(key));
+  const unexpected = actual.filter((key) => !wanted.includes(key));
+  if (missing.length || unexpected.length) {
+    throw new Error(
+      `${path} has invalid fields (missing: ${missing.join(', ') || 'none'}; unexpected: ${unexpected.join(', ') || 'none'})`,
+    );
+  }
+};
+
+const requireString = (record: JsonRecord, field: string, path: string, pattern?: RegExp): string => {
+  const value = record[field];
+  if (typeof value !== 'string' || !value.trim() || /[\r\n]/.test(value)) {
+    throw new Error(`${path}.${field} must be a non-empty single-line string`);
+  }
+  const normalized = value.trim();
+  if (pattern && !pattern.test(normalized)) throw new Error(`${path}.${field} has an invalid format`);
+  return normalized;
+};
+
+const requireBoolean = (record: JsonRecord, field: string, path: string, expected = true): boolean => {
+  const value = record[field];
+  if (typeof value !== 'boolean') throw new Error(`${path}.${field} must be a boolean`);
+  if (value !== expected) throw new Error(`${path}.${field} must be ${expected}`);
+  return value;
+};
+
+const requireInteger = (record: JsonRecord, field: string, path: string, minimum: number): number => {
+  const value = record[field];
+  if (!Number.isInteger(value) || (value as number) < minimum) {
+    throw new Error(`${path}.${field} must be an integer greater than or equal to ${minimum}`);
+  }
+  return value as number;
+};
+
+const requireTimestamp = (record: JsonRecord, field: string, path: string): { iso: string; millis: number } => {
+  const value = requireString(record, field, path);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/.test(value)) {
+    throw new Error(`${path}.${field} must be an ISO-8601 timestamp with a timezone`);
+  }
+  const millis = Date.parse(value);
+  if (!Number.isFinite(millis)) throw new Error(`${path}.${field} is not a valid timestamp`);
+  return { iso: new Date(millis).toISOString(), millis };
+};
+
+const minutesBetween = (earlier: number, later: number, label: string): number => {
+  if (later < earlier) throw new Error(`${label} timestamps are out of order`);
+  return Math.round(((later - earlier) / 60_000) * 100) / 100;
+};
+
+const idPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$/;
+const commitPattern = /^[0-9a-f]{40}$/i;
+const bucketPattern = /^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/;
+const checksumPattern = /^sha256:[0-9a-f]{64}$/i;
+
+const rejectExampleValue = (value: string, path: string): void => {
+  if (value.startsWith('example-')) throw new Error(`${path} still contains an example value`);
+};
+
+export const buildDurableRecoveryEvidence = (source: unknown) => {
+  const root = asRecord(source, 'evidence');
+  requireExactKeys(
+    root,
+    ['schemaVersion', 'environment', 'rehearsal', 'releases', 'railway', 'd1', 'r2', 'recordCounts', 'integrity'],
+    'evidence',
+  );
+  if (root.schemaVersion !== 1) throw new Error('evidence.schemaVersion must be 1');
+  if (root.environment !== 'production') throw new Error('evidence.environment must be production');
+
+  const rehearsal = asRecord(root.rehearsal, 'evidence.rehearsal');
+  requireExactKeys(
+    rehearsal,
+    [
+      'startedAt',
+      'recoveryDeclaredAt',
+      'latestDurableWriteAt',
+      'latestRecoveredWriteAt',
+      'restorePointAt',
+      'verificationCompletedAt',
+    ],
+    'evidence.rehearsal',
+  );
+  const startedAt = requireTimestamp(rehearsal, 'startedAt', 'evidence.rehearsal');
+  const recoveryDeclaredAt = requireTimestamp(rehearsal, 'recoveryDeclaredAt', 'evidence.rehearsal');
+  const latestDurableWriteAt = requireTimestamp(rehearsal, 'latestDurableWriteAt', 'evidence.rehearsal');
+  const latestRecoveredWriteAt = requireTimestamp(rehearsal, 'latestRecoveredWriteAt', 'evidence.rehearsal');
+  const restorePointAt = requireTimestamp(rehearsal, 'restorePointAt', 'evidence.rehearsal');
+  const verificationCompletedAt = requireTimestamp(rehearsal, 'verificationCompletedAt', 'evidence.rehearsal');
+  minutesBetween(startedAt.millis, recoveryDeclaredAt.millis, 'Rehearsal');
+  minutesBetween(startedAt.millis, latestRecoveredWriteAt.millis, 'Recovered-write');
+  const rpoMinutes = minutesBetween(latestRecoveredWriteAt.millis, latestDurableWriteAt.millis, 'RPO');
+  const rtoMinutes = minutesBetween(recoveryDeclaredAt.millis, verificationCompletedAt.millis, 'RTO');
+  if (latestDurableWriteAt.millis > recoveryDeclaredAt.millis) {
+    throw new Error('Latest durable write cannot be newer than the recovery declaration');
+  }
+  if (restorePointAt.millis < latestRecoveredWriteAt.millis) {
+    throw new Error('Selected restore point cannot be older than the latest recovered write');
+  }
+  if (restorePointAt.millis > recoveryDeclaredAt.millis) {
+    throw new Error('Selected restore point cannot be newer than the recovery declaration');
+  }
+  if (rpoMinutes > 15) throw new Error(`Measured RPO ${rpoMinutes} minutes exceeds 15 minutes`);
+  if (rtoMinutes > 240) throw new Error(`Measured RTO ${rtoMinutes} minutes exceeds 240 minutes`);
+
+  const releases = asRecord(root.releases, 'evidence.releases');
+  requireExactKeys(releases, ['frontendWorkerCommit', 'backendGitCommit'], 'evidence.releases');
+  const normalizedReleases = {
+    frontendWorkerCommit: requireString(releases, 'frontendWorkerCommit', 'evidence.releases', commitPattern),
+    backendGitCommit: requireString(releases, 'backendGitCommit', 'evidence.releases', commitPattern),
+  };
+  for (const [field, commit] of Object.entries(normalizedReleases)) {
+    if (/^([0-9a-f])\1{39}$/i.test(commit)) {
+      throw new Error(`evidence.releases.${field} still contains an example value`);
+    }
+  }
+
+  const railway = asRecord(root.railway, 'evidence.railway');
+  requireExactKeys(
+    railway,
+    [
+      'pitrEnabled',
+      'retentionDays',
+      'restoreWindowStart',
+      'restoreWindowEnd',
+      'sourceServiceId',
+      'restoredServiceId',
+      'sourceDeploymentId',
+      'restoredDeploymentId',
+    ],
+    'evidence.railway',
+  );
+  const restoreWindowStart = requireTimestamp(railway, 'restoreWindowStart', 'evidence.railway');
+  const restoreWindowEnd = requireTimestamp(railway, 'restoreWindowEnd', 'evidence.railway');
+  if (restoreWindowStart.millis > restorePointAt.millis || restoreWindowEnd.millis < restorePointAt.millis) {
+    throw new Error('Selected restore point is outside the recorded Railway restore window');
+  }
+  const normalizedRailway = {
+    pitrEnabled: requireBoolean(railway, 'pitrEnabled', 'evidence.railway'),
+    retentionDays: requireInteger(railway, 'retentionDays', 'evidence.railway', 30),
+    restoreWindowStart: restoreWindowStart.iso,
+    restoreWindowEnd: restoreWindowEnd.iso,
+    sourceServiceId: requireString(railway, 'sourceServiceId', 'evidence.railway', idPattern),
+    restoredServiceId: requireString(railway, 'restoredServiceId', 'evidence.railway', idPattern),
+    sourceDeploymentId: requireString(railway, 'sourceDeploymentId', 'evidence.railway', idPattern),
+    restoredDeploymentId: requireString(railway, 'restoredDeploymentId', 'evidence.railway', idPattern),
+  };
+  if (normalizedRailway.sourceServiceId === normalizedRailway.restoredServiceId) {
+    throw new Error('Railway rehearsal must restore into a sibling service');
+  }
+  for (const [field, value] of Object.entries(normalizedRailway)) {
+    if (typeof value === 'string' && field.endsWith('Id')) rejectExampleValue(value, `evidence.railway.${field}`);
+  }
+
+  const d1 = asRecord(root.d1, 'evidence.d1');
+  requireExactKeys(
+    d1,
+    ['databaseId', 'storageVersion', 'selectedBookmark', 'previousBookmark', 'restoreCompletedAt'],
+    'evidence.d1',
+  );
+  if (d1.storageVersion !== 'production') throw new Error('evidence.d1.storageVersion must be production');
+  const d1RestoreCompletedAt = requireTimestamp(d1, 'restoreCompletedAt', 'evidence.d1');
+  if (d1RestoreCompletedAt.millis < recoveryDeclaredAt.millis) {
+    throw new Error('D1 restore completion cannot be earlier than the recovery declaration');
+  }
+  if (d1RestoreCompletedAt.millis > verificationCompletedAt.millis) {
+    throw new Error('D1 restore completion cannot be later than final verification');
+  }
+  const normalizedD1 = {
+    databaseId: requireString(d1, 'databaseId', 'evidence.d1', idPattern),
+    storageVersion: 'production' as const,
+    selectedBookmark: requireString(d1, 'selectedBookmark', 'evidence.d1', idPattern),
+    previousBookmark: requireString(d1, 'previousBookmark', 'evidence.d1', idPattern),
+    restoreCompletedAt: d1RestoreCompletedAt.iso,
+  };
+  rejectExampleValue(normalizedD1.databaseId, 'evidence.d1.databaseId');
+  rejectExampleValue(normalizedD1.selectedBookmark, 'evidence.d1.selectedBookmark');
+  rejectExampleValue(normalizedD1.previousBookmark, 'evidence.d1.previousBookmark');
+
+  const r2 = asRecord(root.r2, 'evidence.r2');
+  requireExactKeys(r2, ['buckets'], 'evidence.r2');
+  if (!Array.isArray(r2.buckets) || r2.buckets.length !== 2) {
+    throw new Error('evidence.r2.buckets must contain the worker and backend upload buckets');
+  }
+  const normalizedBuckets = r2.buckets.map((value, index) => {
+    const path = `evidence.r2.buckets[${index}]`;
+    const bucket = asRecord(value, path);
+    requireExactKeys(
+      bucket,
+      ['role', 'name', 'lockRuleId', 'retentionDays', 'objectChecksum', 'overwriteRejected', 'deleteRejected'],
+      path,
+    );
+    if (bucket.role !== 'worker-uploads' && bucket.role !== 'backend-uploads') {
+      throw new Error(`${path}.role must be worker-uploads or backend-uploads`);
+    }
+    return {
+      role: bucket.role,
+      name: requireString(bucket, 'name', path, bucketPattern),
+      lockRuleId: requireString(bucket, 'lockRuleId', path, idPattern),
+      retentionDays: requireInteger(bucket, 'retentionDays', path, 30),
+      objectChecksum: requireString(bucket, 'objectChecksum', path, checksumPattern).toLowerCase(),
+      overwriteRejected: requireBoolean(bucket, 'overwriteRejected', path),
+      deleteRejected: requireBoolean(bucket, 'deleteRejected', path),
+    };
+  });
+  if (new Set(normalizedBuckets.map(({ role }) => role)).size !== 2) {
+    throw new Error('Evidence must include one worker-uploads and one backend-uploads bucket result');
+  }
+  normalizedBuckets.forEach((bucket, index) => {
+    const path = `evidence.r2.buckets[${index}]`;
+    rejectExampleValue(bucket.name, `${path}.name`);
+    rejectExampleValue(bucket.lockRuleId, `${path}.lockRuleId`);
+    if (/^sha256:([0-9a-f])\1{63}$/i.test(bucket.objectChecksum)) {
+      throw new Error(`${path}.objectChecksum still contains an example value`);
+    }
+  });
+
+  const recordCounts = asRecord(root.recordCounts, 'evidence.recordCounts');
+  requireExactKeys(recordCounts, REQUIRED_RECORD_COUNTS, 'evidence.recordCounts');
+  const normalizedRecordCounts = Object.fromEntries(
+    REQUIRED_RECORD_COUNTS.map((field) => [field, requireInteger(recordCounts, field, 'evidence.recordCounts', 1)]),
+  );
+
+  const integrity = asRecord(root.integrity, 'evidence.integrity');
+  requireExactKeys(integrity, REQUIRED_INTEGRITY_CHECKS, 'evidence.integrity');
+  const normalizedIntegrity = Object.fromEntries(
+    REQUIRED_INTEGRITY_CHECKS.map((field) => [field, requireBoolean(integrity, field, 'evidence.integrity')]),
+  );
+
+  return {
+    schemaVersion: 1,
+    environment: 'production' as const,
+    rehearsal: {
+      startedAt: startedAt.iso,
+      recoveryDeclaredAt: recoveryDeclaredAt.iso,
+      latestDurableWriteAt: latestDurableWriteAt.iso,
+      latestRecoveredWriteAt: latestRecoveredWriteAt.iso,
+      restorePointAt: restorePointAt.iso,
+      verificationCompletedAt: verificationCompletedAt.iso,
+    },
+    releases: normalizedReleases,
+    railway: normalizedRailway,
+    d1: normalizedD1,
+    r2: { buckets: normalizedBuckets },
+    recordCounts: normalizedRecordCounts,
+    integrity: normalizedIntegrity,
+    metrics: { rpoMinutes, rtoMinutes, passed: true },
+  };
+};

--- a/scripts/write-durable-recovery-evidence.ts
+++ b/scripts/write-durable-recovery-evidence.ts
@@ -1,0 +1,19 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildDurableRecoveryEvidence } from './lib/durableRecoveryEvidence.js';
+
+const outputPath = process.argv[2];
+if (!outputPath) throw new Error('Usage: write-durable-recovery-evidence.ts <output.json>');
+
+const source = process.env.RECOVERY_EVIDENCE_JSON;
+if (!source) throw new Error('RECOVERY_EVIDENCE_JSON is required');
+
+let parsed: unknown;
+try {
+  parsed = JSON.parse(source);
+} catch {
+  throw new Error('RECOVERY_EVIDENCE_JSON must be valid JSON');
+}
+
+const evidence = buildDurableRecoveryEvidence(parsed);
+writeFileSync(resolve(outputPath), `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');

--- a/tests/unit/scripts/durableRecoveryEvidence.test.ts
+++ b/tests/unit/scripts/durableRecoveryEvidence.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildDurableRecoveryEvidence } from '../../../scripts/lib/durableRecoveryEvidence.js';
+
+const validEvidence = () => ({
+  schemaVersion: 1,
+  environment: 'production',
+  rehearsal: {
+    startedAt: '2026-07-15T00:00:00Z',
+    recoveryDeclaredAt: '2026-07-15T00:10:00Z',
+    latestDurableWriteAt: '2026-07-15T00:09:00Z',
+    latestRecoveredWriteAt: '2026-07-15T00:00:00Z',
+    restorePointAt: '2026-07-15T00:05:00Z',
+    verificationCompletedAt: '2026-07-15T02:10:00Z',
+  },
+  releases: {
+    frontendWorkerCommit: '0123456789abcdef0123456789abcdef01234567',
+    backendGitCommit: '89abcdef0123456789abcdef0123456789abcdef',
+  },
+  railway: {
+    pitrEnabled: true,
+    retentionDays: 30,
+    restoreWindowStart: '2026-06-15T00:00:00Z',
+    restoreWindowEnd: '2026-07-15T00:10:00Z',
+    sourceServiceId: 'railway-source',
+    restoredServiceId: 'railway-restored',
+    sourceDeploymentId: 'deploy-source',
+    restoredDeploymentId: 'deploy-restored',
+  },
+  d1: {
+    databaseId: 'd1-rehearsal',
+    storageVersion: 'production',
+    selectedBookmark: 'bookmark-selected',
+    previousBookmark: 'bookmark-previous',
+    restoreCompletedAt: '2026-07-15T01:00:00Z',
+  },
+  r2: {
+    buckets: [
+      {
+        role: 'worker-uploads',
+        name: 'blawby-ai-files',
+        lockRuleId: 'lock-worker',
+        retentionDays: 30,
+        objectChecksum: `sha256:${'ab'.repeat(32)}`,
+        overwriteRejected: true,
+        deleteRejected: true,
+      },
+      {
+        role: 'backend-uploads',
+        name: 'blawby-backend-files',
+        lockRuleId: 'lock-backend',
+        retentionDays: 30,
+        objectChecksum: `sha256:${'cd'.repeat(32)}`,
+        overwriteRejected: true,
+        deleteRejected: true,
+      },
+    ],
+  },
+  recordCounts: {
+    identities: 1,
+    memberships: 1,
+    practices: 2,
+    clients: 1,
+    matters: 1,
+    invoices: 1,
+    intakes: 1,
+    approvals: 1,
+    uploads: 2,
+    conversations: 1,
+    messages: 2,
+    reportSchedules: 1,
+    crossTenantControls: 1,
+  },
+  integrity: {
+    referentialIntegrity: true,
+    tenantIsolation: true,
+    financialIntegrity: true,
+    approvalsSafe: true,
+    objectBytesMatch: true,
+    derivedStateRebuilt: true,
+  },
+});
+
+describe('durable recovery evidence', () => {
+  it('refuses to record the unchanged operator example', () => {
+    const example = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'docs/operations/durable-recovery-evidence.example.json'), 'utf8'),
+    );
+    expect(() => buildDurableRecoveryEvidence(example)).toThrow('still contains an example value');
+  });
+
+  it('normalizes passing production evidence and derives RPO/RTO', () => {
+    const result = buildDurableRecoveryEvidence(validEvidence());
+
+    expect(result.metrics).toEqual({ rpoMinutes: 9, rtoMinutes: 120, passed: true });
+    expect(result.r2.buckets.map(({ role }) => role)).toEqual(['worker-uploads', 'backend-uploads']);
+  });
+
+  it('rejects evidence that exceeds the recovery objectives', () => {
+    const rpo = validEvidence();
+    rpo.rehearsal.latestDurableWriteAt = '2026-07-15T00:30:00Z';
+    rpo.rehearsal.recoveryDeclaredAt = '2026-07-15T00:31:00Z';
+    expect(() => buildDurableRecoveryEvidence(rpo)).toThrow('exceeds 15 minutes');
+
+    const rto = validEvidence();
+    rto.rehearsal.verificationCompletedAt = '2026-07-15T04:11:00Z';
+    expect(() => buildDurableRecoveryEvidence(rto)).toThrow('exceeds 240 minutes');
+  });
+
+  it('rejects missing provider and integrity proof', () => {
+    const noPitr = validEvidence();
+    noPitr.railway.pitrEnabled = false;
+    expect(() => buildDurableRecoveryEvidence(noPitr)).toThrow('pitrEnabled must be true');
+
+    const shortLock = validEvidence();
+    shortLock.r2.buckets[0]!.retentionDays = 29;
+    expect(() => buildDurableRecoveryEvidence(shortLock)).toThrow('greater than or equal to 30');
+
+    const failedIsolation = validEvidence();
+    failedIsolation.integrity.tenantIsolation = false;
+    expect(() => buildDurableRecoveryEvidence(failedIsolation)).toThrow('tenantIsolation must be true');
+  });
+
+  it('rejects unexpected fields so the artifact cannot carry arbitrary payloads', () => {
+    const source = { ...validEvidence(), connectionString: 'must-not-be-retained' };
+    expect(() => buildDurableRecoveryEvidence(source)).toThrow('unexpected: connectionString');
+  });
+
+  it('rejects internally inconsistent timestamps', () => {
+    const source = validEvidence();
+    source.rehearsal.latestDurableWriteAt = '2026-07-15T00:11:00Z';
+    expect(() => buildDurableRecoveryEvidence(source)).toThrow('newer than the recovery declaration');
+  });
+});


### PR DESCRIPTION
Advances #723 without claiming that the human provider rehearsal has occurred.

## What changed
- adds a strict validator for sanitized durable-recovery evidence
- derives RPO/RTO from observed timestamps and rejects results over 15 minutes / 4 hours
- requires Railway PITR, a distinct sibling restore, 30-day locks and rejected delete/overwrite for both upload roles, positive representative record counts, and every integrity check to pass
- rejects unexpected fields and unchanged example values so arbitrary payloads, connection data, placeholders, or other unmodeled content cannot be retained
- adds an operator example and a production-environment GitHub workflow that uploads only normalized evidence for 90 days

## Validation
- npm run type-check
- npm run lint
- VITE_WORKER_API_URL=http://worker.test npm run test:unit (101 files, 752 tests)
- VITE_WORKER_API_URL=http://worker.test npm run build
- npm run build:check-size (285.1 KB / 300 KB)
- focused recovery suite after placeholder hardening (9 tests)
- CLI smoke: observed-value fixture normalized with RPO 9 minutes, RTO 120 minutes; unchanged example rejected

## Remaining human gate
The workflow validates and retains evidence; it does not simulate the recovery. Railway PITR/R2 locks and the timed isolated Railway, D1, and R2 rehearsal still require provider-level human execution before #723 can close.