### PR TITLE
Harden recovery evidence requirements

### DIFF
--- a/docs/operations/durable-recovery-evidence.example.json
+++ b/docs/operations/durable-recovery-evidence.example.json
@@ -6,6 +6,9 @@
     "recoveryDeclaredAt": "2026-07-15T00:10:00Z",
     "latestDurableWriteAt": "2026-07-15T00:09:00Z",
     "latestRecoveredWriteAt": "2026-07-15T00:00:00Z",
+    "sourceMarkerWatermark": "example-source-marker",
+    "recoveredMarkerWatermark": "example-recovered-marker",
+    "restoreBoundaryMarkerPresent": true,
     "restorePointAt": "2026-07-15T00:05:00Z",
     "verificationCompletedAt": "2026-07-15T02:10:00Z"
   },
@@ -15,13 +18,19 @@
   },
   "railway": {
     "pitrEnabled": true,
+    "restoredPitrEnabled": true,
+    "restoredArchiveHealthy": true,
     "retentionDays": 30,
     "restoreWindowStart": "2026-06-15T00:00:00Z",
     "restoreWindowEnd": "2026-07-15T00:10:00Z",
     "sourceServiceId": "example-source-service",
     "restoredServiceId": "example-restored-service",
     "sourceDeploymentId": "example-source-deployment",
-    "restoredDeploymentId": "example-restored-deployment"
+    "restoredDeploymentId": "example-restored-deployment",
+    "writeFenceMode": "global-block",
+    "capturedPostTargetWrites": 0,
+    "replayedPostTargetWrites": 0,
+    "allTenantReplayVerified": true
   },
   "d1": {
     "databaseId": "example-rehearsal-database",
@@ -37,18 +46,26 @@
         "name": "example-worker-uploads",
         "lockRuleId": "example-worker-lock",
         "retentionDays": 30,
-        "objectChecksum": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "preUploadSha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "overwriteRejected": true,
-        "deleteRejected": true
+        "deleteRejected": true,
+        "runtimeObjectTokenScoped": true,
+        "controlPlaneIdentitySeparate": true,
+        "lockAuditEventId": "example-worker-lock-audit",
+        "lockEditAlertVerified": true
       },
       {
         "role": "backend-uploads",
         "name": "example-backend-uploads",
         "lockRuleId": "example-backend-lock",
         "retentionDays": 30,
-        "objectChecksum": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "preUploadSha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "overwriteRejected": true,
-        "deleteRejected": true
+        "deleteRejected": true,
+        "runtimeObjectTokenScoped": true,
+        "controlPlaneIdentitySeparate": true,
+        "lockAuditEventId": "example-backend-lock-audit",
+        "lockEditAlertVerified": true
       }
     ]
   },

--- a/docs/operations/durable-recovery.md
+++ b/docs/operations/durable-recovery.md
@@ -46,6 +46,8 @@ monthly and cannot prove a 15-minute RPO.
 - Enable PITR on the production PostgreSQL service.
 - Retain at least 30 days of WAL/base backups.
 - Wait for the first base backup and confirm the displayed restore window.
+- Enable PITR on the restored sibling and verify its base backup plus archive
+  health before any cutover.
 - Keep daily, weekly, and monthly volume schedules as a second recovery layer.
 - Never wipe the source volume; cut over only after the restored sibling passes
   the verification queries below.
@@ -82,7 +84,12 @@ documented deletion workflow.
 - Apply a 30-day bucket-lock rule to `blawby-ai-files`.
 - Apply the same rule to the backend-configured production upload bucket.
 - Do not configure an expiration lifecycle on durable upload prefixes.
-- Record object key, size, ETag, and checksum in the owning PostgreSQL/D1 row.
+- Give application runtimes bucket-scoped object tokens and use a separate
+  human/control-plane identity for lock administration. Retain provider audit
+  evidence and alert on every lock-rule edit.
+- Record object key and size in the owning PostgreSQL/D1 row. Compute a
+  pre-upload SHA-256 for rehearsal evidence; do not treat an R2 ETag as a
+  canonical checksum or claim the current backend upload row stores one.
 - Generated/rebuildable exports may use a separate prefix with a shorter
   lifecycle, but original uploads may not.
 
