### PR TITLE
feat: preserve Practice Assistant citations

### DIFF
--- a/src/shared/hooks/useConversation.ts
+++ b/src/shared/hooks/useConversation.ts
@@ -50,6 +50,7 @@ import {
 } from '@/shared/utils/anonymousIdentity';
 import { quickActionDebugLog, isQuickActionDebugEnabled } from '@/shared/utils/quickActionDebug';
 import { normalizeChatActions } from '@/shared/utils/chatActions';
+import { parsePracticeAssistantSources } from '@/shared/utils/practiceAssistantSources';
 import { useConversationTransport } from '@/shared/hooks/useConversationTransport';
 
 // ─── constants ───────────────────────────────────────────────────────────────
@@ -421,6 +422,7 @@ export const useConversation = ({
       timestamp: new Date(msg.created_at).getTime(),
       metadata: { ...(msg.metadata || {}), __client_id: msg.client_id },
       userId: senderId,
+      sources: parsePracticeAssistantSources(metadataRecord?.sources),
       files: msg.metadata?.attachments
         ? (msg.metadata.attachments as string[]).map((fileId: string) => ({
             id: fileId, name: 'File', size: 0, type: 'application/octet-stream', url: buildFileUrl(fileId),

--- a/src/shared/utils/practiceAssistantSources.ts
+++ b/src/shared/utils/practiceAssistantSources.ts
@@ -1,0 +1,9 @@
+import {
+  PracticeAssistantSourceSchema,
+  type PracticeAssistantSource,
+} from '@/shared/types/wire';
+
+export const parsePracticeAssistantSources = (value: unknown): PracticeAssistantSource[] | undefined => {
+  const parsed = PracticeAssistantSourceSchema.array().safeParse(value);
+  return parsed.success && parsed.data.length > 0 ? parsed.data : undefined;
+};

--- a/tests/unit/utils/practiceAssistantSources.test.ts
+++ b/tests/unit/utils/practiceAssistantSources.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { parsePracticeAssistantSources } from '@/shared/utils/practiceAssistantSources';
+
+describe('parsePracticeAssistantSources', () => {
+  it('preserves valid grounded source metadata for UI messages', () => {
+    expect(parsePracticeAssistantSources([
+      { type: 'matter', id: 'matter-1', label: 'Smith matter', href: '/practice/acme/matters/matter-1' },
+      { type: 'report', id: 'revenue', label: 'Revenue report' },
+    ])).toEqual([
+      { type: 'matter', id: 'matter-1', label: 'Smith matter', href: '/practice/acme/matters/matter-1' },
+      { type: 'report', id: 'revenue', label: 'Revenue report' },
+    ]);
+  });
+
+  it.each([undefined, null, [], [{ type: 'matter', id: '', label: 'Broken' }]])(
+    'omits absent or malformed source metadata: %j',
+    (value) => {
+      expect(parsePracticeAssistantSources(value)).toBeUndefined();
+    },
+  );
+});

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -265,6 +265,7 @@ import type {
   MessageReaction,
   BackendConversation,
 } from './types/wire/conversation';
+import type { PracticeAssistantSource } from './types/wire/practiceAssistant';
 export type { ChatMessage, ChatSession, MessageReaction, BackendConversation };
 
 // Matter types
@@ -444,6 +445,8 @@ export interface UIMessageExtras {
   userId?: string | null;
   files?: FileAttachment[];
   reactions?: MessageReaction[];
+  /** Grounding records used by Practice Assistant to produce this message. */
+  sources?: PracticeAssistantSource[];
 
   matterCreation?: MatterCreationData;
   welcomeMessage?: WelcomeMessageData;

--- a/worker/types/wire/practiceAssistant.ts
+++ b/worker/types/wire/practiceAssistant.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const PracticeAssistantSourceSchema = z.object({
   type: z.enum(['client', 'intake', 'matter', 'engagement', 'invoice', 'report', 'task', 'search', 'practice']),
-  id: z.string(),
-  label: z.string(),
+  id: z.string().min(1),
+  label: z.string().min(1),
   href: z.string().optional(),
 });
 export type PracticeAssistantSource = z.infer<typeof PracticeAssistantSourceSchema>;


### PR DESCRIPTION
## What changed
- expose validated Practice Assistant grounding sources on `UIMessageExtras`
- preserve `metadata.sources` when persisted conversation messages are mapped for the UI
- fast-fail empty source IDs and labels in the shared wire schema
- cover valid, absent, empty, and malformed source metadata

## Why
The Worker already persists grounding sources on every Practice Assistant turn, but `useConversation` dropped them while mapping server messages. That made the existing Citations pattern unavailable after fetch or reconnect.

## Validation
- 98 focused Practice Assistant/source tests passed
- `npm run type-check`
- `npm run lint`

Progresses #662.