### PR TITLE
fix: align production backend health contract

### DIFF
--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -31,7 +31,7 @@ Do not add request/response bodies, names, email addresses, practice/client/matt
 ## First five minutes
 
 1. Open the monitor run and its `production-health.json` artifact. Do not paste response bodies into the incident.
-2. Record the failing component, first observed time, and the exact release markers from `/api/health`, the last production launch artifact, Cloudflare, and Railway.
+2. Record the failing component and first observed time. Read the Worker release marker from `/api/health`; read the backend deployment identity from the last production launch artifact and confirm it against Railway or CI metadata.
 3. Decide whether the failure began with a deployment. If yes, prefer the repository's proven rollback path for the owning surface.
 4. Check whether the failure is isolated (one 4xx/correlation ID) or systemic (two scheduled failures, repeated 5xx, failed queue invocation, or multiple components).
 5. Keep ownership boundaries: this repository may restore Worker/Pages; Railway/backend deployment and database actions require a human backend operator.
@@ -72,4 +72,4 @@ Stop further deploys and preserve the failed migration output. Durable Object mi
 
 ## Backend and Railway gaps
 
-The public backend health endpoint currently proves API uptime and PostgreSQL connectivity, but it does not report Stripe reachability, webhook backlog/age, Graphile Worker heartbeat, failed-job count, or the Railway deployment identifier. Backend task logs also need one consistent sanitized release/correlation/failure contract. [Backend PR #371](https://github.com/Blawby/blawby-backend/pull/371) adds native Railway release identity and a sanitized database-health failure event; it is left for human review and merge. The remaining backend signals stay explicit gaps, and that review does not block the frontend/Worker monitoring and runbooks delivered here.
+The public backend health endpoint proves API uptime and PostgreSQL connectivity. It intentionally does not expose a Railway deployment identifier: the exact identifier is a required production-launch input, is preserved in the launch artifact, and is verified against Railway or CI metadata during an incident. The endpoint also does not report Stripe reachability, webhook backlog/age, Graphile Worker heartbeat, or failed-job count. Backend task logs still need one consistent sanitized release/correlation/failure contract. Those signals remain explicit provider/backend gaps and do not weaken the frontend/Worker monitor.

--- a/docs/operations/production-launch.md
+++ b/docs/operations/production-launch.md
@@ -8,7 +8,7 @@ The operator supplies four explicit confirmations before any production componen
 
 - `confirmation`: exactly `DEPLOY`.
 - `backend_git_commit`: the exact reviewed backend commit already deployed.
-- `backend_deployment_id`: the backend platform deployment identifier.
+- `backend_deployment_id`: the exact backend platform deployment identifier from Railway or CI metadata. Do not derive it from the public health endpoint.
 - `migrations_ready`: confirmation that required backend and Worker migrations are applied.
 
 The preflight then runs typecheck, lint, the unit suite, production configuration validation, strict Worker dry-run, production build and bundle budget, and a bounded backend health check. The `production` GitHub environment remains the human approval boundary for production credentials and deployment.

--- a/scripts/lib/productionHealth.ts
+++ b/scripts/lib/productionHealth.ts
@@ -37,12 +37,11 @@ const jsonRecord = async (response: Response): Promise<Record<string, unknown> |
   }
 };
 