@@ -131,8 +138,10 @@ timestamps for every step.
 3. R2: upload a synthetic object whose checksum is also recorded in its metadata
    row. Confirm a delete/overwrite attempt is rejected by bucket lock.
 4. Wait at least one minute, then mutate/delete the synthetic database records.
-5. Railway: restore a sibling PostgreSQL service to `T0`; never replace the
-   source during rehearsal.
+5. Railway: globally fence the shared database, or durably capture every
+   post-target write for every organization. Restore a sibling PostgreSQL
+   service to `T0`; never replace the source during rehearsal. Enable PITR on
+   the sibling and verify archive health before cutover eligibility.
 6. D1: run Time Travel against a temporary rehearsal database to the recorded
    bookmark, preserving the returned previous bookmark.
 7. Verify the restored rows and R2 bytes with the checks below. Rebuild search,
@@ -148,7 +157,8 @@ timestamps for every step.
   the same practice ID.
 - The negative-control tenant cannot read or mutate the restored records.
 - Message sequence is contiguous and no approval is silently executed.
-- R2 object size, ETag/checksum, and downloaded bytes match the metadata row.
+- R2 storage key and size match the metadata row; downloaded bytes match the
+  separately recorded pre-upload SHA-256.
 - Search and other derived views rebuild from the restored sources.
 - Measured RPO is `<= 15 minutes`; measured RTO is `<= 4 hours`.
 
@@ -179,15 +189,18 @@ rejects unexpected fields, and uploads the normalized artifact for 90 days.
 The accepted document has these top-level fields:
 
 - `schemaVersion` (`1`) and `environment` (`production`);
-- `rehearsal`: start, declaration, latest durable/recovered write, restore-point,
+- `rehearsal`: start, declaration, latest durable/recovered write, source and
+  recovered marker watermarks, restore-boundary marker result, restore-point,
   and verification timestamps;
 - `releases`: exact 40-character frontend/Worker and backend Git commits;
-- `railway`: PITR state, retention, restore window, and distinct source/restored
-  service and deployment IDs;
+- `railway`: source and restored-sibling PITR/archive state, retention, restore
+  window, distinct source/restored service and deployment IDs, global
+  write-fence mode, and captured/replayed all-tenant write counts;
 - `d1`: rehearsal database ID, production storage version, selected/previous
   bookmarks, and restore completion time;
 - `r2.buckets`: exactly one `worker-uploads` and one `backend-uploads` result,
-  including lock rule, retention, SHA-256 checksum, and rejected overwrite/delete;
+  including lock rule, retention, pre-upload SHA-256, rejected overwrite/delete,
+  scoped runtime token, separate control-plane identity, audit event, and alert;
 - `recordCounts`: positive synthetic counts for every representative durable
   domain and the cross-tenant negative control;
 - `integrity`: referential, tenant, financial, approval, object-byte, and

--- a/scripts/lib/durableRecoveryEvidence.ts
+++ b/scripts/lib/durableRecoveryEvidence.ts
@@ -111,6 +111,9 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
       'recoveryDeclaredAt',
       'latestDurableWriteAt',
       'latestRecoveredWriteAt',
+      'sourceMarkerWatermark',
+      'recoveredMarkerWatermark',
+      'restoreBoundaryMarkerPresent',
       'restorePointAt',
       'verificationCompletedAt',
     ],
@@ -120,6 +123,20 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
   const recoveryDeclaredAt = requireTimestamp(rehearsal, 'recoveryDeclaredAt', 'evidence.rehearsal');
   const latestDurableWriteAt = requireTimestamp(rehearsal, 'latestDurableWriteAt', 'evidence.rehearsal');
   const latestRecoveredWriteAt = requireTimestamp(rehearsal, 'latestRecoveredWriteAt', 'evidence.rehearsal');
