### PR TITLE
fix: unblock prelaunch recovery evidence

### DIFF
--- a/.github/workflows/record-durable-recovery.yml
+++ b/.github/workflows/record-durable-recovery.yml
@@ -18,13 +18,16 @@ jobs:
     timeout-minutes: 10
     environment: production
     steps:
-      - name: Require the production branch
+      - name: Require an approved evidence branch
         run: |
           set -euo pipefail
-          [[ "${GITHUB_REF}" == "refs/heads/main" ]] || {
-            echo "Recovery evidence must be recorded from main." >&2
-            exit 1
-          }
+          case "${GITHUB_REF}" in
+            refs/heads/staging|refs/heads/main) ;;
+            *)
+              echo "Recovery evidence must be recorded from staging before cutover or main after cutover." >&2
+              exit 1
+              ;;
+          esac
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/docs/operations/durable-recovery.md
+++ b/docs/operations/durable-recovery.md
@@ -177,7 +177,9 @@ Store a sanitized `durable-recovery-evidence.json` artifact for 90 days with:
 - measured RPO/RTO and pass/fail status.
 
 After the human operator completes the provider rehearsal, run the **Record
-durable recovery evidence** workflow from `main`. Paste only the sanitized JSON
+durable recovery evidence** workflow from `staging` before the initial public
+cutover. After cutover, run later rehearsals from `main`. Both refs retain the
+`production` environment approval boundary. Paste only the sanitized JSON
 described by the workflow input. Copy
 [`durable-recovery-evidence.example.json`](./durable-recovery-evidence.example.json),
 replace every example value with observed rehearsal evidence, and never submit

--- a/tests/unit/scripts/durableRecovery.test.ts
+++ b/tests/unit/scripts/durableRecovery.test.ts
@@ -47,4 +47,12 @@ describe('durable recovery contract', () => {
       expect(runbook).toContain(required);
     }
   });
+
+  it('allows pre-launch evidence from staging without removing the production approval boundary', () => {
+    const workflow = source('.github/workflows/record-durable-recovery.yml');
+
+    expect(workflow).toContain('refs/heads/staging');
+    expect(workflow).toContain('refs/heads/main');
+    expect(workflow).toContain('environment: production');
+  });
 });


### PR DESCRIPTION
## What changed
- allow the durable-recovery evidence recorder to run from `staging` before initial cutover
- retain `main` for post-launch rehearsals
- preserve the protected `production` environment approval boundary on both refs
- document the pre-launch/post-launch branch rule and test it

## Why
#723 blocks #724 until a validated recovery artifact exists. The recorder previously required `main`, but `main` does not contain the workflow and cannot receive the staging release until cutover. That made the pre-launch evidence gate circular.

## Validation
- 11 durable-recovery contract/evidence tests passed
- `npm run type-check`
- `npm run lint`

Progresses #723 and #724.