-const releaseMarker = (
+const workerReleaseMarker = (
   release: Record<string, unknown> | null,
-  deploymentKey: 'workerVersionId' | 'deployment_id',
 ): ProductionCheckResult['release'] =>
-  typeof release?.commit === 'string' && typeof release[deploymentKey] === 'string'
-    ? { commit: release.commit, deploymentId: release[deploymentKey] as string }
+  typeof release?.commit === 'string' && typeof release.workerVersionId === 'string'
+    ? { commit: release.commit, deploymentId: release.workerVersionId }
     : undefined;
 
 export const productionChecks: CheckDefinition[] = [
@@ -76,7 +75,7 @@ export const productionChecks: CheckDefinition[] = [
       const release = data?.release && typeof data.release === 'object' && !Array.isArray(data.release)
         ? data.release as Record<string, unknown>
         : null;
-      return releaseMarker(release, 'workerVersionId');
+      return workerReleaseMarker(release);
     },
   },
   {
@@ -88,20 +87,7 @@ export const productionChecks: CheckDefinition[] = [
       const database = body?.database && typeof body.database === 'object' && !Array.isArray(body.database)
         ? body.database as Record<string, unknown>
         : null;
-      const release = body?.release && typeof body.release === 'object' && !Array.isArray(body.release)
-        ? body.release as Record<string, unknown>
-        : null;
-      return body?.status === 'ok' && database?.status === 'connected' &&
-        typeof release?.commit === 'string' && release.commit !== 'unknown' &&
-        typeof release.deployment_id === 'string' && release.deployment_id !== 'unknown' &&
-        release.environment === 'production';
-    },
-    releaseMarker: async (response) => {
-      const body = await jsonRecord(response);
-      const release = body?.release && typeof body.release === 'object' && !Array.isArray(body.release)
-        ? body.release as Record<string, unknown>
-        : null;
-      return releaseMarker(release, 'deployment_id');
+      return body?.status === 'ok' && database?.status === 'connected';
     },
   },
   {

--- a/tests/unit/scripts/productionHealth.test.ts
+++ b/tests/unit/scripts/productionHealth.test.ts
@@ -36,7 +36,6 @@ describe('production health checks', () => {
         return json({
           status: 'ok',
           database: { status: 'connected' },
-          release: { commit: 'backend-sha', deployment_id: 'railway-id', environment: 'production' },
           private_field: 'do-not-record',
         });
       }
@@ -52,10 +51,7 @@ describe('production health checks', () => {
       commit: 'sha',
       deploymentId: 'worker-id',
     });
-    expect(results.find((result) => result.name === 'backend_database')?.release).toEqual({
-      commit: 'backend-sha',
-      deploymentId: 'railway-id',
-    });
+    expect(results.find((result) => result.name === 'backend_database')?.release).toBeUndefined();
     expect(JSON.stringify(results)).not.toContain('do-not-record');
   });
 
@@ -67,5 +63,33 @@ describe('production health checks', () => {
     expect(results.every((result) => result.outcome === 'failed')).toBe(true);
     expect(results.every((result) => result.failureClass === 'http_status')).toBe(true);
     expect(JSON.stringify(results)).not.toContain('private upstream detail');
+  });
+
+  it('still rejects a backend health response without a connected database', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const target = String(url);
+      if (target.startsWith('https://api.')) {
+        return json({ status: 'ok', database: { status: 'disconnected' } });
+      }
+      if (target.endsWith('/api/health')) {
+        return json({
+          success: true,
+          data: {
+            status: 'ok',
+            environment: 'production',
+            release: { commit: 'sha', workerVersionId: 'worker-id' },
+          },
+        });
+      }
+      if (target.endsWith('/api/auth/get-session')) return json(null);
+      if (target.includes('/api/ai/') || target.endsWith('/api/subscriptions')) return json({}, 401);
+      return new Response('<!doctype html>', { status: 200, headers: { 'content-type': 'text/html' } });
+    }) as unknown as typeof fetch;
+
+    const results = await runProductionHealthChecks({ fetchImpl, attempts: 1, retryDelayMs: 0 });
+    expect(results.find((result) => result.name === 'backend_database')).toMatchObject({
+      outcome: 'failed',
+      failureClass: 'contract',
+    });
   });
 });


### PR DESCRIPTION
## What changed
- validate the public backend health endpoint on API status and PostgreSQL connectivity only
- keep exact Railway deployment identity in the production launch artifact and Railway/CI evidence path
- remove the rejected backend #371 dependency from operations documentation
- add regression coverage proving a disconnected database still fails the monitor

## Why
Backend PR Blawby/blawby-backend#371 was intentionally closed after human review: Railway deployment identity should not be exposed through the public health endpoint. The production monitor still required that rejected response shape, so healthy backend/database responses were reported as contract failures.

## Validation
- `npm run type-check`
- `npm run lint`
- `VITE_WORKER_API_URL=https://local.blawby.com VITE_APP_BASE_URL=https://local.blawby.com npm test` — 125 files, 892 tests passed
- live bounded production check: backend/database now healthy; only the expected pre-cutover Worker contract remains failed

Progresses #746. This PR does not close the incident; #746 still waits for cutover and the next healthy scheduled production run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified incident-response steps for recording failures and verifying Worker and backend deployment identifiers.
  - Updated production-launch guidance to require the exact backend deployment identifier from Railway or CI metadata.
  - Documented that the public health endpoint does not expose the backend deployment identifier.

- **Bug Fixes**
  - Improved Worker release-marker validation.
  - Simplified backend database health validation to focus on status checks.
  - Health checks now correctly flag disconnected backend database contracts as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->