+  const sourceMarkerWatermark = requireString(rehearsal, 'sourceMarkerWatermark', 'evidence.rehearsal', idPattern);
+  const recoveredMarkerWatermark = requireString(
+    rehearsal,
+    'recoveredMarkerWatermark',
+    'evidence.rehearsal',
+    idPattern,
+  );
+  const restoreBoundaryMarkerPresent = requireBoolean(
+    rehearsal,
+    'restoreBoundaryMarkerPresent',
+    'evidence.rehearsal',
+  );
+  rejectExampleValue(sourceMarkerWatermark, 'evidence.rehearsal.sourceMarkerWatermark');
+  rejectExampleValue(recoveredMarkerWatermark, 'evidence.rehearsal.recoveredMarkerWatermark');
   const restorePointAt = requireTimestamp(rehearsal, 'restorePointAt', 'evidence.rehearsal');
   const verificationCompletedAt = requireTimestamp(rehearsal, 'verificationCompletedAt', 'evidence.rehearsal');
   minutesBetween(startedAt.millis, recoveryDeclaredAt.millis, 'Rehearsal');
@@ -155,6 +172,8 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
     railway,
     [
       'pitrEnabled',
+      'restoredPitrEnabled',
+      'restoredArchiveHealthy',
       'retentionDays',
       'restoreWindowStart',
       'restoreWindowEnd',
@@ -162,6 +181,10 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
       'restoredServiceId',
       'sourceDeploymentId',
       'restoredDeploymentId',
+      'writeFenceMode',
+      'capturedPostTargetWrites',
+      'replayedPostTargetWrites',
+      'allTenantReplayVerified',
     ],
     'evidence.railway',
   );
@@ -172,6 +195,8 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
   }
   const normalizedRailway = {
     pitrEnabled: requireBoolean(railway, 'pitrEnabled', 'evidence.railway'),
+    restoredPitrEnabled: requireBoolean(railway, 'restoredPitrEnabled', 'evidence.railway'),
+    restoredArchiveHealthy: requireBoolean(railway, 'restoredArchiveHealthy', 'evidence.railway'),
     retentionDays: requireInteger(railway, 'retentionDays', 'evidence.railway', 30),
     restoreWindowStart: restoreWindowStart.iso,
     restoreWindowEnd: restoreWindowEnd.iso,
@@ -179,7 +204,23 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
     restoredServiceId: requireString(railway, 'restoredServiceId', 'evidence.railway', idPattern),
     sourceDeploymentId: requireString(railway, 'sourceDeploymentId', 'evidence.railway', idPattern),
     restoredDeploymentId: requireString(railway, 'restoredDeploymentId', 'evidence.railway', idPattern),
+    writeFenceMode: railway.writeFenceMode,
+    capturedPostTargetWrites: requireInteger(railway, 'capturedPostTargetWrites', 'evidence.railway', 0),
+    replayedPostTargetWrites: requireInteger(railway, 'replayedPostTargetWrites', 'evidence.railway', 0),
+    allTenantReplayVerified: requireBoolean(railway, 'allTenantReplayVerified', 'evidence.railway'),
   };
+  if (normalizedRailway.writeFenceMode !== 'global-block' && normalizedRailway.writeFenceMode !== 'capture-and-replay') {
+    throw new Error('evidence.railway.writeFenceMode must be global-block or capture-and-replay');
+  }
+  if (normalizedRailway.capturedPostTargetWrites !== normalizedRailway.replayedPostTargetWrites) {
+    throw new Error('Every captured post-target write must be replayed before cutover');
+  }
+  if (
+    normalizedRailway.writeFenceMode === 'global-block' &&
+    (normalizedRailway.capturedPostTargetWrites !== 0 || normalizedRailway.replayedPostTargetWrites !== 0)
+  ) {
+    throw new Error('Global-block evidence must have zero captured and replayed post-target writes');
+  }
   if (normalizedRailway.sourceServiceId === normalizedRailway.restoredServiceId) {
     throw new Error('Railway rehearsal must restore into a sibling service');
   }
@@ -222,7 +263,19 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
     const bucket = asRecord(value, path);
     requireExactKeys(
       bucket,
-      ['role', 'name', 'lockRuleId', 'retentionDays', 'objectChecksum', 'overwriteRejected', 'deleteRejected'],
+      [
+        'role',
+        'name',
+        'lockRuleId',
+        'retentionDays',
+        'preUploadSha256',
+        'overwriteRejected',
+        'deleteRejected',
+        'runtimeObjectTokenScoped',
+        'controlPlaneIdentitySeparate',
+        'lockAuditEventId',
+        'lockEditAlertVerified',
+      ],
       path,
     );
     if (bucket.role !== 'worker-uploads' && bucket.role !== 'backend-uploads') {
@@ -233,9 +286,13 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
       name: requireString(bucket, 'name', path, bucketPattern),
       lockRuleId: requireString(bucket, 'lockRuleId', path, idPattern),
       retentionDays: requireInteger(bucket, 'retentionDays', path, 30),
-      objectChecksum: requireString(bucket, 'objectChecksum', path, checksumPattern).toLowerCase(),
+      preUploadSha256: requireString(bucket, 'preUploadSha256', path, checksumPattern).toLowerCase(),
       overwriteRejected: requireBoolean(bucket, 'overwriteRejected', path),
       deleteRejected: requireBoolean(bucket, 'deleteRejected', path),
+      runtimeObjectTokenScoped: requireBoolean(bucket, 'runtimeObjectTokenScoped', path),
+      controlPlaneIdentitySeparate: requireBoolean(bucket, 'controlPlaneIdentitySeparate', path),
+      lockAuditEventId: requireString(bucket, 'lockAuditEventId', path, idPattern),
+      lockEditAlertVerified: requireBoolean(bucket, 'lockEditAlertVerified', path),
     };
   });
   if (new Set(normalizedBuckets.map(({ role }) => role)).size !== 2) {
@@ -245,8 +302,9 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
     const path = `evidence.r2.buckets[${index}]`;
     rejectExampleValue(bucket.name, `${path}.name`);
     rejectExampleValue(bucket.lockRuleId, `${path}.lockRuleId`);
-    if (/^sha256:([0-9a-f])\1{63}$/i.test(bucket.objectChecksum)) {
-      throw new Error(`${path}.objectChecksum still contains an example value`);
+    rejectExampleValue(bucket.lockAuditEventId, `${path}.lockAuditEventId`);
+    if (/^sha256:([0-9a-f])\1{63}$/i.test(bucket.preUploadSha256)) {
+      throw new Error(`${path}.preUploadSha256 still contains an example value`);
     }
   });
 
@@ -270,6 +328,9 @@ export const buildDurableRecoveryEvidence = (source: unknown) => {
       recoveryDeclaredAt: recoveryDeclaredAt.iso,
       latestDurableWriteAt: latestDurableWriteAt.iso,
       latestRecoveredWriteAt: latestRecoveredWriteAt.iso,
+      sourceMarkerWatermark,
+      recoveredMarkerWatermark,
+      restoreBoundaryMarkerPresent,
       restorePointAt: restorePointAt.iso,
       verificationCompletedAt: verificationCompletedAt.iso,
     },

--- a/tests/unit/scripts/durableRecoveryEvidence.test.ts
+++ b/tests/unit/scripts/durableRecoveryEvidence.test.ts
@@ -11,6 +11,9 @@ const validEvidence = () => ({
     recoveryDeclaredAt: '2026-07-15T00:10:00Z',
     latestDurableWriteAt: '2026-07-15T00:09:00Z',
     latestRecoveredWriteAt: '2026-07-15T00:00:00Z',
+    sourceMarkerWatermark: 'marker-source-100',
+    recoveredMarkerWatermark: 'marker-recovered-091',
+    restoreBoundaryMarkerPresent: true,
     restorePointAt: '2026-07-15T00:05:00Z',
     verificationCompletedAt: '2026-07-15T02:10:00Z',
   },
@@ -20,6 +23,8 @@ const validEvidence = () => ({
   },
   railway: {
     pitrEnabled: true,
+    restoredPitrEnabled: true,
+    restoredArchiveHealthy: true,
     retentionDays: 30,
     restoreWindowStart: '2026-06-15T00:00:00Z',
     restoreWindowEnd: '2026-07-15T00:10:00Z',
@@ -27,6 +32,10 @@ const validEvidence = () => ({
     restoredServiceId: 'railway-restored',
     sourceDeploymentId: 'deploy-source',
     restoredDeploymentId: 'deploy-restored',
+    writeFenceMode: 'global-block',
+    capturedPostTargetWrites: 0,
+    replayedPostTargetWrites: 0,
+    allTenantReplayVerified: true,
   },
   d1: {
     databaseId: 'd1-rehearsal',
@@ -42,18 +51,26 @@ const validEvidence = () => ({
         name: 'blawby-ai-files',
         lockRuleId: 'lock-worker',
         retentionDays: 30,
-        objectChecksum: `sha256:${'ab'.repeat(32)}`,
+        preUploadSha256: `sha256:${'ab'.repeat(32)}`,
         overwriteRejected: true,
         deleteRejected: true,
+        runtimeObjectTokenScoped: true,
+        controlPlaneIdentitySeparate: true,
+        lockAuditEventId: 'audit-worker-lock',
+        lockEditAlertVerified: true,
       },
       {
         role: 'backend-uploads',
         name: 'blawby-backend-files',
         lockRuleId: 'lock-backend',
         retentionDays: 30,
-        objectChecksum: `sha256:${'cd'.repeat(32)}`,
+        preUploadSha256: `sha256:${'cd'.repeat(32)}`,
         overwriteRejected: true,
         deleteRejected: true,
+        runtimeObjectTokenScoped: true,
+        controlPlaneIdentitySeparate: true,
+        lockAuditEventId: 'audit-backend-lock',
+        lockEditAlertVerified: true,
       },
     ],
   },
@@ -113,6 +130,10 @@ describe('durable recovery evidence', () => {
     noPitr.railway.pitrEnabled = false;
     expect(() => buildDurableRecoveryEvidence(noPitr)).toThrow('pitrEnabled must be true');
 
+    const noRestoredPitr = validEvidence();
+    noRestoredPitr.railway.restoredArchiveHealthy = false;
+    expect(() => buildDurableRecoveryEvidence(noRestoredPitr)).toThrow('restoredArchiveHealthy must be true');
+
     const shortLock = validEvidence();
     shortLock.r2.buckets[0]!.retentionDays = 29;
     expect(() => buildDurableRecoveryEvidence(shortLock)).toThrow('greater than or equal to 30');
@@ -120,6 +141,22 @@ describe('durable recovery evidence', () => {
     const failedIsolation = validEvidence();
     failedIsolation.integrity.tenantIsolation = false;
     expect(() => buildDurableRecoveryEvidence(failedIsolation)).toThrow('tenantIsolation must be true');
+
+    const sharedControlPlane = validEvidence();
+    sharedControlPlane.r2.buckets[0]!.controlPlaneIdentitySeparate = false;
+    expect(() => buildDurableRecoveryEvidence(sharedControlPlane)).toThrow('controlPlaneIdentitySeparate must be true');
+  });
+
+  it('rejects incomplete all-tenant write replay and restore markers', () => {
+    const replay = validEvidence();
+    replay.railway.writeFenceMode = 'capture-and-replay';
+    replay.railway.capturedPostTargetWrites = 2;
+    replay.railway.replayedPostTargetWrites = 1;
+    expect(() => buildDurableRecoveryEvidence(replay)).toThrow('Every captured post-target write must be replayed');
+
+    const marker = validEvidence();
+    marker.rehearsal.restoreBoundaryMarkerPresent = false;
+    expect(() => buildDurableRecoveryEvidence(marker)).toThrow('restoreBoundaryMarkerPresent must be true');
   });
 
   it('rejects unexpected fields so the artifact cannot carry arbitrary payloads', () => {


### PR DESCRIPTION
Hardens the recovery evidence recorder delivered in #769 after validating backend PR Blawby/blawby-backend#389 review findings against the real upload schema.

## What changed
- require synthetic source/recovered marker watermarks and restore-boundary proof
- require PITR plus archive health on the restored Railway sibling
- require either a global shared-database write block or complete all-tenant captured/replayed write counts
- require bucket-scoped runtime object access, a separate lock-administration identity, lock audit-event IDs, and verified lock-edit alerts
- rename the R2 digest field to `preUploadSha256`; the backend upload row stores key/size but no canonical checksum, and R2 ETags are not treated as hashes
- update the operator example, runbook, and rejection coverage

## Validation
- npm run type-check
- eslint on changed TypeScript/tests
- focused recovery suite: 10 tests passed
- CLI smoke: RPO 9 minutes, RTO 120 minutes, global-block evidence accepted

Advances #723. The provider rehearsal remains human-owned and is not claimed complete.